### PR TITLE
feat(docs): auto-import interfaces, types, enum declarations in the docs from TS sources

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,9 +9,7 @@
 			"name": "vscode-jest-tests",
 			"request": "launch",
 			"program": "${workspaceFolder}/node_modules/jest/bin/jest",
-			"args": [
-				"--runInBand"
-			],
+			"args": ["--runInBand"],
 			"cwd": "${workspaceFolder}",
 			"console": "integratedTerminal",
 			"internalConsoleOptions": "neverOpen",
@@ -25,19 +23,14 @@
 			"port": 9229,
 			"localRoot": "${workspaceFolder}",
 			"remoteRoot": "/opt/iobroker/node_modules/zwave-js",
-			"skipFiles": [
-				"<node_internals>/**"
-			]
+			"skipFiles": ["<node_internals>/**"]
 		},
 		{
 			"type": "node",
 			"request": "attach",
 			"name": "Attach (localhost)",
 			"port": 9229,
-			"skipFiles": [
-				"<node_internals>/**",
-				"**/typescript.js"
-			],
+			"skipFiles": ["<node_internals>/**", "**/typescript.js"],
 			"sourceMaps": true
 		},
 		{
@@ -55,13 +48,29 @@
 				"${workspaceFolder}/test/run.ts"
 			],
 			"env": {
-				"NO_CACHE": "true",
+				"NO_CACHE": "true"
 				// "LOGLEVEL": "verbose"
 			},
 			"console": "integratedTerminal",
-			"skipFiles": [
-				"<node_internals>/**"
+			"skipFiles": ["<node_internals>/**"],
+			"sourceMaps": true
+		},
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Generate typed docs",
+			"port": 9229,
+			"runtimeArgs": [
+				"--async-stack-traces",
+				"--inspect-brk=9229",
+				"-r",
+				"ts-node/register/transpile-only",
+				"-r",
+				"tsconfig-paths/register",
+				"${workspaceFolder}/maintenance/generateTypedDocs.ts"
 			],
+			"console": "integratedTerminal",
+			"skipFiles": ["<node_internals>/**"],
 			"sourceMaps": true
 		},
 		{
@@ -75,9 +84,7 @@
 				"${workspaceFolder}/test/debug.js"
 			],
 			"console": "integratedTerminal",
-			"skipFiles": [
-				"<node_internals>/**"
-			],
+			"skipFiles": ["<node_internals>/**"],
 			"sourceMaps": true
 		}
 	]

--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -128,6 +128,8 @@ removeNodeFromAllAssocations(nodeId: number): Promise<void>;
 
 Contains information about a single association group.
 
+<!-- #import AssociationGroup from "zwave-js" -->
+
 ```ts
 interface AssociationGroup {
 	/** How many nodes this association group supports */
@@ -149,11 +151,11 @@ interface AssociationGroup {
 
 This defines the target of a node's association:
 
+<!-- #import Association from "zwave-js" -->
+
 ```ts
 interface Association {
-	/** The target node */
 	nodeId: number;
-	/** The target endpoint on the target node */
 	endpoint?: number;
 }
 ```
@@ -191,8 +193,10 @@ readonly type: ZWaveLibraryTypes
 
 Returns the type of the Z-Wave library that is supported by the controller hardware. The following values are possible:
 
+<!-- #import ZWaveLibraryTypes from "zwave-js" -->
+
 ```ts
