### PR TITLE
Assemble partial CCs on the driver level

### DIFF
--- a/src/lib/commandclass/AssociationCC.ts
+++ b/src/lib/commandclass/AssociationCC.ts
@@ -532,6 +532,11 @@ export class AssociationCCReport extends AssociationCC {
 		return this._reportsToFollow;
 	}
 
+	public getPartialCCSessionId(): Record<string, any> | undefined {
+		// Distinguish sessions by the association group ID
+		return { groupId: this._groupId };
+	}
+
 	public expectMoreMessages(): boolean {
 		return this._reportsToFollow > 0;
 	}

--- a/src/lib/commandclass/CommandClass.ts
+++ b/src/lib/commandclass/CommandClass.ts
@@ -709,9 +709,18 @@ export class CommandClass {
 		}
 	}
 
-	/** Whether this CC spans multiple messages and the last report hasn't been received */
+	/**
+	 * When a CC supports to be split into multiple partial CCs, this can be used to identify the
+	 * session the partial CCs belong to.
+	 * If a CC expects `mergePartialCCs` to be always called, you should return an empty object here.
+	 */
+	public getPartialCCSessionId(): Record<string, any> | undefined {
+		return undefined; // Only select CCs support to be split
+	}
+
+	/** When a CC supports to be split into multiple partial CCs, this indicates that the last report hasn't been received yet */
 	public expectMoreMessages(): boolean {
-		return false; // By default it doesn't
+		return false; // By default, all CCs are monolithic
 	}
 
 	/** Include previously received partial responses into a final CC */

--- a/src/lib/commandclass/ConfigurationCC.ts
+++ b/src/lib/commandclass/ConfigurationCC.ts
@@ -1257,6 +1257,11 @@ export class ConfigurationCCBulkReport extends ConfigurationCC {
 		return this._reportsToFollow;
 	}
 
+	public getPartialCCSessionId(): Record<string, any> | undefined {
+		// We don't expect the driver to merge CCs but we want to wait until all reports have been received
+		return {};
+	}
+
 	public expectMoreMessages(): boolean {
 		return this._reportsToFollow > 0;
 	}
@@ -1355,6 +1360,11 @@ export class ConfigurationCCNameReport extends ConfigurationCC {
 		return this._reportsToFollow;
 	}
 
+	public getPartialCCSessionId(): Record<string, any> | undefined {
+		// Distinguish sessions by the parameter number
+		return { parameter: this._parameter };
+	}
+
 	public expectMoreMessages(): boolean {
 		return this._reportsToFollow > 0;
 	}
@@ -1425,6 +1435,11 @@ export class ConfigurationCCInfoReport extends ConfigurationCC {
 	private _reportsToFollow: number;
 	public get reportsToFollow(): number {
 		return this._reportsToFollow;
+	}
+
+	public getPartialCCSessionId(): Record<string, any> | undefined {
+		// Distinguish sessions by the parameter number
+		return { parameter: this._parameter };
 	}
 
 	public expectMoreMessages(): boolean {

--- a/src/lib/commandclass/MultiChannelAssociationCC.ts
+++ b/src/lib/commandclass/MultiChannelAssociationCC.ts
@@ -706,6 +706,11 @@ export class MultiChannelAssociationCCReport extends MultiChannelAssociationCC {
 		return this._reportsToFollow;
 	}
 
+	public getPartialCCSessionId(): Record<string, any> | undefined {
+		// Distinguish sessions by the association group ID
+		return { groupId: this._groupId };
+	}
+
 	public expectMoreMessages(): boolean {
 		return this._reportsToFollow > 0;
 	}

--- a/src/lib/commandclass/MultiChannelCC.ts
+++ b/src/lib/commandclass/MultiChannelCC.ts
@@ -720,6 +720,14 @@ export class MultiChannelCCEndPointFindReport extends MultiChannelCC {
 		return this._reportsToFollow;
 	}
 
+	public getPartialCCSessionId(): Record<string, any> | undefined {
+		// Distinguish sessions by the requested device classes
+		return {
+			genericClass: this.genericClass,
+			specificClass: this.specificClass,
+		};
+	}
+
 	public expectMoreMessages(): boolean {
 		return this._reportsToFollow > 0;
 	}

--- a/src/lib/controller/SendDataMessages.ts
+++ b/src/lib/controller/SendDataMessages.ts
@@ -228,11 +228,7 @@ function testResponseForCC(
 	} else if (staticExtends(expected, CommandClass)) {
 		// The CC always expects the same response, check if this is the one
 		if (received && received instanceof expected) {
-			ret = received.expectMoreMessages()
-				? "partial"
-				: isEncapCC
-				? "checkEncapsulated"
-				: "final";
+			ret = isEncapCC ? "checkEncapsulated" : "final";
 		} else if (isTransmitReport) {
 			ret = isEncapCC ? "checkEncapsulated" : "confirmation";
 		} else {

--- a/src/lib/driver/Driver.ts
+++ b/src/lib/driver/Driver.ts
@@ -1171,11 +1171,65 @@ It is probably asleep, moving its messages to the wakeup queue.`,
 		}
 	}
 
+	private partialCCSessions = new Map<string, CommandClass[]>();
+	/**
+	 * Assembles partial CCs of in a message body. Returns `true` when the message is complete and can be handled further.
+	 * If the message expects another partial one, this returns `false`.
+	 */
+	private assemblePartialCCs(msg: Message & ICommandClassContainer): boolean {
+		let command = msg.command;
+		let sessionId: Record<string, any> | undefined;
+		// We search for the outermost CC that provides us with a session ID
+		while (
+			!(sessionId = command.getPartialCCSessionId()) &&
+			isEncapsulatingCommandClass(command)
+		) {
+			// This one doesnt, but contains an encapsulated CC - look deeper
+			command = command.encapsulated;
+		}
+		if (sessionId) {
+			// This CC belongs to a partial session
+			const partialSessionKey = JSON.stringify({
+				nodeId: msg.getNodeId()!,
+				ccId: msg.command.ccId,
+				ccCommand: msg.command.ccCommand!,
+				...sessionId,
+			});
+			if (!this.partialCCSessions.has(partialSessionKey)) {
+				this.partialCCSessions.set(partialSessionKey, []);
+			}
+			const session = this.partialCCSessions.get(partialSessionKey)!;
+			if (command.expectMoreMessages()) {
+				// this is not the final one, store it
+				session.push(command);
+				// and don't handle the command now
+				log.driver.logMessage(msg, {
+					secondaryTags: ["partial"],
+					direction: "inbound",
+				});
+				return false;
+			} else {
+				// this is the final one, merge the previous responses
+				command.mergePartialCCs(session);
+				this.partialCCSessions.delete(partialSessionKey);
+				return true;
+			}
+		} else {
+			// No partial CC, just continue
+			return true;
+		}
+	}
+
 	/**
 	 * Is called when a complete message was decoded from the receive buffer
 	 * @param msg The decoded message
 	 */
 	private async handleMessage(msg: Message): Promise<void> {
+		// Assemble partial CCs on the driver level
+		if (isCommandClassContainer(msg) && !this.assemblePartialCCs(msg)) {
+			return;
+		}
+
 		// if we have a pending request, check if that is waiting for this message
 		if (this.currentTransaction != undefined) {
 			// Use the entire encapsulation stack to test what to do with this response


### PR DESCRIPTION
This change adds support for sequenced S0 commands as well as partial unsolicited messages.
Fixes: #834