### PR TITLE
Ignore V1 indicator IDs if V2 properties are known, convert boolean indicators

### DIFF
--- a/config/indicators.json
+++ b/config/indicators.json
@@ -50,7 +50,8 @@
 			"label": "Multilevel"
 		},
 		"0x02": {
-			"label": "Binary"
+			"label": "Binary",
+			"type": "boolean"
 		},
 		"0x03": {
 			"label": "On/Off Period: Duration",
@@ -84,7 +85,8 @@
 		"0x10": {
 			"label": "Low power",
 			"description": "This property MAY be used to by a supporting node advertise that the indicator can continue working in sleep mode.",
-			"readonly": true
+			"readonly": true,
+			"type": "boolean"
 		}
 	}
 }

--- a/maintenance/lintConfigFiles.ts
+++ b/maintenance/lintConfigFiles.ts
@@ -31,8 +31,16 @@ async function lintManufacturers(): Promise<void> {
 }
 
 async function lintIndicators(): Promise<void> {
-	await loadIndicatorsInternal();
-	// TODO: Validate that the file is semantically correct
+	const { properties, indicators } = await loadIndicatorsInternal();
+
+	if (!(properties.get(1)?.label === "Multilevel")) {
+		throw new Error(
+			`The indicator property Multilevel (0x01) is required!`,
+		);
+	}
+	if (!(properties.get(2)?.label === "Binary")) {
+		throw new Error(`The indicator property Binary (0x02) is required!`);
+	}
 }
 
 async function lintDevices(): Promise<void> {

--- a/src/lib/commandclass/IndicatorCC.test.ts
+++ b/src/lib/commandclass/IndicatorCC.test.ts
@@ -146,7 +146,7 @@ describe("lib/commandclass/IndicatorCC => ", () => {
 			{
 				indicatorId: 1,
 				propertyId: 2,
-				value: 3,
+				value: true, // this is a binary indicator
 			},
 			{
 				indicatorId: 5,

--- a/src/lib/commandclass/IndicatorCC.ts
+++ b/src/lib/commandclass/IndicatorCC.ts
@@ -387,14 +387,14 @@ export class IndicatorCC extends CommandClass {
 
 	protected supportsV2Indicators(): boolean {
 		// First test if there are any indicator ids defined
-		const supportedIndicatorIds = this.getValueDB().getValue<
-			number[] | undefined
-		>(getSupportedIndicatorIDsValueID(this.endpointIndex));
+		const supportedIndicatorIds = this.getValueDB().getValue<number[]>(
+			getSupportedIndicatorIDsValueID(this.endpointIndex),
+		);
 		if (!supportedIndicatorIds?.length) return false;
 		// Then test if there are any property ids defined
 		return supportedIndicatorIds.some(
 			indicatorId =>
-				!!this.getValueDB().getValue<number[] | undefined>(
+				!!this.getValueDB().getValue<number[]>(
 					getSupportedPropertyIDsValueID(
 						this.endpointIndex,
 						indicatorId,

--- a/src/lib/commandclass/IndicatorCC.ts
+++ b/src/lib/commandclass/IndicatorCC.ts
@@ -539,30 +539,62 @@ export class IndicatorCCReport extends IndicatorCC {
 					value: this.payload[offset + 2],
 				};
 
-				const metadata = getIndicatorMetadata(
-					value.indicatorId,
-					value.propertyId,
-				);
-				// Some values need to be converted
-				if (metadata.type === "boolean") {
-					value.value = !!value.value;
-				}
-				this.values.push(value);
-
-				// Publish the value
-				const valueId = getIndicatorValueValueID(
-					this.endpointIndex,
-					value.indicatorId,
-					value.propertyId,
-				);
-				valueDB.setMetadata(valueId, metadata);
-				valueDB.setValue(valueId, value.value);
+				this.setIndicatorValue(value);
 			}
+
+			// TODO: Think if we want this:
+
+			// // If not all Property IDs are included in the command for the actual Indicator ID,
+			// // a controlling node MUST assume non-specified Property IDs values to be 0x00.
+			// const indicatorId = this.values[0].indicatorId;
+			// const supportedIndicatorProperties =
+			// 	valueDB.getValue<number[]>(
+			// 		getSupportedPropertyIDsValueID(
+			// 			this.endpointIndex,
+			// 			indicatorId,
+			// 		),
+			// 	) ?? [];
+			// // Find out which ones are missing
+			// const missingIndicatorProperties = supportedIndicatorProperties.filter(
+			// 	prop =>
+			// 		!this.values!.find(({ propertyId }) => prop === propertyId),
+			// );
+			// // And assume they are 0 (false)
+			// for (const missing of missingIndicatorProperties) {
+			// 	this.setIndicatorValue({
+			// 		indicatorId,
+			// 		propertyId: missing,
+			// 		value: 0,
+			// 	});
+			// }
 		}
 	}
 
 	public readonly value: number | undefined;
 	public readonly values: IndicatorObject[] | undefined;
+
+	private setIndicatorValue(value: IndicatorObject): void {
+		const valueDB = this.getValueDB();
+
+		const metadata = getIndicatorMetadata(
+			value.indicatorId,
+			value.propertyId,
+		);
+		// Some values need to be converted
+		if (metadata.type === "boolean") {
+			value.value = !!value.value;
+		}
+		this.values!.push(value);
+
+		// Publish the value
+		const valueId = getIndicatorValueValueID(
+			this.endpointIndex,
+			value.indicatorId,
+			value.propertyId,
+		);
+		valueDB.setMetadata(valueId, metadata);
+		valueDB.setValue(valueId, value.value);
+	}
 }
 
 interface IndicatorCCGetOptions extends CCCommandOptions {

--- a/src/lib/config/Indicators.ts
+++ b/src/lib/config/Indicators.ts
@@ -7,6 +7,7 @@ import { ZWaveError, ZWaveErrorCodes } from "../error/ZWaveError";
 import log from "../log";
 import { JSONObject } from "../util/misc";
 import { num2hex } from "../util/strings";
+import { ValueType } from "../values/Metadata";
 import { configDir, hexKeyRegexNDigits, throwInvalidConfig } from "./utils";
 
 const configPath = path.join(configDir, "indicators.json");
@@ -193,6 +194,18 @@ export class IndicatorProperty {
 			);
 		}
 		this.readonly = definition.readonly;
+
+		if (
+			definition.type != undefined &&
+			typeof definition.type !== "string"
+		) {
+			throwInvalidConfig(
+				"indicators",
+				`type for property ${num2hex(id)} is not a string!`,
+			);
+		}
+		// TODO: Validate that the value is ok
+		this.type = definition.type;
 	}
 
 	public readonly id: number;
@@ -201,4 +214,5 @@ export class IndicatorProperty {
 	public readonly min: number | undefined;
 	public readonly max: number | undefined;
 	public readonly readonly: boolean | undefined;
+	public readonly type: ValueType | undefined;
 }

--- a/src/lib/config/Indicators.ts
+++ b/src/lib/config/Indicators.ts
@@ -14,7 +14,10 @@ let indicators: ReadonlyMap<number, string> | undefined;
 let properties: ReadonlyMap<number, IndicatorProperty> | undefined;
 
 /** @internal */
-export async function loadIndicatorsInternal(): Promise<void> {
+export async function loadIndicatorsInternal(): Promise<{
+	indicators: Exclude<typeof indicators, undefined>;
+	properties: Exclude<typeof properties, undefined>;
+}> {
 	if (!(await pathExists(configPath))) {
 		throw new ZWaveError(
 			"The config file does not exist!",
@@ -71,6 +74,8 @@ export async function loadIndicatorsInternal(): Promise<void> {
 			);
 		}
 		properties = _properties;
+
+		return { indicators, properties };
 	} catch (e) {
 		if (e instanceof ZWaveError) {
 			throw e;


### PR DESCRIPTION
Fixes: #514 