### PR TITLE
Verify ValueIDs and ignore invalid value IDs during Cache deserialization

### DIFF
--- a/src/lib/commandclass/CommandClass.ts
+++ b/src/lib/commandclass/CommandClass.ts
@@ -649,8 +649,12 @@ export class CommandClass {
 					propertyKey: val.propertyKey,
 				},
 				deserializeCacheValue(val.value),
-				// Don't emit the added/updated events, as this will spam applications with untranslated events
-				{ noEvent: true },
+				{
+					// Don't emit the added/updated events, as this will spam applications with untranslated events
+					noEvent: true,
+					// Don't throw when there is an invalid Value ID in the cache
+					noThrow: true,
+				},
 			);
 		}
 	}
@@ -667,8 +671,12 @@ export class CommandClass {
 					propertyKey: meta.propertyKey,
 				},
 				meta.metadata,
-				// Don't emit the added/updated events, as this will spam applications with untranslated events
-				{ noEvent: true },
+				{
+					// Don't emit the added/updated events, as this will spam applications with untranslated events
+					noEvent: true,
+					// Don't throw when there is an invalid Value ID in the cache
+					noThrow: true,
+				},
 			);
 		}
 	}

--- a/src/lib/node/ValueDB.test.ts
+++ b/src/lib/node/ValueDB.test.ts
@@ -663,4 +663,35 @@ describe("lib/node/ValueDB => ", () => {
 			}
 		});
 	});
+
+	describe(`invalid value IDs should be ignored by the setXYZ methods when the "noThrow" parameter is true`, () => {
+		const invalidValueIDs = [
+			// missing required properties
+			{ commandClass: undefined, property: "test" },
+			{ commandClass: 1, property: undefined },
+			// wrong type
+			{ commandClass: "1", property: 5, propertyKey: 7, endpoint: 1 },
+			{ commandClass: 1, property: true, propertyKey: 7, endpoint: 1 },
+			{ commandClass: 1, property: 5, propertyKey: false, endpoint: 1 },
+			{ commandClass: 1, property: 5, propertyKey: 7, endpoint: "5" },
+		];
+
+		it("setValue()", () => {
+			for (const valueId of invalidValueIDs) {
+				expect(() =>
+					valueDB.setValue(valueId as any, 0, { noThrow: true }),
+				).not.toThrow();
+			}
+		});
+
+		it("setMetadata()", () => {
+			for (const valueId of invalidValueIDs) {
+				expect(() =>
+					valueDB.setMetadata(valueId as any, {} as any, {
+						noThrow: true,
+					}),
+				).not.toThrow();
+			}
+		});
+	});
 });

--- a/src/lib/node/ValueDB.test.ts
+++ b/src/lib/node/ValueDB.test.ts
@@ -1,4 +1,6 @@
+import { assertZWaveError } from "../../../test/util";
 import { CommandClasses } from "../commandclass/CommandClasses";
+import { ZWaveErrorCodes } from "../error/ZWaveError";
 import { ValueMetadata } from "../values/Metadata";
 import { ValueDB, ValueID } from "./ValueDB";
 
@@ -588,6 +590,77 @@ describe("lib/node/ValueDB => ", () => {
 			it("The callback arg should contain the new metadata", () => {
 				expect(cbArg.metadata).toBe(ValueMetadata.Any);
 			});
+		});
+	});
+
+	describe("invalid value IDs should cause an error to be thrown", () => {
+		const invalidValueIDs = [
+			// missing required properties
+			{ commandClass: undefined, property: "test" },
+			{ commandClass: 1, property: undefined },
+			// wrong type
+			{ commandClass: "1", property: 5, propertyKey: 7, endpoint: 1 },
+			{ commandClass: 1, property: true, propertyKey: 7, endpoint: 1 },
+			{ commandClass: 1, property: 5, propertyKey: false, endpoint: 1 },
+			{ commandClass: 1, property: 5, propertyKey: 7, endpoint: "5" },
+		];
+		it("getValue()", () => {
+			for (const valueId of invalidValueIDs) {
+				assertZWaveError(() => valueDB.getValue(valueId as any), {
+					errorCode: ZWaveErrorCodes.Argument_Invalid,
+				});
+			}
+		});
+
+		it("setValue()", () => {
+			for (const valueId of invalidValueIDs) {
+				assertZWaveError(() => valueDB.setValue(valueId as any, 0), {
+					errorCode: ZWaveErrorCodes.Argument_Invalid,
+				});
+			}
+		});
+
+		it("hasValue()", () => {
+			for (const valueId of invalidValueIDs) {
+				assertZWaveError(() => valueDB.hasValue(valueId as any), {
+					errorCode: ZWaveErrorCodes.Argument_Invalid,
+				});
+			}
+		});
+
+		it("removeValue()", () => {
+			for (const valueId of invalidValueIDs) {
+				assertZWaveError(() => valueDB.removeValue(valueId as any), {
+					errorCode: ZWaveErrorCodes.Argument_Invalid,
+				});
+			}
+		});
+
+		it("getMetadata()", () => {
+			for (const valueId of invalidValueIDs) {
+				assertZWaveError(() => valueDB.getMetadata(valueId as any), {
+					errorCode: ZWaveErrorCodes.Argument_Invalid,
+				});
+			}
+		});
+
+		it("setMetadata()", () => {
+			for (const valueId of invalidValueIDs) {
+				assertZWaveError(
+					() => valueDB.setMetadata(valueId as any, {} as any),
+					{
+						errorCode: ZWaveErrorCodes.Argument_Invalid,
+					},
+				);
+			}
+		});
+
+		it("hasMetadata()", () => {
+			for (const valueId of invalidValueIDs) {
+				assertZWaveError(() => valueDB.hasMetadata(valueId as any), {
+					errorCode: ZWaveErrorCodes.Argument_Invalid,
+				});
+			}
 		});
 	});
 });

--- a/src/lib/node/ValueDB.ts
+++ b/src/lib/node/ValueDB.ts
@@ -133,7 +133,20 @@ export class ValueDB extends EventEmitter {
 			...valueId,
 			newValue: value,
 		};
-		const dbKey: string = valueIdToString(valueId);
+		let dbKey: string;
+		try {
+			dbKey = valueIdToString(valueId);
+		} catch (e) {
+			if (
+				e instanceof ZWaveError &&
+				e.code === ZWaveErrorCodes.Argument_Invalid &&
+				options.noThrow === true
+			) {
+				// ignore invalid value IDs
+				return;
+			}
+			throw e;
+		}
 
 		let event: string;
 		if (this._db.has(dbKey)) {
@@ -219,7 +232,21 @@ export class ValueDB extends EventEmitter {
 		metadata: ValueMetadata | undefined,
 		options: SetValueOptions = {},
 	): void {
-		const dbKey: string = valueIdToString(valueId);
+		let dbKey: string;
+		try {
+			dbKey = valueIdToString(valueId);
+		} catch (e) {
+			if (
+				e instanceof ZWaveError &&
+				e.code === ZWaveErrorCodes.Argument_Invalid &&
+				options.noThrow === true
+			) {
+				// ignore invalid value IDs
+				return;
+			}
+			throw e;
+		}
+
 		if (metadata) {
 			this._metadata.set(dbKey, metadata);
 		} else {


### PR DESCRIPTION
Fixes: #464 
Fixes: #463 