### PR TITLE
Improve nonce handling in Security CC and device compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+### Features
+* Added the compat config option `keepS0NonceUntilNext` to disable automatic nonce invalidation for bugged devices (e.g. ID Lock) which reuse nonces in some situations
+
+### Bugfixes
+* The receiver of a nonce is now stored and after a successful reply, all nonces for said issuer are now invalidated
+
 ## 5.3.6 (2020-11-04)
 ### Bugfixes
 * Compatibility with non-spec-compliant devices has been improved:

--- a/packages/config/config/devices/0x0373/id-150_0.0-1.5.json
+++ b/packages/config/config/devices/0x0373/id-150_0.0-1.5.json
@@ -1,186 +1,192 @@
 // ID Lock AS ID-150
 // Z wave module for ID Lock 150 and 101
 {
-    "_approved": true,
-    "manufacturer": "ID Lock AS",
-    "manufacturerId": "0x0373",
-    "label": "ID-150",
-    "description": "Z wave module for ID Lock 150 and 101",
-    "devices": [
-        {
-            "productType": "0x0003",
-            "productId": "0x0001"
-        }
-    ],
-    "firmwareVersion": {
-        "min": "0.0",
-        "max": "1.5"
-    },
-    "supportsZWavePlus": true,
-    "paramInformation": {
-        "1": {
-            "label": "Door lock mode",
-            "description": "Set if the lock is in away mode and if automatic locking should be enabled",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 3,
-            "defaultValue": 1,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Disable Away Manual Lock",
-                    "value": 0
-                },
-                {
-                    "label": "Disable Away Auto Lock",
-                    "value": 1
-                },
-                {
-                    "label": "Enable Away Manual Lock",
-                    "value": 2
-                },
-                {
-                    "label": "Enable Away Auto Lock",
-                    "value": 3
-                }
-            ]
-        },
-        "3": {
-            "label": "Door Hinge Position Mode",
-            "description": "Tell the lock which side your hinges are on",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Right handle",
-                    "value": 0
-                },
-                {
-                    "label": "Left handle",
-                    "value": 1
-                }
-            ]
-        },
-        "4": {
-            "label": "Door Audio Volume Level",
-            "description": "Set the Audio Volume Level of the Lock",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 6,
-            "defaultValue": 5,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "No sound",
-                    "value": 0
-                },
-                {
-                    "label": "Level 1",
-                    "value": 1
-                },
-                {
-                    "label": "Level 2",
-                    "value": 2
-                },
-                {
-                    "label": "Level 3",
-                    "value": 3
-                },
-                {
-                    "label": "Level 4",
-                    "value": 4
-                },
-                {
-                    "label": "Level 5",
-                    "value": 5
-                },
-                {
-                    "label": "Max. sound level",
-                    "value": 6
-                }
-            ]
-        },
-        "5": {
-            "label": "Door ReLock Mode",
-            "description": "Sets if the door should relock or not",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 1,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Disabled",
-                    "value": 0
-                },
-                {
-                    "label": "Enabled",
-                    "value": 1
-                }
-            ]
-        },
-        "6": {
-            "label": "Service PIN Mode",
-            "description": "Sets the validity of the service PIN",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 9,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Deactivated",
-                    "value": 0
-                },
-                {
-                    "label": "Valid 1 time",
-                    "value": 1
-                },
-                {
-                    "label": "Valid 2 times",
-                    "value": 2
-                },
-                {
-                    "label": "Valid 5 times",
-                    "value": 3
-                },
-                {
-                    "label": "Valid 10 times",
-                    "value": 4
-                },
-                {
-                    "label": "Valid for 12h",
-                    "value": 8
-                },
-                {
-                    "label": "Valid for 24h",
-                    "value": 9
-                }
-            ]
-        },
-        "7": {
-            "label": "Door Lock Model Type",
-            "description": "Sends information if the model of the lock is 101 or 150",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 0,
-            "defaultValue": 0,
-            "readOnly": true,
-            "writeOnly": false,
-            "allowManualEntry": true
-        }
-    }
+	"_approved": true,
+	"manufacturer": "ID Lock AS",
+	"manufacturerId": "0x0373",
+	"label": "ID-150",
+	"description": "Z wave module for ID Lock 150 and 101",
+	"devices": [
+		{
+			"productType": "0x0003",
+			"productId": "0x0001"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "1.5"
+	},
+	"supportsZWavePlus": true,
+	"paramInformation": {
+		"1": {
+			"label": "Door lock mode",
+			"description": "Set if the lock is in away mode and if automatic locking should be enabled",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 3,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable Away Manual Lock",
+					"value": 0
+				},
+				{
+					"label": "Disable Away Auto Lock",
+					"value": 1
+				},
+				{
+					"label": "Enable Away Manual Lock",
+					"value": 2
+				},
+				{
+					"label": "Enable Away Auto Lock",
+					"value": 3
+				}
+			]
+		},
+		"3": {
+			"label": "Door Hinge Position Mode",
+			"description": "Tell the lock which side your hinges are on",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Right handle",
+					"value": 0
+				},
+				{
+					"label": "Left handle",
+					"value": 1
+				}
+			]
+		},
+		"4": {
+			"label": "Door Audio Volume Level",
+			"description": "Set the Audio Volume Level of the Lock",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 6,
+			"defaultValue": 5,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "No sound",
+					"value": 0
+				},
+				{
+					"label": "Level 1",
+					"value": 1
+				},
+				{
+					"label": "Level 2",
+					"value": 2
+				},
+				{
+					"label": "Level 3",
+					"value": 3
+				},
+				{
+					"label": "Level 4",
+					"value": 4
+				},
+				{
+					"label": "Level 5",
+					"value": 5
+				},
+				{
+					"label": "Max. sound level",
+					"value": 6
+				}
+			]
+		},
+		"5": {
+			"label": "Door ReLock Mode",
+			"description": "Sets if the door should relock or not",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disabled",
+					"value": 0
+				},
+				{
+					"label": "Enabled",
+					"value": 1
+				}
+			]
+		},
+		"6": {
+			"label": "Service PIN Mode",
+			"description": "Sets the validity of the service PIN",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 9,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Deactivated",
+					"value": 0
+				},
+				{
+					"label": "Valid 1 time",
+					"value": 1
+				},
+				{
+					"label": "Valid 2 times",
+					"value": 2
+				},
+				{
+					"label": "Valid 5 times",
+					"value": 3
+				},
+				{
+					"label": "Valid 10 times",
+					"value": 4
+				},
+				{
+					"label": "Valid for 12h",
+					"value": 8
+				},
+				{
+					"label": "Valid for 24h",
+					"value": 9
+				}
+			]
+		},
+		"7": {
+			"label": "Door Lock Model Type",
+			"description": "Sends information if the model of the lock is 101 or 150",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 0,
+			"defaultValue": 0,
+			"readOnly": true,
+			"writeOnly": false,
+			"allowManualEntry": true
+		}
+	},
+	"compat": {
+		// This device has a firmware bug where it will reuse previous nonces after
+		// an unencrypted request. In order to be able to use it, we must not invalidate
+		// nonces until it requests a new one itself
+		"keepS0NonceUntilNext": true
+	}
 }

