### PR TITLE
Force-create targetValue valueIDs for switch-type CCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## __WORK IN PROGRESS__
 ### Bugfixes
 * If a node association is duplicated between `Association CC` and `Multi Channel Association CC`, it is now removed from both when using `Controller.removeAssociations`
+* Empty user codes are now also handled as strings instead of Buffer objects
 
 ## 5.3.6 (2020-11-04)
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * The `duration` property for the `Binary Switch`, `Color Switch`, `Multilevel Switch` and `Scene Activation` CCs is now writeable
 * The `Central Scene CC` interview is now skipped if a device does not respond to the supported scenes request
 * Empty user codes are now also handled as strings instead of Buffer objects
+* The `targetValue` property for the `Binary Switch`, `Multilevel Switch` and `Basic` CCs is now created, even if is `undefined`.
 
 ## 5.3.6 (2020-11-04)
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * If a node association is duplicated between `Association CC` and `Multi Channel Association CC`, it is now removed from both when using `Controller.removeAssociations`
 * Add missing production dependency `semver` to `@zwave-js/config`
 * The `duration` property for the `Binary Switch`, `Color Switch`, `Multilevel Switch` and `Scene Activation` CCs is now writeable
+* The `Central Scene CC` interview is now skipped if a device does not respond to the supported scenes request
 
 ## 5.3.6 (2020-11-04)
 ### Bugfixes

--- a/packages/shared/src/strings.ts
+++ b/packages/shared/src/strings.ts
@@ -28,5 +28,5 @@ export function buffer2hex(buffer: Buffer, uppercase: boolean = false): string {
 }
 
 export function isPrintableASCII(text: string): boolean {
-	return /^[\u0020-\u007e]+$/.test(text);
+	return /^[\u0020-\u007e]*$/.test(text);
 }

--- a/packages/zwave-js/src/lib/commandclass/BasicCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BasicCC.ts
@@ -239,7 +239,7 @@ export class BasicCCReport extends BasicCC {
 	}
 
 	private _targetValue: number | undefined;
-	@ccValue()
+	@ccValue({ forceCreation: true })
 	@ccValueMetadata({
 		...ValueMetadata.Level,
 		label: "Target value",

--- a/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
@@ -253,7 +253,7 @@ export class BinarySwitchCCReport extends BinarySwitchCC {
 	}
 
 	private _targetValue: boolean | undefined;
-	@ccValue()
+	@ccValue({ forceCreation: true })
 	@ccValueMetadata({
 		...ValueMetadata.Boolean,
 		label: "Target value",

--- a/packages/zwave-js/src/lib/commandclass/CommandClass.ts
+++ b/packages/zwave-js/src/lib/commandclass/CommandClass.ts
@@ -563,6 +563,22 @@ export class CommandClass {
 		return false;
 	}
 
+	/** Determines if the given value should always be persisted */
+	public shouldValueAlwaysBeCreated(property: keyof this): boolean {
+		// A value is internal if any of the possible definitions say so (true)
+		if (this._registeredCCValues.get(property as string) === true)
+			return true;
+		const ccValueDefinition = getCCValueDefinitions(this).get(
+			property as string,
+		);
+		if (ccValueDefinition?.forceCreation === true) return true;
+		const ccKeyValuePairDefinition = getCCKeyValuePairDefinitions(this).get(
+			property as string,
+		);
+		if (ccKeyValuePairDefinition?.forceCreation === true) return true;
+		return false;
+	}
+
 	/** Persists all values on the given node into the value. Returns true if the process succeeded, false otherwise */
 	public persistValues(valueNames?: (keyof this)[]): boolean {
 		// In order to avoid cluttering applications with heaps of unsupported properties,
@@ -601,7 +617,12 @@ export class CommandClass {
 			if (variable === "interviewComplete") continue;
 			// Only persist non-undefined values
 			const sourceValue = this[variable as keyof this];
-			if (sourceValue == undefined) continue;
+			if (
+				sourceValue == undefined &&
+				!this.shouldValueAlwaysBeCreated(variable as keyof this)
+			) {
+				continue;
+			}
 
 			if (keyValuePairDefinitions.has(variable)) {
 				// This value is one or more key value pair(s) to be stored in a map
@@ -1201,6 +1222,10 @@ export interface CCValueOptions {
 	 * The minimum CC version required for this value to exist.
 	 */
 	minVersion?: number;
+	/**
+	 * Whether this value should always be created/persisted, even if it is undefined. Default: false
+	 */
+	forceCreation?: boolean;
 }
 
 /**
@@ -1214,6 +1239,7 @@ export function ccValue(options?: CCValueOptions): PropertyDecorator {
 		if (!options) options = {};
 		if (options.internal == undefined) options.internal = false;
 		if (options.minVersion == undefined) options.minVersion = 1;
+		if (options.forceCreation == undefined) options.forceCreation = false;
 		// get the class constructor
 		const constr = target.constructor as typeof CommandClass;
 		const cc = getCommandClassStatic(constr);
@@ -1256,6 +1282,7 @@ export function ccKeyValuePair(options?: CCValueOptions): PropertyDecorator {
 		if (!options) options = {};
 		if (options.internal == undefined) options.internal = false;
 		if (options.minVersion == undefined) options.minVersion = 1;
+		if (options.forceCreation == undefined) options.forceCreation = false;
 		// get the class constructor
 		const constr = target.constructor as typeof CommandClass;
 		const cc = getCommandClassStatic(constr);

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -478,7 +478,7 @@ export class MultilevelSwitchCCReport extends MultilevelSwitchCC {
 	}
 
 	private _targetValue: number | undefined;
-	@ccValue()
+	@ccValue({ forceCreation: true })
 	@ccValueMetadata({
 		...ValueMetadata.Level,
 		label: "Target value",

--- a/packages/zwave-js/src/lib/driver/SendThreadMachine.ts
+++ b/packages/zwave-js/src/lib/driver/SendThreadMachine.ts
@@ -692,7 +692,7 @@ export function createSendThreadMachine(
 								{
 									name: "commandQueue",
 								},
-							),
+							) as any,
 					}),
 					// Spawn the command queue when starting the send thread
 					always: "idle",


### PR DESCRIPTION
fixes: #1099