### PR TITLE
Add support for multicast messages

### DIFF
--- a/src/lib/commandclass/AssociationCC.test.ts
+++ b/src/lib/commandclass/AssociationCC.test.ts
@@ -13,11 +13,9 @@ import { CommandClasses } from "./CommandClasses";
 
 const fakeDriver = (createEmptyMockDriver() as unknown) as IDriver;
 
-function buildCCBuffer(nodeId: number, payload: Buffer): Buffer {
+function buildCCBuffer(payload: Buffer): Buffer {
 	return Buffer.concat([
 		Buffer.from([
-			nodeId, // node number
-			payload.length + 1, // remaining length
 			CommandClasses.Association, // CC
 		]),
 		payload,
@@ -30,7 +28,6 @@ describe("lib/commandclass/AssociationCC => ", () => {
 			nodeId: 1,
 		});
 		const expected = buildCCBuffer(
-			1,
 			Buffer.from([
 				AssociationCommand.SupportedGroupingsGet, // CC Command
 			]),
@@ -40,7 +37,6 @@ describe("lib/commandclass/AssociationCC => ", () => {
 
 	it("the SupportedGroupingsReport command should be deserialized correctly", () => {
 		const ccData = buildCCBuffer(
-			1,
 			Buffer.from([
 				AssociationCommand.SupportedGroupingsReport, // CC Command
 				7, // # of groups
@@ -60,7 +56,6 @@ describe("lib/commandclass/AssociationCC => ", () => {
 			nodeIds: [1, 2, 5],
 		});
 		const expected = buildCCBuffer(
-			2,
 			Buffer.from([
 				AssociationCommand.Set, // CC Command
 				5, // group id
@@ -78,7 +73,6 @@ describe("lib/commandclass/AssociationCC => ", () => {
 			groupId: 9,
 		});
 		const expected = buildCCBuffer(
-			1,
 			Buffer.from([
 				AssociationCommand.Get, // CC Command
 				9, // group ID
@@ -89,7 +83,6 @@ describe("lib/commandclass/AssociationCC => ", () => {
 
 	it("the Report command should be deserialized correctly", () => {
 		const ccData = buildCCBuffer(
-			2,
 			Buffer.from([
 				AssociationCommand.Report, // CC Command
 				5, // group id
@@ -118,7 +111,6 @@ describe("lib/commandclass/AssociationCC => ", () => {
 			nodeIds: [1, 2, 5],
 		});
 		const expected = buildCCBuffer(
-			2,
 			Buffer.from([
 				AssociationCommand.Remove, // CC Command
 				5, // group id
@@ -137,7 +129,6 @@ describe("lib/commandclass/AssociationCC => ", () => {
 			groupId: 5,
 		});
 		const expected = buildCCBuffer(
-			2,
 			Buffer.from([
 				AssociationCommand.Remove, // CC Command
 				5, // group id

--- a/src/lib/commandclass/AssociationCC.ts
+++ b/src/lib/commandclass/AssociationCC.ts
@@ -377,7 +377,7 @@ export class AssociationCCSet extends AssociationCC {
 					ZWaveErrorCodes.Argument_Invalid,
 				);
 			}
-			if (!options.nodeIds.every(n => n > 0 && n < MAX_NODES)) {
+			if (options.nodeIds.some(n => n < 1 || n > MAX_NODES)) {
 				throw new ZWaveError(
 					`All node IDs must be between 1 and ${MAX_NODES}!`,
 					ZWaveErrorCodes.Argument_Invalid,

--- a/src/lib/commandclass/AssociationGroupInfoCC.test.ts
+++ b/src/lib/commandclass/AssociationGroupInfoCC.test.ts
@@ -19,11 +19,9 @@ const fakeDriver = (createEmptyMockDriver() as unknown) as IDriver;
 const node1 = new ZWaveNode(1, fakeDriver as any);
 (fakeDriver.controller!.nodes as any).set(1, node1);
 
-function buildCCBuffer(nodeId: number, payload: Buffer): Buffer {
+function buildCCBuffer(payload: Buffer): Buffer {
 	return Buffer.concat([
 		Buffer.from([
-			nodeId, // node number
-			payload.length + 1, // remaining length
 			CommandClasses["Association Group Information"], // CC
 		]),
 		payload,
@@ -37,7 +35,6 @@ describe("lib/commandclass/AssociationGroupInfoCC => ", () => {
 			groupId: 7,
 		});
 		const expected = buildCCBuffer(
-			1,
 			Buffer.from([
 				AssociationGroupInfoCommand.NameGet, // CC Command
 				7, // group id
@@ -48,7 +45,6 @@ describe("lib/commandclass/AssociationGroupInfoCC => ", () => {
 
 	it("the NameReport command should be deserialized correctly", () => {
 		const ccData = buildCCBuffer(
-			1,
 			Buffer.from([
 				AssociationGroupInfoCommand.NameReport, // CC Command
 				7, // group id
@@ -63,6 +59,7 @@ describe("lib/commandclass/AssociationGroupInfoCC => ", () => {
 			]),
 		);
 		const cc = new AssociationGroupInfoCCNameReport(fakeDriver, {
+			nodeId: 1,
 			data: ccData,
 		});
 
@@ -78,7 +75,6 @@ describe("lib/commandclass/AssociationGroupInfoCC => ", () => {
 			refreshCache: false,
 		});
 		const expected = buildCCBuffer(
-			1,
 			Buffer.from([
 				AssociationGroupInfoCommand.InfoGet, // CC Command
 				0, // flags
@@ -96,7 +92,6 @@ describe("lib/commandclass/AssociationGroupInfoCC => ", () => {
 			refreshCache: true,
 		});
 		const expected = buildCCBuffer(
-			1,
 			Buffer.from([
 				AssociationGroupInfoCommand.InfoGet, // CC Command
 				0b1000_0000, // flags
@@ -114,7 +109,6 @@ describe("lib/commandclass/AssociationGroupInfoCC => ", () => {
 			refreshCache: false,
 		});
 		const expected = buildCCBuffer(
-			1,
 			Buffer.from([
 				AssociationGroupInfoCommand.InfoGet, // CC Command
 				0b0100_0000, // flags
@@ -126,7 +120,6 @@ describe("lib/commandclass/AssociationGroupInfoCC => ", () => {
 
 	it("the Info Report command should be deserialized correctly", () => {
 		const ccData = buildCCBuffer(
-			1,
 			Buffer.from([
 				AssociationGroupInfoCommand.InfoReport, // CC Command
 				0b1100_0000 | 2, // Flags | group count
@@ -152,6 +145,7 @@ describe("lib/commandclass/AssociationGroupInfoCC => ", () => {
 			]),
 		);
 		const cc = new AssociationGroupInfoCCInfoReport(fakeDriver, {
+			nodeId: 1,
 			data: ccData,
 		});
 
@@ -173,7 +167,6 @@ describe("lib/commandclass/AssociationGroupInfoCC => ", () => {
 			allowCache: true,
 		});
 		const expected = buildCCBuffer(
-			1,
 			Buffer.from([
 				AssociationGroupInfoCommand.CommandListGet, // CC Command
 				0b1000_0000, // allow cache
@@ -185,7 +178,6 @@ describe("lib/commandclass/AssociationGroupInfoCC => ", () => {
 
 	it("the CommandListReport command should be deserialized correctly", () => {
 		const ccData = buildCCBuffer(
-			1,
 			Buffer.from([
 				AssociationGroupInfoCommand.CommandListReport, // CC Command
 				7, // group id
@@ -199,6 +191,7 @@ describe("lib/commandclass/AssociationGroupInfoCC => ", () => {
 			]),
 		);
 		const cc = new AssociationGroupInfoCCCommandListReport(fakeDriver, {
+			nodeId: 1,
 			data: ccData,
 		});
 
@@ -213,10 +206,10 @@ describe("lib/commandclass/AssociationGroupInfoCC => ", () => {
 
 	it("deserializing an unsupported command should return an unspecified version of AssociationGroupInfoCC", () => {
 		const serializedCC = buildCCBuffer(
-			1,
 			Buffer.from([255]), // not a valid command
 		);
 		const cc: any = new AssociationGroupInfoCC(fakeDriver, {
+			nodeId: 1,
 			data: serializedCC,
 		});
 		expect(cc.constructor).toBe(AssociationGroupInfoCC);

--- a/src/lib/commandclass/BasicCC.test.ts
+++ b/src/lib/commandclass/BasicCC.test.ts
@@ -14,11 +14,9 @@ import { CommandClasses } from "./CommandClasses";
 
 const fakeDriver = (createEmptyMockDriver() as unknown) as IDriver;
 
-function buildCCBuffer(nodeId: number, payload: Buffer): Buffer {
+function buildCCBuffer(payload: Buffer): Buffer {
 	return Buffer.concat([
 		Buffer.from([
-			nodeId, // node number
-			payload.length + 1, // remaining length
 			CommandClasses.Basic, // CC
 		]),
 		payload,
@@ -29,7 +27,6 @@ describe("lib/commandclass/BasicCC => ", () => {
 	it("the Get command should serialize correctly", () => {
 		const basicCC = new BasicCCGet(fakeDriver, { nodeId: 1 });
 		const expected = buildCCBuffer(
-			1,
 			Buffer.from([
 				BasicCommand.Get, // CC Command
 			]),
@@ -43,7 +40,6 @@ describe("lib/commandclass/BasicCC => ", () => {
 			targetValue: 55,
 		});
 		const expected = buildCCBuffer(
-			2,
 			Buffer.from([
 				BasicCommand.Set, // CC Command
 				55, // target value
@@ -54,7 +50,6 @@ describe("lib/commandclass/BasicCC => ", () => {
 
 	it("the Report command (v1) should be deserialized correctly", () => {
 		const ccData = buildCCBuffer(
-			1,
 			Buffer.from([
 				BasicCommand.Report, // CC Command
 				55, // current value
@@ -69,7 +64,6 @@ describe("lib/commandclass/BasicCC => ", () => {
 
 	it("the Report command (v2) should be deserialized correctly", () => {
 		const ccData = buildCCBuffer(
-			1,
 			Buffer.from([
 				BasicCommand.Report, // CC Command
 				55, // current value
@@ -87,7 +81,6 @@ describe("lib/commandclass/BasicCC => ", () => {
 
 	it("deserializing an unsupported command should return an unspecified version of BasicCC", () => {
 		const serializedCC = buildCCBuffer(
-			1,
 			Buffer.from([255]), // not a valid command
 		);
 		const basicCC: any = new BasicCC(fakeDriver, {

--- a/src/lib/commandclass/BasicCC.test.ts
+++ b/src/lib/commandclass/BasicCC.test.ts
@@ -55,7 +55,10 @@ describe("lib/commandclass/BasicCC => ", () => {
 				55, // current value
 			]),
 		);
-		const basicCC = new BasicCCReport(fakeDriver, { data: ccData });
+		const basicCC = new BasicCCReport(fakeDriver, {
+			nodeId: 2,
+			data: ccData,
+		});
 
 		expect(basicCC.currentValue).toBe(55);
 		expect(basicCC.targetValue).toBeUndefined();
@@ -71,7 +74,10 @@ describe("lib/commandclass/BasicCC => ", () => {
 				1, // duration
 			]),
 		);
-		const basicCC = new BasicCCReport(fakeDriver, { data: ccData });
+		const basicCC = new BasicCCReport(fakeDriver, {
+			nodeId: 2,
+			data: ccData,
+		});
 
 		expect(basicCC.currentValue).toBe(55);
 		expect(basicCC.targetValue).toBe(66);
@@ -84,6 +90,7 @@ describe("lib/commandclass/BasicCC => ", () => {
 			Buffer.from([255]), // not a valid command
 		);
 		const basicCC: any = new BasicCC(fakeDriver, {
+			nodeId: 2,
 			data: serializedCC,
 		});
 		expect(basicCC.constructor).toBe(BasicCC);

--- a/src/lib/commandclass/BatteryCC.test.ts
+++ b/src/lib/commandclass/BatteryCC.test.ts
@@ -19,8 +19,6 @@ describe("lib/commandclass/BatteryCC => ", () => {
 	it("the Get command should serialize correctly", () => {
 		const batteryCC = new BatteryCCGet(fakeDriver, { nodeId: 1 });
 		const expected = Buffer.from([
-			1, // node number
-			2, // remaining length
 			CommandClasses.Battery, // CC
 			BatteryCommand.Get, // CC Command
 		]);
@@ -30,13 +28,12 @@ describe("lib/commandclass/BatteryCC => ", () => {
 	describe("the Report command (v1) should be deserialized correctly", () => {
 		it("when the battery is not low", () => {
 			const ccData = Buffer.from([
-				2, // node number
-				3, // remaining length
 				CommandClasses.Battery, // CC
 				BatteryCommand.Report, // CC Command
 				55, // current value
 			]);
 			const batteryCC = new BatteryCC(fakeDriver, {
+				nodeId: 7,
 				data: ccData,
 			}) as BatteryCCReport;
 
@@ -46,13 +43,12 @@ describe("lib/commandclass/BatteryCC => ", () => {
 
 		it("when the battery is low", () => {
 			const ccData = Buffer.from([
-				2, // node number
-				3, // remaining length
 				CommandClasses.Battery, // CC
 				BatteryCommand.Report, // CC Command
 				0xff, // current value
 			]);
 			const batteryCC = new BatteryCC(fakeDriver, {
+				nodeId: 7,
 				data: ccData,
 			}) as BatteryCCReport;
 
@@ -64,8 +60,6 @@ describe("lib/commandclass/BatteryCC => ", () => {
 	describe("the Report command (v2) should be deserialized correctly", () => {
 		it("all flags set", () => {
 			const ccData = Buffer.from([
-				2, // node number
-				5, // remaining length
 				CommandClasses.Battery, // CC
 				BatteryCommand.Report, // CC Command
 				55, // current value
@@ -73,6 +67,7 @@ describe("lib/commandclass/BatteryCC => ", () => {
 				1, // disconnected
 			]);
 			const batteryCC = new BatteryCC(fakeDriver, {
+				nodeId: 7,
 				data: ccData,
 			}) as BatteryCCReport;
 
@@ -85,8 +80,6 @@ describe("lib/commandclass/BatteryCC => ", () => {
 
 		it("charging status", () => {
 			const ccData = Buffer.from([
-				2, // node number
-				5, // remaining length
 				CommandClasses.Battery, // CC
 				BatteryCommand.Report, // CC Command
 				55,
@@ -94,6 +87,7 @@ describe("lib/commandclass/BatteryCC => ", () => {
 				0,
 			]);
 			const batteryCC = new BatteryCC(fakeDriver, {
+				nodeId: 7,
 				data: ccData,
 			}) as BatteryCCReport;
 
@@ -104,8 +98,6 @@ describe("lib/commandclass/BatteryCC => ", () => {
 
 		it("charging status", () => {
 			const ccData = Buffer.from([
-				2, // node number
-				5, // remaining length
 				CommandClasses.Battery, // CC
 				BatteryCommand.Report, // CC Command
 				55,
@@ -113,6 +105,7 @@ describe("lib/commandclass/BatteryCC => ", () => {
 				0,
 			]);
 			const batteryCC = new BatteryCC(fakeDriver, {
+				nodeId: 7,
 				data: ccData,
 			}) as BatteryCCReport;
 
@@ -124,12 +117,11 @@ describe("lib/commandclass/BatteryCC => ", () => {
 
 	it("deserializing an unsupported command should return an unspecified version of BatteryCC", () => {
 		const serializedCC = Buffer.from([
-			2, // node number
-			2, // remaining length
 			CommandClasses.Battery, // CC
 			255, // not a valid command
 		]);
 		const basicCC: any = new BatteryCC(fakeDriver, {
+			nodeId: 7,
 			data: serializedCC,
 		});
 		expect(basicCC.constructor).toBe(BatteryCC);

--- a/src/lib/commandclass/BinarySensorCC.test.ts
+++ b/src/lib/commandclass/BinarySensorCC.test.ts
@@ -13,11 +13,9 @@ import {
 } from "./BinarySensorCC";
 import { CommandClasses } from "./CommandClasses";
 
-function buildCCBuffer(nodeId: number, payload: Buffer): Buffer {
+function buildCCBuffer(payload: Buffer): Buffer {
 	return Buffer.concat([
 		Buffer.from([
-			nodeId, // node number
-			payload.length + 1, // remaining length
 			CommandClasses["Binary Sensor"], // CC
 		]),
 		payload,
@@ -36,7 +34,6 @@ describe("lib/commandclass/BinarySensorCC => ", () => {
 	it("the Get command (v1) should serialize correctly", () => {
 		const cc = new BinarySensorCCGet(fakeDriver, { nodeId: 1 });
 		const expected = buildCCBuffer(
-			1,
 			Buffer.from([
 				BinarySensorCommand.Get, // CC Command
 			]),
@@ -50,7 +47,6 @@ describe("lib/commandclass/BinarySensorCC => ", () => {
 			sensorType: BinarySensorType.CO,
 		});
 		const expected = buildCCBuffer(
-			1,
 			Buffer.from([BinarySensorCommand.Get, BinarySensorType.CO]),
 		);
 		expect(cc.serialize()).toEqual(expected);
@@ -58,27 +54,31 @@ describe("lib/commandclass/BinarySensorCC => ", () => {
 
 	it("the Report command (v1) should be deserialized correctly", () => {
 		const ccData = buildCCBuffer(
-			1,
 			Buffer.from([
 				BinarySensorCommand.Report, // CC Command
 				0xff, // current value
 			]),
 		);
-		const cc = new BinarySensorCCReport(fakeDriver, { data: ccData });
+		const cc = new BinarySensorCCReport(fakeDriver, {
+			nodeId: 1,
+			data: ccData,
+		});
 
 		expect(cc.value).toBe(true);
 	});
 
 	it("the Report command (v2) should be deserialized correctly", () => {
 		const ccData = buildCCBuffer(
-			1,
 			Buffer.from([
 				BinarySensorCommand.Report, // CC Command
 				0x00, // current value
 				BinarySensorType.CO2,
 			]),
 		);
-		const cc = new BinarySensorCCReport(fakeDriver, { data: ccData });
+		const cc = new BinarySensorCCReport(fakeDriver, {
+			nodeId: 1,
+			data: ccData,
+		});
 
 		expect(cc.value).toBe(false);
 		expect(cc.type).toBe(BinarySensorType.CO2);
@@ -87,7 +87,6 @@ describe("lib/commandclass/BinarySensorCC => ", () => {
 	it("the SupportedGet command should serialize correctly", () => {
 		const cc = new BinarySensorCCSupportedGet(fakeDriver, { nodeId: 1 });
 		const expected = buildCCBuffer(
-			1,
 			Buffer.from([
 				BinarySensorCommand.SupportedGet, // CC Command
 			]),
@@ -97,7 +96,6 @@ describe("lib/commandclass/BinarySensorCC => ", () => {
 
 	it("the SupportedReport command should be deserialized correctly", () => {
 		const ccData = buildCCBuffer(
-			1,
 			Buffer.from([
 				BinarySensorCommand.SupportedReport, // CC Command
 				0b01010101,
@@ -105,6 +103,7 @@ describe("lib/commandclass/BinarySensorCC => ", () => {
 			]),
 		);
 		const cc = new BinarySensorCCSupportedReport(fakeDriver, {
+			nodeId: 1,
 			data: ccData,
 		});
 
@@ -119,10 +118,10 @@ describe("lib/commandclass/BinarySensorCC => ", () => {
 
 	it("deserializing an unsupported command should return an unspecified version of BinarySensorCC", () => {
 		const serializedCC = buildCCBuffer(
-			1,
 			Buffer.from([255]), // not a valid command
 		);
 		const cc: any = new BinarySensorCC(fakeDriver, {
+			nodeId: 1,
 			data: serializedCC,
 		});
 		expect(cc.constructor).toBe(BinarySensorCC);

--- a/src/lib/commandclass/BinarySwitchCC.test.ts
+++ b/src/lib/commandclass/BinarySwitchCC.test.ts
@@ -70,7 +70,10 @@ describe("lib/commandclass/BinarySwitchCC => ", () => {
 				0xff, // current value
 			]),
 		);
-		const cc = new BinarySwitchCCReport(fakeDriver, { data: ccData });
+		const cc = new BinarySwitchCCReport(fakeDriver, {
+			nodeId: 2,
+			data: ccData,
+		});
 
 		expect(cc.currentValue).toBe(true);
 		expect(cc.targetValue).toBeUndefined();
@@ -86,7 +89,10 @@ describe("lib/commandclass/BinarySwitchCC => ", () => {
 				1, // duration
 			]),
 		);
-		const cc = new BinarySwitchCCReport(fakeDriver, { data: ccData });
+		const cc = new BinarySwitchCCReport(fakeDriver, {
+			nodeId: 2,
+			data: ccData,
+		});
 
 		expect(cc.currentValue).toBe(true);
 		expect(cc.targetValue).toBe(false);
@@ -99,6 +105,7 @@ describe("lib/commandclass/BinarySwitchCC => ", () => {
 			Buffer.from([255]), // not a valid command
 		);
 		const cc: any = new BinarySwitchCC(fakeDriver, {
+			nodeId: 2,
 			data: serializedCC,
 		});
 		expect(cc.constructor).toBe(BinarySwitchCC);

--- a/src/lib/commandclass/BinarySwitchCC.test.ts
+++ b/src/lib/commandclass/BinarySwitchCC.test.ts
@@ -12,11 +12,9 @@ import { CommandClasses } from "./CommandClasses";
 
 const fakeDriver = (createEmptyMockDriver() as unknown) as IDriver;
 
-function buildCCBuffer(nodeId: number, payload: Buffer): Buffer {
+function buildCCBuffer(payload: Buffer): Buffer {
 	return Buffer.concat([
 		Buffer.from([
-			nodeId, // node number
-			payload.length + 1, // remaining length
 			CommandClasses["Binary Switch"], // CC
 		]),
 		payload,
@@ -27,7 +25,6 @@ describe("lib/commandclass/BinarySwitchCC => ", () => {
 	it("the Get command should serialize correctly", () => {
 		const cc = new BinarySwitchCCGet(fakeDriver, { nodeId: 1 });
 		const expected = buildCCBuffer(
-			1,
 			Buffer.from([
 				BinarySwitchCommand.Get, // CC Command
 			]),
@@ -41,7 +38,6 @@ describe("lib/commandclass/BinarySwitchCC => ", () => {
 			targetValue: false,
 		});
 		const expected = buildCCBuffer(
-			2,
 			Buffer.from([
 				BinarySwitchCommand.Set, // CC Command
 				0x00, // target value
@@ -58,7 +54,6 @@ describe("lib/commandclass/BinarySwitchCC => ", () => {
 			duration,
 		});
 		const expected = buildCCBuffer(
-			2,
 			Buffer.from([
 				BinarySwitchCommand.Set, // CC Command
 				0xff, // target value,
@@ -70,7 +65,6 @@ describe("lib/commandclass/BinarySwitchCC => ", () => {
 
 	it("the Report command (v1) should be deserialized correctly", () => {
 		const ccData = buildCCBuffer(
-			1,
 			Buffer.from([
 				BinarySwitchCommand.Report, // CC Command
 				0xff, // current value
@@ -85,7 +79,6 @@ describe("lib/commandclass/BinarySwitchCC => ", () => {
 
 	it("the Report command (v2) should be deserialized correctly", () => {
 		const ccData = buildCCBuffer(
-			1,
 			Buffer.from([
 				BinarySwitchCommand.Report, // CC Command
 				0xff, // current value
@@ -103,7 +96,6 @@ describe("lib/commandclass/BinarySwitchCC => ", () => {
 
 	it("deserializing an unsupported command should return an unspecified version of BinarySwitchCC", () => {
 		const serializedCC = buildCCBuffer(
-			1,
 			Buffer.from([255]), // not a valid command
 		);
 		const cc: any = new BinarySwitchCC(fakeDriver, {

--- a/src/lib/commandclass/CRC16.ts
+++ b/src/lib/commandclass/CRC16.ts
@@ -103,11 +103,11 @@ export class CRC16CCCommandEncapsulation extends CRC16CC {
 			);
 			validatePayload(expectedCRC === actualCRC);
 
-			this.encapsulatedCC = CommandClass.fromEncapsulated(
-				this.driver,
-				this,
-				ccBuffer,
-			);
+			this.encapsulatedCC = CommandClass.from(this.driver, {
+				data: ccBuffer,
+				fromEncapsulation: true,
+				encapCC: this,
+			});
 		} else {
 			this.encapsulatedCC = options.encapsulatedCC;
 		}
@@ -117,12 +117,12 @@ export class CRC16CCCommandEncapsulation extends CRC16CC {
 	private readonly headerBuffer = Buffer.from([this.ccId, this.ccCommand]);
 
 	public serialize(): Buffer {
-		// The CC header is included in the CRC computation
-		const commandBuffer = this.encapsulatedCC.serializeForEncapsulation();
+		const commandBuffer = this.encapsulatedCC.serialize();
 		// Reserve 2 bytes for the CRC
 		this.payload = Buffer.concat([commandBuffer, Buffer.allocUnsafe(2)]);
 
 		// Compute and save the CRC16 in the payload
+		// The CC header is included in the CRC computation
 		let crc = CRC16_CCITT(this.headerBuffer);
 		crc = CRC16_CCITT(commandBuffer, crc);
 		this.payload.writeUInt16BE(crc, this.payload.length - 2);

--- a/src/lib/commandclass/CentralSceneCC.test.ts
+++ b/src/lib/commandclass/CentralSceneCC.test.ts
@@ -18,11 +18,9 @@ const fakeDriver = (createEmptyMockDriver() as unknown) as IDriver;
 const node1 = new ZWaveNode(1, fakeDriver as any);
 (fakeDriver.controller!.nodes as any).set(1, node1);
 
-function buildCCBuffer(nodeId: number, payload: Buffer): Buffer {
+function buildCCBuffer(payload: Buffer): Buffer {
 	return Buffer.concat([
 		Buffer.from([
-			nodeId, // node number
-			payload.length + 1, // remaining length
 			CommandClasses["Central Scene"], // CC
 		]),
 		payload,
@@ -35,7 +33,6 @@ describe("lib/commandclass/CentralSceneCC => ", () => {
 			nodeId: 1,
 		});
 		const expected = buildCCBuffer(
-			1,
 			Buffer.from([
 				CentralSceneCommand.ConfigurationGet, // CC Command
 			]),
@@ -49,7 +46,6 @@ describe("lib/commandclass/CentralSceneCC => ", () => {
 			slowRefresh: true,
 		});
 		const expected = buildCCBuffer(
-			2,
 			Buffer.from([
 				CentralSceneCommand.ConfigurationSet, // CC Command
 				0b1000_0000,
@@ -64,7 +60,6 @@ describe("lib/commandclass/CentralSceneCC => ", () => {
 			slowRefresh: false,
 		});
 		const expected = buildCCBuffer(
-			2,
 			Buffer.from([
 				CentralSceneCommand.ConfigurationSet, // CC Command
 				0,
@@ -75,13 +70,13 @@ describe("lib/commandclass/CentralSceneCC => ", () => {
 
 	it("the ConfigurationReport command should be deserialized correctly", () => {
 		const ccData = buildCCBuffer(
-			1,
 			Buffer.from([
 				CentralSceneCommand.ConfigurationReport, // CC Command
 				0b1000_0000,
 			]),
 		);
 		const cc = new CentralSceneCCConfigurationReport(fakeDriver, {
+			nodeId: 1,
 			data: ccData,
 		});
 
@@ -93,7 +88,6 @@ describe("lib/commandclass/CentralSceneCC => ", () => {
 			nodeId: 1,
 		});
 		const expected = buildCCBuffer(
-			1,
 			Buffer.from([
 				CentralSceneCommand.SupportedGet, // CC Command
 			]),
@@ -103,7 +97,6 @@ describe("lib/commandclass/CentralSceneCC => ", () => {
 
 	it("the SupportedReport command should be deserialized correctly", () => {
 		const ccData = buildCCBuffer(
-			1,
 			Buffer.from([
 				CentralSceneCommand.SupportedReport, // CC Command
 				2, // # of scenes
@@ -115,6 +108,7 @@ describe("lib/commandclass/CentralSceneCC => ", () => {
 			]),
 		);
 		const cc = new CentralSceneCCSupportedReport(fakeDriver, {
+			nodeId: 1,
 			data: ccData,
 		});
 
@@ -128,7 +122,6 @@ describe("lib/commandclass/CentralSceneCC => ", () => {
 
 	it("the Notification command should be deserialized correctly", () => {
 		const ccData = buildCCBuffer(
-			1,
 			Buffer.from([
 				CentralSceneCommand.Notification, // CC Command
 				7, // sequence number
@@ -137,6 +130,7 @@ describe("lib/commandclass/CentralSceneCC => ", () => {
 			]),
 		);
 		const cc = new CentralSceneCCNotification(fakeDriver, {
+			nodeId: 1,
 			data: ccData,
 		});
 
@@ -149,7 +143,6 @@ describe("lib/commandclass/CentralSceneCC => ", () => {
 
 	it("the Notification command should be deserialized correctly (KeyHeldDown)", () => {
 		const ccData = buildCCBuffer(
-			1,
 			Buffer.from([
 				CentralSceneCommand.Notification, // CC Command
 				7, // sequence number
@@ -158,6 +151,7 @@ describe("lib/commandclass/CentralSceneCC => ", () => {
 			]),
 		);
 		const cc = new CentralSceneCCNotification(fakeDriver, {
+			nodeId: 1,
 			data: ccData,
 		});
 
@@ -169,10 +163,10 @@ describe("lib/commandclass/CentralSceneCC => ", () => {
 
 	it("deserializing an unsupported command should return an unspecified version of CentralSceneCC", () => {
 		const serializedCC = buildCCBuffer(
-			1,
 			Buffer.from([255]), // not a valid command
 		);
 		const cc: any = new CentralSceneCC(fakeDriver, {
+			nodeId: 1,
 			data: serializedCC,
 		});
 		expect(cc.constructor).toBe(CentralSceneCC);

--- a/src/lib/commandclass/CommandClass.test.ts
+++ b/src/lib/commandclass/CommandClass.test.ts
@@ -3,7 +3,7 @@ import { assertZWaveError } from "../../../test/util";
 import { IDriver } from "../driver/IDriver";
 import { ZWaveErrorCodes } from "../error/ZWaveError";
 import { ZWaveNode } from "../node/Node";
-import { BasicCC, BasicCCSet, BasicCommand } from "./BasicCC";
+import { BasicCC, BasicCCSet } from "./BasicCC";
 import {
 	CommandClass,
 	commandClass,
@@ -14,14 +14,6 @@ import {
 	implementedVersion,
 } from "./CommandClass";
 import { CommandClasses } from "./CommandClasses";
-import {
-	MultiChannelCC,
-	MultiChannelCCCommandEncapsulation,
-} from "./MultiChannelCC";
-import {
-	MultiCommandCC,
-	MultiCommandCCCommandEncapsulation,
-} from "./MultiCommandCC";
 
 @implementedVersion(7)
 @commandClass(0xffff as any)
@@ -50,86 +42,6 @@ describe("lib/commandclass/CommandClass => ", () => {
 					errorCode: ZWaveErrorCodes.CC_NotImplemented,
 				},
 			);
-		});
-	});
-
-	describe("fromEncapsulated()", () => {
-		it.skip("throws CC_NotImplemented when receiving a non-implemented CC", () => {
-			// TODO: This is a meter CC. Change it when that CC is implemented
-			assertZWaveError(
-				() =>
-					CommandClass.fromEncapsulated(
-						fakeDriver,
-						undefined as any,
-						Buffer.from("0b0a32022144000000a30000", "hex"),
-					),
-				{
-					errorCode: ZWaveErrorCodes.CC_NotImplemented,
-				},
-			);
-		});
-
-		it("correctly copies the source endpoint from the encapsulating CC", () => {
-			let cc: CommandClass = new BasicCCSet(fakeDriver, {
-				nodeId: 4,
-				targetValue: 5,
-			});
-			cc = MultiChannelCC.encapsulate(fakeDriver, cc);
-			(cc as MultiChannelCCCommandEncapsulation).endpointIndex = 5;
-			const serialized = cc.serialize();
-			// ---------------
-			let deserialized: CommandClass = CommandClass.from(
-				fakeDriver,
-				serialized,
-			);
-			deserialized = MultiChannelCC.unwrap(
-				deserialized as MultiChannelCCCommandEncapsulation,
-			);
-			expect(deserialized.endpointIndex).toBe(
-				(cc as MultiChannelCCCommandEncapsulation).endpointIndex,
-			);
-		});
-
-		it("correctly copies the source endpoint from the encapsulating CC (multiple layers)", () => {
-			let cc: CommandClass = new BasicCCSet(fakeDriver, {
-				nodeId: 4,
-				targetValue: 5,
-			});
-			cc.endpointIndex = 5;
-			// TODO: Add this method
-			cc = MultiCommandCC.encapsulate(fakeDriver, [cc]);
-			cc = MultiChannelCC.encapsulate(fakeDriver, cc);
-			const serialized = cc.serialize();
-			// ---------------
-			let deserialized: CommandClass = CommandClass.from(
-				fakeDriver,
-				serialized,
-			);
-			deserialized = MultiChannelCC.unwrap(
-				deserialized as MultiChannelCCCommandEncapsulation,
-			);
-			// TODO: Add this method
-			deserialized = MultiCommandCC.unwrap(
-				deserialized as MultiCommandCCCommandEncapsulation,
-			)[0];
-			expect(deserialized.endpointIndex).toBe(cc.endpointIndex);
-		});
-	});
-
-	describe("serializeForEncapsulation()", () => {
-		it("works correctly", () => {
-			// Test with a BasicCC Set
-			const cc = new BasicCCSet(fakeDriver, {
-				nodeId: 2,
-				targetValue: 55,
-			});
-			const serialized = cc.serializeForEncapsulation();
-			const expected = Buffer.from([
-				CommandClasses.Basic,
-				BasicCommand.Set,
-				cc.targetValue,
-			]);
-			expect(serialized).toEqual(expected);
 		});
 	});
 

--- a/src/lib/commandclass/CommandClass.ts
+++ b/src/lib/commandclass/CommandClass.ts
@@ -34,6 +34,7 @@ export interface CommandClassInfo {
 export type CommandClassDeserializationOptions = { data: Buffer } & (
 	| {
 			fromEncapsulation?: false;
+			nodeId: number;
 	  }
 	| {
 			fromEncapsulation: true;
@@ -83,9 +84,7 @@ export class CommandClass {
 
 		if (gotDeserializationOptions(options)) {
 			// For deserialized commands, try to invoke the correct subclass constructor
-			const ccCommand = options.fromEncapsulation
-				? CommandClass.getCCCommandWithoutHeader(options.data)
-				: CommandClass.getCCCommand(options.data);
+			const ccCommand = CommandClass.getCCCommand(options.data);
 			if (ccCommand != undefined) {
 				const CommandConstructor = getCCCommandConstructor(
 					this.ccId,
@@ -101,32 +100,19 @@ export class CommandClass {
 
 			// If the constructor is correct or none was found, fall back to normal deserialization
 			if (options.fromEncapsulation) {
-				({
-					nodeId: this.nodeId,
-					ccId: this.ccId,
-					ccCommand: this.ccCommand,
-					payload: this.payload,
-				} = this.deserializeFromEncapsulation(
-					options.encapCC,
-					options.data,
-				));
-				// Propagate the endpoint index from the encapsulating CC
+				// Propagate the node ID and endpoint index from the encapsulating CC
+				this.nodeId = options.encapCC.nodeId;
 				if (!this.endpointIndex && options.encapCC.endpointIndex) {
 					this.endpointIndex = options.encapCC.endpointIndex;
 				}
 			} else {
-				this.nodeId = CommandClass.getNodeId(options.data);
-				const lengthWithoutHeader = options.data[1];
-				const dataWithoutHeader = options.data.slice(
-					2,
-					2 + lengthWithoutHeader,
-				);
-				({
-					ccId: this.ccId,
-					ccCommand: this.ccCommand,
-					payload: this.payload,
-				} = this.deserializeWithoutHeader(dataWithoutHeader));
+				this.nodeId = options.nodeId;
 			}
+			({
+				ccId: this.ccId,
+				ccCommand: this.ccCommand,
+				payload: this.payload,
+			} = this.deserialize(options.data));
 		} else if (gotCCCommandOptions(options)) {
 			const {
 				nodeId,
@@ -220,11 +206,11 @@ export class CommandClass {
 	}
 
 	/**
-	 * Deserializes a CC from a buffer that does not start with the CC header (node id + serialized length)
+	 * Deserializes a CC from a buffer that contains a serialized CC
 	 */
 	// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-	private deserializeWithoutHeader(data: Buffer) {
-		const ccId = CommandClass.getCommandClassWithoutHeader(data);
+	private deserialize(data: Buffer) {
+		const ccId = CommandClass.getCommandClass(data);
 		const ccIdLength = this.isExtended() ? 2 : 1;
 		if (data.length > ccIdLength) {
 			// This is not a NoOp CC (contains command and payload)
@@ -243,34 +229,12 @@ export class CommandClass {
 	}
 
 	/**
-	 * Serializes this CommandClass without the nodeId + length header
-	 * as required for encapsulation
-	 */
-	public serializeForEncapsulation(): Buffer {
-		// We need to invoke the subclassed serialize implementations or
-		// this.payload will not be filled.
-		// TODO: Refactor this so we don't append two bytes and strip them out immediately afterwards
-		return this.serialize().slice(2);
-	}
-
-	/** Creates the CC header (node id + serialized length) */
-	private getHeader(dataLength: number): Buffer {
-		return Buffer.from([this.nodeId, dataLength]);
-	}
-
-	/** Prepends the CC header (node id + serialized length) to a buffer */
-	private prependHeader(data: Buffer): Buffer {
-		return Buffer.concat([this.getHeader(data.length), data]);
-	}
-
-	/**
-	 * Serializes this CommandClass to be embedded in a message payload.
-	 * The result of this operation will include the header bytes
+	 * Serializes this CommandClass to be embedded in a message payload or another CC
 	 */
 	public serialize(): Buffer {
 		// NoOp CCs have no command and no payload
 		if (this.ccId === CommandClasses["No Operation"])
-			return this.prependHeader(Buffer.from([this.ccId]));
+			return Buffer.from([this.ccId]);
 		else if (this.ccCommand == undefined) {
 			throw new ZWaveError(
 				"Cannot serialize a Command Class without a command",
@@ -286,56 +250,28 @@ export class CommandClass {
 		if (payloadLength > 0 /* implies payload != undefined */) {
 			this.payload.copy(data, 1 + ccIdLength);
 		}
-		return this.prependHeader(data);
+		return data;
 	}
 
-	// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-	private deserializeFromEncapsulation(encapCC: CommandClass, data: Buffer) {
-		return {
-			nodeId: encapCC.nodeId,
-			...this.deserializeWithoutHeader(data),
-		};
-	}
-
-	/** Extracts the node id from a serialized CC */
-	public static getNodeId(ccData: Buffer): number {
-		return ccData[0];
-	}
-
-	/** Extracts the CC id from a buffer that does NOT contain the header bytes */
-	private static getCommandClassWithoutHeader(data: Buffer): CommandClasses {
+	/** Extracts the CC id from a buffer that contains a serialized CC */
+	private static getCommandClass(data: Buffer): CommandClasses {
 		return parseCCId(data).ccId;
 	}
 
-	/** Extracts the CC id from a buffer that DOES contain the header bytes */
-	public static getCommandClass(ccData: Buffer): CommandClasses {
-		return this.getCommandClassWithoutHeader(ccData.slice(2));
-	}
-
-	/** Extracts the CC command from a buffer that does NOT contain the header bytes */
-	public static getCCCommandWithoutHeader(data: Buffer): number | undefined {
+	/** Extracts the CC command from a buffer that contains a serialized CC  */
+	public static getCCCommand(data: Buffer): number | undefined {
 		if (data[0] === 0) return undefined; // NoOp
 		const isExtendedCC = data[0] >= 0xf1;
 		return isExtendedCC ? data[2] : data[1];
-	}
-
-	/** Extracts the CC command from a buffer that DOES contain the header bytes */
-	public static getCCCommand(ccData: Buffer): number | undefined {
-		return this.getCCCommandWithoutHeader(ccData.slice(2));
 	}
 
 	/**
 	 * Retrieves the correct constructor for the CommandClass in the given Buffer.
 	 * It is assumed that the buffer only contains the serialized CC. This throws if the CC is not implemented.
 	 */
-	public static getConstructor(
-		ccData: Buffer,
-		encapsulated: boolean = false,
-	): Constructable<CommandClass> {
+	public static getConstructor(ccData: Buffer): Constructable<CommandClass> {
 		// Encapsulated CCs don't have the two header bytes
-		const cc = encapsulated
-			? CommandClass.getCommandClassWithoutHeader(ccData)
-			: CommandClass.getCommandClass(ccData);
+		const cc = CommandClass.getCommandClass(ccData);
 		const ret = getCCConstructor(cc);
 		if (!ret) {
 			const ccName = getCCName(cc);
@@ -347,30 +283,17 @@ export class CommandClass {
 		return ret;
 	}
 
-	/** Creates an instance of the CC that is serialized in the given buffer */
-	public static from(driver: IDriver, serializedCC: Buffer): CommandClass {
-		// Fall back to unspecified command class in case we receive one that is not implemented
-		const Constructor = CommandClass.getConstructor(serializedCC);
-		const ret = new Constructor(driver, { data: serializedCC });
-		return ret;
-	}
-
 	/**
-	 * Creates an instance of the CC that is serialized in the given buffer.
-	 * The buffer must be the payload of an encapsulation CC, so it must not contain the header bytes.
+	 * Creates an instance of the CC that is serialized in the given buffer
+	 * @param encapCC The command class that is encapsulating this CC payload
 	 */
-	public static fromEncapsulated(
+	public static from(
 		driver: IDriver,
-		encapCC: CommandClass,
-		serializedCC: Buffer,
+		options: CommandClassDeserializationOptions,
 	): CommandClass {
 		// Fall back to unspecified command class in case we receive one that is not implemented
-		const Constructor = CommandClass.getConstructor(serializedCC, true);
-		const ret = new Constructor(driver, {
-			data: serializedCC,
-			fromEncapsulation: true,
-			encapCC,
-		});
+		const Constructor = CommandClass.getConstructor(options.data);
+		const ret = new Constructor(driver, options);
 		return ret;
 	}
 

--- a/src/lib/commandclass/CommandClass.ts
+++ b/src/lib/commandclass/CommandClass.ts
@@ -148,6 +148,10 @@ export class CommandClass {
 			) {
 				this.version = 1;
 			}
+		} else {
+			// For multicast CCs, we just use the highest implemented version to serialize
+			// Older nodes will ignore the additional fields
+			this.version = getImplementedVersion(this.ccId);
 		}
 	}
 
@@ -291,7 +295,6 @@ export class CommandClass {
 
 	/**
 	 * Creates an instance of the CC that is serialized in the given buffer
-	 * @param encapCC The command class that is encapsulating this CC payload
 	 */
 	public static from(
 		driver: IDriver,

--- a/src/lib/commandclass/DeviceResetLocallyCC.ts
+++ b/src/lib/commandclass/DeviceResetLocallyCC.ts
@@ -17,6 +17,8 @@ export enum DeviceResetLocallyCommand {
 @implementedVersion(1)
 export class DeviceResetLocallyCC extends CommandClass {
 	declare ccCommand: DeviceResetLocallyCommand;
+	// Force singlecast
+	declare nodeId: number;
 }
 
 @CCCommand(DeviceResetLocallyCommand.Notification)

--- a/src/lib/commandclass/IndicatorCC.ts
+++ b/src/lib/commandclass/IndicatorCC.ts
@@ -530,12 +530,14 @@ export class IndicatorCCReport extends IndicatorCC {
 				});
 				valueDB.setValue(valueId, this.value);
 			} else {
-				// Don't!
-				log.controller.logNode(this.nodeId, {
-					message: `ignoring V1 indicator report because the node supports V2 indicators`,
-					direction: "none",
-					endpoint: this.endpointIndex,
-				});
+				if (this.isSinglecast()) {
+					// Don't!
+					log.controller.logNode(this.nodeId, {
+						message: `ignoring V1 indicator report because the node supports V2 indicators`,
+						direction: "none",
+						endpoint: this.endpointIndex,
+					});
+				}
 			}
 		} else {
 			validatePayload(this.payload.length >= 2 + 3 * objCount);

--- a/src/lib/commandclass/LanguageCC.test.ts
+++ b/src/lib/commandclass/LanguageCC.test.ts
@@ -11,11 +11,9 @@ import {
 
 const fakeDriver = (createEmptyMockDriver() as unknown) as IDriver;
 
-function buildCCBuffer(nodeId: number, payload: Buffer): Buffer {
+function buildCCBuffer(payload: Buffer): Buffer {
 	return Buffer.concat([
 		Buffer.from([
-			nodeId, // node number
-			payload.length + 1, // remaining length
 			CommandClasses.Language, // CC
 		]),
 		payload,
@@ -26,7 +24,6 @@ describe("lib/commandclass/LanguageCC => ", () => {
 	it("the Get command should serialize correctly", () => {
 		const cc = new LanguageCCGet(fakeDriver, { nodeId: 1 });
 		const expected = buildCCBuffer(
-			1,
 			Buffer.from([
 				LanguageCommand.Get, // CC Command
 			]),
@@ -40,7 +37,6 @@ describe("lib/commandclass/LanguageCC => ", () => {
 			language: "deu",
 		});
 		const expected = buildCCBuffer(
-			2,
 			Buffer.from([
 				LanguageCommand.Set, // CC Command
 				// "deu"
@@ -59,7 +55,6 @@ describe("lib/commandclass/LanguageCC => ", () => {
 			country: "DE",
 		});
 		const expected = buildCCBuffer(
-			2,
 			Buffer.from([
 				LanguageCommand.Set, // CC Command
 				// "deu"
@@ -76,7 +71,6 @@ describe("lib/commandclass/LanguageCC => ", () => {
 
 	it("the Report command should be deserialized correctly (w/o country code)", () => {
 		const ccData = buildCCBuffer(
-			1,
 			Buffer.from([
 				LanguageCommand.Report, // CC Command
 				// "deu"
@@ -85,7 +79,10 @@ describe("lib/commandclass/LanguageCC => ", () => {
 				0x75,
 			]),
 		);
-		const cc = new LanguageCCReport(fakeDriver, { data: ccData });
+		const cc = new LanguageCCReport(fakeDriver, {
+			nodeId: 4,
+			data: ccData,
+		});
 
 		expect(cc.language).toBe("deu");
 		expect(cc.country).toBeUndefined();
@@ -93,7 +90,6 @@ describe("lib/commandclass/LanguageCC => ", () => {
 
 	it("the Report command should be deserialized correctly (w/ country code)", () => {
 		const ccData = buildCCBuffer(
-			1,
 			Buffer.from([
 				LanguageCommand.Report, // CC Command
 				// "deu"
@@ -105,7 +101,10 @@ describe("lib/commandclass/LanguageCC => ", () => {
 				0x45,
 			]),
 		);
-		const cc = new LanguageCCReport(fakeDriver, { data: ccData });
+		const cc = new LanguageCCReport(fakeDriver, {
+			nodeId: 4,
+			data: ccData,
+		});
 
 		expect(cc.language).toBe("deu");
 		expect(cc.country).toBe("DE");
@@ -113,10 +112,10 @@ describe("lib/commandclass/LanguageCC => ", () => {
 
 	it("deserializing an unsupported command should return an unspecified version of LanguageCC", () => {
 		const serializedCC = buildCCBuffer(
-			1,
 			Buffer.from([255]), // not a valid command
 		);
 		const cc: any = new LanguageCC(fakeDriver, {
+			nodeId: 4,
 			data: serializedCC,
 		});
 		expect(cc.constructor).toBe(LanguageCC);

--- a/src/lib/commandclass/ManufacturerSpecificCC.test.ts
+++ b/src/lib/commandclass/ManufacturerSpecificCC.test.ts
@@ -27,11 +27,14 @@ describe("lib/commandclass/ManufacturerSpecificCC => ", () => {
 
 	it("should serialize correctly", () => {
 		serialized = cc.serialize();
-		expect(serialized).toEqual(Buffer.from("02027204", "hex"));
+		expect(serialized).toEqual(Buffer.from("7204", "hex"));
 	});
 
 	it("should deserialize correctly", () => {
-		const deserialized = CommandClass.from(fakeDriver, serialized);
+		const deserialized = CommandClass.from(fakeDriver, {
+			nodeId: cc.nodeId,
+			data: serialized,
+		});
 		expect(deserialized).toBeInstanceOf(ManufacturerSpecificCC);
 		expect(deserialized.nodeId).toBe(cc.nodeId);
 	});

--- a/src/lib/commandclass/MultiChannelAssociationCC.test.ts
+++ b/src/lib/commandclass/MultiChannelAssociationCC.test.ts
@@ -13,11 +13,9 @@ import {
 
 const fakeDriver = (createEmptyMockDriver() as unknown) as IDriver;
 
-function buildCCBuffer(nodeId: number, payload: Buffer): Buffer {
+function buildCCBuffer(payload: Buffer): Buffer {
 	return Buffer.concat([
 		Buffer.from([
-			nodeId, // node number
-			payload.length + 1, // remaining length
 			CommandClasses["Multi Channel Association"], // CC
 		]),
 		payload,
@@ -31,7 +29,6 @@ describe("lib/commandclass/MultiChannelAssociationCC => ", () => {
 			{ nodeId: 1 },
 		);
 		const expected = buildCCBuffer(
-			1,
 			Buffer.from([
 				MultiChannelAssociationCommand.SupportedGroupingsGet, // CC Command
 			]),
@@ -41,7 +38,6 @@ describe("lib/commandclass/MultiChannelAssociationCC => ", () => {
 
 	it("the SupportedGroupingsReport command should be deserialized correctly", () => {
 		const ccData = buildCCBuffer(
-			1,
 			Buffer.from([
 				MultiChannelAssociationCommand.SupportedGroupingsReport, // CC Command
 				7, // # of groups
@@ -50,6 +46,7 @@ describe("lib/commandclass/MultiChannelAssociationCC => ", () => {
 		const cc = new MultiChannelAssociationCCSupportedGroupingsReport(
 			fakeDriver,
 			{
+				nodeId: 4,
 				data: ccData,
 			},
 		);
@@ -64,7 +61,6 @@ describe("lib/commandclass/MultiChannelAssociationCC => ", () => {
 			nodeIds: [1, 2, 5],
 		});
 		const expected = buildCCBuffer(
-			2,
 			Buffer.from([
 				MultiChannelAssociationCommand.Set, // CC Command
 				5, // group id
@@ -93,7 +89,6 @@ describe("lib/commandclass/MultiChannelAssociationCC => ", () => {
 			],
 		});
 		const expected = buildCCBuffer(
-			2,
 			Buffer.from([
 				MultiChannelAssociationCommand.Set, // CC Command
 				5, // group id
@@ -126,7 +121,6 @@ describe("lib/commandclass/MultiChannelAssociationCC => ", () => {
 			],
 		});
 		const expected = buildCCBuffer(
-			2,
 			Buffer.from([
 				MultiChannelAssociationCommand.Set, // CC Command
 				5, // group id
@@ -152,7 +146,6 @@ describe("lib/commandclass/MultiChannelAssociationCC => ", () => {
 			groupId: 9,
 		});
 		const expected = buildCCBuffer(
-			1,
 			Buffer.from([
 				MultiChannelAssociationCommand.Get, // CC Command
 				9, // group ID
@@ -163,7 +156,6 @@ describe("lib/commandclass/MultiChannelAssociationCC => ", () => {
 
 	it("the Report command should be deserialized correctly (node IDs only)", () => {
 		const ccData = buildCCBuffer(
-			2,
 			Buffer.from([
 				MultiChannelAssociationCommand.Report, // CC Command
 				5, // group id
@@ -176,6 +168,7 @@ describe("lib/commandclass/MultiChannelAssociationCC => ", () => {
 			]),
 		);
 		const cc = new MultiChannelAssociationCCReport(fakeDriver, {
+			nodeId: 4,
 			data: ccData,
 		});
 
@@ -188,7 +181,6 @@ describe("lib/commandclass/MultiChannelAssociationCC => ", () => {
 
 	it("the Report command should be deserialized correctly (endpoint addresses only)", () => {
 		const ccData = buildCCBuffer(
-			2,
 			Buffer.from([
 				MultiChannelAssociationCommand.Report, // CC Command
 				5, // group id
@@ -204,6 +196,7 @@ describe("lib/commandclass/MultiChannelAssociationCC => ", () => {
 			]),
 		);
 		const cc = new MultiChannelAssociationCCReport(fakeDriver, {
+			nodeId: 4,
 			data: ccData,
 		});
 
@@ -222,7 +215,6 @@ describe("lib/commandclass/MultiChannelAssociationCC => ", () => {
 
 	it("the Report command should be deserialized correctly (both options)", () => {
 		const ccData = buildCCBuffer(
-			2,
 			Buffer.from([
 				MultiChannelAssociationCommand.Report, // CC Command
 				5, // group id
@@ -241,6 +233,7 @@ describe("lib/commandclass/MultiChannelAssociationCC => ", () => {
 			]),
 		);
 		const cc = new MultiChannelAssociationCCReport(fakeDriver, {
+			nodeId: 4,
 			data: ccData,
 		});
 
@@ -264,7 +257,6 @@ describe("lib/commandclass/MultiChannelAssociationCC => ", () => {
 			nodeIds: [1, 2, 5],
 		});
 		const expected = buildCCBuffer(
-			2,
 			Buffer.from([
 				MultiChannelAssociationCommand.Remove, // CC Command
 				5, // group id
@@ -293,7 +285,6 @@ describe("lib/commandclass/MultiChannelAssociationCC => ", () => {
 			],
 		});
 		const expected = buildCCBuffer(
-			2,
 			Buffer.from([
 				MultiChannelAssociationCommand.Remove, // CC Command
 				5, // group id
@@ -326,7 +317,6 @@ describe("lib/commandclass/MultiChannelAssociationCC => ", () => {
 			],
 		});
 		const expected = buildCCBuffer(
-			2,
 			Buffer.from([
 				MultiChannelAssociationCommand.Remove, // CC Command
 				5, // group id
@@ -352,7 +342,6 @@ describe("lib/commandclass/MultiChannelAssociationCC => ", () => {
 			groupId: 5,
 		});
 		const expected = buildCCBuffer(
-			2,
 			Buffer.from([
 				MultiChannelAssociationCommand.Remove, // CC Command
 				5, // group id

--- a/src/lib/commandclass/MultiChannelAssociationCC.ts
+++ b/src/lib/commandclass/MultiChannelAssociationCC.ts
@@ -403,7 +403,7 @@ export class MultiChannelAssociationCCSet extends MultiChannelAssociationCC {
 			}
 			this.groupId = options.groupId;
 			this.nodeIds = ("nodeIds" in options && options.nodeIds) || [];
-			if (!this.nodeIds.every(n => n > 0 && n < MAX_NODES)) {
+			if (this.nodeIds.some(n => n < 1 || n > MAX_NODES)) {
 				throw new ZWaveError(
 					`All node IDs must be between 1 and ${MAX_NODES}!`,
 					ZWaveErrorCodes.Argument_Invalid,

--- a/src/lib/commandclass/MultiChannelCC.ts
+++ b/src/lib/commandclass/MultiChannelCC.ts
@@ -721,11 +721,11 @@ export class MultiChannelCCCommandEncapsulation extends MultiChannelCC {
 				this.destination = destination;
 			}
 			// No need to validate further, each CC does it for itself
-			this.encapsulated = CommandClass.fromEncapsulated(
-				this.driver,
-				this,
-				this.payload.slice(2),
-			);
+			this.encapsulated = CommandClass.from(this.driver, {
+				data: this.payload.slice(2),
+				fromEncapsulation: true,
+				encapCC: this,
+			});
 		} else {
 			this.encapsulated = options.encapsulated;
 			this.destination = options.destination;
@@ -745,7 +745,7 @@ export class MultiChannelCCCommandEncapsulation extends MultiChannelCC {
 				  encodeBitMask(this.destination, 7)[0] | 0b1000_0000;
 		this.payload = Buffer.concat([
 			Buffer.from([this.endpointIndex & 0b0111_1111, destination]),
-			this.encapsulated.serializeForEncapsulation(),
+			this.encapsulated.serialize(),
 		]);
 		return super.serialize();
 	}

--- a/src/lib/commandclass/MultiCommandCC.ts
+++ b/src/lib/commandclass/MultiCommandCC.ts
@@ -107,11 +107,14 @@ export class MultiCommandCCCommandEncapsulation extends MultiCommandCC {
 				const cmdLength = this.payload[offset];
 				validatePayload(this.payload.length >= offset + 1 + cmdLength);
 				this.encapsulated.push(
-					CommandClass.fromEncapsulated(
-						this.driver,
-						this,
-						this.payload.slice(offset + 1, offset + 1 + cmdLength),
-					),
+					CommandClass.from(this.driver, {
+						data: this.payload.slice(
+							offset + 1,
+							offset + 1 + cmdLength,
+						),
+						fromEncapsulation: true,
+						encapCC: this,
+					}),
 				);
 				offset += 1 + cmdLength;
 			}
@@ -126,7 +129,7 @@ export class MultiCommandCCCommandEncapsulation extends MultiCommandCC {
 		const buffers: Buffer[] = [];
 		buffers.push(Buffer.from([this.encapsulated.length]));
 		for (const cmd of this.encapsulated) {
-			const cmdBuffer = cmd.serializeForEncapsulation();
+			const cmdBuffer = cmd.serialize();
 			buffers.push(Buffer.from([cmdBuffer.length]));
 			buffers.push(cmdBuffer);
 		}

--- a/src/lib/commandclass/NoOperationCC.test.ts
+++ b/src/lib/commandclass/NoOperationCC.test.ts
@@ -5,11 +5,9 @@ import { NoOperationCC } from "./NoOperationCC";
 
 const fakeDriver = (createEmptyMockDriver() as unknown) as IDriver;
 
-function buildCCBuffer(nodeId: number, payload: Buffer): Buffer {
+function buildCCBuffer(payload: Buffer): Buffer {
 	return Buffer.concat([
 		Buffer.from([
-			nodeId, // node number
-			payload.length + 1, // remaining length
 			CommandClasses["No Operation"], // CC
 		]),
 		payload,
@@ -20,7 +18,6 @@ describe("lib/commandclass/NoOperationCC => ", () => {
 	it("the CC should serialize correctly", () => {
 		const cc = new NoOperationCC(fakeDriver, { nodeId: 1 });
 		const expected = buildCCBuffer(
-			1,
 			Buffer.from([]), // No command!
 		);
 		expect(cc.serialize()).toEqual(expected);
@@ -28,7 +25,6 @@ describe("lib/commandclass/NoOperationCC => ", () => {
 
 	it("the CC should be deserialized correctly", () => {
 		const ccData = buildCCBuffer(
-			1,
 			Buffer.from([]), // No command!
 		);
 		void new NoOperationCC(fakeDriver, { data: ccData });

--- a/src/lib/commandclass/NoOperationCC.ts
+++ b/src/lib/commandclass/NoOperationCC.ts
@@ -36,6 +36,8 @@ export class NoOperationCCAPI extends CCAPI {
 @implementedVersion(1)
 export class NoOperationCC extends CommandClass {
 	declare ccCommand: undefined;
+	// Force singlecast
+	declare nodeId: number;
 }
 
 /** Tests if a given message is a ping */

--- a/src/lib/commandclass/NotificationCC.ts
+++ b/src/lib/commandclass/NotificationCC.ts
@@ -494,11 +494,11 @@ export class NotificationCCReport extends NotificationCC {
 			NotificationParameterWithCommandClass
 		) {
 			// The parameters contain a CC
-			this._eventParameters = CommandClass.fromEncapsulated(
-				this.driver,
-				this,
-				this._eventParameters,
-			);
+			this._eventParameters = CommandClass.from(this.driver, {
+				data: this._eventParameters,
+				fromEncapsulation: true,
+				encapCC: this,
+			});
 		} else if (
 			valueConfig.parameter instanceof NotificationParameterWithValue
 		) {

--- a/src/lib/commandclass/SceneActivationCC.test.ts
+++ b/src/lib/commandclass/SceneActivationCC.test.ts
@@ -10,11 +10,9 @@ import {
 
 const fakeDriver = (createEmptyMockDriver() as unknown) as IDriver;
 
-function buildCCBuffer(nodeId: number, payload: Buffer): Buffer {
+function buildCCBuffer(payload: Buffer): Buffer {
 	return Buffer.concat([
 		Buffer.from([
-			nodeId, // node number
-			payload.length + 1, // remaining length
 			CommandClasses["Scene Activation"], // CC
 		]),
 		payload,
@@ -28,7 +26,6 @@ describe("lib/commandclass/SceneActivationCC => ", () => {
 			sceneId: 55,
 		});
 		const expected = buildCCBuffer(
-			2,
 			Buffer.from([
 				SceneActivationCommand.Set, // CC Command
 				55, // id
@@ -45,7 +42,6 @@ describe("lib/commandclass/SceneActivationCC => ", () => {
 			dimmingDuration: new Duration(1, "minutes"),
 		});
 		const expected = buildCCBuffer(
-			2,
 			Buffer.from([
 				SceneActivationCommand.Set, // CC Command
 				56, // id
@@ -57,14 +53,16 @@ describe("lib/commandclass/SceneActivationCC => ", () => {
 
 	it("the Set command should be deserialized correctly", () => {
 		const ccData = buildCCBuffer(
-			1,
 			Buffer.from([
 				SceneActivationCommand.Set, // CC Command
 				15, // id
 				0x00, // 0 seconds
 			]),
 		);
-		const cc = new SceneActivationCCSet(fakeDriver, { data: ccData });
+		const cc = new SceneActivationCCSet(fakeDriver, {
+			nodeId: 2,
+			data: ccData,
+		});
 
 		expect(cc.sceneId).toBe(15);
 		expect(cc.dimmingDuration).toEqual(new Duration(0, "seconds"));
@@ -72,10 +70,10 @@ describe("lib/commandclass/SceneActivationCC => ", () => {
 
 	it("deserializing an unsupported command should return an unspecified version of SceneActivationCC", () => {
 		const serializedCC = buildCCBuffer(
-			1,
 			Buffer.from([255]), // not a valid command
 		);
 		const cc: any = new SceneActivationCC(fakeDriver, {
+			nodeId: 2,
 			data: serializedCC,
 		});
 		expect(cc.constructor).toBe(SceneActivationCC);

--- a/src/lib/commandclass/SupervisionCC.ts
+++ b/src/lib/commandclass/SupervisionCC.ts
@@ -78,6 +78,8 @@ export class SupervisionCCAPI extends CCAPI {
 @implementedVersion(1)
 export class SupervisionCC extends CommandClass {
 	declare ccCommand: SupervisionCommand;
+	// Force singlecast for the supervision CC
+	declare nodeId: number;
 
 	/** Tests if a command should be supervised and thus requires encapsulation */
 	public static requiresEncapsulation(cc: CommandClass): boolean {
@@ -90,6 +92,13 @@ export class SupervisionCC extends CommandClass {
 		cc: CommandClass,
 		requestStatusUpdates: boolean = true,
 	): SupervisionCCGet {
+		if (!cc.isSinglecast()) {
+			throw new ZWaveError(
+				`Supervision is only possible for singlecast commands!`,
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+
 		return new SupervisionCCGet(driver, {
 			nodeId: cc.nodeId,
 			// Supervision CC is wrapped inside MultiChannel CCs, so the endpoint must be copied

--- a/src/lib/commandclass/SupervisionCC.ts
+++ b/src/lib/commandclass/SupervisionCC.ts
@@ -197,7 +197,7 @@ export class SupervisionCCGet extends SupervisionCC {
 	public encapsulated: CommandClass;
 
 	public serialize(): Buffer {
-		const encapCC = this.encapsulated.serializeForEncapsulation();
+		const encapCC = this.encapsulated.serialize();
 		this.payload = Buffer.concat([
 			Buffer.from([
 				(this.requestStatusUpdates ? 0b10_000000 : 0) |

--- a/src/lib/commandclass/TimeCC.test.ts
+++ b/src/lib/commandclass/TimeCC.test.ts
@@ -12,11 +12,9 @@ import {
 
 const fakeDriver = (createEmptyMockDriver() as unknown) as IDriver;
 
-function buildCCBuffer(nodeId: number, payload: Buffer): Buffer {
+function buildCCBuffer(payload: Buffer): Buffer {
 	return Buffer.concat([
 		Buffer.from([
-			nodeId, // node number
-			payload.length + 1, // remaining length
 			CommandClasses.Time, // CC
 		]),
 		payload,
@@ -27,7 +25,6 @@ describe("lib/commandclass/TimeCC => ", () => {
 	it("the TimeGet command should serialize correctly", () => {
 		const cc = new TimeCCTimeGet(fakeDriver, { nodeId: 1 });
 		const expected = buildCCBuffer(
-			1,
 			Buffer.from([
 				TimeCommand.TimeGet, // CC Command
 			]),
@@ -37,7 +34,6 @@ describe("lib/commandclass/TimeCC => ", () => {
 
 	it("the TimeReport command should be deserialized correctly", () => {
 		const ccData = buildCCBuffer(
-			1,
 			Buffer.from([
 				TimeCommand.TimeReport, // CC Command
 				14,
@@ -45,7 +41,10 @@ describe("lib/commandclass/TimeCC => ", () => {
 				59,
 			]),
 		);
-		const cc = new TimeCCTimeReport(fakeDriver, { data: ccData });
+		const cc = new TimeCCTimeReport(fakeDriver, {
+			nodeId: 8,
+			data: ccData,
+		});
 
 		expect(cc.hour).toBe(14);
 		expect(cc.minute).toBe(23);
@@ -55,7 +54,6 @@ describe("lib/commandclass/TimeCC => ", () => {
 	it("the DateGet command should serialize correctly", () => {
 		const cc = new TimeCCDateGet(fakeDriver, { nodeId: 1 });
 		const expected = buildCCBuffer(
-			1,
 			Buffer.from([
 				TimeCommand.DateGet, // CC Command
 			]),
@@ -65,7 +63,6 @@ describe("lib/commandclass/TimeCC => ", () => {
 
 	it("the DateReport command should be deserialized correctly", () => {
 		const ccData = buildCCBuffer(
-			1,
 			Buffer.from([
 				TimeCommand.DateReport, // CC Command
 				0x07,
@@ -74,7 +71,10 @@ describe("lib/commandclass/TimeCC => ", () => {
 				17,
 			]),
 		);
-		const cc = new TimeCCDateReport(fakeDriver, { data: ccData });
+		const cc = new TimeCCDateReport(fakeDriver, {
+			nodeId: 8,
+			data: ccData,
+		});
 
 		expect(cc.year).toBe(1989);
 		expect(cc.month).toBe(10);
@@ -83,10 +83,10 @@ describe("lib/commandclass/TimeCC => ", () => {
 
 	it("deserializing an unsupported command should return an unspecified version of TimeCC", () => {
 		const serializedCC = buildCCBuffer(
-			1,
 			Buffer.from([255]), // not a valid command
 		);
 		const cc: any = new TimeCC(fakeDriver, {
+			nodeId: 8,
 			data: serializedCC,
 		});
 		expect(cc.constructor).toBe(TimeCC);

--- a/src/lib/commandclass/manufacturerProprietary/Fibaro.test.ts
+++ b/src/lib/commandclass/manufacturerProprietary/Fibaro.test.ts
@@ -14,8 +14,6 @@ describe("lib/commandclass/manufacturerProprietary/Fibaro => ", () => {
 			proprietaryCommand: new FibaroVenetianBlindCCSet({ tilt: 99 }),
 		});
 		const expected = Buffer.from([
-			1, // node number
-			8, // remaining length
 			CommandClasses["Manufacturer Proprietary"], // CC
 			0x01,
 			0x0f,

--- a/src/lib/controller/ApplicationCommandRequest.ts
+++ b/src/lib/controller/ApplicationCommandRequest.ts
@@ -1,4 +1,4 @@
-import { CommandClass } from "../commandclass/CommandClass";
+import { CommandClass, SinglecastCC } from "../commandclass/CommandClass";
 import { ICommandClassContainer } from "../commandclass/ICommandClassContainer";
 import { IDriver } from "../driver/IDriver";
 import {
@@ -31,7 +31,7 @@ enum StatusFlags {
 }
 
 interface ApplicationCommandRequestOptions extends MessageBaseOptions {
-	command: CommandClass;
+	command: SinglecastCC;
 	frameType?: ApplicationCommandRequest["frameType"];
 	routedBusy?: boolean;
 }
@@ -75,7 +75,7 @@ export class ApplicationCommandRequest extends Message
 			this.command = CommandClass.from(this.driver, {
 				data: this.payload.slice(3, 3 + commandLength),
 				nodeId,
-			});
+			}) as SinglecastCC;
 		} else {
 			this.frameType = options.frameType ?? "singlecast";
 			this.routedBusy = !!options.routedBusy;
@@ -93,7 +93,7 @@ export class ApplicationCommandRequest extends Message
 	public readonly fromForeignHomeId: boolean;
 
 	// This needs to be writable or unwrapping MultiChannelCCs crashes
-	public command: CommandClass;
+	public command: CommandClass & { nodeId: number };
 
 	public serialize(): Buffer {
 		const statusByte =

--- a/src/lib/controller/ApplicationCommandRequest.ts
+++ b/src/lib/controller/ApplicationCommandRequest.ts
@@ -16,14 +16,24 @@ import {
 } from "../message/Message";
 
 enum StatusFlags {
-	RoutedBusy = 1 << 0,
-	Broadcast = 1 << 2,
+	RoutedBusy = 0b1, // A response route is locked by the application
+	LowPower = 0b10, // Received at low output power level
+
+	TypeSingle = 0b0000, // Received a single cast frame
+	TypeBroad = 0b0100, // Received a broad cast frame
+	TypeMulti = 0b1000, // Received a multi cast frame
+	TypeMask = TypeSingle | TypeBroad | TypeMulti,
+
+	Explore = 0b10000, // Received an explore frame
+
+	ForeignFrame = 0b0100_0000, // Received a foreign frame (only promiscous mode)
+	ForeignHomeId = 0b1000_0000, // The received frame is received from a foreign HomeID. Only Controllers in Smart Start AddNode mode can receive this status.
 }
 
 interface ApplicationCommandRequestOptions extends MessageBaseOptions {
-	isBroadcast?: boolean;
-	routedBusy?: boolean;
 	command: CommandClass;
+	frameType?: ApplicationCommandRequest["frameType"];
+	routedBusy?: boolean;
 }
 
 @messageTypes(MessageType.Request, FunctionType.ApplicationCommand)
@@ -41,8 +51,23 @@ export class ApplicationCommandRequest extends Message
 		if (gotDeserializationOptions(options)) {
 			// first byte is a status flag
 			const status = this.payload[0];
-			this._isBroadcast = (status & StatusFlags.Broadcast) !== 0;
-			this._routedBusy = (status & StatusFlags.RoutedBusy) !== 0;
+			this.routedBusy = !!(status & StatusFlags.RoutedBusy);
+			switch (status & StatusFlags.TypeMask) {
+				case StatusFlags.TypeMulti:
+					this.frameType = "multicast";
+					break;
+				case StatusFlags.TypeBroad:
+					this.frameType = "broadcast";
+					break;
+				default:
+					this.frameType = "singlecast";
+			}
+			this.isExploreFrame =
+				this.frameType === "broadcast" &&
+				!!(status & StatusFlags.Explore);
+			this.isForeignFrame = !!(status & StatusFlags.ForeignFrame);
+			this.fromForeignHomeId = !!(status & StatusFlags.ForeignHomeId);
+
 			// followed by a node ID
 			const nodeId = this.payload[1];
 			// and a command class
@@ -52,29 +77,31 @@ export class ApplicationCommandRequest extends Message
 				nodeId,
 			});
 		} else {
-			this._isBroadcast = !!options.isBroadcast;
-			this._routedBusy = !!options.routedBusy;
+			this.frameType = options.frameType ?? "singlecast";
+			this.routedBusy = !!options.routedBusy;
 			this.command = options.command;
+			this.isExploreFrame = false;
+			this.isForeignFrame = false;
+			this.fromForeignHomeId = false;
 		}
 	}
 
-	private _routedBusy: boolean;
-	public get routedBusy(): boolean {
-		return this._routedBusy;
-	}
-
-	private _isBroadcast: boolean;
-	public get isBroadcast(): boolean {
-		return this._isBroadcast;
-	}
+	public readonly routedBusy: boolean;
+	public readonly frameType: "singlecast" | "broadcast" | "multicast";
+	public readonly isExploreFrame: boolean;
+	public readonly isForeignFrame: boolean;
+	public readonly fromForeignHomeId: boolean;
 
 	// This needs to be writable or unwrapping MultiChannelCCs crashes
 	public command: CommandClass;
 
 	public serialize(): Buffer {
 		const statusByte =
-			(this._isBroadcast ? StatusFlags.Broadcast : 0) |
-			(this._routedBusy ? StatusFlags.RoutedBusy : 0);
+			(this.frameType === "broadcast"
+				? StatusFlags.TypeBroad
+				: this.frameType === "multicast"
+				? StatusFlags.TypeMulti
+				: 0) | (this.routedBusy ? StatusFlags.RoutedBusy : 0);
 
 		const serializedCC = this.command.serialize();
 		this.payload = Buffer.concat([

--- a/src/lib/controller/SendDataMessages.test.ts
+++ b/src/lib/controller/SendDataMessages.test.ts
@@ -180,6 +180,10 @@ describe("lib/controller/SendDataRequest => ", () => {
 		const serializedMsg = msg.payload;
 
 		const expected = Buffer.concat([
+			Buffer.from([
+				1, // nodeId
+				serializedCC.length, // data length
+			]),
 			serializedCC,
 			Buffer.from([TransmitOptions.DEFAULT, 66]),
 		]);

--- a/src/lib/controller/SendDataMessages.ts
+++ b/src/lib/controller/SendDataMessages.ts
@@ -103,6 +103,7 @@ export class SendDataRequest<CCType extends CommandClass = CommandClass>
 	public serialize(): Buffer {
 		const serializedCC = this.command.serialize();
 		this.payload = Buffer.concat([
+			Buffer.from([this.command.nodeId, serializedCC.length]),
 			serializedCC,
 			Buffer.from([this.transmitOptions, this.callbackId]),
 		]);
@@ -381,8 +382,7 @@ export class SendDataMulticastRequest<
 
 	public serialize(): Buffer {
 		// The payload CC must not include the target node ids, so strip the header out
-		// TODO: Refactor this and CommandClass.serialize()
-		const serializedCC = this.command.serializeForEncapsulation();
+		const serializedCC = this.command.serialize();
 		const destinationBitMask = encodeBitMask(
 			this.nodeIds,
 			Math.max(...this.nodeIds),

--- a/src/lib/controller/SendDataMessages.ts
+++ b/src/lib/controller/SendDataMessages.ts
@@ -338,7 +338,7 @@ export class SendDataMulticastRequestBase extends Message {
 interface SendDataMulticastRequestOptions<
 	CCType extends CommandClass = CommandClass
 > extends MessageBaseOptions {
-	nodeIds: [number, ...number[]];
+	nodeIds: [number, number, ...number[]];
 	command: CCType;
 	transmitOptions?: TransmitOptions;
 }

--- a/src/lib/controller/SendDataMessages.ts
+++ b/src/lib/controller/SendDataMessages.ts
@@ -518,3 +518,25 @@ export class SendDataMulticastResponse extends Message {
 		};
 	}
 }
+
+/** Checks whether the message is a report that tells us that a message was sent */
+export function isSendReport(
+	msg: Message,
+): msg is SendDataResponse | SendDataMulticastResponse {
+	return (
+		msg instanceof SendDataResponse ||
+		msg instanceof SendDataMulticastResponse
+	);
+}
+
+/** Checks whether the message is a report that contains the transmit status of a message */
+export function isTransmitReport(
+	msg: Message,
+): msg is
+	| SendDataRequestTransmitReport
+	| SendDataMulticastRequestTransmitReport {
+	return (
+		msg instanceof SendDataRequestTransmitReport ||
+		msg instanceof SendDataMulticastRequestTransmitReport
+	);
+}

--- a/src/lib/message/Constants.ts
+++ b/src/lib/message/Constants.ts
@@ -70,8 +70,7 @@ export enum FunctionType {
 	FUNC_ID_ZW_SEND_NODE_INFORMATION = 0x12, // Send Node Information Frame of the stick
 
 	SendData = 0x13, // Send data
-
-	UNKNOWN_FUNC_SEND_DATA_MULTI = 0x14, // ??
+	SendDataMulticast = 0x14, // Send data using multicast
 
 	GetControllerVersion = 0x15,
 

--- a/src/lib/message/Message.ts
+++ b/src/lib/message/Message.ts
@@ -305,7 +305,9 @@ export class Message {
 	/** Finds the ID of the target or source node in a message, if it contains that information */
 	public getNodeId(): number | undefined {
 		if (isNodeQuery(this)) return this.nodeId;
-		if (isCommandClassContainer(this)) return this.command.nodeId;
+		if (isCommandClassContainer(this) && this.command.isSinglecast()) {
+			return this.command.nodeId;
+		}
 	}
 
 	/**

--- a/src/lib/node/Node.ts
+++ b/src/lib/node/Node.ts
@@ -78,8 +78,6 @@ import {
 	ValueUpdatedArgs,
 } from "./ValueDB";
 
-/** This id is used internally for multicast messages */
-export const NODE_ID_MULTICAST = 0xfe;
 /** The broadcast target node id */
 export const NODE_ID_BROADCAST = 0xff;
 /** The highest allowed node id */

--- a/src/lib/node/Node.ts
+++ b/src/lib/node/Node.ts
@@ -44,6 +44,7 @@ import {
 	GetRoutingInfoRequest,
 	GetRoutingInfoResponse,
 } from "../controller/GetRoutingInfoMessages";
+import { MAX_NODES } from "../controller/NodeBitMask";
 import { Driver } from "../driver/Driver";
 import { ZWaveError, ZWaveErrorCodes } from "../error/ZWaveError";
 import log from "../log";
@@ -76,6 +77,13 @@ import {
 	ValueRemovedArgs,
 	ValueUpdatedArgs,
 } from "./ValueDB";
+
+/** This id is used internally for multicast messages */
+export const NODE_ID_MULTICAST = 0xfe;
+/** The broadcast target node id */
+export const NODE_ID_BROADCAST = 0xff;
+/** The highest allowed node id */
+export const NODE_ID_MAX = MAX_NODES;
 
 export interface TranslatedValueID extends ValueID {
 	commandClassName: string;


### PR DESCRIPTION
With this PR we support sending CCs to a list of nodes (multicast) using the `SendDataMulticast` message. Therefore the `nodeId` property of the `CommandClass` class has been extended to accept a numeric array. When this is the case, the `Driver.sendCommand` method automatically sends the command to multiple nodes using `SendDataMulticast`. Multicast CCs always use the implemented version for serialization as opposed to singlecast CCs which check the target node's version.

As a side-effect, serializing the node id and payload length has been moved from `CommandClass` to the respective `Message` subclasses, which reduces some complexity (and a refactor TODO) in `CommandClass`.

fixes: #675 