### PR TITLE
Use node list instead of bit mask for SendDataMulti

### DIFF
--- a/src/lib/controller/SendDataMessages.ts
+++ b/src/lib/controller/SendDataMessages.ts
@@ -382,7 +382,11 @@ export class SendDataMulticastRequest<CCType extends MulticastCC = MulticastCC>
 		const serializedCC = this.command.serialize();
 		this.payload = Buffer.concat([
 			// # of target nodes and nodeIds
-			Buffer.from([this.command.nodeId.length, ...this.command.nodeId]),
+			Buffer.from([
+				this.command.nodeId.length,
+				...this.command.nodeId,
+				serializedCC.length,
+			]),
 			// payload
 			serializedCC,
 			Buffer.from([this.transmitOptions, this.callbackId]),

--- a/src/lib/controller/SendDataMessages.ts
+++ b/src/lib/controller/SendDataMessages.ts
@@ -35,7 +35,6 @@ import {
 } from "../message/Message";
 import { getEnumMemberName, JSONObject, staticExtends } from "../util/misc";
 import { num2hex } from "../util/strings";
-import { encodeBitMask } from "../values/Primitive";
 import { ApplicationCommandRequest } from "./ApplicationCommandRequest";
 import { MAX_NODES } from "./NodeBitMask";
 
@@ -381,14 +380,9 @@ export class SendDataMulticastRequest<CCType extends MulticastCC = MulticastCC>
 	public serialize(): Buffer {
 		// The payload CC must not include the target node ids, so strip the header out
 		const serializedCC = this.command.serialize();
-		const destinationBitMask = encodeBitMask(
-			this.command.nodeId,
-			Math.max(...this.command.nodeId),
-		);
 		this.payload = Buffer.concat([
-			// Target bit mask + length
-			Buffer.from([destinationBitMask.length]),
-			destinationBitMask,
+			// # of target nodes and nodeIds
+			Buffer.from([this.command.nodeId.length, ...this.command.nodeId]),
 			// payload
 			serializedCC,
 			Buffer.from([this.transmitOptions, this.callbackId]),

--- a/src/lib/driver/Driver.ts
+++ b/src/lib/driver/Driver.ts
@@ -1048,10 +1048,25 @@ It is probably asleep, moving its messages to the wakeup queue.`,
 				}
 
 				case "fatal_node": {
-					// The node did not acknowledge the receipt
-					this.handleMissingNodeResponse(
-						isTransmitReport(msg) ? msg.transmitStatus : undefined,
-					);
+					if (
+						this.currentTransaction.message instanceof
+						SendDataMulticastRequest
+					) {
+						// Don't try to resend multicast messages. One or more nodes might have already reacted
+						this.rejectCurrentTransaction(
+							new ZWaveError(
+								`One or more nodes did not respond to the request.`,
+								ZWaveErrorCodes.Controller_MessageDropped,
+							),
+						);
+					} else {
+						// The node did not acknowledge the receipt
+						this.handleMissingNodeResponse(
+							isTransmitReport(msg)
+								? msg.transmitStatus
+								: undefined,
+						);
+					}
 					return;
 				}
 


### PR DESCRIPTION
@lukescott I could use your help testing the Multicast support. With this change, I get a report from the controller that the messages are actually sent, but my test plug does not react to the BinarySwitchSet command.
