### PR TITLE
Validate value size in ConfigurationCC[Bulk]Set

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,11 +33,10 @@ fs.readFile(path.join(__dirname, "../package.json"), "utf8").then(
 					}
 				}
 				return event;
-			}
+			},
 		});
 	},
 );
 
 export { Driver } from "./lib/driver/Driver";
 export { ZWaveNode } from "./lib/node/Node";
-

--- a/src/lib/node/Node.ts
+++ b/src/lib/node/Node.ts
@@ -498,14 +498,22 @@ export class ZWaveNode extends Endpoint implements IZWaveNode {
 			// Define which errors during setValue are expected and won't crash
 			// the driver:
 			if (e instanceof ZWaveError) {
+				let handled = false;
+				let emitErrorEvent = false;
 				switch (e.code) {
 					// This CC or API is not implemented
 					case ZWaveErrorCodes.CC_NotImplemented:
 					case ZWaveErrorCodes.CC_NoAPI:
+						handled = true;
+						break;
 					// A user tried to set an invalid value
 					case ZWaveErrorCodes.Argument_Invalid:
-						return false;
+						handled = true;
+						emitErrorEvent = true;
+						break;
 				}
+				if (emitErrorEvent) this.driver.emit("error", e.message);
+				if (handled) return false;
 			}
 			throw e;
 		}

--- a/src/lib/node/Node.ts
+++ b/src/lib/node/Node.ts
@@ -495,13 +495,17 @@ export class ZWaveNode extends Endpoint implements IZWaveNode {
 			);
 			return true;
 		} catch (e) {
-			if (
-				e instanceof ZWaveError &&
-				(e.code === ZWaveErrorCodes.CC_NotImplemented ||
-					e.code === ZWaveErrorCodes.CC_NoAPI)
-			) {
-				// This CC or API is not implemented
-				return false;
+			// Define which errors during setValue are expected and won't crash
+			// the driver:
+			if (e instanceof ZWaveError) {
+				switch (e.code) {
+					// This CC or API is not implemented
+					case ZWaveErrorCodes.CC_NotImplemented:
+					case ZWaveErrorCodes.CC_NoAPI:
+					// A user tried to set an invalid value
+					case ZWaveErrorCodes.Argument_Invalid:
+						return false;
+				}
 			}
 			throw e;
 		}


### PR DESCRIPTION
This avoids crashing the driver when a user tries to set an invalid value with `ConfigurationCC[Bulk]Set`. 
Instead, the error message is emitted using the `"error"` channel and the `setValue` call returns `false`.

Fixes: https://sentry.io/share/issue/7569c03814784a1998cc7215ebd59f38/