### PR TITLE
Ping nodes during the interview to check if they are alive/asleep/dead

### DIFF
--- a/src/lib/driver/Driver.ts
+++ b/src/lib/driver/Driver.ts
@@ -1960,6 +1960,16 @@ ${handlers.length} left`,
 				this.sendQueue.add(this.currentTransaction);
 				// Reset send attempts - we might have already used all of them
 				this.currentTransaction.sendAttempts = 0;
+			} else {
+				// Pings must be rejected, so the next message may be queued
+				this.rejectCurrentTransaction(
+					new ZWaveError(
+						`The node is asleep`,
+						ZWaveErrorCodes.Controller_MessageDropped,
+					),
+					// Don't resume send queue, it will be done outside this method call
+					false,
+				);
 			}
 			// "reset" the current transaction to none
 			this.currentTransaction = undefined;

--- a/src/lib/node/Node.ts
+++ b/src/lib/node/Node.ts
@@ -666,6 +666,9 @@ export class ZWaveNode extends Endpoint {
 		}
 
 		if (this.interviewStage === InterviewStage.ProtocolInfo) {
+			// Ping node to check if it is alive/asleep/...
+			// TODO: #739, point 3 -> Do this automatically for the first message
+			await this.ping();
 			await this.queryNodeInfo();
 		}
 
@@ -678,6 +681,9 @@ export class ZWaveNode extends Endpoint {
 			this.nodeMayBeReady = true;
 			// Sleeping nodes are assumed to be ready immediately. Otherwise the library would wait until 3 messages have timed out, which is weird.
 			if (!this._isListening) this.emitReadyEventOnce();
+			// Ping node to check if it is alive/asleep/...
+			// TODO: #739, point 3 -> Do this automatically for the first message
+			await this.ping();
 		}
 
 		// At this point the basic interview of new nodes is done. Start here when re-interviewing known nodes

--- a/test/run.ts
+++ b/test/run.ts
@@ -48,10 +48,10 @@ const driver = new Driver("COM4").once("driver ready", async () => {
 	// await driver.controller.beginExclusion();
 	// await require("alcalzone-shared/async").wait(60000);
 	// await driver.controller.stopExclusion();
-	const node = driver.controller.nodes.get(4)!;
-	node.once("ready", async () => {
-		console.log(node.status);
-	});
+	// const node = driver.controller.nodes.get(4)!;
+	// node.once("ready", async () => {
+	// 	console.log(node.status);
+	// });
 	// await driver.controller.healNetwork();
 	// console.error();
 	// 	console.error("GOGOGO");


### PR DESCRIPTION
fixes: #805 
and speeds up the interview for battery powered nodes that currently have mains power and therefore respond immediately.

This also causes the "current" ping to be rejected instead of when moving pending messages to the wakeup queue, so the calling code does not get stuck on the ping Promise.