### PR TITLE
feat(log): filter node logging with LOG_NODES env variable

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,7 +36,7 @@
 			],
 			"env": {
 				// "NO_CACHE": "true",
-				// "LOGLEVEL": "info"
+				// "LOGLEVEL": "verbose"
 			},
 			"console": "integratedTerminal",
 			"skipFiles": ["<node_internals>/**"],

--- a/src/lib/driver/Driver.ts
+++ b/src/lib/driver/Driver.ts
@@ -1003,7 +1003,11 @@ It is probably asleep, moving its messages to the wakeup queue.`,
 				msg,
 			);
 			if (responseRole !== "unexpected") {
-				log.driver.transactionResponse(msg, responseRole);
+				log.driver.transactionResponse(
+					msg,
+					this.currentTransaction,
+					responseRole,
+				);
 			}
 			// For further actions, we are only interested in the innermost CC
 			if (isCommandClassContainer(msg)) this.unwrapCommands(msg);
@@ -1152,7 +1156,11 @@ It is probably asleep, moving its messages to the wakeup queue.`,
 			// This is a request we might have registered handlers for
 			await this.handleRequest(msg);
 		} else {
-			log.driver.transactionResponse(msg, "unexpected");
+			log.driver.transactionResponse(
+				msg,
+				this.currentTransaction,
+				"unexpected",
+			);
 			log.driver.print("unexpected response, discarding...", "warn");
 		}
 	}

--- a/src/lib/log/Controller.ts
+++ b/src/lib/log/Controller.ts
@@ -14,6 +14,7 @@ import {
 	getDirectionPrefix,
 	getNodeTag,
 	isLoglevelVisible,
+	shouldLogNode,
 	tagify,
 	ZWaveLogger,
 } from "./shared";
