### PR TITLE
Stop logging messages nobody is going to see

### DIFF
--- a/src/lib/log/Reflection.ts
+++ b/src/lib/log/Reflection.ts
@@ -3,6 +3,7 @@ import {
 	createConsoleTransport,
 	createLoggerFormat,
 	getDirectionPrefix,
+	isLoglevelVisible,
 	tagify,
 	ZWaveLogger,
 } from "./shared";
@@ -19,6 +20,7 @@ if (!winston.loggers.has("reflection")) {
 	});
 }
 const logger: ZWaveLogger = winston.loggers.get("reflection");
+const isVisible = isLoglevelVisible(REFLECTION_LOGLEVEL);
 
 /**
  * Logs the process of defining metadata for a class
@@ -27,6 +29,8 @@ const logger: ZWaveLogger = winston.loggers.get("reflection");
  * @param message An additional message
  */
 export function define(name: string, type: string, message: string): void {
+	if (!isVisible) return;
+
 	logger.log({
 		level: REFLECTION_LOGLEVEL,
 		primaryTags: tagify([name]),
@@ -42,6 +46,8 @@ export function define(name: string, type: string, message: string): void {
  * @param message An additional message, e.g. the resulting value
  */
 export function lookup(name: string, type: string, message: string): void {
+	if (!isVisible) return;
+
 	logger.log({
 		level: REFLECTION_LOGLEVEL,
 		primaryTags: tagify([name]),
@@ -55,8 +61,11 @@ export function lookup(name: string, type: string, message: string): void {
  * @param msg The message to output
  */
 export function print(message: string, level?: "warn" | "error"): void {
+	const actualLevel = level || REFLECTION_LOGLEVEL;
+	if (!isLoglevelVisible(actualLevel)) return;
+
 	logger.log({
-		level: level || REFLECTION_LOGLEVEL,
+		level: actualLevel,
 		message,
 		direction: getDirectionPrefix("none"),
 	});

--- a/src/lib/log/Serial.ts
+++ b/src/lib/log/Serial.ts
@@ -6,6 +6,7 @@ import {
 	createLoggerFormat,
 	DataDirection,
 	getDirectionPrefix,
+	isLoglevelVisible,
 	ZWaveLogger,
 } from "./shared";
 
@@ -21,13 +22,14 @@ if (!winston.loggers.has("serial")) {
 	});
 }
 const logger: ZWaveLogger = winston.loggers.get("serial");
+const isVisible = isLoglevelVisible(SERIAL_LOGLEVEL);
 
 /**
  * Logs transmission or receipt of an ACK frame
  * @param direction The direction this ACK was sent
  */
 export function ACK(direction: DataDirection): void {
-	logMessageHeader(direction, MessageHeaders.ACK);
+	if (isVisible) logMessageHeader(direction, MessageHeaders.ACK);
 }
 
 /**
@@ -35,7 +37,7 @@ export function ACK(direction: DataDirection): void {
  * @param direction The direction this NAK was sent
  */
 export function NAK(direction: DataDirection): void {
-	logMessageHeader(direction, MessageHeaders.NAK);
+	if (isVisible) logMessageHeader(direction, MessageHeaders.NAK);
 }
 
 /**
@@ -43,7 +45,7 @@ export function NAK(direction: DataDirection): void {
  * @param direction The direction this CAN was sent
  */
 export function CAN(direction: DataDirection): void {
-	logMessageHeader(direction, MessageHeaders.CAN);
+	if (isVisible) logMessageHeader(direction, MessageHeaders.CAN);
 }
 
 function logMessageHeader(
@@ -65,12 +67,14 @@ function logMessageHeader(
  * @param data The data that was transmitted or received
  */
 export function data(direction: DataDirection, data: Buffer): void {
-	logger.log({
-		level: SERIAL_LOGLEVEL,
-		message: `0x${data.toString("hex")}`,
-		secondaryTags: `(${data.length} bytes)`,
-		direction: getDirectionPrefix(direction),
-	});
+	if (isVisible) {
+		logger.log({
+			level: SERIAL_LOGLEVEL,
+			message: `0x${data.toString("hex")}`,
+			secondaryTags: `(${data.length} bytes)`,
+			direction: getDirectionPrefix(direction),
+		});
+	}
 }
 
 /**
@@ -78,13 +82,15 @@ export function data(direction: DataDirection, data: Buffer): void {
  * @param data The data that is currently in the receive buffer
  */
 export function receiveBuffer(data: Buffer, isComplete: boolean): void {
-	logger.log({
-		level: SERIAL_LOGLEVEL,
-		primaryTags: isComplete ? undefined : "[incomplete]",
-		message: `Buffer := 0x${data.toString("hex")}`,
-		secondaryTags: `(${data.length} bytes)`,
-		direction: getDirectionPrefix("none"),
-	});
+	if (isVisible) {
+		logger.log({
+			level: SERIAL_LOGLEVEL,
+			primaryTags: isComplete ? undefined : "[incomplete]",
+			message: `Buffer := 0x${data.toString("hex")}`,
+			secondaryTags: `(${data.length} bytes)`,
+			direction: getDirectionPrefix("none"),
+		});
+	}
 }
 
 /**
@@ -92,9 +98,11 @@ export function receiveBuffer(data: Buffer, isComplete: boolean): void {
  * @param msg The message to output
  */
 export function message(message: string): void {
-	logger.log({
-		level: SERIAL_LOGLEVEL,
-		message,
-		direction: getDirectionPrefix("none"),
-	});
+	if (isVisible) {
+		logger.log({
+			level: SERIAL_LOGLEVEL,
+			message,
+			direction: getDirectionPrefix("none"),
+		});
+	}
 }

--- a/src/lib/log/shared.ts
+++ b/src/lib/log/shared.ts
@@ -1,10 +1,15 @@
 import colors from "ansi-colors";
 import { Format, TransformableInfo, TransformFunction } from "logform";
-import { MESSAGE } from "triple-beam";
+import { configs, MESSAGE } from "triple-beam";
 import winston, { Logger } from "winston";
 import Transport from "winston-transport";
 import { colorizer } from "./Colorizer";
 const { combine, timestamp, label } = winston.format;
+
+const loglevels = configs.npm.levels;
+const transportLoglevel =
+	process.env.LOGLEVEL! in loglevels ? process.env.LOGLEVEL! : "debug";
+const transportLoglevelNumeric = loglevels[transportLoglevel];
 
 /** An invisible char with length >= 0 */
 // This is necessary to "print" zero spaces for the right padding
@@ -230,7 +235,23 @@ export function restoreSilence(
 
 export function createConsoleTransport(): Transport {
 	return new winston.transports.Console({
-		level: process.env.LOGLEVEL || "debug",
+		level: transportLoglevel,
 		silent: process.env.NODE_ENV === "test",
 	});
+}
+
+const loglevelVisibleCache = new Map<string, boolean>();
+/** Tests whether a log using the given loglevel will be logged */
+export function isLoglevelVisible(loglevel: string): boolean {
+	// If we are not connected to a TTY, we won't see anything
+	if (!process.stdout.isTTY) return false;
+
+	if (!loglevelVisibleCache.has(loglevel)) {
+		loglevelVisibleCache.set(
+			loglevel,
+			loglevel in loglevels &&
+				loglevels[loglevel] <= transportLoglevelNumeric,
+		);
+	}
+	return loglevelVisibleCache.get(loglevel)!;
 }

--- a/src/lib/log/shared.ts
+++ b/src/lib/log/shared.ts
@@ -241,10 +241,13 @@ export function createConsoleTransport(): Transport {
 }
 
 const loglevelVisibleCache = new Map<string, boolean>();
+const isTTY = process.stdout.isTTY;
+const isUnitTest = process.env.NODE_ENV === "test";
 /** Tests whether a log using the given loglevel will be logged */
 export function isLoglevelVisible(loglevel: string): boolean {
-	// If we are not connected to a TTY, we won't see anything
-	if (!process.stdout.isTTY) return false;
+	// If we are not connected to a TTY (or unit testing), we won't see anything
+	if (isUnitTest) return true;
+	if (!isTTY) return false;
 
 	if (!loglevelVisibleCache.has(loglevel)) {
 		loglevelVisibleCache.set(


### PR DESCRIPTION
This should **massively** reduce the CPU usage while logs are filtered out or no stdout is visible at all.