### PR TITLE
feat(config): allow specify device IDs for OZW config file import

### DIFF
--- a/maintenance/importConfig.ts
+++ b/maintenance/importConfig.ts
@@ -520,7 +520,8 @@ async function parseOZWProduct(
 
 	// Load the existing config so we can merge it with the updated information
 	let existingDevice: Record<string, any> | undefined;
-	if (latestConfig) {
+
+	if (await fs.pathExists(fileNameAbsolute)) {
 		existingDevice = JSON5.parse(
 			await fs.readFile(fileNameAbsolute, "utf8"),
 		);

--- a/maintenance/importConfig.ts
+++ b/maintenance/importConfig.ts
@@ -536,12 +536,23 @@ async function parseOZWProduct(
 	// const name = metadata.find((m: any) => m.name === "Name")?.$t;
 	// const description = metadata.find((m: any) => m.name === "Description")?.$t;
 
+	const devices = existingDevice?.devices ?? [];
+
+	if (
+		!devices.find(
+			(d: { productType: string; productId: string }) =>
+				d.productType === productType && d.productId === productId,
+		)
+	) {
+		devices.push({ productType, productId });
+	}
+
 	const newConfig: Record<string, any> = {
 		manufacturer,
 		manufacturerId: manufacturerIdHex,
 		label: productLabel,
 		description: existingDevice?.description ?? productName, // don't override the descrition
-		devices: [{ productType, productId }],
+		devices: devices,
 		firmwareVersion: {
 			min: existingDevice?.firmwareVersion.min ?? "0.0",
 			max: existingDevice?.firmwareVersion.max ?? "255.255",

--- a/maintenance/importConfig.ts
+++ b/maintenance/importConfig.ts
@@ -251,13 +251,8 @@ function matchId(
 	prodType: string,
 	prodId: string,
 ): boolean {
-	return (
-		program.ids !== undefined &&
-		program.ids?.includes(
-			`${formatId(manufacturer)}-${formatId(prodType)}-${formatId(
-				prodId,
-			)}`,
-		)
+	return !!program.ids?.includes(
+		`${formatId(manufacturer)}-${formatId(prodType)}-${formatId(prodId)}`,
 	);
 }
 

--- a/maintenance/importConfig.ts
+++ b/maintenance/importConfig.ts
@@ -253,7 +253,7 @@ function matchId(
 ): boolean {
 	return (
 		program.ids !== undefined &&
-		program.ids.includes(
+		program.ids?.includes(
 			`${formatId(manufacturer)}-${formatId(prodType)}-${formatId(
 				prodId,
 			)}`,
@@ -301,7 +301,7 @@ async function parseOZWConfig(): Promise<void> {
 			for (const product of products) {
 				if (product.config !== undefined) {
 					if (
-						program.ids === undefined ||
+						!program.ids ||
 						matchId(man.id, product.id, product.type)
 					) {
 						await parseOZWProduct(
@@ -540,7 +540,7 @@ async function parseOZWProduct(
 	const devices = existingDevice?.devices ?? [];
 
 	if (
-		!devices.find(
+		!devices.some(
 			(d: { productType: string; productId: string }) =>
 				d.productType === productType && d.productId === productId,
 		)


### PR DESCRIPTION
Fixes #1242 

Example command: 

`npm run config -- import -s ozw -Dmid --ids 0x0086-0x0075-0x0004`

Or for of https://github.com/zwave-js/node-zwave-js/issues/1221:

`npm run config -- import -s ozw -Dmid --ids 0x0258-0x1027-0x0200 0x041a-0x0008-0x0200`