### PR TITLE
feat(config): support config files without firmware version, load them after Manufacturer Info is known

### DIFF
--- a/maintenance/importConfig.ts
+++ b/maintenance/importConfig.ts
@@ -1044,8 +1044,14 @@ function getLatestConfigVersion(
 	configs: DeviceConfigIndexEntry[],
 ): DeviceConfigIndexEntry | undefined {
 	configs.sort((a, b) => {
-		const vA = padVersion(a.firmwareVersion.max);
-		const vB = padVersion(b.firmwareVersion.max);
+		const vA =
+			typeof a.firmwareVersion === "boolean"
+				? "255.255.255"
+				: padVersion(a.firmwareVersion.max);
+		const vB =
+			typeof b.firmwareVersion === "boolean"
+				? "255.255.255"
+				: padVersion(b.firmwareVersion.max);
 
 		return compare(vA, vB);
 	});

--- a/packages/config/config/devices/0x0373/id-150_compat.json
+++ b/packages/config/config/devices/0x0373/id-150_compat.json
@@ -1,0 +1,21 @@
+// ID Lock AS ID-150
+// Compatibility configuration (without known firmware version)
+{
+	"manufacturer": "ID Lock AS",
+	"manufacturerId": "0x0373",
+	"label": "ID-150",
+	"description": "Z wave module for ID Lock 150 and 101",
+	"devices": [
+		{
+			"productType": "0x0003",
+			"productId": "0x0001"
+		}
+	],
+	"firmwareVersion": false,
+	"compat": {
+		// This device has a firmware bug where it will reuse previous nonces after
+		// an unencrypted request. In order to be able to use it, we must not invalidate
+		// nonces until it requests a new one itself
+		"keepS0NonceUntilNext": true
+	}
+}

--- a/packages/config/config/devices/index.json
+++ b/packages/config/config/devices/index.json
@@ -12656,7 +12656,7 @@
         "productId": "0x0203",
         "firmwareVersion": {
             "min": "0.0",
-            "max": "255.0"
+            "max": "255.255"
         },
         "filename": "0x019b/z-trm3.json"
     },
@@ -15019,6 +15019,13 @@
             "max": "255.255"
         },
         "filename": "0x0373/id-150_1.6.json"
+    },
+    {
+        "manufacturerId": "0x0373",
+        "productType": "0x0003",
+        "productId": "0x0001",
+        "firmwareVersion": false,
+        "filename": "0x0373/id-150_compat.json"
     },
     {
         "manufacturerId": "0x0403",

--- a/packages/config/src/utils.ts
+++ b/packages/config/src/utils.ts
@@ -24,19 +24,26 @@ export function getDeviceEntryPredicate(
 	productId: number,
 	firmwareVersion?: string,
 ): (entry: DeviceConfigIndexEntry) => boolean {
-	return (entry) =>
-		entry.manufacturerId === formatId(manufacturerId) &&
-		entry.productType === formatId(productType) &&
-		entry.productId === formatId(productId) &&
-		(firmwareVersion == undefined ||
-			(semver.lte(
-				padVersion(entry.firmwareVersion.min),
-				padVersion(firmwareVersion),
-			) &&
+	return (entry) => {
+		if (entry.manufacturerId !== formatId(manufacturerId)) return false;
+		if (entry.productType !== formatId(productType)) return false;
+		if (entry.productId !== formatId(productId)) return false;
+		if (firmwareVersion != undefined) {
+			// A firmware version was given, only look at files with a matching firmware version
+			return (
+				typeof entry.firmwareVersion !== "boolean" &&
+				semver.lte(
+					padVersion(entry.firmwareVersion.min),
+					padVersion(firmwareVersion),
+				) &&
 				semver.gte(
 					padVersion(entry.firmwareVersion.max),
 					padVersion(firmwareVersion),
-				)));
+				)
+			);
+		}
+		return true;
+	};
 }
 
 export function formatId(id: number | string): string {


### PR DESCRIPTION
With this PR, we add support for config files which explicitly have no firmware version (`firmwareVersion: false`). This allows us to look up those fallback files directly after the `Manufacturer Specific CC` interview, before the `Version CC` is interviewed.

The change is required to support devices like the ID lock, which require compat flags to even complete the Version CC interview.

fixes: #1037