### PR TITLE
Rework the ignoreTimeout mechanic and option scope to CCAPI

### DIFF
--- a/packages/core/src/util/misc.ts
+++ b/packages/core/src/util/misc.ts
@@ -48,27 +48,3 @@ export function getMinimumShiftForBitMask(mask: number): number {
 	}
 	return i;
 }
-
-/**
- * Executes the given action and ignores any node timeout errors
- * Returns whether the execution was successful (`true`) or timed out (`false`)
- */
-export async function ignoreTimeout(
-	action: () => Promise<void>,
-	onTimeout?: () => void,
-): Promise<boolean> {
-	try {
-		await action();
-		return true;
-	} catch (e: unknown) {
-		if (
-			e instanceof ZWaveError &&
-			e.code === ZWaveErrorCodes.Controller_NodeTimeout
-		) {
-			onTimeout?.();
-			return false;
-		}
-		// We don't want to swallow any other errors
-		throw e;
-	}
-}

--- a/packages/zwave-js/src/lib/commandclass/API.ts
+++ b/packages/zwave-js/src/lib/commandclass/API.ts
@@ -1,3 +1,4 @@
+import type { ValueID } from "@zwave-js/core";
 import {
 	CommandClasses,
 	Maybe,
@@ -5,9 +6,8 @@ import {
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
-import type { ValueID } from "@zwave-js/core";
 import { getEnumMemberName } from "@zwave-js/shared";
-import type { Driver } from "../driver/Driver";
+import type { Driver, SendCommandOptions } from "../driver/Driver";
 import type { Endpoint } from "../node/Endpoint";
 import { getCommandClass } from "./CommandClass";
 
@@ -132,6 +132,25 @@ export class CCAPI {
 				ZWaveErrorCodes.CC_NotSupported,
 			);
 		}
+	}
+
+	/** Returns the command options to use for sendCommand calls */
+	protected get commandOptions(): SendCommandOptions {
+		// No default options
+		return {};
+	}
+
+	/** Creates an instance of this API, scoped to use the given options */
+	public withOptions(options: SendCommandOptions): this {
+		return new Proxy(this, {
+			get: (target, property) => {
+				if (property === "commandOptions") {
+					return options;
+				} else {
+					return (target as any)[property];
+				}
+			},
+		});
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/AlarmSensorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/AlarmSensorCC.ts
@@ -116,6 +116,7 @@ export class AlarmSensorCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<AlarmSensorCCReport>(
 			cc,
+			this.commandOptions,
 		))!;
 		return pick(response, ["state", "severity", "duration"]);
 	}
@@ -133,7 +134,7 @@ export class AlarmSensorCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			AlarmSensorCCSupportedReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.supportedSensorTypes;
 	}
 }

