### PR TITLE
fix: handle missing node ACK before blindly rejecting the transaction

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -127,6 +127,7 @@ module.exports = {
 				"@typescript-eslint/no-floating-promises": "off",
 				"@typescript-eslint/require-await": "off",
 				"@typescript-eslint/unbound-method": "off",
+				"@typescript-eslint/no-unused-vars": "warn",
 			},
 		},
 		{

--- a/packages/serial/src/ZWaveSerialPort.test.ts
+++ b/packages/serial/src/ZWaveSerialPort.test.ts
@@ -19,7 +19,6 @@ async function createAndOpenMockedZWaveSerialPort(
 		readyData: Buffer.from([]),
 	});
 	const port = new ZWaveSerialPort("/dev/ZWaveTest");
-	// eslint-disable-next-line @typescript-eslint/dot-notation
 	const binding = (port["serial"] as SerialPort).binding as MockBinding;
 	if (open) await port.open();
 	return { port, binding };

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepMessageOrder.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepMessageOrder.test.ts
@@ -28,7 +28,6 @@ describe("regression tests", () => {
 
 	it("marking a node with a pending message as asleep does not mess up the remaining transactions", async () => {
 		jest.setTimeout(5000);
-		jest.retryTimes(3); // Wonder what's going on here
 		// Repro from #1107
 
 		// Node 10's awake timer elapses before its ping is rejected,

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepNoReject.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepNoReject.test.ts
@@ -1,0 +1,82 @@
+import { CommandClasses } from "@zwave-js/core";
+import { MessageHeaders, MockSerialPort } from "@zwave-js/serial";
+import { wait } from "alcalzone-shared/async";
+import { BasicCCSet } from "../../commandclass/BasicCC";
+import type { Driver } from "../../driver/Driver";
+import { ZWaveNode } from "../../node/Node";
+import { NodeStatus } from "../../node/Types";
+import { createAndStartDriver } from "../utils";
+
+describe("regression tests", () => {
+	let driver: Driver;
+	let serialport: MockSerialPort;
+	process.env.LOGLEVEL = "debug";
+
+	beforeEach(async () => {
+		({ driver, serialport } = await createAndStartDriver());
+
+		driver["_controller"] = {
+			ownNodeId: 1,
+			isFunctionSupported: () => true,
+			nodes: new Map(),
+		} as any;
+	});
+
+	afterEach(async () => {
+		await driver.destroy();
+		driver.removeAllListeners();
+	});
+
+	it("when a node does not respond because it is asleep, the transaction does not get rejected", async () => {
+		jest.setTimeout(5000);
+		// Repro from #1078
+
+		const node2 = new ZWaveNode(2, driver);
+		(driver.controller.nodes as Map<number, ZWaveNode>).set(2, node2);
+		// Add event handlers for the nodes
+		for (const node of driver.controller.nodes.values()) {
+			driver["addNodeEventHandlers"](node);
+		}
+
+		node2.addCC(CommandClasses["Wake Up"], { isSupported: true });
+		node2.markAsAwake();
+		expect(node2.status).toBe(NodeStatus.Awake);
+
+		const ACK = Buffer.from([MessageHeaders.ACK]);
+
+		const command = new BasicCCSet(driver, {
+			nodeId: 2,
+			targetValue: 99,
+		});
+		const basicSetPromise = driver.sendCommand(command, {
+			maxSendAttempts: 1,
+		});
+		// » [Node 002] [REQ] [SendData]
+		//   │ transmit options: 0x25
+		//   │ callback id:      1
+		//   └─[BasicCCSet]
+		//     └─ targetValue: 99
+		expect(serialport.lastWrite).toEqual(
+			Buffer.from("010a00130203200163250181", "hex"),
+		);
+		await wait(10);
+		serialport.receiveData(ACK);
+
+		await wait(50);
+
+		// « [RES] [SendData]
+		//     was sent: true
+		serialport.receiveData(Buffer.from("0104011301e8", "hex"));
+		// » [ACK]
+		expect(serialport.lastWrite).toEqual(ACK);
+
+		await wait(50);
+
+		// « [REQ] [SendData]
+		//   callback id:     1
+		//   transmit status: NoACK
+		serialport.receiveData(Buffer.from("0107001301010002e9", "hex"));
+		expect(serialport.lastWrite).toEqual(ACK);
+		await expect(basicSetPromise).not.toReject();
+	});
+});

--- a/packages/zwave-js/src/lib/test/utils.ts
+++ b/packages/zwave-js/src/lib/test/utils.ts
@@ -1,6 +1,7 @@
 /* wotan-disable no-restricted-property-access */
 
 import { MockSerialPort } from "@zwave-js/serial";
+import type { DeepPartial } from "@zwave-js/shared";
 import { Driver, ZWaveOptions } from "../driver/Driver";
 
 // load the driver with stubbed out Serialport
@@ -19,7 +20,7 @@ export const PORT_ADDRESS = "/tty/FAKE";
 /** Creates a real driver instance with a mocked serial port to enable end to end tests */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export async function createAndStartDriver(
-	options: Partial<ZWaveOptions> = {},
+	options: DeepPartial<ZWaveOptions> = {},
 ) {
 	const driver = new Driver(PORT_ADDRESS, {
 		...options,


### PR DESCRIPTION
This restores the (correct) behavior we had pre-5.0.0 where a transaction with a sleeping was not rejected when the target node did not acknowledge the command. Instead, the node is now correctly marked as asleep and the transaction is re-added to the command queue.

fixes: #1078
and likely improves the stability of communication with battery-powered nodes