### PR TITLE
Disable emitDecoratorMetadata to fix crash on load

### DIFF
--- a/src/lib/node/Node.ts
+++ b/src/lib/node/Node.ts
@@ -55,7 +55,7 @@ import {
 	GetRoutingInfoRequest,
 	GetRoutingInfoResponse,
 } from "../controller/GetRoutingInfoMessages";
-import { Driver } from "../driver/Driver";
+import type { Driver } from "../driver/Driver";
 import { ZWaveError, ZWaveErrorCodes } from "../error/ZWaveError";
 import log from "../log";
 import { timespan } from "../util/date";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
 		"outDir": "build/",
 		"removeComments": false,
 		"experimentalDecorators": true,
-		"emitDecoratorMetadata": true,
+		"emitDecoratorMetadata": false,
 		"importsNotUsedAsValues": "error",
 		"sourceMap": true,
 		"inlineSourceMap": false,


### PR DESCRIPTION
See https://github.com/AlCalzone/node-zwave-js/issues/749 for more information