### PR TITLE
Add "node ready" and "all nodes ready" events

### DIFF
--- a/src/lib/driver/IDriver.ts
+++ b/src/lib/driver/IDriver.ts
@@ -6,6 +6,7 @@ import { SendMessageOptions, ZWaveOptions } from "./Driver";
 
 export interface DriverEventCallbacks {
 	"driver ready": () => void;
+	"all nodes ready": () => void;
 	error: (err: Error) => void;
 }
 

--- a/src/lib/node/Node.ts
+++ b/src/lib/node/Node.ts
@@ -596,7 +596,6 @@ export class ZWaveNode extends Endpoint implements IZWaveNode {
 
 		// The node is deemed ready when has been interviewed completely at least once
 		if (this.interviewStage === InterviewStage.RestartFromCache) {
-			// TODO: delay this until the node has responded
 			this.emit("ready", this);
 			nodeReadyEmitted = true;
 		}

--- a/src/lib/node/Node.ts
+++ b/src/lib/node/Node.ts
@@ -113,9 +113,13 @@ interface ZWaveNodeValueEventCallbacks {
 
 type ZWaveNodeEventCallbacks = Overwrite<
 	{
-		[K in "wake up" | "sleep" | "interview completed" | "dead" | "alive"]: (
-			node: ZWaveNode,
-		) => void;
+		[K in
+			| "wake up"
+			| "sleep"
+			| "interview completed"
+			| "ready"
+			| "dead"
+			| "alive"]: (node: ZWaveNode) => void;
 	},
 	ZWaveNodeValueEventCallbacks
 >;
@@ -568,6 +572,8 @@ export class ZWaveNode extends Endpoint implements IZWaveNode {
 			log.controller.interviewStart(this);
 		}
 
+		let nodeReadyEmitted = false;
+
 		// The interview is done in several stages. At each point, the interview process might be aborted
 		// due to a stage failing. The reached stage is saved, so we can continue it later without
 		// repeating stages unnecessarily
@@ -588,6 +594,13 @@ export class ZWaveNode extends Endpoint implements IZWaveNode {
 		// // TODO:
 		// // SecurityReport,			// [ ] Retrieve a list of Command Classes that require Security
 
+		// The node is deemed ready when has been interviewed completely at least once
+		if (this.interviewStage === InterviewStage.RestartFromCache) {
+			// TODO: delay this until the node has responded
+			this.emit("ready", this);
+			nodeReadyEmitted = true;
+		}
+
 		// At this point the basic interview of new nodes is done. Start here when re-interviewing known nodes
 		// to get updated information about command classes
 		if (
@@ -607,11 +620,11 @@ export class ZWaveNode extends Endpoint implements IZWaveNode {
 			await this.queryNeighbors();
 		}
 
-		// for testing purposes we skip to the end
 		await this.setInterviewStage(InterviewStage.Complete);
 
 		// Tell listeners that the interview is completed
-		// The driver will send this node to sleep
+		// The driver will then send this node to sleep
+		if (!nodeReadyEmitted) this.emit("ready", this);
 		this.emit("interview completed", this);
 		return true;
 	}


### PR DESCRIPTION
fixes: #498 

TODO: Do we need to delay node ready until communication has happened? It probably defeats the purpose of these events.