### PR TITLE
Remove unnecessary code path from Driver

### DIFF
--- a/src/lib/commandclass/CommandClass.ts
+++ b/src/lib/commandclass/CommandClass.ts
@@ -142,6 +142,7 @@ export class CommandClass {
 			this.ccCommand = ccCommand;
 			this.payload = payload;
 		}
+		// Set the CC version as high as possible
 		this.version = this.driver.getSafeCCVersionForNode(
 			this.ccId,
 			this.nodeId,

--- a/src/lib/driver/Driver.ts
+++ b/src/lib/driver/Driver.ts
@@ -1361,23 +1361,8 @@ ${handlers.length} left`,
 				})${targetNode ? ` to node ${targetNode.id}` : ""}...`,
 				"debug",
 			);
-			// for messages containing a CC, i.e. a SendDataRequest, set the CC version as high as possible
-			if (isCommandClassContainer(msg)) {
-				const ccId = msg.command.ccId;
-				// TODO: If the message is for an endpoint, determine the safe version for that endpoint
-				msg.command.version = this.getSafeCCVersionForNode(
-					ccId,
-					msg.command.nodeId,
-				);
-				// TODO: This could be improved
-				log.driver.print(
-					`CC = ${CommandClasses[ccId]} (${num2hex(
-						ccId,
-					)}) => using version ${msg.command.version}`,
-					"debug",
-				);
-			}
-			// Actually send the message
+
+			// And send it
 			this.currentTransaction.markAsSent();
 			const data = msg.serialize();
 			log.serial.data("outbound", data);


### PR DESCRIPTION
fixes: #402 

The logic was already in place, only the Driver was replacing it with with the root endpoint version again.