### PR TITLE
fix(cc): persist targetValue during set() calls

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/API.ts
+++ b/packages/zwave-js/src/lib/commandclass/API.ts
@@ -181,7 +181,10 @@ export class CCAPI {
 	}
 
 	protected isSinglecast(): this is this & { endpoint: Endpoint } {
-		return typeof this.endpoint.nodeId === "number";
+		return (
+			typeof this.endpoint.nodeId === "number" &&
+			this.endpoint.nodeId !== NODE_ID_BROADCAST
+		);
 	}
 
 	protected isMulticast(): this is this & {

--- a/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
@@ -7,6 +7,7 @@ import {
 	parseBoolean,
 	parseMaybeBoolean,
 	validatePayload,
+	ValueID,
 	ValueMetadata,
 	ZWaveError,
 	ZWaveErrorCodes,
@@ -34,6 +35,14 @@ import {
 	gotDeserializationOptions,
 	implementedVersion,
 } from "./CommandClass";
+
+function getTargetValueValueId(endpoint?: number): ValueID {
+	return {
+		commandClass: CommandClasses["Binary Switch"],
+		endpoint,
+		property: "targetValue",
+	};
+}
 
 // All the supported commands
 export enum BinarySwitchCommand {
@@ -94,6 +103,16 @@ export class BinarySwitchCCAPI extends CCAPI {
 			targetValue,
 			duration,
 		});
+		if (this.isSinglecast()) {
+			// remember the value in case the device does not respond with a target value
+			this.endpoint
+				.getNodeUnsafe()
+				?.valueDB.setValue(
+					getTargetValueValueId(this.endpoint.index),
+					targetValue,
+					{ noEvent: true },
+				);
+		}
 		await this.driver.sendCommand(cc, this.commandOptions);
 
 		if (this.isSinglecast()) {

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -99,6 +99,14 @@ function getCurrentValueValueID(endpoint: number): ValueID {
 	};
 }
 
+function getTargetValueValueId(endpoint?: number): ValueID {
+	return {
+		commandClass: CommandClasses["Binary Switch"],
+		endpoint,
+		property: "targetValue",
+	};
+}
+
 /** Returns the ValueID used to remember whether a node supports supervision on the start/stop level change commands*/
 function getSuperviseStartStopLevelChangeValueId(): ValueID {
 	return {
@@ -163,6 +171,16 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 			targetValue,
 			duration,
 		});
+		if (this.isSinglecast()) {
+			// remember the value in case the device does not respond with a target value
+			this.endpoint
+				.getNodeUnsafe()
+				?.valueDB.setValue(
+					getTargetValueValueId(this.endpoint.index),
+					targetValue,
+					{ noEvent: true },
+				);
+		}
 
 		// Multilevel Switch commands may take some time to be executed.
 		// Therefore we try to supervise the command execution


### PR DESCRIPTION
https://github.com/zwave-js/node-zwave-js/pull/1139 was missing a puzzle piece, causing a previously-set `targetValue` to be cleared from the value DB.
Now we persist the targetValue before sending the set command to the Node, making sure that we have a guaranteed value for `targetValue`.