### PR TITLE
Implement interview for ConfigurationCC, include spec changes

### DIFF
--- a/src/lib/error/ZWaveError.ts
+++ b/src/lib/error/ZWaveError.ts
@@ -46,6 +46,14 @@ export enum ZWaveErrorCodes {
 	 * available in a node's configuration
 	 */
 	ConfigurationCC_FirstParameterNumber = 100,
+	/**
+	 * Used to report that a V3+ node should not have its parameters scanned with get/set commands
+	 */
+	ConfigurationCC_NoLegacyScanOnNewDevices,
+	/**
+	 * Used to report that a node using V3 or less MUST not use the resetToDefault flag
+	 */
+	ConfigurationCC_NoResetToDefaultOnLegacyDevices,
 }
 
 /**


### PR DESCRIPTION
Spec changes include:
* `requiresReinclusion` is now called `altersCapabilities`
* using the `resetToDefault` flag is now forbidden on legacy devices (V3 or less)

Fixes: #193