### PR TITLE
Create 39351_jasco_zw3010.json

### DIFF
--- a/packages/config/config/devices/0x0039/39351_jasco_zw3010.json
+++ b/packages/config/config/devices/0x0039/39351_jasco_zw3010.json
@@ -1,0 +1,68 @@
+// Honeywell 39351 / Jasco ZW3010
+// In-Wall Smart Dimmer
+{
+    "_approved": true,
+    "manufacturer": "Honeywell",
+    "manufacturerId": "0x0039",
+    "label": "39351 / Jasco ZW3010",
+    "description": "In-Wall Smart Dimmer",
+    "devices": [
+        {
+            "productType": "0x4944",
+            "productId": "0x3235"
+        }
+    ],
+    "firmwareVersion": {
+        "min": "0.0",
+        "max": "255.255"
+    },
+    "supportsZWavePlus": true,
+    "paramInformation": {
+        "3": {
+            "label": "LED Light",
+            "description": "LED status when device on or off.",
+            "valueSize": 1,
+            "minValue": 0,
+            "maxValue": 2,
+            "defaultValue": 0,
+            "readOnly": false,
+            "writeOnly": false,
+            "allowManualEntry": false,
+            "options": [
+                {
+                    "label": "LED ON when load is OFF",
+                    "value": 0
+                },
+                {
+                    "label": "LED ON when load is ON",
+                    "value": 1
+                },
+                {
+                    "label": "LED always OFF",
+                    "value": 2
+                }
+            ]
+        },
+        "4": {
+            "label": "Invert Switch",
+            "description": "Switch orientation.",
+            "valueSize": 1,
+            "minValue": 0,
+            "maxValue": 1,
+            "defaultValue": 0,
+            "readOnly": false,
+            "writeOnly": false,
+            "allowManualEntry": false,
+            "options": [
+                {
+                    "label": "Default",
+                    "value": 0
+                },
+                {
+                    "label": "Invert Switch",
+                    "value": 1
+                }
+            ]
+        }
+    }
+}

--- a/packages/config/config/devices/index.json
+++ b/packages/config/config/devices/index.json
@@ -1412,6 +1412,16 @@
     },
     {
         "manufacturerId": "0x0039",
+        "productType": "0x4944",
+        "productId": "0x3235",
+        "firmwareVersion": {
+            "min": "0.0",
+            "max": "255.255"
+        },
+        "filename": "0x0039/39351_jasco_zw3010.json"
+    },
+    {
+        "manufacturerId": "0x0039",
         "productType": "0x4952",
         "productId": "0x3037",
         "firmwareVersion": {


### PR DESCRIPTION
Adds new honeywell (by jasco) switch model 3010.

Copied 39351_jasco_zw3005.json and updated to support newer version of the switch. 

New version is showing in zwavejs2mqtt with "Unknown manufacturer 57", "Product 18756", and "Unknown product 12853". I believe I've updated the appropriate JSON values.