### PR TITLE
feat: expose node name and location as a writeable property

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -216,6 +216,28 @@ readonly id: number
 
 Returns the ID this node has been assigned by the controller. This is a number between 1 and 232.
 
+### `name`
+
+```ts
+name: string | undefined;
+```
+
+The user-defined name of this node. Uses the value reported by `Node Naming and Location CC` if it exists.
+
+> [!NOTE]
+> Setting this value only updates the name locally. To permanently change the name of the node, use the [`commandClasses` API](api/endpoint.md#commandClasses).
+
+### `location`
+
+```ts
+location: string | undefined;
+```
+
+The user-defined location of this node. Uses the value reported by `Node Naming and Location CC` if it exists.
+
+> [!NOTE]
+> Setting this value only updates the location locally. To permanently change the location of the node, use the [`commandClasses` API](api/endpoint.md#commandClasses).
+
 ### `status`
 
 ```ts

--- a/packages/zwave-js/src/lib/commandclass/NodeNamingCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/NodeNamingCC.ts
@@ -1,10 +1,5 @@
-import type { Maybe, MessageOrCCLogEntry } from "@zwave-js/core";
-import {
-	CommandClasses,
-	ValueMetadata,
-	ZWaveError,
-	ZWaveErrorCodes,
-} from "@zwave-js/core";
+import type { Maybe, MessageOrCCLogEntry, ValueID } from "@zwave-js/core";
+import { CommandClasses, ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
 import type { Driver } from "../driver/Driver";
 import log from "../log";
 import { MessagePriority } from "../message/Constants";
@@ -20,7 +15,6 @@ import {
 	CCCommand,
 	CCCommandOptions,
 	ccValue,
-	ccValueMetadata,
 	CommandClass,
 	commandClass,
 	CommandClassDeserializationOptions,
@@ -41,6 +35,20 @@ export enum NodeNamingAndLocationCommand {
 	LocationSet = 0x04,
 	LocationGet = 0x05,
 	LocationReport = 0x06,
+}
+
+export function getNodeNameValueId(): ValueID {
+	return {
+		commandClass: CommandClasses["Node Naming and Location"],
+		property: "name",
+	};
+}
+
+export function getNodeLocationValueId(): ValueID {
+	return {
+		commandClass: CommandClasses["Node Naming and Location"],
+		property: "location",
+	};
 }
 
 @API(CommandClasses["Node Naming and Location"])
@@ -145,6 +153,11 @@ export class NodeNamingAndLocationCCAPI extends CCAPI {
 @implementedVersion(1)
 export class NodeNamingAndLocationCC extends CommandClass {
 	declare ccCommand: NodeNamingAndLocationCommand;
+
+	public skipEndpointInterview(): boolean {
+		// As the name says, this is for the node, not for endpoints
+		return true;
+	}
 
 	public async interview(complete: boolean = true): Promise<void> {
 		const node = this.getNode()!;
@@ -259,11 +272,7 @@ export class NodeNamingAndLocationCCNameReport extends NodeNamingAndLocationCC {
 		this.persistValues();
 	}
 
-	@ccValue()
-	@ccValueMetadata({
-		...ValueMetadata.Any,
-		label: "Node name",
-	})
+	@ccValue({ internal: true })
 	public readonly name: string;
 
 	public toLogEntry(): MessageOrCCLogEntry {
@@ -350,11 +359,7 @@ export class NodeNamingAndLocationCCLocationReport extends NodeNamingAndLocation
 		this.persistValues();
 	}
 
-	@ccValue()
-	@ccValueMetadata({
-		...ValueMetadata.Any,
-		label: "Node location",
-	})
+	@ccValue({ internal: true })
 	public readonly location: string;
 
 	public toLogEntry(): MessageOrCCLogEntry {

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -68,6 +68,10 @@ import {
 } from "../commandclass/ManufacturerSpecificCC";
 import { getEndpointCCsValueId } from "../commandclass/MultiChannelCC";
 import {
+	getNodeLocationValueId,
+	getNodeNameValueId,
+} from "../commandclass/NodeNamingCC";
+import {
 	NotificationCC,
 	NotificationCCReport,
 } from "../commandclass/NotificationCC";
@@ -518,6 +522,40 @@ export class ZWaveNode extends Endpoint {
 
 	public get roleType(): ZWavePlusRoleType | undefined {
 		return this.getValue(getRoleTypeValueId());
+	}
+
+	/**
+	 * The user-defined name of this node. Uses the value reported by `Node Naming and Location CC` if it exists.
+	 *
+	 * **Note:** Setting this value only updates the name locally. To permanently change the name of the node, use
+	 * the `commandClasses` API.
+	 */
+	public get name(): string | undefined {
+		return this.getValue(getNodeNameValueId());
+	}
+	public set name(value: string | undefined) {
+		if (value != undefined) {
+			this._valueDB.setValue(getNodeNameValueId(), value);
+		} else {
+			this._valueDB.removeValue(getNodeNameValueId());
+		}
+	}
+
+	/**
+	 * The user-defined location of this node. Uses the value reported by `Node Naming and Location CC` if it exists.
+	 *
+	 * **Note:** Setting this value only updates the location locally. To permanently change the location of the node, use
+	 * the `commandClasses` API.
+	 */
+	public get location(): string | undefined {
+		return this.getValue(getNodeLocationValueId());
+	}
+	public set location(value: string | undefined) {
+		if (value != undefined) {
+			this._valueDB.setValue(getNodeLocationValueId(), value);
+		} else {
+			this._valueDB.removeValue(getNodeLocationValueId());
+		}
 	}
 
 	private _deviceConfig: DeviceConfig | undefined;


### PR DESCRIPTION
With this PR, we expose two new properties on the `ZWaveNode` class: `name` and `location`. Both use the corresponding value IDs from `Node Naming and Location CC` to read and locally store the value.
To change it on the node, the `commandClasses` API must be used.

fixes: #1204 