### PR TITLE
feat: perform a CC interview for the controller if the config file marks CCs as supported

### DIFF
--- a/packages/config/config/devices/0x0086/zw090.json
+++ b/packages/config/config/devices/0x0086/zw090.json
@@ -1,10 +1,6 @@
 // AEON Labs ZW090
 // Z‐Stick Gen5 USB Controller
 {
-	"_approved": true,
-	"_warnings": [
-		"No channels have been assigned even though there are user configurable command classes."
-	],
 	"manufacturer": "AEON Labs",
 	"manufacturerId": "0x0086",
 	"label": "ZW090",
@@ -121,6 +117,16 @@
 					"value": 1
 				}
 			]
+		}
+	},
+	"compat": {
+		"commandClasses": {
+			"add": {
+				"0x70": {
+					// This is a controller stick - need to manually enable Configuration CC interview
+					"isSupported": true
+				}
+			}
 		}
 	}
 }

--- a/packages/zwave-js/src/lib/node/Types.ts
+++ b/packages/zwave-js/src/lib/node/Types.ts
@@ -115,6 +115,13 @@ export enum InterviewStage {
 	// ===== the stuff below changes frequently, so it has to be redone on every start =====
 
 	/**
+	 * Device information for the controller node has been loaded from a config file.
+	 * If defined, some of the reported information will be overwritten based on the
+	 * config file contents.
+	 */
+	OverwriteControllerConfig,
+
+	/**
 	 * Information for all command classes has been queried.
 	 * This includes static information that is requested once as well as dynamic
 	 * information that is requested on every restart.
@@ -124,7 +131,7 @@ export enum InterviewStage {
 	// TODO: Heal network on startup
 
 	/**
-	 * Device information for the node has been loaded from a config file.
+	 * Device information for a secondary node has been loaded from a config file.
 	 * If defined, some of the reported information will be overwritten based on the
 	 * config file contents.
 	 */


### PR DESCRIPTION
Via the serial API we have no means of detecting which CCs the controller supports because it does not respond to the `getNodeInfo` call. With this PR, we now apply the config file for the controller node before executing the CC interview, so we know in advance it if supports any CCs.

This allows us to display configuration parameters for the controller node, e.g. for the Aeotec Z-Stick Gen5+. To enable this for a device, the section must be added to the config file.
```json
	"compat": {
		"commandClasses": {
			"add": {
				"0x70": {
					// This is a controller stick - need to manually enable Configuration CC interview
					"isSupported": true
				}
			}
		}
	}
```

fixes: #1208 
fixes: #1032