### PR TITLE
Ignore node timeouts for name/info query in ConfigurationCC V3+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Empty user codes are now also handled as strings instead of Buffer objects
 * The `targetValue` property for the `Binary Switch`, `Multilevel Switch` and `Basic` CCs is now created, even if is `undefined`.
 * The type `CommandClass` is now exported from `zwave-js/CommandClass`
+* The interview process for `Configuration CC V3+` now continues even if the response to `NameGet` and/or `InfoGet` commands is missing or incomplete
 
 ## 5.3.6 (2020-11-04)
 ### Bugfixes

--- a/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
@@ -567,10 +567,16 @@ export class ConfigurationCC extends CommandClass {
 					message: `querying parameter #${param} information...`,
 					direction: "outbound",
 				});
+
 				// Query name and info
-				const name = await api.getName(param);
-				// This is probably long, should we log it?
-				await api.getInfo(param);
+				let name = "(unknown)";
+				// let info = "(unknown)";
+				await ignoreTimeout(async () => {
+					name = await api.getName(param);
+				});
+				await ignoreTimeout(async () => {
+					await api.getInfo(param);
+				});
 
 				// Query properties and the next param
 				const {


### PR DESCRIPTION
fixes: #1106 by ignoring incomplete name/info reports