### PR TITLE
feat: implement expire message option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@
 -->
 
 ## __WORK IN PROGRESS__
+### Features
+* It is now possible to add an expiration timeout to sent messages by using the `expire` option for `sendMessage`.
+
 ### Changes under the hood
-* Formatting log messages has been simplified. Log messages are now defined as objects and the log formatter auto-aligns the values
+* Formatting log messages has been simplified. Log messages are now defined as objects and the log formatter auto-aligns the values.
 * Many CCs had their log representation improved. If an error occurs during this conversion, this error is now caught.
 
 ## 5.1.0 (2020-09-28)

--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -247,6 +247,8 @@ interface SendMessageOptions {
 	supportCheck?: boolean;
 	/** Whether the driver should update the node status to asleep or dead when a transaction is not acknowledged (repeatedly). Setting this to false will cause the simply transaction to be rejected on failure. Default: true */
 	changeNodeStatusOnMissingACK?: boolean;
+	/** Sets the number of milliseconds after which a message expires. When the expiration timer elapses, the promise is rejected with the error code `Controller_MessageExpired`. */
+	expire?: number;
 }
 ```
 

--- a/packages/core/src/error/ZWaveError.ts
+++ b/packages/core/src/error/ZWaveError.ts
@@ -39,6 +39,9 @@ export enum ZWaveErrorCodes {
 	/** The node was removed from the network */
 	Controller_NodeRemoved,
 
+	/** The message has expired (the given timeout has elapsed) */
+	Controller_MessageExpired,
+
 	CC_Invalid,
 	CC_NoNodeID,
 	CC_NotSupported,


### PR DESCRIPTION
This PR adds the property `expire` to `SendMessageOptions`. A message with this option set is automatically scheduled to be expired after the given timeout. Once the timeout elapses, the message is removed from all queues and the Promise returned by `sendMessage`/`sendCommand` is rejected with the code `Controller_MessageExpired`.

fixes: #873 