### PR TITLE
Enforce that an error handler is attached before starting the driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 	## __WORK IN PROGRESS__
 -->
 
-## 5.0.0-alpha.3 (2020-09-11)
+## __WORK IN PROGRESS__
 ### Breaking changes
 * The status `Alive` was added to the `NodeStatus` enumeration. The node status can no longer switch between all states, only between `Dead` and `Alive`, between `Asleep` and `Awake` and from and to `Unknown`.
 * The `status` property on `ZWaveNode` is now readonly. To change the status, use the `markAsAsleep` and similar methods, which only change the status if it is legal to do so.
 * Unsolicited commands are now discarded in accordance with the Z-Wave specs if they are unencrypted but the CC is supported secure only
+* `driver.start()` now throws if no handler for the `"error"` is attached
 
 ### Features
 * A new method `withOptions` was added to `CCAPI`, which controls the used `SendCommandOptions`. For example, this allows changing the priority of each API call for that instance.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -19,6 +19,11 @@
     ```ts
     // Tell the driver which serial port to use
     const driver = new Driver("COM3");
+    // You must add a handler for the error event before starting the driver
+    driver.on("error", (e) => {
+        // Do something with it
+        console.error(e);
+    });
     // Listen for the driver ready event before doing anything with the driver
     driver.once("driver ready", () => {
         /*

--- a/packages/core/src/error/ZWaveError.ts
+++ b/packages/core/src/error/ZWaveError.ts
@@ -21,6 +21,7 @@ export enum ZWaveErrorCodes {
 	Driver_InvalidCache,
 	Driver_InvalidOptions,
 	Driver_NoSecurity,
+	Driver_NoErrorHandler,
 
 	/** The controller has timed out while waiting for a report from the node */
 	Controller_Timeout,

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -420,15 +420,21 @@ export class Driver extends EventEmitter {
 	public async start(): Promise<void> {
 		// avoid starting twice
 		if (this._wasDestroyed) {
-			return Promise.reject(
-				new ZWaveError(
-					"The driver was destroyed. Create a new instance and start that one.",
-					ZWaveErrorCodes.Driver_Destroyed,
-				),
+			throw new ZWaveError(
+				"The driver was destroyed. Create a new instance and start that one.",
+				ZWaveErrorCodes.Driver_Destroyed,
 			);
 		}
 		if (this._wasStarted) return Promise.resolve();
 		this._wasStarted = true;
+
+		// Enforce that an error handler is attached
+		if ((this as EventEmitter).listenerCount("error") === 0) {
+			throw new ZWaveError(
+				`Before starting the driver, a handler for the "error" event must be attached.`,
+				ZWaveErrorCodes.Driver_NoErrorHandler,
+			);
+		}
 
 		const spOpenPromise = createDeferredPromise();
 


### PR DESCRIPTION
With this change, `driver.start()` now throws an error if no `"error"` handler is attached.

fixes: #979 