### PR TITLE
Add compat option to device config to do some node queries on wakeup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 -->
 
 ## __WORK IN PROGRESS__
+### Features
+* Added compatibility option `queryOnWakeup` to configure which API methods must be called when a device wakes up. Some devices (like the Danfoss thermostats) expect to be queried after wakeup, even if they send the required information themselves.
+
 ### Bugfixes
 * CCs that can split their information into multiple messages now correctly store that information when only a single message is received
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+### Bugfixes
+* CCs that can split their information into multiple messages now correctly store that information when only a single message is received
+
 ## 3.1.0 (2020-05-11)
 ### Features
 * Added `getAssociationGroups` method to `Controller` to retrieve all defined association groups and their information for a node (#794)

--- a/config/devices/0x0002/010101.json
+++ b/config/devices/0x0002/010101.json
@@ -1,26 +1,36 @@
 // Danfoss 010101
 // Popp Wireless Thermostatic Valve TRV
 {
-    "_approved": true,
-    "manufacturer": "Danfoss",
-    "manufacturerId": "0x0002",
-    "label": "010101",
-    "description": "Popp Wireless Thermostatic Valve TRV",
-    "devices": [
-        {
-            "productType": "0x0115",
-            "productId": "0xa010"
-        }
-    ],
-    "firmwareVersion": {
-        "min": "0.0",
-        "max": "255.255"
-    },
-    "associations": {
-        "1": {
-            "label": "Target for Wakeup and Override Notifications",
-            "maxNodes": 1,
-            "isLifeline": true
-        }
-    }
+	"_approved": true,
+	"manufacturer": "Danfoss",
+	"manufacturerId": "0x0002",
+	"label": "010101",
+	"description": "Popp Wireless Thermostatic Valve TRV",
+	"devices": [
+		{
+			"productType": "0x0115",
+			"productId": "0xa010"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Target for Wakeup and Override Notifications",
+			"maxNodes": 1,
+			"isLifeline": true
+		}
+	},
+	"compat": {
+		// If we don't query specific things on wake up, this device will
+		// think it is not connected and show error E5
+		"queryOnWakeup": [
+			// ["CommandClass", "API method", ...arguments]
+			["Battery", "get"],
+			["Thermostat Setpoint", "set", 1, "$value$[\"setpoint\", 1]", 0],
+			["Thermostat Setpoint", "get"]
+		]
+	}
 }

--- a/config/devices/0x0002/dthermz6.json
+++ b/config/devices/0x0002/dthermz6.json
@@ -1,26 +1,36 @@
 // Danfoss DTHERMZ6
 // Living Connect Z Thermostat
 {
-    "_approved": true,
-    "manufacturer": "Danfoss",
-    "manufacturerId": "0x0002",
-    "label": "DTHERMZ6",
-    "description": "Living Connect Z Thermostat",
-    "devices": [
-        {
-            "productType": "0x0248",
-            "productId": "0xa010"
-        }
-    ],
-    "firmwareVersion": {
-        "min": "0.0",
-        "max": "255.255"
-    },
-    "associations": {
-        "1": {
-            "label": "Target for Wakeup and Override Notifications",
-            "maxNodes": 1,
-            "isLifeline": true
-        }
-    }
+	"_approved": true,
+	"manufacturer": "Danfoss",
+	"manufacturerId": "0x0002",
+	"label": "DTHERMZ6",
+	"description": "Living Connect Z Thermostat",
+	"devices": [
+		{
+			"productType": "0x0248",
+			"productId": "0xa010"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Target for Wakeup and Override Notifications",
+			"maxNodes": 1,
+			"isLifeline": true
+		}
+	},
+	"compat": {
+		// If we don't query specific things on wake up, this device will
+		// think it is not connected and show error E5
+		"queryOnWakeup": [
+			// ["CommandClass", "API method", ...arguments]
+			["Battery", "get"],
+			["Thermostat Setpoint", "set", 1, "$value$[\"setpoint\", 1]", 0],
+			["Thermostat Setpoint", "get"]
+		]
+	}
 }

--- a/config/devices/0x0002/hrvccm.json
+++ b/config/devices/0x0002/hrvccm.json
@@ -1,26 +1,23 @@
 // Danfoss HRVCCM
 // Air CCM
 {
-    "_approved": true,
-    "_warnings": [
-        "No channels have been assigned even though there are user configurable command classes."
-    ],
-    "manufacturer": "Danfoss",
-    "manufacturerId": "0x0002",
-    "label": "HRVCCM",
-    "description": "Air CCM",
-    "devices": [
-        {
-            "productType": "0x8007",
-            "productId": "0x0200"
-        },
-        {
-            "productType": "0x8007",
-            "productId": "0x0202"
-        }
-    ],
-    "firmwareVersion": {
-        "min": "0.0",
-        "max": "255.255"
-    }
+	"_approved": true,
+	"manufacturer": "Danfoss",
+	"manufacturerId": "0x0002",
+	"label": "HRVCCM",
+	"description": "Air CCM",
+	"devices": [
+		{
+			"productType": "0x8007",
+			"productId": "0x0200"
+		},
+		{
+			"productType": "0x8007",
+			"productId": "0x0202"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	}
 }

--- a/config/devices/0x0002/lc-13.json
+++ b/config/devices/0x0002/lc-13.json
@@ -1,34 +1,44 @@
 // Danfoss LC-13
 // Living Connect Z Thermostat
 {
-    "_approved": false,
-    "manufacturer": "Danfoss",
-    "manufacturerId": "0x0002",
-    "label": "LC-13",
-    "description": "Living Connect Z Thermostat",
-    "devices": [
-        {
-            "productType": "0x0005",
-            "productId": "0x0004"
-        },
-        {
-            "productType": "0x8005",
-            "productId": "0x0001"
-        },
-        {
-            "productType": "0x8005",
-            "productId": "0x0002"
-        }
-    ],
-    "firmwareVersion": {
-        "min": "0.0",
-        "max": "255.255"
-    },
-    "associations": {
-        "1": {
-            "label": "Target for Wakeup and Override Notifications",
-            "maxNodes": 1,
-            "isLifeline": true
-        }
-    }
+	"_approved": false,
+	"manufacturer": "Danfoss",
+	"manufacturerId": "0x0002",
+	"label": "LC-13",
+	"description": "Living Connect Z Thermostat",
+	"devices": [
+		{
+			"productType": "0x0005",
+			"productId": "0x0004"
+		},
+		{
+			"productType": "0x8005",
+			"productId": "0x0001"
+		},
+		{
+			"productType": "0x8005",
+			"productId": "0x0002"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Target for Wakeup and Override Notifications",
+			"maxNodes": 1,
+			"isLifeline": true
+		}
+	},
+	"compat": {
+		// If we don't query specific things on wake up, this device will
+		// think it is not connected and show error E5
+		"queryOnWakeup": [
+			// ["CommandClass", "API method", ...arguments]
+			["Battery", "get"],
+			["Thermostat Setpoint", "set", 1, "$value$[\"setpoint\", 1]", 0],
+			["Thermostat Setpoint", "get"]
+		]
+	}
 }

--- a/config/devices/0x0002/lcz251.json
+++ b/config/devices/0x0002/lcz251.json
@@ -1,26 +1,36 @@
 // Danfoss LCZ251
 // Living Connect Z Thermostat 2.51
 {
-    "_approved": true,
-    "manufacturer": "Danfoss",
-    "manufacturerId": "0x0002",
-    "label": "LCZ251",
-    "description": "Living Connect Z Thermostat 2.51",
-    "devices": [
-        {
-            "productType": "0x0005",
-            "productId": "0x0003"
-        }
-    ],
-    "firmwareVersion": {
-        "min": "0.0",
-        "max": "255.255"
-    },
-    "associations": {
-        "1": {
-            "label": "Target for Wakeup and Override Notifications",
-            "maxNodes": 1,
-            "isLifeline": true
-        }
-    }
+	"_approved": true,
+	"manufacturer": "Danfoss",
+	"manufacturerId": "0x0002",
+	"label": "LCZ251",
+	"description": "Living Connect Z Thermostat 2.51",
+	"devices": [
+		{
+			"productType": "0x0005",
+			"productId": "0x0003"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Target for Wakeup and Override Notifications",
+			"maxNodes": 1,
+			"isLifeline": true
+		}
+	},
+	"compat": {
+		// If we don't query specific things on wake up, this device will
+		// think it is not connected and show error E5
+		"queryOnWakeup": [
+			// ["CommandClass", "API method", ...arguments]
+			["Battery", "get"],
+			["Thermostat Setpoint", "set", 1, "$value$[\"setpoint\", 1]", 0],
+			["Thermostat Setpoint", "get"]
+		]
+	}
 }

--- a/config/devices/0x0002/mt02650.json
+++ b/config/devices/0x0002/mt02650.json
@@ -1,30 +1,40 @@
 // Danfoss MT02650
 // Devolo Thermostat (09356)
 {
-    "_approved": true,
-    "manufacturer": "Danfoss",
-    "manufacturerId": "0x0002",
-    "label": "MT02650",
-    "description": "Devolo Thermostat (09356)",
-    "devices": [
-        {
-            "productType": "0x0005",
-            "productId": "0x0175"
-        }
-    ],
-    "firmwareVersion": {
-        "min": "0.0",
-        "max": "255.255"
-    },
-    "associations": {
-        "1": {
-            "label": "Target for Wakeup and Override Notifications",
-            "maxNodes": 10,
-            "isLifeline": true
-        },
-        "2": {
-            "label": "Temprature sensor",
-            "maxNodes": 1
-        }
-    }
+	"_approved": true,
+	"manufacturer": "Danfoss",
+	"manufacturerId": "0x0002",
+	"label": "MT02650",
+	"description": "Devolo Thermostat (09356)",
+	"devices": [
+		{
+			"productType": "0x0005",
+			"productId": "0x0175"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Target for Wakeup and Override Notifications",
+			"maxNodes": 10,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "Temperature sensor",
+			"maxNodes": 1
+		}
+	},
+	"compat": {
+		// If we don't query specific things on wake up, this device will
+		// think it is not connected and show error E5
+		"queryOnWakeup": [
+			// ["CommandClass", "API method", ...arguments]
+			["Battery", "get"],
+			["Thermostat Setpoint", "set", 1, "$value$[\"setpoint\", 1]", 0],
+			["Thermostat Setpoint", "get"]
+		]
+	}
 }

--- a/src/lib/commandclass/API.ts
+++ b/src/lib/commandclass/API.ts
@@ -68,8 +68,11 @@ export class CCAPI {
 		this.ccId = getCommandClass(this);
 	}
 
-	/** The identifier of the Command Class this API is for */
-	protected readonly ccId: CommandClasses;
+	/**
+	 * @internal
+	 * The identifier of the Command Class this API is for
+	 */
+	public readonly ccId: CommandClasses;
 
 	protected [SET_VALUE]: SetValueImplementation | undefined;
 	/**

--- a/src/lib/controller/ApplicationCommandRequest.ts
+++ b/src/lib/controller/ApplicationCommandRequest.ts
@@ -104,6 +104,13 @@ export class ApplicationCommandRequest extends Message
 	// This needs to be writable or unwrapping MultiChannelCCs crashes
 	public command: SinglecastCC;
 
+	/** Include previously received partial responses into a final message */
+	public mergePartialMessages(partials: Message[]): void {
+		this.command.mergePartialCCs(
+			(partials as ApplicationCommandRequest[]).map((p) => p.command),
+		);
+	}
+
 	public serialize(): Buffer {
 		const statusByte =
 			(this.frameType === "broadcast"


### PR DESCRIPTION
This is required by some devices (like Danfoss LC-13) for normal operation, although they report the relevant data themselves.

This also sends nodes without pending messages back to sleep quickly.
Fixes: #792 