### PR TITLE
Update jsonl-db to elimitate exported references to fs-extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   * `NODE_ID_BROADCAST` and `NODE_ID_MAX` are now value exports
   * The `Endpoint` class is now exported
   * The `InterviewStage` enum is now exported
+* Internal references to `@types/fs-extra` and `jest` are no longer leaked, allowing users to consume this library without `skipLibCheck`
 
 ### Changes under the hood
 * `SpyTransport` was moved to `@zwave-js/testing`, a development-only testing package

--- a/package-lock.json
+++ b/package-lock.json
@@ -6487,7 +6487,7 @@
     "@zwave-js/core": {
       "version": "file:packages/core",
       "requires": {
-        "@alcalzone/jsonl-db": "^1.2.1",
+        "@alcalzone/jsonl-db": "^1.2.2",
         "@zwave-js/shared": "file:packages/shared",
         "alcalzone-shared": "^3.0.0",
         "ansi-colors": "^4.1.1",
@@ -20493,7 +20493,7 @@
     "zwave-js": {
       "version": "file:packages/zwave-js",
       "requires": {
-        "@alcalzone/jsonl-db": "^1.2.1",
+        "@alcalzone/jsonl-db": "^1.2.2",
         "@sentry/integrations": "^5.24.2",
         "@sentry/node": "^5.24.2",
         "@zwave-js/config": "file:packages/config",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,7 @@
     "node": ">=10.0.0"
   },
   "dependencies": {
-    "@alcalzone/jsonl-db": "^1.2.1",
+    "@alcalzone/jsonl-db": "^1.2.2",
     "@zwave-js/shared": "file:../shared",
     "alcalzone-shared": "^3.0.0",
     "ansi-colors": "^4.1.1",

--- a/packages/zwave-js/package.json
+++ b/packages/zwave-js/package.json
@@ -60,7 +60,7 @@
     "node": ">=10.0.0"
   },
   "dependencies": {
-    "@alcalzone/jsonl-db": "^1.2.1",
+    "@alcalzone/jsonl-db": "^1.2.2",
     "@sentry/integrations": "^5.24.2",
     "@sentry/node": "^5.24.2",
     "@zwave-js/config": "file:../config",


### PR DESCRIPTION
After this change, `--traceResolution` shows no references to jest or fs-extra

fixes: #1040 