### PR TITLE
fix: propagate the CC secure flag during encapsulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * `Sound Switch Tone Play Report` commands now parse the volume if it exists
 * The log entries for `Notification CC Report`s now contain the correct notification event/state
 * The value IDs of `Multi Channel Association CC` are now marked as internal
+* When encapsulating commands, the `secure` flag is now correctly propagated
 
 ## 5.5.0 (2020-11-24)
 ### Config file changes

--- a/packages/zwave-js/src/lib/commandclass/MultiChannelCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultiChannelCC.ts
@@ -978,6 +978,8 @@ export class MultiChannelCCCommandEncapsulation extends MultiChannelCC {
 			this.encapsulated = options.encapsulated;
 			options.encapsulated.encapsulatingCC = this as any;
 			this.destination = options.destination;
+			// If the encapsulated command requires security, so does this one
+			if (this.encapsulated.secure) this.secure = true;
 		}
 	}
 

--- a/packages/zwave-js/src/lib/commandclass/SupervisionCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SupervisionCC.ts
@@ -209,6 +209,8 @@ export class SupervisionCCGet extends SupervisionCC {
 			this.requestStatusUpdates = options.requestStatusUpdates;
 			this.encapsulated = options.encapsulated;
 			options.encapsulated.encapsulatingCC = this as any;
+			// If the encapsulated command requires security, so does this one
+			if (this.encapsulated.secure) this.secure = true;
 		}
 	}
 

--- a/packages/zwave-js/src/lib/test/driver/secureAndSupervisionEncap.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/secureAndSupervisionEncap.test.ts
@@ -1,0 +1,73 @@
+import { CommandClasses, SecurityManager } from "@zwave-js/core";
+import { MockSerialPort } from "@zwave-js/serial";
+import type { Driver } from "../../driver/Driver";
+import { ZWaveNode } from "../../node/Node";
+import { createAndStartDriver } from "../utils";
+
+describe("regression tests", () => {
+	let driver: Driver;
+	let serialport: MockSerialPort;
+	process.env.LOGLEVEL = "debug";
+
+	beforeEach(async () => {
+		({ driver, serialport } = await createAndStartDriver({
+			networkKey: Buffer.alloc(16, 0),
+		}));
+
+		driver["_securityManager"] = new SecurityManager({
+			networkKey: driver.options.networkKey!,
+			ownNodeId: 1,
+			nonceTimeout: driver.options.timeouts.nonce,
+		});
+
+		driver["_controller"] = {
+			ownNodeId: 1,
+			isFunctionSupported: () => true,
+			nodes: new Map(),
+		} as any;
+	});
+
+	afterEach(() => {
+		driver.destroy();
+		driver.removeAllListeners();
+	});
+
+	it("secure encapsulation should be used when encapsulated command requires it", async () => {
+		jest.setTimeout(5000);
+		// Repro from Qubino's testing results:
+
+		// A command is sent to a node which supports Multilevel Switch only secure and Supervision is allowed non-securely
+		const node2 = new ZWaveNode(2, driver);
+		(driver.controller.nodes as Map<number, ZWaveNode>).set(2, node2);
+		// Add event handlers for the nodes
+		for (const node of driver.controller.nodes.values()) {
+			driver["addNodeEventHandlers"](node);
+		}
+
+		node2.addCC(CommandClasses["Multilevel Switch"], {
+			isSupported: true,
+			isControlled: false,
+			secure: true,
+			version: 4,
+		});
+		node2.addCC(CommandClasses.Supervision, {
+			isSupported: true,
+			isControlled: false,
+			secure: false,
+			version: 0,
+		});
+		node2.addCC(CommandClasses.Security, {
+			isSupported: true,
+			version: 1,
+		});
+		node2.markAsAlive();
+
+		node2.commandClasses["Multilevel Switch"].startLevelChange({
+			direction: "up",
+			ignoreStartLevel: true,
+		});
+
+		// The driver should send a secure command
+		expect(serialport.lastWrite?.[6]).toBe(0x98);
+	});
+});


### PR DESCRIPTION
This PR fixes a report by the Qubino staff who detected that the command encapsulation "Supervision > (any secure command)" does not use Security encapsulation.