### PR TITLE
docs: fix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 -   [License](LICENSE)
 -   [Changelog](CHANGELOG.md)
--   [Documentation](https://alcalzone.github.io/node-zwave-js/)
+-   [Documentation](https://zwave-js.github.io/node-zwave-js/)
 
 <!--
 TODO: Move all this to the documentation


### PR DESCRIPTION
Current link points to the previous repo location.