--- a/packages/config/config/devices/0x0373/id-150_1.6.json
+++ b/packages/config/config/devices/0x0373/id-150_1.6.json
@@ -212,5 +212,11 @@
 			"writeOnly": false,
 			"allowManualEntry": true
 		}
+	},
+	"compat": {
+		// This device has a firmware bug where it will reuse previous nonces after
+		// an unencrypted request. In order to be able to use it, we must not invalidate
+		// nonces until it requests a new one itself
+		"keepS0NonceUntilNext": true
 	}
 }

--- a/packages/config/src/Devices.ts
+++ b/packages/config/src/Devices.ts
@@ -439,6 +439,18 @@ error in compat option queryOnWakeup`,
 					}),
 			) as any;
 		}
+
+		if (definition.keepS0NonceUntilNext != undefined) {
+			if (definition.keepS0NonceUntilNext !== true) {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+error in compat option keepS0NonceUntilNext`,
+				);
+			}
+
+			this.keepS0NonceUntilNext = definition.keepS0NonceUntilNext;
+		}
 	}
 
 	public readonly queryOnWakeup?: [
@@ -451,6 +463,8 @@ error in compat option queryOnWakeup`,
 			| Pick<ValueID, "property" | "propertyKey">
 		)[]
 	][];
+
+	public keepS0NonceUntilNext?: boolean;
 }
 
 export class ParamInformation {

--- a/packages/core/src/security/Manager.test.ts
+++ b/packages/core/src/security/Manager.test.ts
@@ -109,7 +109,7 @@ describe("lib/security/Manager", () => {
 			).toBeUndefined();
 		});
 
-		it("the nonces should timeout after the given timeout", () => {
+		it("the nonces should expire after the given timeout", () => {
 			const man = new SecurityManager(options);
 			const nonce = man.generateNonce(2, 8);
 			const nonceId = nonce[0];
@@ -117,6 +117,16 @@ describe("lib/security/Manager", () => {
 
 			jest.advanceTimersByTime(options.nonceTimeout + 50);
 			expect(man.getNonce(nonceId)).toBeUndefined();
+		});
+
+		it("...except if this was explicitly forbidden", () => {
+			const man = new SecurityManager(options);
+			const nonce = man.generateNonce(2, 8, false);
+			const nonceId = nonce[0];
+			expect(man.getNonce(nonceId)).toEqual(nonce);
+
+			jest.advanceTimersByTime(options.nonceTimeout + 50);
+			expect(man.getNonce(nonceId)).not.toBeUndefined();
 		});
 
 		it(`the nonce should be marked as "reserved"`, () => {

--- a/packages/core/src/security/Manager.test.ts
+++ b/packages/core/src/security/Manager.test.ts
@@ -45,9 +45,9 @@ describe("lib/security/Manager", () => {
 		it("should return a random Buffer of the given length", () => {
 			const man = new SecurityManager(options);
 			// I know, this is not really checking if the value is random
-			const nonce1 = man.generateNonce(8);
-			const nonce2 = man.generateNonce(8);
-			const nonce3 = man.generateNonce(8);
+			const nonce1 = man.generateNonce(2, 8);
+			const nonce2 = man.generateNonce(2, 8);
+			const nonce3 = man.generateNonce(2, 8);
 
 			expect(Buffer.isBuffer(nonce1)).toBeTrue();
 			expect(Buffer.isBuffer(nonce2)).toBeTrue();
@@ -80,8 +80,8 @@ describe("lib/security/Manager", () => {
 					.SecurityManager;
 
 				const man = new SM(options);
-				const nonce1 = man.generateNonce(8);
-				const nonce2 = man.generateNonce(8);
+				const nonce1 = man.generateNonce(2, 8);
+				const nonce2 = man.generateNonce(2, 8);
 				expect(nonce1).toEqual(buf1a);
 				expect(nonce2).toEqual(buf2);
 
@@ -94,24 +94,24 @@ describe("lib/security/Manager", () => {
 		it("should store nonces for the current node id", () => {
 			const man = new SecurityManager(options);
 
-			const nonce1 = man.generateNonce(8);
-			const nonce2 = man.generateNonce(8);
-			const nonce3 = man.generateNonce(8);
+			const nonce1 = man.generateNonce(2, 8);
+			const nonce2 = man.generateNonce(2, 8);
+			const nonce3 = man.generateNonce(2, 8);
 
 			expect(
-				man.getNonce({ nodeId: 2, nonceId: man.getNonceId(nonce1) }),
+				man.getNonce({ issuer: 2, nonceId: man.getNonceId(nonce1) }),
 			).toBeUndefined();
 			expect(
-				man.getNonce({ nodeId: 2, nonceId: man.getNonceId(nonce2) }),
+				man.getNonce({ issuer: 2, nonceId: man.getNonceId(nonce2) }),
 			).toBeUndefined();
 			expect(
-				man.getNonce({ nodeId: 2, nonceId: man.getNonceId(nonce3) }),
+				man.getNonce({ issuer: 2, nonceId: man.getNonceId(nonce3) }),
 			).toBeUndefined();
 		});
 
 		it("the nonces should timeout after the given timeout", () => {
 			const man = new SecurityManager(options);
-			const nonce = man.generateNonce(8);
+			const nonce = man.generateNonce(2, 8);
 			const nonceId = nonce[0];
 			expect(man.getNonce(nonceId)).toEqual(nonce);
 
@@ -121,7 +121,7 @@ describe("lib/security/Manager", () => {
 
 		it(`the nonce should be marked as "reserved"`, () => {
 			const man = new SecurityManager(options);
-			man.generateNonce(8);
+			man.generateNonce(2, 8);
 			expect(man.getFreeNonce(ownNodeId)).toBeUndefined();
 		});
 	});
@@ -130,9 +130,9 @@ describe("lib/security/Manager", () => {
 		it("should return the first byte of the nonce", () => {
 			const man = new SecurityManager(options);
 
-			const nonce1 = man.generateNonce(8);
-			const nonce2 = man.generateNonce(8);
-			const nonce3 = man.generateNonce(8);
+			const nonce1 = man.generateNonce(2, 8);
+			const nonce2 = man.generateNonce(2, 8);
+			const nonce3 = man.generateNonce(2, 8);
 
 			expect(man.getNonceId(nonce1)).toBe(nonce1[0]);
 			expect(man.getNonceId(nonce2)).toBe(nonce2[0]);
@@ -144,9 +144,9 @@ describe("lib/security/Manager", () => {
 		it("should return a previously generated nonce with the same id", () => {
 			const man = new SecurityManager(options);
 
-			const nonce1 = man.generateNonce(8);
-			const nonce2 = man.generateNonce(8);
-			const nonce3 = man.generateNonce(8);
+			const nonce1 = man.generateNonce(2, 8);
+			const nonce2 = man.generateNonce(2, 8);
+			const nonce3 = man.generateNonce(2, 8);
 
 			const nonceId1 = man.getNonceId(nonce1);
 			const nonceId2 = man.getNonceId(nonce2);
@@ -166,7 +166,7 @@ describe("lib/security/Manager", () => {
 
 			const nonce: Buffer = randomBytes(8);
 			nonce[0] = 1;
-			man.setNonce(1, nonce);
+			man.setNonce(1, { nonce, receiver: 2 });
 			expect(man.getNonce(1)).toEqual(nonce);
 		});
 
@@ -174,7 +174,7 @@ describe("lib/security/Manager", () => {
 			const man = new SecurityManager(options);
 			const nonce: Buffer = randomBytes(8);
 			const nonceId = nonce[0];
-			man.setNonce(nonceId, nonce);
+			man.setNonce(nonceId, { nonce, receiver: 2 });
 			expect(man.getNonce(nonceId)).toEqual(nonce);
 
 			jest.advanceTimersByTime(options.nonceTimeout + 50);
@@ -188,10 +188,10 @@ describe("lib/security/Manager", () => {
 			nonce[0] = 1;
 			man.setNonce(
 				{
-					nodeId: 2,
+					issuer: 2,
 					nonceId: 1,
 				},
-				nonce,
+				{ nonce, receiver: options.ownNodeId },
 			);
 			// Wrong node
 			expect(man.getFreeNonce(1)).toBeUndefined();
@@ -203,10 +203,10 @@ describe("lib/security/Manager", () => {
 			const nonce: Buffer = randomBytes(8);
 			man.setNonce(
 				{
-					nodeId: 2,
+					issuer: 2,
 					nonceId: 1,
 				},
-				nonce,
+				{ nonce, receiver: options.ownNodeId },
 			);
 
 			jest.advanceTimersByTime(options.nonceTimeout + 50);
@@ -222,11 +222,11 @@ describe("lib/security/Manager", () => {
 			expect(man.hasNonce(1)).toBeFalse();
 			const nonce1: Buffer = randomBytes(8);
 			nonce1[0] = 1;
-			man.setNonce(1, nonce1);
+			man.setNonce(1, { nonce: nonce1, receiver: 2 });
 			expect(man.hasNonce(1)).toBeTrue();
 
 			// And generated
-			const nonce2 = man.generateNonce(8);
+			const nonce2 = man.generateNonce(2, 8);
 			const nonceId2 = man.getNonceId(nonce2);
 			expect(man.hasNonce(nonceId2)).toBeTrue();
 		});
@@ -236,12 +236,49 @@ describe("lib/security/Manager", () => {
 		it("should remove a nonce from the database", () => {
 			const man = new SecurityManager(options);
 
-			const nonce = man.generateNonce(8);
+			const nonce = man.generateNonce(2, 8);
 			const nonceId = man.getNonceId(nonce);
 
 			man.deleteNonce(nonceId);
 			expect(man.getNonce(nonceId)).toBeUndefined();
 			expect(man.hasNonce(nonceId)).toBeFalse();
+		});
+
+		it("and all other nonces that were created for the same receiver", () => {
+			const man = new SecurityManager(options);
+
+			const nonce1 = man.generateNonce(2, 8);
+			const nonceId1 = man.getNonceId(nonce1);
+			const nonce2 = man.generateNonce(2, 8);
+			const nonceId2 = man.getNonceId(nonce2);
+
+			man.deleteNonce(nonceId1);
+			expect(man.getNonce(nonceId1)).toBeUndefined();
+			expect(man.hasNonce(nonceId1)).toBeFalse();
+			expect(man.getNonce(nonceId2)).toBeUndefined();
+			expect(man.hasNonce(nonceId2)).toBeFalse();
+		});
+	});
+
+	describe("deleteAllNoncesForReceiver", () => {
+		it("should only delete the nonces for the given receiver", () => {
+			const man = new SecurityManager(options);
+
+			const nonce1 = man.generateNonce(2, 8);
+			const nonceId1 = man.getNonceId(nonce1);
+			const nonce2 = man.generateNonce(2, 8);
+			const nonceId2 = man.getNonceId(nonce2);
+			// different receiver
+			const nonce3 = man.generateNonce(3, 8);
+			const nonceId3 = man.getNonceId(nonce3);
+
+			man.deleteNonce(nonceId1);
+			expect(man.getNonce(nonceId1)).toBeUndefined();
+			expect(man.hasNonce(nonceId1)).toBeFalse();
+			expect(man.getNonce(nonceId2)).toBeUndefined();
+			expect(man.hasNonce(nonceId2)).toBeFalse();
+			expect(man.getNonce(nonceId3)).not.toBeUndefined();
+			expect(man.hasNonce(nonceId3)).not.toBeFalse();
 		});
 	});
 
@@ -252,10 +289,10 @@ describe("lib/security/Manager", () => {
 			nonce[0] = 1;
 			man.setNonce(
 				{
-					nodeId: 2,
+					issuer: 2,
 					nonceId: 1,
 				},
-				nonce,
+				{ nonce, receiver: options.ownNodeId },
 			);
 			expect(man.getFreeNonce(2)).toEqual(nonce);
 			expect(man.getFreeNonce(2)).toBeUndefined();
@@ -265,17 +302,17 @@ describe("lib/security/Manager", () => {
 	it("nonces should be stored separately for each node", () => {
 		const man = new SecurityManager(options);
 
-		const nonce1 = man.generateNonce(8);
+		const nonce1 = man.generateNonce(3, 8);
 		const nonceId1 = man.getNonceId(nonce1);
-		// Create a duplicate for another node
+		// Create a nonce with the same nonceId but with another issuer
 		const nonce2: Buffer = randomBytes(8);
 		nonce2[0] = nonceId1;
 
-		const id2 = { nodeId: 7, nonceId: nonceId1 };
+		const id2 = { issuer: 4, nonceId: nonceId1 };
 		expect(man.hasNonce(id2)).toBeFalse();
 		expect(man.getNonce(id2)).toBeUndefined();
 
-		man.setNonce(id2, nonce2);
+		man.setNonce(id2, { nonce: nonce2, receiver: 1 });
 		expect(man.hasNonce(id2)).toBeTrue();
 		expect(man.getNonce(id2)).toEqual(nonce2);
 	});

--- a/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
@@ -153,10 +153,10 @@ export class SecurityCCAPI extends CCAPI {
 			const secMan = this.driver.securityManager!;
 			secMan.setNonce(
 				{
-					nodeId: this.endpoint.nodeId,
+					issuer: this.endpoint.nodeId,
 					nonceId: secMan.getNonceId(nonce),
 				},
-				nonce,
+				{ nonce, receiver: this.driver.controller.ownNodeId! },
 				true,
 			);
 		}
@@ -181,6 +181,7 @@ export class SecurityCCAPI extends CCAPI {
 		}
 
 		const nonce = this.driver.securityManager.generateNonce(
+			this.endpoint.nodeId,
 			HALF_NONCE_SIZE,
 		);
 
@@ -573,7 +574,7 @@ export class SecurityCCCommandEncapsulation extends SecurityCC {
 		if (
 			this.nonceId != undefined &&
 			secMan.hasNonce({
-				nodeId: this.nodeId,
+				issuer: this.nodeId,
 				nonceId: this.nonceId,
 			})
 		) {
@@ -598,10 +599,10 @@ export class SecurityCCCommandEncapsulation extends SecurityCC {
 		this.nonceId = secMan.getNonceId(nonce);
 		secMan.setNonce(
 			{
-				nodeId: this.nodeId,
+				issuer: this.nodeId,
 				nonceId: this.nonceId,
 			},
-			nonce,
+			{ nonce, receiver: this.driver.controller.ownNodeId },
 			// The nonce is reserved for this command
 			false,
 		);
@@ -618,13 +619,13 @@ export class SecurityCCCommandEncapsulation extends SecurityCC {
 		// Try to find an active nonce
 		if (this.nonceId == undefined) throwNoNonce();
 		const receiverNonce = this.driver.securityManager.getNonce({
-			nodeId: this.nodeId,
+			issuer: this.nodeId,
 			nonceId: this.nonceId,
 		});
 		if (!receiverNonce) throwNoNonce();
 		// and mark it as used
 		this.driver.securityManager.deleteNonce({
-			nodeId: this.nodeId,
+			issuer: this.nodeId,
 			nonceId: this.nonceId,
 		});
 

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1697,6 +1697,10 @@ version:               ${this.version}`;
 			ZWaveErrorCodes.Controller_MessageDropped,
 		);
 
