### PR TITLE
Do not mismatch messages when a node with a pending transaction is marked asleep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * The `targetValue` property for the `Binary Switch`, `Multilevel Switch` and `Basic` CCs is now created, even if is `undefined`.
 * The type `CommandClass` is now exported from `zwave-js/CommandClass`
 * The interview process for `Configuration CC V3+` now continues even if the response to `NameGet` and/or `InfoGet` commands is missing or incomplete
+* Fixed an issue where marking nodes with active transaction as asleep would mess up the serial communication with the controller
 
 ## 5.3.6 (2020-11-04)
 ### Bugfixes

--- a/packages/core/src/log/shared.ts
+++ b/packages/core/src/log/shared.ts
@@ -315,7 +315,7 @@ ${logFilename}`);
 export function createConsoleTransport(): Transport {
 	return new winston.transports.Console({
 		level: getTransportLoglevel(),
-		// silent: process.env.NODE_ENV === "test",
+		silent: process.env.NODE_ENV === "test",
 	});
 }
 

--- a/packages/core/src/log/shared.ts
+++ b/packages/core/src/log/shared.ts
@@ -315,7 +315,7 @@ ${logFilename}`);
 export function createConsoleTransport(): Transport {
 	return new winston.transports.Console({
 		level: getTransportLoglevel(),
-		silent: process.env.NODE_ENV === "test",
+		// silent: process.env.NODE_ENV === "test",
 	});
 }
 