@@ -81,6 +82,7 @@ export function logNode(
 	const { level, message, direction, endpoint } = messageOrOptions;
 	const actualLevel = level || CONTROLLER_LOGLEVEL;
 	if (!isLoglevelVisible(actualLevel)) return;
+	if (!shouldLogNode(nodeId)) return;
 
 	logger.log({
 		level: actualLevel,
@@ -199,6 +201,7 @@ export function metadataUpdated(args: LogValueArgs<ValueID>): void {
 /** Logs the interview progress of a node */
 export function interviewStage(node: ZWaveNode): void {
 	if (!isControllerLogVisible) return;
+	if (!shouldLogNode(node.id)) return;
 
 	logger.log({
 		level: CONTROLLER_LOGLEVEL,
@@ -216,6 +219,7 @@ export function interviewStage(node: ZWaveNode): void {
 /** Logs the interview progress of a node */
 export function interviewStart(node: ZWaveNode): void {
 	if (!isControllerLogVisible) return;
+	if (!shouldLogNode(node.id)) return;
 
 	const message = `Beginning interview - last completed stage: ${
 		InterviewStage[node.interviewStage]

--- a/src/lib/log/Driver.test.ts
+++ b/src/lib/log/Driver.test.ts
@@ -217,7 +217,7 @@ describe("lib/log/Driver =>", () => {
 	describe("transactionResponse() (for inbound messages)", () => {
 		it("contains the direction", () => {
 			const msg = createMessage(fakeDriver, {});
-			log.driver.transactionResponse(msg, null as any);
+			log.driver.transactionResponse(msg, undefined, null as any);
 			assertMessage(spyTransport, {
 				predicate: (msg) =>
 					msg.startsWith(getDirectionPrefix("inbound")),
@@ -228,7 +228,7 @@ describe("lib/log/Driver =>", () => {
 			let msg = createMessage(fakeDriver, {
 				type: MessageType.Request,
 			});
-			log.driver.transactionResponse(msg, null as any);
+			log.driver.transactionResponse(msg, undefined, null as any);
 			assertMessage(spyTransport, {
 				predicate: (msg) => msg.includes("[REQ]"),
 			});
@@ -236,7 +236,7 @@ describe("lib/log/Driver =>", () => {
 			msg = createMessage(fakeDriver, {
 				type: MessageType.Response,
 			});
-			log.driver.transactionResponse(msg, null as any);
+			log.driver.transactionResponse(msg, undefined, null as any);
 			assertMessage(spyTransport, {
 				predicate: (msg) => msg.includes("[RES]"),
 				callNumber: 1,
@@ -247,7 +247,7 @@ describe("lib/log/Driver =>", () => {
 			const msg = createMessage(fakeDriver, {
 				functionType: FunctionType.HardReset,
 			});
-			log.driver.transactionResponse(msg, null as any);
+			log.driver.transactionResponse(msg, undefined, null as any);
 			assertMessage(spyTransport, {
 				predicate: (msg) => msg.includes("[HardReset]"),
 			});
@@ -257,7 +257,7 @@ describe("lib/log/Driver =>", () => {
 			const msg = createMessage(fakeDriver, {
 				functionType: FunctionType.HardReset,
 			});
-			log.driver.transactionResponse(msg, "fatal_controller");
+			log.driver.transactionResponse(msg, undefined, "fatal_controller");
 			assertMessage(spyTransport, {
 				predicate: (msg) => msg.includes("[fatal_controller]"),
 			});
@@ -340,7 +340,7 @@ describe("lib/log/Driver =>", () => {
 				functionType: FunctionType.HardReset,
 				type: MessageType.Response,
 			});
-			log.driver.transactionResponse(msg, null as any);
+			log.driver.transactionResponse(msg, undefined, null as any);
 
 			const expected1 = colors.cyan(
 				colors.bgCyan("[") +

--- a/src/lib/log/Driver.ts
+++ b/src/lib/log/Driver.ts
@@ -86,7 +86,7 @@ export function transactionResponse(
 ): void {
 	if (!isDriverLogVisible) return;
 	logMessage(message, {
-		nodeId: originalTransaction?.message.getNodeId(),
+		nodeId: originalTransaction?.message?.getNodeId(),
 		secondaryTags: [role],
 		direction: "inbound",
 	});

--- a/src/lib/log/Driver.ts
+++ b/src/lib/log/Driver.ts
@@ -16,6 +16,7 @@ import {
 	getDirectionPrefix,
 	isLoglevelVisible,
 	messageToLines,
+	shouldLogNode,
 	tagify,
 	ZWaveLogger,
 } from "./shared";
@@ -80,23 +81,33 @@ export function transaction(transaction: Transaction): void {
 /** Logs information about a message that is received as a response to a transaction */
 export function transactionResponse(
 	message: Message,
+	originalTransaction: Transaction | undefined,
 	role: ResponseRole,
 ): void {
 	if (!isDriverLogVisible) return;
-	logMessage(message, { secondaryTags: [role], direction: "inbound" });
+	logMessage(message, {
+		nodeId: originalTransaction?.message.getNodeId(),
+		secondaryTags: [role],
+		direction: "inbound",
+	});
 }
 
 function logMessage(
 	message: Message,
 	{
+		// Used to relate this log message to a node
+		nodeId,
 		secondaryTags,
 		direction = "none",
 	}: {
+		nodeId?: number;
 		secondaryTags?: string[];
 		direction?: DataDirection;
 	},
 ): void {
 	if (!isDriverLogVisible) return;
+	if (nodeId == undefined) nodeId = message.getNodeId();
+	if (nodeId != undefined && !shouldLogNode(nodeId)) return;
 
 	const isCCContainer = isCommandClassContainer(message);
 	const logEntry = message.toLogEntry();

--- a/src/lib/log/shared.ts
+++ b/src/lib/log/shared.ts
@@ -24,6 +24,16 @@ const logFilename = path.join(
 	`zwave-${process.pid}.log`,
 );
 
+/**
+ * Checks the LOG_NODES env variable whether logs should be written for a given node id
+ */
+export function shouldLogNode(nodeId: number): boolean {
+	const activeFilters = (process.env.LOG_NODES ?? "*").split(",");
+	if (activeFilters.includes("*")) return true;
+	if (activeFilters.includes(nodeId.toString())) return true;
+	return false;
+}
+
 export type DataDirection = "inbound" | "outbound" | "none";
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type


### PR DESCRIPTION
This PR adds support for a `LOG_NODES` env variable to limit the log output to certain nodes:
* `LOG_NODES=""`: no nodes are logged
* `LOG_NODES="1"`: only node 1
* `LOG_NODES="2,4,5,8"`: nodes 2, 4, 5 and 8 are logged.

It is recommended to set the `LOGLEVEL=verbose` together with this, so only the formatted messages are printed, not the raw serial output.

E.g.:
```
17:27:05.718 DRIVER   driver ready
17:27:05.719 DRIVER   Cache file for homeId 0xcfb742fd found, attempting to restore the network from
                       cache...
17:27:05.725 CNTRLR   [Node 003] trying to load device config
17:27:05.735 CNTRLR   [Node 003] device config loaded
17:27:05.739 DRIVER   Restoring the network from cache was successful!
17:27:05.750 DRIVER   ACK received from controller for current transaction
17:27:05.755 CNTRLR   [Node 003] Beginning interview - last completed stage: RestartFromCache
17:27:05.755 CNTRLR   [Node 003] The node is ready to be used
17:27:05.755 CNTRLR   [Node 003] node is ready
17:27:05.757 CNTRLR   [Node 003] ManufacturerSpecificCC: doing a partial interview...
17:27:05.758 CNTRLR   [Node 003] VersionCC: doing a partial interview...
17:27:05.767 CNTRLR   [Node 003] trying to load device config
17:27:05.769 CNTRLR   [Node 003] device config loaded
17:27:05.770 CNTRLR   [Node 003] ZWavePlusCC: doing a partial interview...
17:27:05.771 CNTRLR » [Node 003] querying device endpoint information...
17:27:05.773 DRIVER » [Node 003] [REQ] [SendData]                                     [P: NodeQuery]
                      │ transmitOptions: 0x25
                      │ callbackId:      1
                      └─[MultiChannelCCEndPointGet]
17:27:05.775 DRIVER   ACK received from controller for current transaction
17:27:05.786 DRIVER « [RES] [SendData]                                                [confirmation]
                        wasSent: true
17:27:09.929 DRIVER « [REQ] [SendData]                                                  [fatal_node]
                        callbackId:     1
                        transmitStatus: NoAck
```

Fixes: #765
Fixes: #768