+		// And also delete all previous nonces we sent the node since they
+		// should no longer be used
+		this.driver.securityManager.deleteAllNoncesForReceiver(this.id);
+
 		// Now send the current nonce
 		try {
 			await this.commandClasses.Security.sendNonce();
@@ -1718,10 +1722,13 @@ version:               ${this.version}`;
 
 		secMan.setNonce(
 			{
-				nodeId: this.id,
+				issuer: this.id,
 				nonceId: secMan.getNonceId(command.nonce),
 			},
-			command.nonce,
+			{
+				nonce: command.nonce,
+				receiver: this.driver.controller.ownNodeId!,
+			},
 			true,
 		);
 	}

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1729,7 +1729,7 @@ version:               ${this.version}`;
 				nonce: command.nonce,
 				receiver: this.driver.controller.ownNodeId!,
 			},
-			true,
+			{ free: true },
 		);
 	}
 


### PR DESCRIPTION
With this PR, we now store both the `issuer` of a nonce (previously `nodeId`) and the `receiver` (the node for which a nonce was generated). This allows us to be more spec-compliant, since all nonces for a receiver should be invalidated once it has replied with one of them.

This also enables us to selectively **not** invalidate nonces to improve compatibility with devices that reuse nonces like ID Lock.

fixes: #1037