### PR TITLE
fix: use lookupValue to determine notification event label in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bugfixes
 * `Driver.destroy()` no longer does anything after the first call
+* The log entries for `Notification CC Report`s now contain the correct notification event/state
 
 ## 5.5.0 (2020-11-24)
 ### Config file changes

--- a/packages/zwave-js/src/lib/commandclass/NotificationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/NotificationCC.ts
@@ -754,15 +754,17 @@ export class NotificationCCReport extends NotificationCC {
 				"V1 alarm level": this.alarmLevel,
 			};
 		} else {
+			const valueConfig = lookupNotification(
+				this.notificationType!,
+			)?.lookupValue(this.notificationEvent!);
 			message = {
 				"notification type": getNotificationName(
 					this.notificationType!,
 				),
 				"notification status": this.notificationStatus,
-				"notification event":
-					lookupNotification(this.notificationType!)?.events.get(
-						this.notificationEvent!,
-					)?.label ?? `Unknown (${num2hex(this.notificationEvent)})`,
+				[`notification ${valueConfig?.type ?? "event"}`]:
+					valueConfig?.label ??
+					`Unknown (${num2hex(this.notificationEvent)})`,
 			};
 		}
 		if (this.zensorNetSourceNodeId) {


### PR DESCRIPTION
fixes: #1162