--- a/packages/serial/src/MockSerialPort.ts
+++ b/packages/serial/src/MockSerialPort.ts
@@ -77,7 +77,7 @@ export class MockSerialPort extends ZWaveSerialPort {
 	public readonly closeStub: jest.Mock = jest.fn(() => Promise.resolve());
 
 	public receiveData(data: Buffer): void {
-		this["parser"].push(data);
+		this["serial"].push(data);
 	}
 
 	public raiseError(err: Error): void {

--- a/packages/serial/src/MockSerialPort.ts
+++ b/packages/serial/src/MockSerialPort.ts
@@ -76,13 +76,8 @@ export class MockSerialPort extends ZWaveSerialPort {
 	}
 	public readonly closeStub: jest.Mock = jest.fn(() => Promise.resolve());
 
-	public async receiveData(data: Buffer): Promise<void> {
-		return new Promise((resolve, reject) => {
-			this.serial.write(data, (err) => {
-				if (err) reject(err);
-				else resolve();
-			});
-		});
+	public receiveData(data: Buffer): void {
+		this["parser"].push(data);
 	}
 
 	public raiseError(err: Error): void {

--- a/packages/serial/src/MockSerialPort.ts
+++ b/packages/serial/src/MockSerialPort.ts
@@ -77,7 +77,7 @@ export class MockSerialPort extends ZWaveSerialPort {
 	public readonly closeStub: jest.Mock = jest.fn(() => Promise.resolve());
 
 	public receiveData(data: Buffer): void {
-		this["serial"].push(data);
+		this.serial.push(data);
 	}
 
 	public raiseError(err: Error): void {

--- a/packages/zwave-js/src/lib/driver/Driver.test.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.test.ts
@@ -6,6 +6,8 @@ import {
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
 import { MessageHeaders, MockSerialPort } from "@zwave-js/serial";
+import { wait } from "alcalzone-shared/async";
+import { NodeStatus } from "zwave-js/src/lib/node/Types";
 import {
 	AssociationCCReport,
 	AssociationCommand,
@@ -24,7 +26,7 @@ import {
 import { MessageType } from "../message/Constants";
 import { Message, messageTypes } from "../message/Message";
 import { ZWaveNode } from "../node/Node";
-import { Driver } from "./Driver";
+import { Driver, ZWaveOptions } from "./Driver";
 
 // load the driver with stubbed out Serialport
 jest.mock("@zwave-js/serial", () => {
@@ -39,8 +41,11 @@ jest.mock("@zwave-js/serial", () => {
 
 const PORT_ADDRESS = "/tty/FAKE";
 
-async function createAndStartDriver() {
-	const driver = new Driver(PORT_ADDRESS, { skipInterview: true });
+async function createAndStartDriver(options: Partial<ZWaveOptions> = {}) {
+	const driver = new Driver(PORT_ADDRESS, {
+		...options,
+		skipInterview: true,
+	});
 	driver.on("error", () => {
 		/* swallow error events during testing */
 	});
@@ -55,6 +60,7 @@ async function createAndStartDriver() {
 	// Mock the value DB, because the original one will not be initialized
 	// with skipInterview: true
 	driver["_valueDB"] = new Map() as any;
+	driver["_valueDB"]!.close = () => Promise.resolve();
 
 	return {
 		driver,
@@ -449,7 +455,6 @@ describe("lib/driver/Driver => ", () => {
 			expect(driver.computeNetCCPayloadSize(testMsg3)).toBe(46 - 20 - 2);
 		});
 	});
-
 	it("passes errors from the serialport through", async () => {
 		const { driver, serialport } = await createAndStartDriver();
 		const errorSpy = jest.fn();
@@ -753,6 +758,114 @@ describe("lib/driver/Driver => ", () => {
 				command: cc,
 			});
 			expect(() => driver["assemblePartialCCs"](msg)).toThrow("invalid");
+		});
+	});
+
+	describe("regression tests", () => {
+		let driver: Driver;
+		let serialport: MockSerialPort;
+		process.env.LOGLEVEL = "debug";
+
+		beforeEach(async () => {
+			({ driver, serialport } = await createAndStartDriver({
+				timeouts: {
+					ack: 1000000000,
+					byte: 1000000000,
+					nodeAwake: 1000000000,
+					nonce: 1000000000,
+					report: 1000000000,
+					response: 1000000000,
+					sendDataCallback: 1000000000,
+				},
+			}));
+
+			driver["_controller"] = {
+				ownNodeId: 1,
+				isFunctionSupported: () => true,
+				nodes: new Map(),
+			} as any;
+		});
+
+		afterEach(() => {
+			driver.destroy();
+			driver.removeAllListeners();
+		});
+
+		it.only("marking a node with a pending message as asleep does not mess up the remaining transactions", async () => {
+			jest.setTimeout(5000);
+			jest.useRealTimers();
+			// Repro from #1107
+
+			// Node 10's awake timer elapses before its ping is rejected,
+			// this causes mismatched responses for all following messages
+
+			const node10 = new ZWaveNode(10, driver);
+			const node17 = new ZWaveNode(17, driver);
+			(driver.controller.nodes as Map<number, ZWaveNode>).set(10, node10);
+			(driver.controller.nodes as Map<number, ZWaveNode>).set(17, node17);
+			// Add event handlers for the nodes
+			for (const node of driver.controller.nodes.values()) {
+				driver["addNodeEventHandlers"](node);
+			}
+
+			node10.addCC(CommandClasses["Wake Up"], { isSupported: true });
+			node10.markAsAwake();
+			expect(node10.status).toBe(NodeStatus.Awake);
+
+			driver["lastCallbackId"] = 2;
+			const ACK = Buffer.from([MessageHeaders.ACK]);
+
+			const pingPromise10 = node10.ping();
+			const pingPromise17 = node17.ping();
+			// » [Node 010] [REQ] [SendData]
+			//   │ transmit options: 0x25
+			//   │ callback id:      3
+			//   └─[NoOperationCC]
+			expect(serialport.lastWrite).toEqual(
+				Buffer.from("010800130a01002503c9", "hex"),
+			);
+			await wait(10);
+			serialport.receiveData(MessageHeaders.ACK as any);
+
+			await wait(100);
+
+			// « [RES] [SendData]
+			//     was sent: true
+			serialport.receiveData(Buffer.from("0104011301e8", "hex"));
+			// » [ACK]
+			expect(serialport.lastWrite).toEqual(ACK);
+
+			await wait(100);
+
+			node10.markAsAsleep();
+			expect(node10.status).toBe(NodeStatus.Asleep);
+
+			await wait(100);
+
+			await expect(pingPromise10).resolves.toBe(false);
+
+			// « [REQ] [SendData]
+			//     callback id:     3
+			//     transmit status: NoAck
+			serialport.receiveData(
+				Buffer.from(
+					"011800130301019b007f7f7f7f7f010107000000000204000012",
+					"hex",
+				),
+			);
+			expect(serialport.lastWrite).toEqual(ACK);
+
+			await wait(100);
+
+			// » [Node 017] [REQ] [SendData]
+			//   │ transmit options: 0x25
+			//   │ callback id:      4
+			//   └─[NoOperationCC]
+			expect(serialport.lastWrite).toEqual(
+				Buffer.from("010800131101002504d5", "hex"),
+			);
+
+			await expect(pingPromise17).not.toResolve();
 		});
 	});
 });

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -40,6 +40,7 @@ import fsExtra from "fs-extra";
 import path from "path";
 import SerialPort from "serialport";
 import { URL } from "url";
+import * as util from "util";
 import { interpret } from "xstate";
 import { FirmwareUpdateStatus } from "../commandclass";
 import {
@@ -444,7 +445,7 @@ export class Driver extends EventEmitter {
 			defaultOptions,
 		) as ZWaveOptions;
 		// And make sure they contain valid values
-		// checkOptions(this.options);
+		checkOptions(this.options);
 		this.cacheDir = this.options.cacheDir;
 
 		// register some cleanup handlers in case the program doesn't get closed cleanly
@@ -492,9 +493,6 @@ export class Driver extends EventEmitter {
 			pick(this.options, ["timeouts", "attempts"]),
 		);
 		this.sendThread = interpret(sendThreadMachine);
-		this.sendThread.onEvent((e) => {
-			console.dir(e);
-		});
 		this.sendThread.onTransition((state) => {
 			if (state.changed)
 				log.driver.print(
@@ -2363,5 +2361,10 @@ ${handlers.length} left`,
 				: new SendDataRequest(this, { command: commandOrMsg });
 		this.encapsulateCommands(msg);
 		return msg.command.getMaxPayloadLength(msg.getMaxPayloadLength());
+	}
+
+	// This does not all need to be printed to the console
+	public [util.inspect.custom](): string {
+		return "[Driver]";
 	}
 }

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -444,7 +444,7 @@ export class Driver extends EventEmitter {
 			defaultOptions,
 		) as ZWaveOptions;
 		// And make sure they contain valid values
-		checkOptions(this.options);
+		// checkOptions(this.options);
 		this.cacheDir = this.options.cacheDir;
 
 		// register some cleanup handlers in case the program doesn't get closed cleanly
@@ -492,13 +492,16 @@ export class Driver extends EventEmitter {
 			pick(this.options, ["timeouts", "attempts"]),
 		);
 		this.sendThread = interpret(sendThreadMachine);
-		// this.sendThread.onTransition((state) => {
-		// 	if (state.changed)
-		// 		log.driver.print(
-		// 			`send thread state: ${state.toStrings().slice(-1)[0]}`,
-		// 			"verbose",
-		// 		);
-		// });
+		this.sendThread.onEvent((e) => {
+			console.dir(e);
+		});
+		this.sendThread.onTransition((state) => {
+			if (state.changed)
+				log.driver.print(
+					`send thread state: ${state.toStrings().slice(-1)[0]}`,
+					"verbose",
+				);
+		});
 	}
 
 	/** Enumerates all existing serial ports */

--- a/packages/zwave-js/src/lib/driver/Transaction.ts
+++ b/packages/zwave-js/src/lib/driver/Transaction.ts
@@ -1,4 +1,5 @@
 import { highResTimestamp } from "@zwave-js/core";
+import { pick } from "@zwave-js/shared";
 import {
 	Comparable,
 	compareNumberOrString,
@@ -107,5 +108,16 @@ export class Transaction implements Comparable<Transaction> {
 			other.creationTimestamp,
 			this.creationTimestamp,
 		);
+	}
+
+	public toJSON(): any {
+		return pick(this, [
+			"creationTimestamp",
+			"changeNodeStatusOnTimeout",
+			"tag",
+			"message",
+			"priority",
+			"stack",
+		]);
 	}
 }

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -2515,7 +2515,7 @@ version:               ${this.version}`;
 
 		// Refresh the get timeout
 		if (this._firmwareUpdateStatus.getTimeout) {
-			console.warn("refreshed get timeout");
+			// console.warn("refreshed get timeout");
 			this._firmwareUpdateStatus.getTimeout = this._firmwareUpdateStatus.getTimeout
 				.refresh()
 				.unref();


### PR DESCRIPTION
So, this is a sneaky one. The bug was an xstate transaction that would re-enter the `sending` state, thus re-triggering the entry action.

Also, if a node goes to sleep and its transaction is discarded while waiting for a response, we need to abort the ongoing `Send Data` API call to avoid overlapping transactions or waiting unnecessary long.

fixes: #1107 