-export enum ZWaveLibraryTypes {
+enum ZWaveLibraryTypes {
 	"Unknown",
 	"Static Controller",
 	"Controller",

--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -131,9 +131,6 @@ Contains information about a single association group.
 <!-- #import AssociationGroup from "zwave-js" -->
 
 ```ts
-/**
- * @publicAPI
- */
 interface AssociationGroup {
 	/** How many nodes this association group supports */
 	maxNodes: number;
@@ -157,9 +154,6 @@ This defines the target of a node's association:
 <!-- #import Association from "zwave-js" -->
 
 ```ts
-/**
- * @publicAPI
- */
 interface Association {
 	nodeId: number;
 	endpoint?: number;

--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -131,6 +131,9 @@ Contains information about a single association group.
 <!-- #import AssociationGroup from "zwave-js" -->
 
 ```ts
+/**
+ * @publicAPI
+ */
 interface AssociationGroup {
 	/** How many nodes this association group supports */
 	maxNodes: number;
@@ -154,6 +157,9 @@ This defines the target of a node's association:
 <!-- #import Association from "zwave-js" -->
 
 ```ts
+/**
+ * @publicAPI
+ */
 interface Association {
 	nodeId: number;
 	endpoint?: number;

--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -226,6 +226,7 @@ The `Driver` class inherits from the Node.js [EventEmitter](https://nodejs.org/a
 <!-- #import FileSystem from "zwave-js" -->
 
 ```ts
+/** Defines which methods must be supported by a replacement filesystem */
 interface FileSystem {
 	ensureDir(path: string): Promise<void>;
 	writeFile(
@@ -276,6 +277,7 @@ The message priority must one of the following enum values. Consuming applicatio
 <!-- #import MessagePriority from "zwave-js" -->
 
 ```ts
+/** The priority of messages, sorted from high (0) to low (>0) */
 enum MessagePriority {
 	// Handshake messages have the highest priority because they are part of other transactions
 	// which have already started when the handshakes are needed (e.g. Security Nonce exchange)
@@ -324,6 +326,7 @@ The `onUpdate` has the signature `(status: SupervisionStatus, remainingDuration?
 <!-- #import SupervisionStatus from "zwave-js" -->
 
 ```ts
+/** @publicAPI */
 enum SupervisionStatus {
 	NoSupport = 0x00,
 	Working = 0x01,
@@ -339,6 +342,7 @@ Is used to report the status of a supervised command execution.
 <!-- #import SupervisionResult from "zwave-js" -->
 
 ```ts
+/** @publicAPI */
 interface SupervisionResult {
 	status: SupervisionStatus;
 	remainingDuration?: Duration;

--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -223,10 +223,11 @@ The `Driver` class inherits from the Node.js [EventEmitter](https://nodejs.org/a
 
 ### `FileSystem`
 
+This interface defines which methods must be supported by a replacement filesystem.
+
 <!-- #import FileSystem from "zwave-js" -->
 
 ```ts
-/** Defines which methods must be supported by a replacement filesystem */
 interface FileSystem {
 	ensureDir(path: string): Promise<void>;
 	writeFile(
@@ -268,16 +269,11 @@ interface SendMessageOptions {
 }
 ```
 
-The message priority must one of the following enum values. Consuming applications typically don't need to overwrite the priority.
-
-> [!ATTENTION]
-> DO NOT rely on the numeric values of the enum if you're using it in your application.
-> The ordinal values are likely to change in future updates. Instead, refer to the enum properties directly.
+The message priority must one of the following enum values, which are sorted from high (0) to low (> 0). Consuming applications typically don't need to overwrite the priority.
 
 <!-- #import MessagePriority from "zwave-js" with comments -->
 
 ```ts
-/** The priority of messages, sorted from high (0) to low (>0) */
 enum MessagePriority {
 	// Handshake messages have the highest priority because they are part of other transactions
 	// which have already started when the handshakes are needed (e.g. Security Nonce exchange)
@@ -308,6 +304,10 @@ enum MessagePriority {
 }
 ```
 
+> [!ATTENTION]
+> DO NOT rely on the numeric values of the enum if you're using it in your application.
+> The ordinal values are likely to change in future updates. Instead, refer to the enum properties directly.
+
 ### `SendCommandOptions`
 
 Influences the behavior of `driver.sendCommand`. Has all the properties of [`SendMessageOptions`](#SendMessageOptions) plus the following:
@@ -326,7 +326,6 @@ The `onUpdate` has the signature `(status: SupervisionStatus, remainingDuration?
 <!-- #import SupervisionStatus from "zwave-js" -->
 
 ```ts
-/** @publicAPI */
 enum SupervisionStatus {
 	NoSupport = 0x00,
 	Working = 0x01,
@@ -342,7 +341,6 @@ Is used to report the status of a supervised command execution.
 <!-- #import SupervisionResult from "zwave-js" -->
 
 ```ts
-/** @publicAPI */
 interface SupervisionResult {
 	status: SupervisionStatus;
 	remainingDuration?: Duration;
@@ -352,6 +350,8 @@ interface SupervisionResult {
 ### `ZWaveOptions`
 
 This interface specifies the optional options object that is passed to the `Driver` constructor. All properties are optional and are internally filled with default values.
+
+<!-- #import ZWaveOptions from "zwave-js" with comments -->
 
 ```ts
 interface ZWaveOptions {
@@ -386,7 +386,6 @@ interface ZWaveOptions {
 		 */
 		nodeInterview: number; // [1...10], default: 5
 	};
-
 	/**
 	 * Allows you to replace the default file system driver used to store and read the cache
 	 */

--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -223,6 +223,8 @@ The `Driver` class inherits from the Node.js [EventEmitter](https://nodejs.org/a
 
 ### `FileSystem`
 
+<!-- #import FileSystem from "zwave-js" -->
+
 ```ts
 interface FileSystem {
 	ensureDir(path: string): Promise<void>;
@@ -244,16 +246,24 @@ interface FileSystem {
 
 Influences the behavior of `driver.sendMessage`.
 
+<!-- #import SendMessageOptions from "zwave-js" -->
+
 ```ts
 interface SendMessageOptions {
 	/** The priority of the message to send. If none is given, the defined default priority of the message class will be used. */
 	priority?: MessagePriority;
 	/** If an exception should be thrown when the message to send is not supported. Setting this to false is is useful if the capabilities haven't been determined yet. Default: true */
 	supportCheck?: boolean;
-	/** Whether the driver should update the node status to asleep or dead when a transaction is not acknowledged (repeatedly). Setting this to false will cause the simply transaction to be rejected on failure. Default: true */
+	/**
+	 * Whether the driver should update the node status to asleep or dead when a transaction is not acknowledged (repeatedly).
+	 * Setting this to false will cause the simply transaction to be rejected on failure.
+	 * Default: true
+	 */
 	changeNodeStatusOnMissingACK?: boolean;
-	/** Sets the number of milliseconds after which a message expires. When the expiration timer elapses, the promise is rejected with the error code `Controller_MessageExpired`. */
+	/** Sets the number of milliseconds after which a transaction expires. When the expiration timer elapses, the transaction promise is rejected. */
 	expire?: number;
+	/** Internal information used to identify or mark this transaction */
+	tag?: any;
 }
 ```
 
@@ -263,8 +273,9 @@ The message priority must one of the following enum values. Consuming applicatio
 > DO NOT rely on the numeric values of the enum if you're using it in your application.
 > The ordinal values are likely to change in future updates. Instead, refer to the enum properties directly.
 
+<!-- #import MessagePriority from "zwave-js" -->
+
 ```ts
-/** The priority of messages, sorted from high (0) to low (>0) */
 enum MessagePriority {
 	// Handshake messages have the highest priority because they are part of other transactions
 	// which have already started when the handshakes are needed (e.g. Security Nonce exchange)
@@ -275,23 +286,23 @@ enum MessagePriority {
 	// Our handshake requests must be prioritized over all other messages
 	PreTransmitHandshake = 1,
 	// Controller commands usually finish quickly and should be preferred over node queries
-	Controller = 2,
+	Controller,
 	// Pings (NoOP) are used for device probing at startup and for network diagnostics
-	Ping = 3,
+	Ping,
 	// Multistep controller commands typically require user interaction but still
 	// should happen at a higher priority than any node data exchange
-	MultistepController = 4,
+	MultistepController,
 	// Whenever sleeping devices wake up, their queued messages must be handled quickly
 	// because they want to go to sleep soon. So prioritize them over non-sleeping devices
-	WakeUp = 5,
+	WakeUp,
 	// Normal operation and node data exchange
-	Normal = 6,
+	Normal,
 	// Node querying is expensive and happens whenever a new node is discovered.
 	// In order to keep the system responsive, give them a lower priority
-	NodeQuery = 7,
+	NodeQuery,
 	// Some devices need their state to be polled at regular intervals. Only do that when
 	// nothing else needs to be done
-	Poll = 8,
+	Poll,
 }
 ```
 
@@ -310,6 +321,8 @@ Influences the behavior of `driver.sendSupervisedCommand`. Has all the propertie
 
 The `onUpdate` has the signature `(status: SupervisionStatus, remainingDuration?: Duration) => void` where `SupervisionStatus` is defined as follows:
 
+<!-- #import SupervisionStatus from "zwave-js" -->
+
 ```ts
 enum SupervisionStatus {
 	NoSupport = 0x00,
@@ -322,6 +335,8 @@ enum SupervisionStatus {
 ### `SupervisionResult`
 
 Is used to report the status of a supervised command execution.
+
+<!-- #import SupervisionResult from "zwave-js" -->
 
 ```ts
 interface SupervisionResult {

--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -274,7 +274,7 @@ The message priority must one of the following enum values. Consuming applicatio
 > DO NOT rely on the numeric values of the enum if you're using it in your application.
 > The ordinal values are likely to change in future updates. Instead, refer to the enum properties directly.
 
-<!-- #import MessagePriority from "zwave-js" -->
+<!-- #import MessagePriority from "zwave-js" with comments -->
 
 ```ts
 /** The priority of messages, sorted from high (0) to low (>0) */

--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -262,10 +262,8 @@ interface SendMessageOptions {
 	 * Default: true
 	 */
 	changeNodeStatusOnMissingACK?: boolean;
-	/** Sets the number of milliseconds after which a transaction expires. When the expiration timer elapses, the transaction promise is rejected. */
+	/** Sets the number of milliseconds after which a message expires. When the expiration timer elapses, the promise is rejected with the error code `Controller_MessageExpired`. */
 	expire?: number;
-	/** Internal information used to identify or mark this transaction */
-	tag?: any;
 }
 ```
 

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -146,10 +146,12 @@ function extractFirmware(data: Buffer, format: FirmwareFileFormat): Firmware
 
 If successful, `extractFirmware` returns an object of the following form, whose properties can be passed to `beginFirmwareUpdate`:
 
+<!-- #import Firmware from "zwave-js" -->
+
 ```ts
 interface Firmware {
-	data: Buffer;
-	firmwareTarget?: number;
+    data: Buffer;
+    firmwareTarget?: number;
 }
 ```
 
@@ -197,6 +199,8 @@ readonly interviewStage: InterviewStage
 
 This property tracks the current status of the node interview. It contains a value representing the **last completed step** of the interview. You shouldn't need to use this in your application. If you do, here are the possible values.
 
+<!-- #import InterviewStage from "zwave-js" -->
+
 ```ts
 enum InterviewStage {
 	/** The interview process hasn't started for this node */
@@ -205,25 +209,36 @@ enum InterviewStage {
 	ProtocolInfo,
 	/** The node has been queried for supported and controlled command classes */
 	NodeInfo,
+
+	// ===== the stuff above should never change =====
+
 	/**
 	 * This marks the beginning of re-interviews on application startup.
 	 * RestartFromCache and later stages will be serialized as "Complete" in the cache
 	 */
 	RestartFromCache,
+
+	// ===== the stuff below changes frequently, so it has to be redone on every start =====
+
 	/**
 	 * Information for all command classes has been queried.
 	 * This includes static information that is requested once as well as dynamic
 	 * information that is requested on every restart.
 	 */
 	CommandClasses,
+
+	// TODO: Heal network on startup
+
 	/**
 	 * Device information for the node has been loaded from a config file.
 	 * If defined, some of the reported information will be overwritten based on the
 	 * config file contents.
 	 */
 	OverwriteConfig,
+
 	/** The node has been queried for its current neighbor list */
 	Neighbors,
+
 	/** The interview process has finished */
 	Complete,
 }

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -202,38 +202,34 @@ This property tracks the current status of the node interview. It contains a val
 <!-- #import InterviewStage from "zwave-js" -->
 
 ```ts
-// prettier-ignore
 enum InterviewStage {
-    /** The interview process hasn't started for this node */
-    None,
-    /** The node's protocol information has been queried from the controller */
-    ProtocolInfo,
-    /** The node has been queried for supported and controlled command classes */
-    NodeInfo,
-    // ===== the stuff above should never change =====
-    /**
-     * This marks the beginning of re-interviews on application startup.
-     * RestartFromCache and later stages will be serialized as "Complete" in the cache
-     */
-    RestartFromCache,
-    // ===== the stuff below changes frequently, so it has to be redone on every start =====
-    /**
-     * Information for all command classes has been queried.
-     * This includes static information that is requested once as well as dynamic
-     * information that is requested on every restart.
-     */
-    CommandClasses,
-    // TODO: Heal network on startup
-    /**
-     * Device information for the node has been loaded from a config file.
-     * If defined, some of the reported information will be overwritten based on the
-     * config file contents.
-     */
-    OverwriteConfig,
-    /** The node has been queried for its current neighbor list */
-    Neighbors,
-    /** The interview process has finished */
-    Complete
+	/** The interview process hasn't started for this node */
+	None,
+	/** The node's protocol information has been queried from the controller */
+	ProtocolInfo,
+	/** The node has been queried for supported and controlled command classes */
+	NodeInfo,
+	/**
+	 * This marks the beginning of re-interviews on application startup.
+	 * RestartFromCache and later stages will be serialized as "Complete" in the cache
+	 */
+	RestartFromCache,
+	/**
+	 * Information for all command classes has been queried.
+	 * This includes static information that is requested once as well as dynamic
+	 * information that is requested on every restart.
+	 */
+	CommandClasses,
+	/**
+	 * Device information for the node has been loaded from a config file.
+	 * If defined, some of the reported information will be overwritten based on the
+	 * config file contents.
+	 */
+	OverwriteConfig,
+	/** The node has been queried for its current neighbor list */
+	Neighbors,
+	/** The interview process has finished */
+	Complete,
 }
 ```
 

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -150,8 +150,8 @@ If successful, `extractFirmware` returns an object of the following form, whose 
 
 ```ts
 interface Firmware {
-    data: Buffer;
-    firmwareTarget?: number;
+	data: Buffer;
+	firmwareTarget?: number;
 }
 ```
 
@@ -202,45 +202,38 @@ This property tracks the current status of the node interview. It contains a val
 <!-- #import InterviewStage from "zwave-js" -->
 
 ```ts
+// prettier-ignore
 enum InterviewStage {
-	/** The interview process hasn't started for this node */
-	None,
-	/** The node's protocol information has been queried from the controller */
-	ProtocolInfo,
-	/** The node has been queried for supported and controlled command classes */
-	NodeInfo,
-
-	// ===== the stuff above should never change =====
-
-	/**
-	 * This marks the beginning of re-interviews on application startup.
-	 * RestartFromCache and later stages will be serialized as "Complete" in the cache
-	 */
-	RestartFromCache,
-
-	// ===== the stuff below changes frequently, so it has to be redone on every start =====
-
-	/**
-	 * Information for all command classes has been queried.
-	 * This includes static information that is requested once as well as dynamic
-	 * information that is requested on every restart.
-	 */
-	CommandClasses,
-
-	// TODO: Heal network on startup
-
-	/**
-	 * Device information for the node has been loaded from a config file.
-	 * If defined, some of the reported information will be overwritten based on the
-	 * config file contents.
-	 */
-	OverwriteConfig,
-
-	/** The node has been queried for its current neighbor list */
-	Neighbors,
-
-	/** The interview process has finished */
-	Complete,
+    /** The interview process hasn't started for this node */
+    None,
+    /** The node's protocol information has been queried from the controller */
+    ProtocolInfo,
+    /** The node has been queried for supported and controlled command classes */
+    NodeInfo,
+    // ===== the stuff above should never change =====
+    /**
+     * This marks the beginning of re-interviews on application startup.
+     * RestartFromCache and later stages will be serialized as "Complete" in the cache
+     */
+    RestartFromCache,
+    // ===== the stuff below changes frequently, so it has to be redone on every start =====
+    /**
+     * Information for all command classes has been queried.
+     * This includes static information that is requested once as well as dynamic
+     * information that is requested on every restart.
+     */
+    CommandClasses,
+    // TODO: Heal network on startup
+    /**
+     * Device information for the node has been loaded from a config file.
+     * If defined, some of the reported information will be overwritten based on the
+     * config file contents.
+     */
+    OverwriteConfig,
+    /** The node has been queried for its current neighbor list */
+    Neighbors,
+    /** The interview process has finished */
+    Complete
 }
 ```
 

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -209,25 +209,30 @@ enum InterviewStage {
 	ProtocolInfo,
 	/** The node has been queried for supported and controlled command classes */
 	NodeInfo,
+
 	/**
 	 * This marks the beginning of re-interviews on application startup.
 	 * RestartFromCache and later stages will be serialized as "Complete" in the cache
 	 */
 	RestartFromCache,
+
 	/**
 	 * Information for all command classes has been queried.
 	 * This includes static information that is requested once as well as dynamic
 	 * information that is requested on every restart.
 	 */
 	CommandClasses,
+
 	/**
 	 * Device information for the node has been loaded from a config file.
 	 * If defined, some of the reported information will be overwritten based on the
 	 * config file contents.
 	 */
 	OverwriteConfig,
+
 	/** The node has been queried for its current neighbor list */
 	Neighbors,
+
 	/** The interview process has finished */
 	Complete,
 }

--- a/docs/api/valueid.md
+++ b/docs/api/valueid.md
@@ -5,7 +5,6 @@ The `ValueID` interface uniquely identifies to which CC, endpoint and property a
 <!-- #import ValueID from "zwave-js" -->
 
 ```ts
-/** Uniquely identifies to which CC, endpoint and property a value belongs to */
 interface ValueID {
 	commandClass: CommandClasses;
 	endpoint?: number;
@@ -148,9 +147,6 @@ The structure of the `ccSpecific` fields is shown here for each CC that provides
 <!-- #import AlarmSensorValueMetadata from "zwave-js" -->
 
 ```ts
-/**
- * @publicAPI
- */
 type AlarmSensorValueMetadata = ValueMetadata & {
 	ccSpecific: {
 		sensorType: AlarmSensorType;
@@ -163,9 +159,6 @@ type AlarmSensorValueMetadata = ValueMetadata & {
 <!-- #import BinarySensorValueMetadata from "zwave-js" -->
 
 ```ts
-/**
- * @publicAPI
- */
 type BinarySensorValueMetadata = ValueMetadata & {
 	ccSpecific: {
 		sensorType: BinarySensorType;
@@ -178,9 +171,6 @@ type BinarySensorValueMetadata = ValueMetadata & {
 <!-- #import IndicatorMetadata from "zwave-js" -->
 
 ```ts
-/**
- * @publicAPI
- */
 type IndicatorMetadata = ValueMetadata & {
 	ccSpecific: {
 		indicatorId: number;
@@ -196,9 +186,6 @@ The indicator and property IDs may change with newer Z-Wave specs. You can find 
 <!-- #import MeterMetadata from "zwave-js" -->
 
 ```ts
-/**
- * @publicAPI
- */
 type MeterMetadata = ValueMetadata & {
 	ccSpecific: {
 		meterType: number;
@@ -215,9 +202,6 @@ The meter type and scale keys may change with newer Z-Wave specs. You can find t
 <!-- #import MultilevelSensorValueMetadata from "zwave-js" -->
 
 ```ts
-/**
- * @publicAPI
- */
 type MultilevelSensorValueMetadata = ValueMetadata & {
 	ccSpecific: {
 		sensorType: number;
@@ -233,9 +217,6 @@ The multilevel sensor types may change with newer Z-Wave specs. You can find the
 <!-- #import MultilevelSwitchLevelChangeMetadata from "zwave-js" -->
 
 ```ts
-/**
- * @publicAPI
- */
 type MultilevelSwitchLevelChangeMetadata = ValueMetadata & {
 	ccSpecific: {
 		switchType: SwitchType;
@@ -248,9 +229,6 @@ type MultilevelSwitchLevelChangeMetadata = ValueMetadata & {
 <!-- #import NotificationMetadata from "zwave-js" -->
 
 ```ts
-/**
- * @publicAPI
- */
 type NotificationMetadata = ValueMetadata & {
 	ccSpecific: {
 		notificationType: number;
@@ -266,9 +244,6 @@ The notification variable is not included in this metadata, since there's curren
 <!-- #import ThermostatSetpointMetadata from "zwave-js" -->
 
 ```ts
-/**
- * @publicAPI
- */
 type ThermostatSetpointMetadata = ValueMetadata & {
 	ccSpecific: {
 		setpointType: ThermostatSetpointType;

--- a/docs/api/valueid.md
+++ b/docs/api/valueid.md
@@ -2,12 +2,14 @@
 
 The `ValueID` interface uniquely identifies to which CC, endpoint and property a value belongs to:
 
+<!-- #import ValueID from "zwave-js" -->
+
 ```ts
 interface ValueID {
-	commandClass: CommandClasses;
-	endpoint?: number;
-	property: number | string;
-	propertyKey?: number | string;
+    commandClass: CommandClasses;
+    endpoint?: number;
+    property: string | number;
+    propertyKey?: string | number;
 }
 ```
 
@@ -19,6 +21,8 @@ It has four properties:
 -   `propertyKey` - _(optional)_ Allows sub-addressing properties that contain multiple values (like combined sensors).
 
 Since both `property` and `propertyKey` can be cryptic, value IDs are exposed to consuming applications in a "translated" form, which contains all properties from `ValueID` plus the following ones:
+
+<!-- #import TranslatedValueID from "zwave-js" -->
 
 ```ts
 interface TranslatedValueID extends ValueID {
@@ -33,6 +37,8 @@ These properties are meant to provide a human-readable representation of the Com
 ## ValueMetadata
 
 Value metadata is used to get additional information about a specific `ValueID`. All metadata shares the following structure (with additional information added) for each value type:
+
+<!-- TODO: Import from "core" does not work for some reason -->
 
 ```ts
 interface ValueMetadataBase {
@@ -58,9 +64,12 @@ Here you can find all the type specific metadata fields
 
 #### `any`
 
+<!-- #import ValueMetadataAny from "zwave-js" -->
+
 ```ts
 interface ValueMetadataAny extends ValueMetadataBase {
-	default?: any;
+    /** The default value */
+    default?: any;
 }
 ```
 
@@ -68,15 +77,23 @@ interface ValueMetadataAny extends ValueMetadataBase {
 
 #### `number`
 
+<!-- #import ValueMetadataNumeric from "zwave-js" -->
+
 ```ts
 interface ValueMetadataNumeric extends ValueMetadataBase {
-	type: "number";
-	min?: number;
-	max?: number;
-	steps?: number;
-	default?: number;
-	states?: Record<number, string>;
-	unit?: string;
+    type: "number";
+    /** The minimum value that can be assigned to a CC value (optional) */
+    min?: number;
+    /** The maximum value that can be assigned to a CC value (optional) */
+    max?: number;
+    /** When only certain values between min and max are allowed, this determines the step size */
+    steps?: number;
+    /** The default value */
+    default?: number;
+    /** Speaking names for numeric values */
+    states?: Record<number, string>;
+    /** An optional unit for numeric values */
+    unit?: string;
 }
 ```
 
@@ -89,10 +106,13 @@ interface ValueMetadataNumeric extends ValueMetadataBase {
 
 #### boolean
 
+<!-- #import ValueMetadataBoolean from "zwave-js" -->
+
 ```ts
 interface ValueMetadataBoolean extends ValueMetadataBase {
-	type: "boolean";
-	default?: number;
+    type: "boolean";
+    /** The default value */
+    default?: number;
 }
 ```
 
@@ -100,12 +120,17 @@ interface ValueMetadataBoolean extends ValueMetadataBase {
 
 ### string
 
+<!-- #import ValueMetadataString from "zwave-js" -->
+
 ```ts
 interface ValueMetadataString extends ValueMetadataBase {
-	type: "string";
-	minLength?: number;
-	maxLength?: number;
-	default?: string;
+    type: "string";
+    /** The minimum length this string must have (optional) */
+    minLength?: number;
+    /** The maximum length this string may have (optional) */
+    maxLength?: number;
+    /** The default value */
+    default?: string;
 }
 ```
 
@@ -119,6 +144,8 @@ The structure of the `ccSpecific` fields is shown here for each CC that provides
 
 #### Alarm Sensor CC
 
+<!-- #import AlarmSensorValueMetadata from "zwave-js" -->
+
 ```ts
 type AlarmSensorValueMetadata = ValueMetadata & {
 	ccSpecific: {
@@ -128,6 +155,8 @@ type AlarmSensorValueMetadata = ValueMetadata & {
 ```
 
 #### Binary Sensor CC
+
+<!-- #import BinarySensorValueMetadata from "zwave-js" -->
 
 ```ts
 type BinarySensorValueMetadata = ValueMetadata & {
@@ -139,11 +168,13 @@ type BinarySensorValueMetadata = ValueMetadata & {
 
 #### Indicator CC
 
+<!-- #import IndicatorMetadata from "zwave-js" -->
+
 ```ts
 type IndicatorMetadata = ValueMetadata & {
 	ccSpecific: {
 		indicatorId: number;
-		propertyId?: number; // only present on V2+ indicators
+		propertyId?: number;
 	};
 };
 ```
@@ -151,6 +182,8 @@ type IndicatorMetadata = ValueMetadata & {
 The indicator and property IDs may change with newer Z-Wave specs. You can find the current definitions [here](https://github.com/zwave-js/node-zwave-js/blob/master/packages/config/config/indicators.json).
 
 #### Meter CC
+
+<!-- #import MeterMetadata from "zwave-js" -->
 
 ```ts
 type MeterMetadata = ValueMetadata & {
@@ -166,6 +199,8 @@ The meter type and scale keys may change with newer Z-Wave specs. You can find t
 
 #### Multilevel Sensor CC
 
+<!-- #import MultilevelSensorValueMetadata from "zwave-js" -->
+
 ```ts
 type MultilevelSensorValueMetadata = ValueMetadata & {
 	ccSpecific: {
@@ -179,6 +214,8 @@ The multilevel sensor types may change with newer Z-Wave specs. You can find the
 
 #### Multilevel Switch CC
 
+<!-- #import MultilevelSwitchLevelChangeMetadata from "zwave-js" -->
+
 ```ts
 type MultilevelSwitchLevelChangeMetadata = ValueMetadata & {
 	ccSpecific: {
@@ -188,6 +225,8 @@ type MultilevelSwitchLevelChangeMetadata = ValueMetadata & {
 ```
 
 #### Notification CC
+
+<!-- #import NotificationMetadata from "zwave-js" -->
 
 ```ts
 type NotificationMetadata = ValueMetadata & {
@@ -201,6 +240,8 @@ The notification types and variable names may change with newer Z-Wave specs. Yo
 The notification variable is not included in this metadata, since there's currently no way to identify them except their name, which is used as the `propertyKey` of the value ID.
 
 #### Thermostat Setpoint CC
+
+<!-- #import ThermostatSetpointMetadata from "zwave-js" -->
 
 ```ts
 type ThermostatSetpointMetadata = ValueMetadata & {

--- a/docs/api/valueid.md
+++ b/docs/api/valueid.md
@@ -5,11 +5,12 @@ The `ValueID` interface uniquely identifies to which CC, endpoint and property a
 <!-- #import ValueID from "zwave-js" -->
 
 ```ts
+/** Uniquely identifies to which CC, endpoint and property a value belongs to */
 interface ValueID {
-    commandClass: CommandClasses;
-    endpoint?: number;
-    property: string | number;
-    propertyKey?: string | number;
+	commandClass: CommandClasses;
+	endpoint?: number;
+	property: string | number;
+	propertyKey?: string | number;
 }
 ```
 
@@ -68,8 +69,8 @@ Here you can find all the type specific metadata fields
 
 ```ts
 interface ValueMetadataAny extends ValueMetadataBase {
-    /** The default value */
-    default?: any;
+	/** The default value */
+	default?: any;
 }
 ```
 
@@ -81,19 +82,19 @@ interface ValueMetadataAny extends ValueMetadataBase {
 
 ```ts
 interface ValueMetadataNumeric extends ValueMetadataBase {
-    type: "number";
-    /** The minimum value that can be assigned to a CC value (optional) */
-    min?: number;
-    /** The maximum value that can be assigned to a CC value (optional) */
-    max?: number;
-    /** When only certain values between min and max are allowed, this determines the step size */
-    steps?: number;
-    /** The default value */
-    default?: number;
-    /** Speaking names for numeric values */
-    states?: Record<number, string>;
-    /** An optional unit for numeric values */
-    unit?: string;
+	type: "number";
+	/** The minimum value that can be assigned to a CC value (optional) */
+	min?: number;
+	/** The maximum value that can be assigned to a CC value (optional) */
+	max?: number;
+	/** When only certain values between min and max are allowed, this determines the step size */
+	steps?: number;
+	/** The default value */
+	default?: number;
+	/** Speaking names for numeric values */
+	states?: Record<number, string>;
+	/** An optional unit for numeric values */
+	unit?: string;
 }
 ```
 
@@ -110,9 +111,9 @@ interface ValueMetadataNumeric extends ValueMetadataBase {
 
 ```ts
 interface ValueMetadataBoolean extends ValueMetadataBase {
-    type: "boolean";
-    /** The default value */
-    default?: number;
+	type: "boolean";
+	/** The default value */
+	default?: number;
 }
 ```
 
@@ -124,13 +125,13 @@ interface ValueMetadataBoolean extends ValueMetadataBase {
 
 ```ts
 interface ValueMetadataString extends ValueMetadataBase {
-    type: "string";
-    /** The minimum length this string must have (optional) */
-    minLength?: number;
-    /** The maximum length this string may have (optional) */
-    maxLength?: number;
-    /** The default value */
-    default?: string;
+	type: "string";
+	/** The minimum length this string must have (optional) */
+	minLength?: number;
+	/** The maximum length this string may have (optional) */
+	maxLength?: number;
+	/** The default value */
+	default?: string;
 }
 ```
 
@@ -147,6 +148,9 @@ The structure of the `ccSpecific` fields is shown here for each CC that provides
 <!-- #import AlarmSensorValueMetadata from "zwave-js" -->
 
 ```ts
+/**
+ * @publicAPI
+ */
 type AlarmSensorValueMetadata = ValueMetadata & {
 	ccSpecific: {
 		sensorType: AlarmSensorType;
@@ -159,6 +163,9 @@ type AlarmSensorValueMetadata = ValueMetadata & {
 <!-- #import BinarySensorValueMetadata from "zwave-js" -->
 
 ```ts
+/**
+ * @publicAPI
+ */
 type BinarySensorValueMetadata = ValueMetadata & {
 	ccSpecific: {
 		sensorType: BinarySensorType;
@@ -171,6 +178,9 @@ type BinarySensorValueMetadata = ValueMetadata & {
 <!-- #import IndicatorMetadata from "zwave-js" -->
 
 ```ts
+/**
+ * @publicAPI
+ */
 type IndicatorMetadata = ValueMetadata & {
 	ccSpecific: {
 		indicatorId: number;
@@ -186,6 +196,9 @@ The indicator and property IDs may change with newer Z-Wave specs. You can find 
 <!-- #import MeterMetadata from "zwave-js" -->
 
 ```ts
+/**
+ * @publicAPI
+ */
 type MeterMetadata = ValueMetadata & {
 	ccSpecific: {
 		meterType: number;
@@ -202,6 +215,9 @@ The meter type and scale keys may change with newer Z-Wave specs. You can find t
 <!-- #import MultilevelSensorValueMetadata from "zwave-js" -->
 
 ```ts
+/**
+ * @publicAPI
+ */
 type MultilevelSensorValueMetadata = ValueMetadata & {
 	ccSpecific: {
 		sensorType: number;
@@ -217,6 +233,9 @@ The multilevel sensor types may change with newer Z-Wave specs. You can find the
 <!-- #import MultilevelSwitchLevelChangeMetadata from "zwave-js" -->
 
 ```ts
+/**
+ * @publicAPI
+ */
 type MultilevelSwitchLevelChangeMetadata = ValueMetadata & {
 	ccSpecific: {
 		switchType: SwitchType;
@@ -229,6 +248,9 @@ type MultilevelSwitchLevelChangeMetadata = ValueMetadata & {
 <!-- #import NotificationMetadata from "zwave-js" -->
 
 ```ts
+/**
+ * @publicAPI
+ */
 type NotificationMetadata = ValueMetadata & {
 	ccSpecific: {
 		notificationType: number;
@@ -244,6 +266,9 @@ The notification variable is not included in this metadata, since there's curren
 <!-- #import ThermostatSetpointMetadata from "zwave-js" -->
 
 ```ts
+/**
+ * @publicAPI
+ */
 type ThermostatSetpointMetadata = ValueMetadata & {
 	ccSpecific: {
 		setpointType: ThermostatSetpointType;

--- a/docs/api/valueid.md
+++ b/docs/api/valueid.md
@@ -77,22 +77,16 @@ interface ValueMetadataAny extends ValueMetadataBase {
 
 #### `number`
 
-<!-- #import ValueMetadataNumeric from "zwave-js" -->
+<!-- #import ValueMetadataNumeric from "zwave-js" with no-jsdoc -->
 
 ```ts
 interface ValueMetadataNumeric extends ValueMetadataBase {
 	type: "number";
-	/** The minimum value that can be assigned to a CC value (optional) */
 	min?: number;
-	/** The maximum value that can be assigned to a CC value (optional) */
 	max?: number;
-	/** When only certain values between min and max are allowed, this determines the step size */
 	steps?: number;
-	/** The default value */
 	default?: number;
-	/** Speaking names for numeric values */
 	states?: Record<number, string>;
-	/** An optional unit for numeric values */
 	unit?: string;
 }
 ```
@@ -106,12 +100,11 @@ interface ValueMetadataNumeric extends ValueMetadataBase {
 
 #### boolean
 
-<!-- #import ValueMetadataBoolean from "zwave-js" -->
+<!-- #import ValueMetadataBoolean from "zwave-js" with no-jsdoc -->
 
 ```ts
 interface ValueMetadataBoolean extends ValueMetadataBase {
 	type: "boolean";
-	/** The default value */
 	default?: number;
 }
 ```
@@ -120,21 +113,18 @@ interface ValueMetadataBoolean extends ValueMetadataBase {
 
 ### string
 
-<!-- #import ValueMetadataString from "zwave-js" -->
+<!-- #import ValueMetadataString from "zwave-js" with no-jsdoc -->
 
 ```ts
 interface ValueMetadataString extends ValueMetadataBase {
 	type: "string";
-	/** The minimum length this string must have (optional) */
 	minLength?: number;
-	/** The maximum length this string may have (optional) */
 	maxLength?: number;
-	/** The default value */
 	default?: string;
 }
 ```
 
--   `minLength`: The minimum length this string may have
+-   `minLength`: The minimum length this string must have
 -   `maxLength`: The maximum length this string may have
 -   `default`: The default value
 
@@ -168,13 +158,13 @@ type BinarySensorValueMetadata = ValueMetadata & {
 
 #### Indicator CC
 
-<!-- #import IndicatorMetadata from "zwave-js" -->
+<!-- #import IndicatorMetadata from "zwave-js" with comments -->
 
 ```ts
 type IndicatorMetadata = ValueMetadata & {
 	ccSpecific: {
 		indicatorId: number;
-		propertyId?: number;
+		propertyId?: number; // only present on V2+ indicators
 	};
 };
 ```

--- a/maintenance/generateTypedDocs.ts
+++ b/maintenance/generateTypedDocs.ts
@@ -1,0 +1,125 @@
+/*!
+ * This method returns the original source code for an interface or type so it can be put into documentation
+ */
+
+import { red } from "ansi-colors";
+import * as fs from "fs-extra";
+import * as path from "path";
+import ts from "typescript";
+import { loadTSConfig } from "../packages/zwave-js/maintenance/tsTools";
+import { enumFilesRecursive } from "./tools";
+
+export function findSource(
+	program: ts.Program,
+	checker: ts.TypeChecker,
+	exportingFile: string,
+	identifier: string,
+): string | undefined {
+	// Scan all source files
+	const file = program.getSourceFile(exportingFile);
+	if (file) {
+		const fileSymbol = checker.getSymbolAtLocation(file)!;
+		const exportSymbols = checker.getExportsOfModule(fileSymbol);
+		const wantedSymbol = exportSymbols.find(
+			(e) => e.escapedName === identifier,
+		);
+		if (wantedSymbol) {
+			let code = checker
+				.getAliasedSymbol(wantedSymbol)
+				.declarations[0].getText();
+			// Remove some stuff we don't need
+			code = code
+				.replace(/^export type/g, "type")
+				.replace(/^export interface/g, "interface")
+				.replace(/^export class/g, "class")
+				.replace(/^export enum/g, "enum");
+			return code;
+		}
+	}
+}
+
+interface ImportRange {
+	index: number;
+	end: number;
+	module: string;
+	symbol: string;
+}
+
+const importRegex = /<!-- #import (?<symbol>.*?) from "(?<module>.*?)" -->(?:[\s\r\n]*```ts[\r\n]*(?<source>(.|\n)*?)```)?/g;
+
+export function findImportRanges(docFile: string): ImportRange[] {
+	const matches = [...docFile.matchAll(importRegex)];
+	return matches.map((match) => ({
+		index: match.index!,
+		// eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+		end: match.index! + match[0].length,
+		module: match.groups!.module,
+		symbol: match.groups!.symbol,
+	}));
+}
+
+export async function processDocFile(
+	program: ts.Program,
+	checker: ts.TypeChecker,
+	docFile: string,
+): Promise<boolean> {
+	let fileContent = await fs.readFile(docFile, "utf8");
+	const ranges = findImportRanges(fileContent);
+	let hasErrors = false;
+	// Replace from back to start so we can reuse the indizes
+	for (let i = ranges.length - 1; i >= 0; i--) {
+		const range = ranges[i];
+		const source = findSource(
+			program,
+			checker,
+			`packages/${range.module}/src/index.ts`,
+			range.symbol,
+		);
+		if (!source) {
+			console.error(
+				red(
+					`Cannot find symbol ${range.symbol} in module ${range.module}!`,
+				),
+			);
+			hasErrors = true;
+		} else {
+			fileContent = `${fileContent.slice(0, range.index)}<!-- #import ${
+				range.symbol
+			} from "${range.module}" -->
+
+\`\`\`ts
+${source}
+\`\`\`${fileContent.slice(range.end)}`;
+		}
+	}
+	fileContent = fileContent.replace(/\r\n/g, "\n");
+	if (!hasErrors) {
+		await fs.writeFile(docFile, fileContent, "utf8");
+	}
+	return hasErrors;
+}
+
+async function main(): Promise<void> {
+	// Create a Program to represent the project, then pull out the
+	// source file to parse its AST.
+
+	const tsConfig = loadTSConfig();
+	const program = ts.createProgram(tsConfig.fileNames, tsConfig.options);
+	const checker = program.getTypeChecker();
+
+	const files = await enumFilesRecursive(
+		path.join(__dirname, "../docs"),
+		(f) => f.endsWith(".md"),
+	);
+	let hasErrors = false;
+	for (const file of files) {
+		hasErrors ||= await processDocFile(program, checker, file);
+	}
+	if (hasErrors) {
+		process.exit(1);
+	}
+}
+
+if (!module.parent) {
+	void main();
+}

--- a/maintenance/importConfig.ts
+++ b/maintenance/importConfig.ts
@@ -38,6 +38,7 @@ import { formatId, padVersion } from "../packages/config/src/utils";
 import { CommandClasses, getIntegerLimits } from "../packages/core/src";
 import { num2hex } from "../packages/shared/src";
 import { stringify } from "../packages/shared/src/strings";
+import { enumFilesRecursive } from "./tools";
 
 const execPromise = promisify(child.exec);
 
@@ -1050,29 +1051,6 @@ function getLatestConfigVersion(
 	});
 
 	return configs[configs.length - 1];
-}
-
-async function enumFilesRecursive(
-	rootDir: string,
-	predicate?: (filename: string) => boolean,
-) {
-	const ret: string[] = [];
-	try {
-		const filesAndDirs = await fs.readdir(rootDir);
-		for (const f of filesAndDirs) {
-			const fullPath = path.join(rootDir, f);
-
-			if (fs.statSync(fullPath).isDirectory()) {
-				ret.push(...(await enumFilesRecursive(fullPath, predicate)));
-			} else if (predicate?.(fullPath)) {
-				ret.push(fullPath);
-			}
-		}
-	} catch (err) {
-		console.error(`Cannot read directory: "${rootDir}": ${err}`);
-	}
-
-	return ret;
 }
 
 /** Generates an index for all device config files */

--- a/maintenance/tools.ts
+++ b/maintenance/tools.ts
@@ -1,0 +1,25 @@
+import * as fs from "fs-extra";
+import * as path from "path";
+
+export async function enumFilesRecursive(
+	rootDir: string,
+	predicate?: (filename: string) => boolean,
+): Promise<string[]> {
+	const ret: string[] = [];
+	try {
+		const filesAndDirs = await fs.readdir(rootDir);
+		for (const f of filesAndDirs) {
+			const fullPath = path.join(rootDir, f);
+
+			if (fs.statSync(fullPath).isDirectory()) {
+				ret.push(...(await enumFilesRecursive(fullPath, predicate)));
+			} else if (predicate?.(fullPath)) {
+				ret.push(fullPath);
+			}
+		}
+	} catch (err) {
+		console.error(`Cannot read directory: "${rootDir}": ${err}`);
+	}
+
+	return ret;
+}

--- a/maintenance/tsconfig.json
+++ b/maintenance/tsconfig.json
@@ -5,8 +5,12 @@
 		"module": "commonjs",
 		"moduleResolution": "node",
 		// "noImplicitAny": true,
+		"lib": [
+			"ES2020"
+		],
 		"target": "es2015",
-		"rootDir": "../"
+		"rootDir": "../",
+		"newLine": "lf"
 	},
 	"include": [
 		"*.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "prettier-plugin-organize-imports": "^1.1.1",
         "semver": "^7.3.2",
         "supports-color": "^7.2.0",
+        "ts-morph": "^9.1.0",
         "ts-node": "^9.0.0",
         "tsconfig-paths": "^3.9.0",
         "typescript": "^4.2.0-dev.20201117",
@@ -1842,6 +1843,19 @@
         "colorspace": "1.1.x",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@dsherret/to-absolute-glob": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+      "integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
+      "dev": true,
+      "dependencies": {
+        "is-absolute": "^1.0.0",
+        "is-negated-glob": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -5151,6 +5165,82 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@ts-morph/common": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.7.2.tgz",
+      "integrity": "sha512-XyUPLf1UHtteP5C5FEgVJqgIEOcmaSEoJyU/jQ1gTBKlz/lb1Uss4ix+D2e5qRwPFiBMqM/jwJpna0yVDE5V/g==",
+      "dev": true,
+      "dependencies": {
+        "@dsherret/to-absolute-glob": "^2.0.2",
+        "fast-glob": "^3.2.4",
+        "is-negated-glob": "^1.0.0",
+        "mkdirp": "^1.0.4",
+        "multimatch": "^5.0.0",
+        "typescript": "~4.1.2"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/array-differ": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
+      "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/multimatch": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",
+      "integrity": "sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "array-differ": "^3.0.0",
+        "array-union": "^2.1.0",
+        "arrify": "^2.0.1",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/typescript": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
+      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.1.12",
       "dev": true,
@@ -6937,6 +7027,12 @@
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
       }
+    },
+    "node_modules/code-block-writer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.1.tgz",
+      "integrity": "sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==",
+      "dev": true
     },
     "node_modules/code-point-at": {
       "version": "1.1.0",
@@ -19133,6 +19229,17 @@
       "version": "1.3.0",
       "license": "MIT"
     },
+    "node_modules/ts-morph": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-9.1.0.tgz",
+      "integrity": "sha512-sei4u651MBenr27sD6qLDXN3gZ4thiX71E3qV7SuVtDas0uvK2LtgZkIYUf9DKm/fLJ6AB/+yhRJ1vpEBJgy7Q==",
+      "dev": true,
+      "dependencies": {
+        "@dsherret/to-absolute-glob": "^2.0.2",
+        "@ts-morph/common": "~0.7.0",
+        "code-block-writer": "^10.1.1"
+      }
+    },
     "node_modules/ts-node": {
       "version": "9.0.0",
       "dev": true,
@@ -21657,6 +21764,16 @@
         "kuler": "^2.0.0"
       }
     },
+    "@dsherret/to-absolute-glob": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+      "integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
+      "dev": true,
+      "requires": {
+        "is-absolute": "^1.0.0",
+        "is-negated-glob": "^1.0.0"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.2.1",
       "dev": true,
@@ -24035,6 +24152,59 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@ts-morph/common": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.7.2.tgz",
+      "integrity": "sha512-XyUPLf1UHtteP5C5FEgVJqgIEOcmaSEoJyU/jQ1gTBKlz/lb1Uss4ix+D2e5qRwPFiBMqM/jwJpna0yVDE5V/g==",
+      "dev": true,
+      "requires": {
+        "@dsherret/to-absolute-glob": "^2.0.2",
+        "fast-glob": "^3.2.4",
+        "is-negated-glob": "^1.0.0",
+        "mkdirp": "^1.0.4",
+        "multimatch": "^5.0.0",
+        "typescript": "~4.1.2"
+      },
+      "dependencies": {
+        "array-differ": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
+          "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
+          "dev": true
+        },
+        "arrify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "multimatch": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",
+          "integrity": "sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==",
+          "dev": true,
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "array-differ": "^3.0.0",
+            "array-union": "^2.1.0",
+            "arrify": "^2.0.1",
+            "minimatch": "^3.0.4"
+          }
+        },
+        "typescript": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
+          "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
+          "dev": true
+        }
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.12",
       "dev": true,
@@ -25287,6 +25457,12 @@
     },
     "co": {
       "version": "4.6.0",
+      "dev": true
+    },
+    "code-block-writer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.1.tgz",
+      "integrity": "sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==",
       "dev": true
     },
     "code-point-at": {
@@ -33580,6 +33756,17 @@
     },
     "triple-beam": {
       "version": "1.3.0"
+    },
+    "ts-morph": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-9.1.0.tgz",
+      "integrity": "sha512-sei4u651MBenr27sD6qLDXN3gZ4thiX71E3qV7SuVtDas0uvK2LtgZkIYUf9DKm/fLJ6AB/+yhRJ1vpEBJgy7Q==",
+      "dev": true,
+      "requires": {
+        "@dsherret/to-absolute-glob": "^2.0.2",
+        "@ts-morph/common": "~0.7.0",
+        "code-block-writer": "^10.1.1"
+      }
     },
     "ts-node": {
       "version": "9.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15593,6 +15593,7 @@
     "node_modules/node-expat": {
       "version": "2.3.18",
       "dev": true,
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "workspaces": [
     "packages/*"
   ],
-  "dependencies": {},
   "devDependencies": {
     "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.4",
@@ -83,6 +82,7 @@
     "prettier-plugin-organize-imports": "^1.1.1",
     "semver": "^7.3.2",
     "supports-color": "^7.2.0",
+    "ts-morph": "^9.1.0",
     "ts-node": "^9.0.0",
     "tsconfig-paths": "^3.9.0",
     "typescript": "^4.2.0-dev.20201117",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,8 @@
     "version": "rm package-lock.json && npm i && release-script --lerna",
     "postversion": "git push && git push --tags",
     "config": "ts-node maintenance/importConfig.ts",
-    "docs": "docsify serve docs"
+    "docs": "docsify serve docs",
+    "generate-docs": "ts-node -P maintenance/tsconfig.json maintenance/generateTypedDocs.ts"
   },
   "readme": "README.md",
   "husky": {

--- a/packages/zwave-js/maintenance/tsTools.ts
+++ b/packages/zwave-js/maintenance/tsTools.ts
@@ -33,6 +33,9 @@ export function loadTSConfig(): {
 	};
 }
 
+/** Used for ts-morph */
+export const tsConfigFilePath = path.join(projectRoot, "tsconfig.json");
+
 export function compareStrings(a: string, b: string): number {
 	if (a > b) return 1;
 	if (b > a) return -1;
@@ -50,80 +53,4 @@ export function formatWithPrettier(
 		filepath: filename,
 	};
 	return prettier.format(sourceText, prettierOptions);
-}
-
-export function updateModifiers<T extends ts.Node>(
-	factory: ts.NodeFactory,
-	s: T,
-	add: ts.ModifierSyntaxKind[] | undefined,
-	remove: ts.ModifierSyntaxKind[] | undefined,
-): T {
-	let modifiers = [...(s.modifiers ?? [])];
-	if (remove?.length) {
-		modifiers = modifiers.filter((m) => !remove.includes(m.kind));
-	}
-	if (add?.length) {
-		const reallyNew = add.filter(
-			(kind) => !modifiers.some((m) => m.kind === kind),
-		);
-		modifiers.push(...reallyNew.map((kind) => ts.createModifier(kind)));
-	}
-
-	if (ts.isVariableStatement(s)) {
-		return (factory.updateVariableStatement(
-			s,
-			modifiers,
-			s.declarationList,
-		) as unknown) as T;
-	} else if (ts.isTypeAliasDeclaration(s)) {
-		return (factory.updateTypeAliasDeclaration(
-			s,
-			s.decorators,
-			modifiers,
-			s.name,
-			s.typeParameters,
-			s.type,
-		) as unknown) as T;
-	} else if (ts.isInterfaceDeclaration(s)) {
-		return (factory.updateInterfaceDeclaration(
-			s,
-			s.decorators,
-			modifiers,
-			s.name,
-			s.typeParameters,
-			s.heritageClauses,
-			s.members,
-		) as unknown) as T;
-	} else if (ts.isEnumDeclaration(s)) {
-		return (factory.updateEnumDeclaration(
-			s,
-			s.decorators,
-			modifiers,
-			s.name,
-			s.members,
-		) as unknown) as T;
-	} else if (ts.isClassDeclaration(s)) {
-		return (factory.updateClassDeclaration(
-			s,
-			s.decorators,
-			modifiers,
-			s.name,
-			s.typeParameters,
-			s.heritageClauses,
-			s.members,
-		) as unknown) as T;
-	} else if (ts.isFunctionDeclaration(s)) {
-		return (factory.updateFunctionDeclaration(
-			s,
-			s.decorators,
-			modifiers,
-			s.asteriskToken,
-			s.name,
-			s.typeParameters,
-			s.parameters,
-			s.type,
-			s.body,
-		) as unknown) as T;
-	}
-	return s;
 }

--- a/packages/zwave-js/maintenance/tsTools.ts
+++ b/packages/zwave-js/maintenance/tsTools.ts
@@ -51,3 +51,79 @@ export function formatWithPrettier(
 	};
 	return prettier.format(sourceText, prettierOptions);
 }
+
+export function updateModifiers<T extends ts.Node>(
+	factory: ts.NodeFactory,
+	s: T,
+	add: ts.ModifierSyntaxKind[] | undefined,
+	remove: ts.ModifierSyntaxKind[] | undefined,
+): T {
+	let modifiers = [...(s.modifiers ?? [])];
+	if (remove?.length) {
+		modifiers = modifiers.filter((m) => !remove.includes(m.kind));
+	}
+	if (add?.length) {
+		const reallyNew = add.filter(
+			(kind) => !modifiers.some((m) => m.kind === kind),
+		);
+		modifiers.push(...reallyNew.map((kind) => ts.createModifier(kind)));
+	}
+
+	if (ts.isVariableStatement(s)) {
+		return (factory.updateVariableStatement(
+			s,
+			modifiers,
+			s.declarationList,
+		) as unknown) as T;
+	} else if (ts.isTypeAliasDeclaration(s)) {
+		return (factory.updateTypeAliasDeclaration(
+			s,
+			s.decorators,
+			modifiers,
+			s.name,
+			s.typeParameters,
+			s.type,
+		) as unknown) as T;
+	} else if (ts.isInterfaceDeclaration(s)) {
+		return (factory.updateInterfaceDeclaration(
+			s,
+			s.decorators,
+			modifiers,
+			s.name,
+			s.typeParameters,
+			s.heritageClauses,
+			s.members,
+		) as unknown) as T;
+	} else if (ts.isEnumDeclaration(s)) {
+		return (factory.updateEnumDeclaration(
+			s,
+			s.decorators,
+			modifiers,
+			s.name,
+			s.members,
+		) as unknown) as T;
+	} else if (ts.isClassDeclaration(s)) {
+		return (factory.updateClassDeclaration(
+			s,
+			s.decorators,
+			modifiers,
+			s.name,
+			s.typeParameters,
+			s.heritageClauses,
+			s.members,
+		) as unknown) as T;
+	} else if (ts.isFunctionDeclaration(s)) {
+		return (factory.updateFunctionDeclaration(
+			s,
+			s.decorators,
+			modifiers,
+			s.asteriskToken,
+			s.name,
+			s.typeParameters,
+			s.parameters,
+			s.type,
+			s.body,
+		) as unknown) as T;
+	}
+	return s;
+}

--- a/packages/zwave-js/src/Driver.ts
+++ b/packages/zwave-js/src/Driver.ts
@@ -1,3 +1,4 @@
 export { Driver } from "./lib/driver/Driver";
-export type { ZWaveOptions } from "./lib/driver/Driver";
+export type { SendMessageOptions, ZWaveOptions } from "./lib/driver/Driver";
 export type { FileSystem } from "./lib/driver/FileSystem";
+export { MessagePriority } from "./lib/message/Constants";

--- a/packages/zwave-js/src/Node.ts
+++ b/packages/zwave-js/src/Node.ts
@@ -1,4 +1,8 @@
 export { NODE_ID_BROADCAST, NODE_ID_MAX } from "@zwave-js/core";
 export { Endpoint } from "./lib/node/Endpoint";
 export { ZWaveNode } from "./lib/node/Node";
-export { InterviewStage, NodeStatus } from "./lib/node/Types";
+export {
+	InterviewStage,
+	NodeInterviewFailedEventArgs,
+	NodeStatus,
+} from "./lib/node/Types";

--- a/packages/zwave-js/src/Values.ts
+++ b/packages/zwave-js/src/Values.ts
@@ -10,6 +10,7 @@ export type {
 	ValueMetadataAny,
 	ValueMetadataBoolean,
 	ValueMetadataNumeric,
+	ValueMetadataString,
 	ValueType,
 } from "@zwave-js/core";
 export type {

--- a/packages/zwave-js/src/lib/commandclass/IndicatorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/IndicatorCC.ts
@@ -43,7 +43,7 @@ import {
 export type IndicatorMetadata = ValueMetadata & {
 	ccSpecific: {
 		indicatorId: number;
-		propertyId?: number;
+		propertyId?: number; // only present on V2+ indicators
 	};
 };
 

--- a/packages/zwave-js/src/lib/commandclass/SupervisionCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SupervisionCC.ts
@@ -31,6 +31,7 @@ export enum SupervisionCommand {
 	Report = 0x02,
 }
 
+/** @publicAPI */
 export enum SupervisionStatus {
 	NoSupport = 0x00,
 	Working = 0x01,
@@ -38,6 +39,7 @@ export enum SupervisionStatus {
 	Success = 0xff,
 }
 
+/** @publicAPI */
 export interface SupervisionResult {
 	status: SupervisionStatus;
 	remainingDuration?: Duration;

--- a/packages/zwave-js/src/lib/commandclass/index.ts
+++ b/packages/zwave-js/src/lib/commandclass/index.ts
@@ -50,6 +50,8 @@ export type { MultilevelSwitchLevelChangeMetadata } from "./MultilevelSwitchCC";
 export type { NotificationMetadata } from "./NotificationCC";
 export { LocalProtectionState, RFProtectionState } from "./ProtectionCC";
 export { ToneId } from "./SoundSwitchCC";
+export { SupervisionStatus } from "./SupervisionCC";
+export type { SupervisionResult } from "./SupervisionCC";
 export { ThermostatMode } from "./ThermostatModeCC";
 export { ThermostatOperatingState } from "./ThermostatOperatingStateCC";
 export { SetbackType } from "./ThermostatSetbackCC";

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -324,9 +324,12 @@ export interface SendMessageOptions {
 	 * Default: true
 	 */
 	changeNodeStatusOnMissingACK?: boolean;
-	/** Sets the number of milliseconds after which a transaction expires. When the expiration timer elapses, the transaction promise is rejected. */
+	/** Sets the number of milliseconds after which a message expires. When the expiration timer elapses, the promise is rejected with the error code `Controller_MessageExpired`. */
 	expire?: number;
-	/** Internal information used to identify or mark this transaction */
+	/**
+	 * Internal information used to identify or mark this transaction
+	 * @internal
+	 */
 	tag?: any;
 }
 

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -122,33 +122,33 @@ export interface ZWaveOptions {
 	/** Specify timeouts in milliseconds */
 	timeouts: {
 		/** how long to wait for an ACK */
-		ack: number;
+		ack: number; // >=1, default: 1000 ms
 		/** not sure */
-		byte: number;
+		byte: number; // >=1, default: 150 ms
 		/**
 		 * How long to wait for a controller response. Usually this timeout should never elapse,
 		 * so this is merely a safeguard against the driver stalling
 		 */
-		response: number;
+		response: number; // [500...5000], default: 1600 ms
 		/** How long to wait for a callback from the host for a SendData[Multicast]Request */
-		sendDataCallback: number;
+		sendDataCallback: number; // >=10000, default: 65000 ms
 		/** How much time a node gets to process a request and send a response */
-		report: number;
+		report: number; // [1000...40000], default: 1600 ms
 		/** How long generated nonces are valid */
-		nonce: number;
+		nonce: number; // [3000...20000], default: 5000 ms
 		/** How long a node is assumed to be awake after the last communication with it */
-		nodeAwake: number;
+		nodeAwake: number; // [1000...30000], default: 10000 ms
 	};
 
 	attempts: {
 		/** How often the driver should try communication with the controller before giving up */
-		controller: number;
+		controller: number; // [1...3], default: 3
 		/** How often the driver should try sending SendData commands before giving up */
-		sendData: number;
+		sendData: number; // [1...5], default: 3
 		/**
 		 * How many attempts should be made for each node interview before giving up
 		 */
-		nodeInterview: number;
+		nodeInterview: number; // [1...10], default: 5
 	};
 
 	/**
@@ -168,7 +168,7 @@ export interface ZWaveOptions {
 	/** Allows you to specify a different cache directory */
 	cacheDir: string;
 
-	/** Specify the network key to use for encryption */
+	/** Specify the network key to use for encryption. This must be a Buffer with exactly 16 bytes length */
 	networkKey?: Buffer;
 }
 


### PR DESCRIPTION
With this PR, we have the ability to import the actual definition of types, interfaces and enums into documentation. To do so, I've introduced a comment syntax that is similar to TypeScripts imports:

```md
<!-- #import Firmware from "zwave-js" -->
```
will be converted to
~~~md
<!-- #import Firmware from "zwave-js" -->

```ts
interface Firmware {
    data: Buffer;
    firmwareTarget?: number;
}
```
~~~
for example. There are a few kinks to work out, but the basic functionality is there.

**Next steps:**

- [x] review the generated files if we like the changes
- [x] add the option to remove comments (e.g. if we have better comments in the docs)
- [ ] use this in a github action that checks if the docs can be built
- [ ] use this action to detect changes and create a PR if changes are detected