--- a/packages/zwave-js/src/lib/commandclass/AssociationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/AssociationCC.ts
@@ -1,3 +1,4 @@
+import type { Maybe, ValueID } from "@zwave-js/core";
 import {
 	CommandClasses,
 	MAX_NODES,
@@ -6,7 +7,6 @@ import {
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
-import type { Maybe, ValueID } from "@zwave-js/core";
 import { distinct } from "alcalzone-shared/arrays";
 import type { Driver } from "../driver/Driver";
 import log from "../log";
@@ -140,7 +140,7 @@ export class AssociationCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			AssociationCCSupportedGroupingsReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.groupCount;
 	}
 
@@ -158,6 +158,7 @@ export class AssociationCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<AssociationCCReport>(
 			cc,
+			this.commandOptions,
 		))!;
 		return {
 			maxNodes: response.maxNodes,
@@ -180,7 +181,7 @@ export class AssociationCCAPI extends CCAPI {
 			groupId,
 			nodeIds,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	/**
@@ -199,7 +200,7 @@ export class AssociationCCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 			...options,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	/**

--- a/packages/zwave-js/src/lib/commandclass/AssociationGroupInfoCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/AssociationGroupInfoCC.ts
@@ -1,3 +1,4 @@
+import type { Maybe, ValueID } from "@zwave-js/core";
 import {
 	CommandClasses,
 	parseCCId,
@@ -5,7 +6,6 @@ import {
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
-import type { Maybe, ValueID } from "@zwave-js/core";
 import { getEnumMemberName } from "@zwave-js/shared";
 import type { Driver } from "../driver/Driver";
 import log from "../log";
@@ -294,7 +294,7 @@ export class AssociationGroupInfoCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			AssociationGroupInfoCCNameReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.name;
 	}
 
@@ -313,7 +313,7 @@ export class AssociationGroupInfoCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			AssociationGroupInfoCCInfoReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		// SDS13782: If List Mode is set to 0, the Group Count field MUST be set to 1.
 		const { groupId: _, ...info } = response.groups[0];
 		return {
@@ -339,7 +339,7 @@ export class AssociationGroupInfoCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			AssociationGroupInfoCCCommandListReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.commands;
 	}
 }

--- a/packages/zwave-js/src/lib/commandclass/BasicCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BasicCC.ts
@@ -1,7 +1,6 @@
 import {
 	CommandClasses,
 	Duration,
-	ignoreTimeout,
 	Maybe,
 	parseMaybeNumber,
 	parseNumber,
@@ -13,6 +12,7 @@ import type { Driver } from "../driver/Driver";
 import log from "../log";
 import {
 	CCAPI,
+	ignoreTimeout,
 	SetValueImplementation,
 	SET_VALUE,
 	throwUnsupportedProperty,
@@ -118,7 +118,8 @@ export class BasicCC extends CommandClass {
 
 		// try to query the current state - the node might not respond to BasicGet
 		await ignoreTimeout(
-			async () => {
+			api,
+			async (api) => {
 				log.controller.logNode(node.id, {
 					endpoint: this.endpointIndex,
 					message: "querying Basic CC state...",

--- a/packages/zwave-js/src/lib/commandclass/BasicCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BasicCC.ts
@@ -72,7 +72,10 @@ export class BasicCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 		});
-		const response = (await this.driver.sendCommand<BasicCCReport>(cc))!;
+		const response = (await this.driver.sendCommand<BasicCCReport>(
+			cc,
+			this.commandOptions,
+		))!;
 		return {
 			currentValue: response.currentValue,
 			targetValue: response.targetValue,
@@ -88,7 +91,7 @@ export class BasicCCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 			targetValue,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 
 		// Refresh the current value
 		await this.get();

--- a/packages/zwave-js/src/lib/commandclass/BatteryCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BatteryCC.ts
@@ -2,7 +2,6 @@ import type { ValueID } from "@zwave-js/core";
 import {
 	CommandClasses,
 	enumValuesToMetadataStates,
-	ignoreTimeout,
 	Maybe,
 	parseFloatWithScale,
 	validatePayload,
@@ -11,7 +10,7 @@ import {
 import type { JSONObject } from "@zwave-js/shared";
 import type { Driver } from "../driver/Driver";
 import log from "../log";
-import { CCAPI } from "./API";
+import { CCAPI, ignoreTimeout } from "./API";
 import {
 	API,
 	CCCommand,
@@ -126,7 +125,8 @@ export class BatteryCC extends CommandClass {
 		});
 
 		await ignoreTimeout(
-			async () => {
+			api,
+			async (api) => {
 				// always query the status
 				log.controller.logNode(node.id, {
 					endpoint: this.endpointIndex,
@@ -174,7 +174,8 @@ is disconnected:                 ${batteryStatus.disconnected}`;
 
 		if (this.version >= 2) {
 			await ignoreTimeout(
-				async () => {
+				api,
+				async (api) => {
 					// always query the health
 					log.controller.logNode(node.id, {
 						endpoint: this.endpointIndex,

--- a/packages/zwave-js/src/lib/commandclass/BatteryCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BatteryCC.ts
@@ -1,3 +1,4 @@
+import type { ValueID } from "@zwave-js/core";
 import {
 	CommandClasses,
 	enumValuesToMetadataStates,
@@ -7,7 +8,6 @@ import {
 	validatePayload,
 	ValueMetadata,
 } from "@zwave-js/core";
-import type { ValueID } from "@zwave-js/core";
 import type { JSONObject } from "@zwave-js/shared";
 import type { Driver } from "../driver/Driver";
 import log from "../log";
@@ -71,7 +71,10 @@ export class BatteryCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 		});
-		const response = (await this.driver.sendCommand<BatteryCCReport>(cc))!;
+		const response = (await this.driver.sendCommand<BatteryCCReport>(
+			cc,
+			this.commandOptions,
+		))!;
 		return {
 			level: response.level,
 			isLow: response.isLow,
@@ -95,6 +98,7 @@ export class BatteryCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<BatteryCCHealthReport>(
 			cc,
+			this.commandOptions,
 		))!;
 		return {
 			maximumCapacity: response.maximumCapacity,

--- a/packages/zwave-js/src/lib/commandclass/BinarySensorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySensorCC.ts
@@ -104,6 +104,7 @@ export class BinarySensorCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<BinarySensorCCReport>(
 			cc,
+			this.commandOptions,
 		))!;
 		// We don't want to repeat the sensor type
 		return response.value;
@@ -122,7 +123,7 @@ export class BinarySensorCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			BinarySensorCCSupportedReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		// We don't want to repeat the sensor type
 		return response.supportedSensorTypes;
 	}

--- a/packages/zwave-js/src/lib/commandclass/BinarySensorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySensorCC.ts
@@ -1,6 +1,5 @@
 import {
 	CommandClasses,
-	ignoreTimeout,
 	Maybe,
 	parseBitMask,
 	validatePayload,
@@ -12,7 +11,7 @@ import {
 import { getEnumMemberName } from "@zwave-js/shared";
 import type { Driver } from "../driver/Driver";
 import log from "../log";
-import { CCAPI } from "./API";
+import { CCAPI, ignoreTimeout } from "./API";
 import {
 	API,
 	CCCommand,
@@ -174,7 +173,8 @@ export class BinarySensorCC extends CommandClass {
 		// Always query (all of) the sensor's current value(s)
 		if (this.version === 1) {
 			await ignoreTimeout(
-				async () => {
+				api,
+				async (api) => {
 					log.controller.logNode(node.id, {
 						endpoint: this.endpointIndex,
 						message: "querying current value...",
@@ -200,7 +200,8 @@ export class BinarySensorCC extends CommandClass {
 			for (const type of supportedSensorTypes) {
 				const sensorName = getEnumMemberName(BinarySensorType, type);
 				await ignoreTimeout(
-					async () => {
+					api,
+					async (api) => {
 						log.controller.logNode(node.id, {
 							endpoint: this.endpointIndex,
 							message: `querying current value for ${sensorName}...`,

--- a/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
@@ -64,6 +64,7 @@ export class BinarySwitchCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<BinarySwitchCCReport>(
 			cc,
+			this.commandOptions,
 		))!;
 		return {
 			// interpret unknown values as false
@@ -90,7 +91,7 @@ export class BinarySwitchCCAPI extends CCAPI {
 			targetValue,
 			duration,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 
 		// Refresh the current value
 		await this.get();

--- a/packages/zwave-js/src/lib/commandclass/CRC16CC.ts
+++ b/packages/zwave-js/src/lib/commandclass/CRC16CC.ts
@@ -43,7 +43,7 @@ export class CRC16CCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 			encapsulated: encapsulatedCC,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/CentralSceneCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/CentralSceneCC.ts
@@ -1,3 +1,4 @@
+import type { ValueID } from "@zwave-js/core";
 import {
 	CommandClasses,
 	enumValuesToMetadataStates,
@@ -8,7 +9,6 @@ import {
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
-import type { ValueID } from "@zwave-js/core";
 import type { JSONObject } from "@zwave-js/shared";
 import { padStart } from "alcalzone-shared/strings";
 import type { Driver } from "../driver/Driver";
@@ -96,7 +96,7 @@ export class CentralSceneCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			CentralSceneCCSupportedReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return {
 			sceneCount: response.sceneCount,
 			supportsSlowRefresh: response.supportsSlowRefresh,
@@ -117,7 +117,7 @@ export class CentralSceneCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			CentralSceneCCConfigurationReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return {
 			slowRefresh: response.slowRefresh,
 		};
@@ -134,7 +134,7 @@ export class CentralSceneCCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 			slowRefresh,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	protected [SET_VALUE]: SetValueImplementation = async (

--- a/packages/zwave-js/src/lib/commandclass/ClimateControlScheduleCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ClimateControlScheduleCC.ts
@@ -1,10 +1,10 @@
+import type { Maybe } from "@zwave-js/core";
 import {
 	CommandClasses,
 	validatePayload,
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
-import type { Maybe } from "@zwave-js/core";
 import type { Driver } from "../driver/Driver";
 import {
 	decodeSetbackState,
@@ -81,7 +81,7 @@ export class ClimateControlScheduleCCAPI extends CCAPI {
 			weekday,
 			switchPoints,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	public async get(weekday: Weekday): Promise<readonly Switchpoint[]> {
@@ -97,7 +97,7 @@ export class ClimateControlScheduleCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			ClimateControlScheduleCCReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.switchPoints;
 	}
 
@@ -113,7 +113,7 @@ export class ClimateControlScheduleCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			ClimateControlScheduleCCChangedReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.changeCounter;
 	}
 
@@ -130,7 +130,7 @@ export class ClimateControlScheduleCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			ClimateControlScheduleCCOverrideReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return {
 			type: response.overrideType,
 			state: response.overrideState,
@@ -152,7 +152,7 @@ export class ClimateControlScheduleCCAPI extends CCAPI {
 			overrideType: type,
 			overrideState: state,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/ClockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ClockCC.ts
@@ -1,10 +1,10 @@
+import type { Maybe } from "@zwave-js/core";
 import {
 	CommandClasses,
 	validatePayload,
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
-import type { Maybe } from "@zwave-js/core";
 import type { Driver } from "../driver/Driver";
 import log from "../log";
 import { CCAPI } from "./API";
@@ -62,7 +62,10 @@ export class ClockCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 		});
-		const response = (await this.driver.sendCommand<ClockCCReport>(cc))!;
+		const response = (await this.driver.sendCommand<ClockCCReport>(
+			cc,
+			this.commandOptions,
+		))!;
 		return {
 			weekday: response.weekday,
 			hour: response.hour,
@@ -84,7 +87,7 @@ export class ClockCCAPI extends CCAPI {
 			minute,
 			weekday: weekday ?? Weekday.Unknown,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 
 		// Refresh the current value
 		await this.get();

--- a/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
@@ -161,7 +161,7 @@ export class ColorSwitchCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			ColorSwitchCCSupportedReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.supportedColorComponents;
 	}
 
@@ -176,6 +176,7 @@ export class ColorSwitchCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<ColorSwitchCCReport>(
 			cc,
+			this.commandOptions,
 		))!;
 		return {
 			currentValue: response.currentValue,
@@ -193,7 +194,7 @@ export class ColorSwitchCCAPI extends CCAPI {
 			...options,
 		});
 
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	public async startLevelChange(
@@ -210,7 +211,7 @@ export class ColorSwitchCCAPI extends CCAPI {
 			...options,
 		});
 
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	public async stopLevelChange(
@@ -227,7 +228,7 @@ export class ColorSwitchCCAPI extends CCAPI {
 			colorComponent,
 		});
 
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	protected [SET_VALUE]: SetValueImplementation = async (

--- a/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
@@ -244,7 +244,7 @@ export class ConfigurationCCAPI extends CCAPI {
 		try {
 			const response = (await this.driver.sendCommand<
 				ConfigurationCCReport
-			>(cc))!;
+			>(cc, this.commandOptions))!;
 			// Nodes may respond with a different parameter, e.g. if we
 			// requested a non-existing one
 			if (response.parameter === parameter) {
@@ -303,7 +303,7 @@ export class ConfigurationCCAPI extends CCAPI {
 			valueSize,
 		});
 		try {
-			await this.driver.sendCommand(cc);
+			await this.driver.sendCommand(cc, this.commandOptions);
 			return true;
 		} catch (e: unknown) {
 			if (
@@ -337,7 +337,7 @@ export class ConfigurationCCAPI extends CCAPI {
 			resetToDefault: true,
 		});
 		try {
-			await this.driver.sendCommand(cc);
+			await this.driver.sendCommand(cc, this.commandOptions);
 			return true;
 		} catch (e: unknown) {
 			if (
@@ -363,7 +363,7 @@ export class ConfigurationCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			// Don't set an endpoint here, Configuration is device specific, not endpoint specific
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -375,7 +375,7 @@ export class ConfigurationCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			ConfigurationCCPropertiesReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return {
 			valueSize: response.valueSize,
 			valueFormat: response.valueFormat,
@@ -399,7 +399,7 @@ export class ConfigurationCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			ConfigurationCCNameReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.name;
 	}
 
@@ -412,7 +412,7 @@ export class ConfigurationCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			ConfigurationCCInfoReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.info;
 	}
 

--- a/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
@@ -1,3 +1,4 @@
+import type { ValueID } from "@zwave-js/core";
 import {
 	CommandClasses,
 	Duration,
@@ -9,7 +10,6 @@ import {
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
-import type { ValueID } from "@zwave-js/core";
 import { getEnumMemberName, pick } from "@zwave-js/shared";
 import type { Driver } from "../driver/Driver";
 import log from "../log";
@@ -175,7 +175,7 @@ export class DoorLockCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			DoorLockCCCapabilitiesReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return pick(response, [
 			"autoRelockSupported",
 			"blockToBlockSupported",
@@ -204,7 +204,7 @@ export class DoorLockCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			DoorLockCCOperationReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return pick(response, [
 			"currentMode",
 			"targetMode",
@@ -229,7 +229,7 @@ export class DoorLockCCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 			mode,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 
 		// Refresh the current value
 		await this.get();
@@ -248,7 +248,7 @@ export class DoorLockCCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 			...configuration,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 
 		// Refresh the current value
 		await this.getConfiguration();
@@ -267,7 +267,7 @@ export class DoorLockCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			DoorLockCCConfigurationReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return pick(response, [
 			"operationType",
 			"outsideHandlesCanOpenDoorConfiguration",

--- a/packages/zwave-js/src/lib/commandclass/FirmwareUpdateMetaDataCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/FirmwareUpdateMetaDataCC.ts
@@ -1,3 +1,4 @@
+import type { ValueID } from "@zwave-js/core";
 import {
 	CommandClasses,
 	CRC16_CCITT,
@@ -8,7 +9,6 @@ import {
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
-import type { ValueID } from "@zwave-js/core";
 import { AllOrNone, getEnumMemberName, num2hex, pick } from "@zwave-js/shared";
 import type { Driver } from "../driver/Driver";
 import { CCAPI } from "./API";
@@ -142,7 +142,7 @@ export class FirmwareUpdateMetaDataCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			FirmwareUpdateMetaDataCCMetaDataReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return pick(response, [
 			"manufacturerId",
 			"firmwareId",
@@ -176,7 +176,7 @@ export class FirmwareUpdateMetaDataCCAPI extends CCAPI {
 		// Since the response may take longer than with other commands,
 		// we do not use the built-in waiting functionality, which would block
 		// all other communication
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 		const { status } = await this.driver.waitForCommand<
 			FirmwareUpdateMetaDataCCRequestReport
 		>(
@@ -208,7 +208,7 @@ export class FirmwareUpdateMetaDataCCAPI extends CCAPI {
 			isLast: isLastFragment,
 			firmwareData: data,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/IndicatorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/IndicatorCC.ts
@@ -1,4 +1,5 @@
 import { lookupIndicator, lookupProperty } from "@zwave-js/config";
+import type { ValueID } from "@zwave-js/core";
 import {
 	CommandClasses,
 	Maybe,
@@ -8,7 +9,6 @@ import {
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
-import type { ValueID } from "@zwave-js/core";
 import { num2hex } from "@zwave-js/shared";
 import type { Driver } from "../driver/Driver";
 import log from "../log";
@@ -200,6 +200,7 @@ export class IndicatorCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<IndicatorCCReport>(
 			cc,
+			this.commandOptions,
 		))!;
 		if (response.values) return response.values;
 		return response.value!;
@@ -213,7 +214,7 @@ export class IndicatorCCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 			...(typeof value === "number" ? { value } : { values: value }),
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	public async getSupported(
@@ -235,7 +236,7 @@ export class IndicatorCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			IndicatorCCSupportedReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return {
 			// Include the actual indicator ID if 0x00 was requested
 			...(indicatorId === 0x00

--- a/packages/zwave-js/src/lib/commandclass/LanguageCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/LanguageCC.ts
@@ -1,3 +1,4 @@
+import type { Maybe } from "@zwave-js/core";
 import {
 	CommandClasses,
 	validatePayload,
@@ -5,7 +6,6 @@ import {
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
-import type { Maybe } from "@zwave-js/core";
 import type { Driver } from "../driver/Driver";
 import log from "../log";
 import { CCAPI } from "./API";
@@ -50,7 +50,10 @@ export class LanguageCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 		});
-		const response = (await this.driver.sendCommand<LanguageCCReport>(cc))!;
+		const response = (await this.driver.sendCommand<LanguageCCReport>(
+			cc,
+			this.commandOptions,
+		))!;
 		return {
 			language: response.language,
 			country: response.country,
@@ -66,7 +69,7 @@ export class LanguageCCAPI extends CCAPI {
 			language,
 			country,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/LockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/LockCC.ts
@@ -1,3 +1,4 @@
+import type { Maybe } from "@zwave-js/core";
 import {
 	CommandClasses,
 	validatePayload,
@@ -5,7 +6,6 @@ import {
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
-import type { Maybe } from "@zwave-js/core";
 import type { Driver } from "../driver/Driver";
 import log from "../log";
 import {
@@ -54,7 +54,10 @@ export class LockCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 		});
-		const response = (await this.driver.sendCommand<LockCCReport>(cc))!;
+		const response = (await this.driver.sendCommand<LockCCReport>(
+			cc,
+			this.commandOptions,
+		))!;
 		return response.locked;
 	}
 
@@ -70,7 +73,7 @@ export class LockCCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 			locked,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 
 		// Refresh the current value
 		await this.get();

--- a/packages/zwave-js/src/lib/commandclass/ManufacturerProprietaryCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ManufacturerProprietaryCC.ts
@@ -41,7 +41,7 @@ export class ManufacturerProprietaryCCAPI extends CCAPI {
 		cc.manufacturerId = manufacturerId;
 		cc.payload = data ?? Buffer.allocUnsafe(0);
 
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -56,7 +56,7 @@ export class ManufacturerProprietaryCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			FibaroVenetianBlindCCReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return {
 			position: response.position,
 			tilt: response.tilt,
@@ -73,7 +73,7 @@ export class ManufacturerProprietaryCCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 			position: value,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	public async fibaroVenetianBlindsSetTilt(value: number): Promise<void> {
@@ -86,7 +86,7 @@ export class ManufacturerProprietaryCCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 			tilt: value,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	protected [SET_VALUE]: SetValueImplementation = async (

--- a/packages/zwave-js/src/lib/commandclass/ManufacturerSpecificCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ManufacturerSpecificCC.ts
@@ -1,4 +1,5 @@
 import { lookupManufacturer } from "@zwave-js/config";
+import type { Maybe, ValueID } from "@zwave-js/core";
 import {
 	CommandClasses,
 	validatePayload,
@@ -6,7 +7,6 @@ import {
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
-import type { Maybe, ValueID } from "@zwave-js/core";
 import { num2hex } from "@zwave-js/shared";
 import type { Driver } from "../driver/Driver";
 import log from "../log";
@@ -112,6 +112,7 @@ export class ManufacturerSpecificCCAPI extends CCAPI {
 		const response = (await this.driver.sendCommand<
 			ManufacturerSpecificCCReport
 		>(cc, {
+			...this.commandOptions,
 			priority: MessagePriority.NodeQuery,
 		}))!;
 		return {
@@ -136,7 +137,7 @@ export class ManufacturerSpecificCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			ManufacturerSpecificCCDeviceSpecificReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.deviceId;
 	}
 }

--- a/packages/zwave-js/src/lib/commandclass/MeterCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MeterCC.ts
@@ -148,7 +148,10 @@ export class MeterCCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 			...options,
 		});
-		const response = (await this.driver.sendCommand<MeterCCReport>(cc))!;
+		const response = (await this.driver.sendCommand<MeterCCReport>(
+			cc,
+			this.commandOptions,
+		))!;
 		return {
 			type: response.type,
 			scale: response.scale,
@@ -204,6 +207,7 @@ export class MeterCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<MeterCCSupportedReport>(
 			cc,
+			this.commandOptions,
 		))!;
 		return {
 			type: response.type,
@@ -221,7 +225,7 @@ export class MeterCCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 			...options,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	protected [SET_VALUE]: SetValueImplementation = async (

--- a/packages/zwave-js/src/lib/commandclass/MultiChannelAssociationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultiChannelAssociationCC.ts
@@ -1,3 +1,4 @@
+import type { ValueID } from "@zwave-js/core";
 import {
 	CommandClasses,
 	encodeBitMask,
@@ -9,7 +10,6 @@ import {
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
-import type { ValueID } from "@zwave-js/core";
 import type { Driver } from "../driver/Driver";
 import log from "../log";
 import { CCAPI } from "./API";
@@ -209,7 +209,7 @@ export class MultiChannelAssociationCCAPI extends CCAPI {
 		);
 		const response = (await this.driver.sendCommand<
 			MultiChannelAssociationCCSupportedGroupingsReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.groupCount;
 	}
 
@@ -230,7 +230,7 @@ export class MultiChannelAssociationCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			MultiChannelAssociationCCReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return {
 			maxNodes: response.maxNodes,
 			nodeIds: response.nodeIds,
@@ -254,7 +254,7 @@ export class MultiChannelAssociationCCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 			...options,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	/**
@@ -287,7 +287,7 @@ export class MultiChannelAssociationCCAPI extends CCAPI {
 							!!d.endpoint,
 					),
 				});
-				await this.driver.sendCommand(cc);
+				await this.driver.sendCommand(cc, this.commandOptions);
 			}
 		} else {
 			const cc = new MultiChannelAssociationCCRemove(this.driver, {
@@ -295,7 +295,7 @@ export class MultiChannelAssociationCCAPI extends CCAPI {
 				endpoint: this.endpoint.index,
 				...options,
 			});
-			await this.driver.sendCommand(cc);
+			await this.driver.sendCommand(cc, this.commandOptions);
 		}
 	}
 }

--- a/packages/zwave-js/src/lib/commandclass/MultiChannelCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultiChannelCC.ts
@@ -129,6 +129,7 @@ export class MultiChannelCCAPI extends CCAPI {
 		const response = (await this.driver.sendCommand<
 			MultiChannelCCEndPointReport
 		>(cc, {
+			...this.commandOptions,
 			priority: MessagePriority.NodeQuery,
 		}))!;
 		return {
@@ -155,6 +156,7 @@ export class MultiChannelCCAPI extends CCAPI {
 		const response = (await this.driver.sendCommand<
 			MultiChannelCCCapabilityReport
 		>(cc, {
+			...this.commandOptions,
 			priority: MessagePriority.NodeQuery,
 		}))!;
 		return response.capability;
@@ -178,6 +180,7 @@ export class MultiChannelCCAPI extends CCAPI {
 		const response = (await this.driver.sendCommand<
 			MultiChannelCCEndPointFindReport
 		>(cc, {
+			...this.commandOptions,
 			priority: MessagePriority.NodeQuery,
 		}))!;
 		return response.foundEndpoints;
@@ -199,6 +202,7 @@ export class MultiChannelCCAPI extends CCAPI {
 		const response = (await this.driver.sendCommand<
 			MultiChannelCCAggregatedMembersReport
 		>(cc, {
+			...this.commandOptions,
 			priority: MessagePriority.NodeQuery,
 		}))!;
 		return response.members;
@@ -219,7 +223,7 @@ export class MultiChannelCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			...options,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	public async getEndpointCountV1(ccId: CommandClasses): Promise<number> {
@@ -235,6 +239,7 @@ export class MultiChannelCCAPI extends CCAPI {
 		const response = (await this.driver.sendCommand<MultiChannelCCV1Report>(
 			cc,
 			{
+				...this.commandOptions,
 				priority: MessagePriority.NodeQuery,
 			},
 		))!;
@@ -251,7 +256,7 @@ export class MultiChannelCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			encapsulated,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/MultiChannelCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultiChannelCC.ts
@@ -8,7 +8,6 @@ import type { ValueID } from "@zwave-js/core";
 import {
 	CommandClasses,
 	encodeBitMask,
-	ignoreTimeout,
 	Maybe,
 	MessageOrCCLogEntry,
 	parseBitMask,
@@ -21,7 +20,7 @@ import { getEnumMemberName, num2hex } from "@zwave-js/shared";
 import type { Driver } from "../driver/Driver";
 import log from "../log";
 import { MessagePriority } from "../message/Constants";
-import { CCAPI } from "./API";
+import { CCAPI, ignoreTimeout } from "./API";
 import {
 	API,
 	CCCommand,
@@ -348,7 +347,8 @@ identical capabilities:      ${multiResponse.identicalCapabilities}`;
 		if (api.supportsCommand(MultiChannelCommand.EndPointFind)) {
 			// Step 2a: Find all endpoints
 			await ignoreTimeout(
-				async () => {
+				api,
+				async (api) => {
 					log.controller.logNode(node.id, {
 						endpoint: this.endpointIndex,
 						message: "querying all endpoints...",

--- a/packages/zwave-js/src/lib/commandclass/MultiCommandCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultiCommandCC.ts
@@ -1,5 +1,5 @@
-import { CommandClasses, validatePayload } from "@zwave-js/core";
 import type { Maybe } from "@zwave-js/core";
+import { CommandClasses, validatePayload } from "@zwave-js/core";
 import type { Driver } from "../driver/Driver";
 import { CCAPI } from "./API";
 import {
@@ -44,7 +44,7 @@ export class MultiCommandCCAPI extends CCAPI {
 			encapsulated: commands,
 		});
 		cc.endpointIndex = this.endpoint.index;
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSensorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSensorCC.ts
@@ -8,7 +8,6 @@ import type { ValueID } from "@zwave-js/core";
 import {
 	CommandClasses,
 	encodeFloatWithScale,
-	ignoreTimeout,
 	Maybe,
 	parseBitMask,
 	parseFloatWithScale,
@@ -19,7 +18,7 @@ import {
 } from "@zwave-js/core";
 import type { Driver } from "../driver/Driver";
 import log from "../log";
-import { CCAPI } from "./API";
+import { CCAPI, ignoreTimeout } from "./API";
 import {
 	API,
 	CCCommand,
@@ -263,7 +262,8 @@ value:       ${mlsResponse.value} ${sensorScale.unit || ""}`;
 
 				// Always query the current sensor reading
 				await ignoreTimeout(
-					async () => {
+					api,
+					async (api) => {
 						log.controller.logNode(node.id, {
 							endpoint: this.endpointIndex,
 							message: `querying ${getSensorTypeName(

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSensorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSensorCC.ts
@@ -85,7 +85,7 @@ export class MultilevelSensorCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			MultilevelSensorCCReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 
 		if (sensorType === undefined) {
 			// Overload #1: return the full response
@@ -112,7 +112,7 @@ export class MultilevelSensorCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			MultilevelSensorCCSupportedSensorReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.supportedSensorTypes;
 	}
 
@@ -131,7 +131,7 @@ export class MultilevelSensorCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			MultilevelSensorCCSupportedScaleReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.sensorSupportedScales;
 	}
 
@@ -152,7 +152,7 @@ export class MultilevelSensorCCAPI extends CCAPI {
 			scale,
 			value,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -1,3 +1,4 @@
+import type { ValueID } from "@zwave-js/core";
 import {
 	CommandClasses,
 	Duration,
@@ -10,7 +11,6 @@ import {
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
-import type { ValueID } from "@zwave-js/core";
 import { getEnumMemberName } from "@zwave-js/shared";
 import type { Driver } from "../driver/Driver";
 import log from "../log";
@@ -116,7 +116,7 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			MultilevelSwitchCCReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return {
 			currentValue: response.currentValue,
 			targetValue: response.targetValue,
@@ -241,7 +241,7 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			MultilevelSwitchCCSupportedReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.switchType;
 	}
 

--- a/packages/zwave-js/src/lib/commandclass/NoOperationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/NoOperationCC.ts
@@ -22,6 +22,7 @@ export class NoOperationCCAPI extends CCAPI {
 				endpoint: this.endpoint.index,
 			}),
 			{
+				...this.commandOptions,
 				// Don't retry sending ping packets
 				maxSendAttempts: 1,
 				// set the priority manually, as SendData can be Application level too

--- a/packages/zwave-js/src/lib/commandclass/NodeNamingCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/NodeNamingCC.ts
@@ -1,10 +1,10 @@
+import type { Maybe } from "@zwave-js/core";
 import {
 	CommandClasses,
 	ValueMetadata,
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
-import type { Maybe } from "@zwave-js/core";
 import type { Driver } from "../driver/Driver";
 import {
 	CCAPI,
@@ -88,7 +88,7 @@ export class NodeNamingAndLocationCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			NodeNamingAndLocationCCNameReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.name;
 	}
 
@@ -103,7 +103,7 @@ export class NodeNamingAndLocationCCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 			name,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	public async getLocation(): Promise<string> {
@@ -118,7 +118,7 @@ export class NodeNamingAndLocationCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			NodeNamingAndLocationCCLocationReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.location;
 	}
 
@@ -133,7 +133,7 @@ export class NodeNamingAndLocationCCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 			location,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/NotificationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/NotificationCC.ts
@@ -4,6 +4,7 @@ import {
 	NotificationParameterWithDuration,
 	NotificationParameterWithValue,
 } from "@zwave-js/config";
+import type { ValueID } from "@zwave-js/core";
 import {
 	CommandClasses,
 	Duration,
@@ -15,7 +16,6 @@ import {
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
-import type { ValueID } from "@zwave-js/core";
 import { JSONObject, num2hex } from "@zwave-js/shared";
 import type { Driver } from "../driver/Driver";
 import log from "../log";
@@ -78,7 +78,10 @@ export class NotificationCCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 			...options,
 		});
-		return (await this.driver.sendCommand<NotificationCCReport>(cc))!;
+		return (await this.driver.sendCommand<NotificationCCReport>(
+			cc,
+			this.commandOptions,
+		))!;
 	}
 
 	public async sendReport(
@@ -94,7 +97,7 @@ export class NotificationCCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 			...options,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -125,7 +128,7 @@ export class NotificationCCAPI extends CCAPI {
 			notificationType,
 			notificationStatus,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -141,7 +144,7 @@ export class NotificationCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			NotificationCCSupportedReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return {
 			supportsV1Alarm: response.supportsV1Alarm,
 			supportedNotificationTypes: response.supportedNotificationTypes,
@@ -162,7 +165,7 @@ export class NotificationCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			NotificationCCEventSupportedReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.supportedEvents;
 	}
 }

--- a/packages/zwave-js/src/lib/commandclass/ProtectionCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ProtectionCC.ts
@@ -1,3 +1,4 @@
+import type { ValueID } from "@zwave-js/core";
 import {
 	CommandClasses,
 	enumValuesToMetadataStates,
@@ -10,7 +11,6 @@ import {
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
-import type { ValueID } from "@zwave-js/core";
 import { getEnumMemberName } from "@zwave-js/shared";
 import { padStart } from "alcalzone-shared/strings";
 import type { Driver } from "../driver/Driver";
@@ -208,6 +208,7 @@ export class ProtectionCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<ProtectionCCReport>(
 			cc,
+			this.commandOptions,
 		))!;
 		return {
 			local: response.local,
@@ -227,7 +228,7 @@ export class ProtectionCCAPI extends CCAPI {
 			local,
 			rf,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -243,7 +244,7 @@ export class ProtectionCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			ProtectionCCSupportedReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return {
 			supportsExclusiveControl: response.supportsExclusiveControl,
 			supportsTimeout: response.supportsTimeout,
@@ -264,7 +265,7 @@ export class ProtectionCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			ProtectionCCExclusiveControlReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.exclusiveControlNodeId;
 	}
 
@@ -279,7 +280,7 @@ export class ProtectionCCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 			exclusiveControlNodeId: nodeId,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	public async getTimeout(): Promise<Timeout> {
@@ -294,7 +295,7 @@ export class ProtectionCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			ProtectionCCTimeoutReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.timeout;
 	}
 
@@ -309,7 +310,7 @@ export class ProtectionCCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 			timeout,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/SceneActivationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneActivationCC.ts
@@ -1,10 +1,10 @@
+import type { Maybe, ValueID } from "@zwave-js/core";
 import {
 	CommandClasses,
 	Duration,
 	validatePayload,
 	ValueMetadata,
 } from "@zwave-js/core";
-import type { Maybe, ValueID } from "@zwave-js/core";
 import type { Driver } from "../driver/Driver";
 import {
 	CCAPI,
@@ -89,7 +89,7 @@ export class SceneActivationCCAPI extends CCAPI {
 			sceneId,
 			dimmingDuration,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
@@ -107,7 +107,7 @@ export class SecurityCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			encapsulated,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	public async getNonce(): Promise<Buffer> {
@@ -120,6 +120,7 @@ export class SecurityCCAPI extends CCAPI {
 		const response = (await this.driver.sendCommand<SecurityCCNonceReport>(
 			cc,
 			{
+				...this.commandOptions,
 				// Nonce requests must be handled immediately
 				priority: MessagePriority.PreTransmitHandshake,
 				// Only try getting a nonce once
@@ -194,7 +195,7 @@ export class SecurityCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 		// There is only one scheme, so we hardcode it
 		return [0];
 	}
@@ -209,7 +210,7 @@ export class SecurityCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 		// There is only one scheme, so we don't return anything here
 	}
 
@@ -230,7 +231,7 @@ export class SecurityCCAPI extends CCAPI {
 			encapsulated: keySet,
 			alternativeNetworkKey: Buffer.alloc(16, 0),
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -249,6 +250,7 @@ export class SecurityCCAPI extends CCAPI {
 		const response = (await this.driver.sendCommand<
 			SecurityCCCommandsSupportedReport
 		>(cc, {
+			...this.commandOptions,
 			// This command doubles as a check if the node is actually included securely
 			// If we're unsure, don't change the node status when this times out,
 			// so a missing response can be detected as "not secure"

--- a/packages/zwave-js/src/lib/commandclass/SoundSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SoundSwitchCC.ts
@@ -96,7 +96,7 @@ export class SoundSwitchCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			SoundSwitchCCTonesNumberReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.toneCount;
 	}
 
@@ -114,7 +114,7 @@ export class SoundSwitchCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			SoundSwitchCCToneInfoReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return pick(response, ["duration", "name"]);
 	}
 
@@ -133,7 +133,7 @@ export class SoundSwitchCCAPI extends CCAPI {
 			defaultToneId,
 			defaultVolume,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 
 		// Refresh the current value
 		await this.getConfiguration();
@@ -152,7 +152,7 @@ export class SoundSwitchCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			SoundSwitchCCConfigurationReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return pick(response, ["defaultToneId", "defaultVolume"]);
 	}
 
@@ -175,7 +175,7 @@ export class SoundSwitchCCAPI extends CCAPI {
 			toneId,
 			volume,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 
 		// Refresh the current value
 		await this.getPlaying();
@@ -193,7 +193,7 @@ export class SoundSwitchCCAPI extends CCAPI {
 			toneId: 0x00,
 			volume: 0x00,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 
 		// Refresh the current value
 		await this.getPlaying();
@@ -212,7 +212,7 @@ export class SoundSwitchCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			SoundSwitchCCTonePlayReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return pick(response, ["toneId", "volume"]);
 	}
 

--- a/packages/zwave-js/src/lib/commandclass/SupervisionCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SupervisionCC.ts
@@ -74,7 +74,7 @@ export class SupervisionCCAPI extends CCAPI {
 			requestStatusUpdates,
 			encapsulated,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/ThermostatModeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatModeCC.ts
@@ -1,3 +1,4 @@
+import type { ValueID } from "@zwave-js/core";
 import {
 	CommandClasses,
 	enumValuesToMetadataStates,
@@ -8,7 +9,6 @@ import {
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
-import type { ValueID } from "@zwave-js/core";
 import { getEnumMemberName } from "@zwave-js/shared";
 import type { Driver } from "../driver/Driver";
 import log from "../log";
@@ -105,6 +105,7 @@ export class ThermostatModeCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<ThermostatModeCCReport>(
 			cc,
+			this.commandOptions,
 		))!;
 		return {
 			mode: response.mode,
@@ -138,7 +139,7 @@ export class ThermostatModeCCAPI extends CCAPI {
 			mode,
 			manufacturerData: manufacturerData as any,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	public async getSupportedModes(): Promise<readonly ThermostatMode[]> {
@@ -153,7 +154,7 @@ export class ThermostatModeCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			ThermostatModeCCSupportedReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.supportedModes;
 	}
 }

--- a/packages/zwave-js/src/lib/commandclass/ThermostatOperatingStateCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatOperatingStateCC.ts
@@ -1,10 +1,10 @@
+import type { Maybe } from "@zwave-js/core";
 import {
 	CommandClasses,
 	enumValuesToMetadataStates,
 	validatePayload,
 	ValueMetadata,
 } from "@zwave-js/core";
-import type { Maybe } from "@zwave-js/core";
 import { getEnumMemberName } from "@zwave-js/shared";
 import type { Driver } from "../driver/Driver";
 import log from "../log";
@@ -76,7 +76,7 @@ export class ThermostatOperatingStateCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			ThermostatOperatingStateCCReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.state;
 	}
 }

--- a/packages/zwave-js/src/lib/commandclass/ThermostatSetbackCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatSetbackCC.ts
@@ -1,3 +1,4 @@
+import type { Maybe } from "@zwave-js/core";
 import {
 	CommandClasses,
 	validatePayload,
@@ -5,7 +6,6 @@ import {
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
-import type { Maybe } from "@zwave-js/core";
 import { getEnumMemberName } from "@zwave-js/shared";
 import type { Driver } from "../driver/Driver";
 import log from "../log";
@@ -71,7 +71,7 @@ export class ThermostatSetbackCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			ThermostatSetbackCCReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return {
 			setbackType: response.setbackType,
 			setbackState: response.setbackState,
@@ -93,7 +93,7 @@ export class ThermostatSetbackCCAPI extends CCAPI {
 			setbackType,
 			setbackState,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
@@ -160,7 +160,7 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			ThermostatSetpointCCReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.type === ThermostatSetpointType["N/A"]
 			? // not supported
 			  undefined
@@ -188,7 +188,7 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 			value,
 			scale,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -205,7 +205,7 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			ThermostatSetpointCCCapabilitiesReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return {
 			minValue: response.minValue,
 			maxValue: response.maxValue,
@@ -233,7 +233,7 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			ThermostatSetpointCCSupportedReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.supportedSetpointTypes;
 	}
 }

--- a/packages/zwave-js/src/lib/commandclass/TimeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/TimeCC.ts
@@ -1,3 +1,4 @@
+import type { Maybe } from "@zwave-js/core";
 import {
 	CommandClasses,
 	DSTInfo,
@@ -7,7 +8,6 @@ import {
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
-import type { Maybe } from "@zwave-js/core";
 import type { Driver } from "../driver/Driver";
 import log from "../log";
 import { CCAPI } from "./API";
@@ -59,7 +59,10 @@ export class TimeCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 		});
-		const response = (await this.driver.sendCommand<TimeCCTimeReport>(cc))!;
+		const response = (await this.driver.sendCommand<TimeCCTimeReport>(
+			cc,
+			this.commandOptions,
+		))!;
 		return {
 			hour: response.hour,
 			minute: response.minute,
@@ -75,7 +78,10 @@ export class TimeCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 		});
-		const response = (await this.driver.sendCommand<TimeCCDateReport>(cc))!;
+		const response = (await this.driver.sendCommand<TimeCCDateReport>(
+			cc,
+			this.commandOptions,
+		))!;
 		return {
 			day: response.day,
 			month: response.month,
@@ -94,7 +100,7 @@ export class TimeCCAPI extends CCAPI {
 			dstStart: timezone.startDate,
 			dstEnd: timezone.endDate,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	public async getTimezone(): Promise<DSTInfo> {
@@ -106,6 +112,7 @@ export class TimeCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<TimeCCTimeOffsetReport>(
 			cc,
+			this.commandOptions,
 		))!;
 		return {
 			standardOffset: response.standardOffset,

--- a/packages/zwave-js/src/lib/commandclass/TimeParametersCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/TimeParametersCC.ts
@@ -1,5 +1,5 @@
-import { CommandClasses, validatePayload } from "@zwave-js/core";
 import type { Maybe } from "@zwave-js/core";
+import { CommandClasses, validatePayload } from "@zwave-js/core";
 import type { Driver } from "../driver/Driver";
 import log from "../log";
 import type { Endpoint } from "../node/Endpoint";
@@ -133,6 +133,7 @@ export class TimeParametersCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<TimeParametersCCReport>(
 			cc,
+			this.commandOptions,
 		))!;
 		return response.dateAndTime;
 	}
@@ -148,7 +149,7 @@ export class TimeParametersCCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 			dateAndTime,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/VersionCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/VersionCC.ts
@@ -93,7 +93,10 @@ export class VersionCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 		});
-		const response = (await this.driver.sendCommand<VersionCCReport>(cc))!;
+		const response = (await this.driver.sendCommand<VersionCCReport>(
+			cc,
+			this.commandOptions,
+		))!;
 		return {
 			libraryType: response.libraryType,
 			protocolVersion: response.protocolVersion,
@@ -115,7 +118,7 @@ export class VersionCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			VersionCCCommandClassReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return response.ccVersion;
 	}
 
@@ -132,7 +135,7 @@ export class VersionCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			VersionCCCapabilitiesReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return {
 			supportsZWaveSoftwareGet: response.supportsZWaveSoftwareGet,
 		};
@@ -151,7 +154,7 @@ export class VersionCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			VersionCCZWaveSoftwareReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return {
 			sdkVersion: response.sdkVersion,
 			applicationFrameworkAPIVersion:

--- a/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
@@ -88,6 +88,7 @@ export class WakeUpCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<WakeUpCCIntervalReport>(
 			cc,
+			this.commandOptions,
 		))!;
 		return {
 			wakeUpInterval: response.wakeUpInterval,
@@ -108,7 +109,7 @@ export class WakeUpCCAPI extends CCAPI {
 		});
 		const response = (await this.driver.sendCommand<
 			WakeUpCCIntervalCapabilitiesReport
-		>(cc))!;
+		>(cc, this.commandOptions))!;
 		return {
 			defaultWakeUpInterval: response.defaultWakeUpInterval,
 			minWakeUpInterval: response.minWakeUpInterval,
@@ -129,7 +130,7 @@ export class WakeUpCCAPI extends CCAPI {
 			wakeUpInterval,
 			controllerNodeId,
 		});
-		await this.driver.sendCommand(cc);
+		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
 	public async sendNoMoreInformation(): Promise<void> {
@@ -143,6 +144,7 @@ export class WakeUpCCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 		});
 		await this.driver.sendCommand(cc, {
+			...this.commandOptions,
 			// This command must be sent as part of the wake up queue
 			priority: MessagePriority.WakeUp,
 		});

--- a/packages/zwave-js/src/lib/commandclass/ZWavePlusCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ZWavePlusCC.ts
@@ -1,5 +1,5 @@
-import { CommandClasses, validatePayload, ValueMetadata } from "@zwave-js/core";
 import type { Maybe, ValueID } from "@zwave-js/core";
+import { CommandClasses, validatePayload, ValueMetadata } from "@zwave-js/core";
 import { num2hex } from "@zwave-js/shared";
 import type { Driver } from "../driver/Driver";
 import log from "../log";
@@ -74,6 +74,7 @@ export class ZWavePlusCCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 		});
 		const response = (await this.driver.sendCommand<ZWavePlusCCReport>(cc, {
+			...this.commandOptions,
 			priority: MessagePriority.NodeQuery,
 		}))!;
 		return {

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1369,6 +1369,9 @@ ${handlers.length} left`,
 	private async handleRequest(msg: Message): Promise<void> {
 		let handlers: RequestHandlerEntry[] | undefined;
 
+		// For further actions, we are only interested in the innermost CC
+		if (isCommandClassContainer(msg)) this.unwrapCommands(msg);
+
 		if (isNodeQuery(msg) || isCommandClassContainer(msg)) {
 			const node = msg.getNodeUnsafe();
 			if (node?.status === NodeStatus.Dead) {


### PR DESCRIPTION
Lays the groundwork for https://github.com/AlCalzone/node-zwave-js/issues/739, point 5 by adding the ability to scope API instances to an options set

fixes: #947 
fixes: #948 