### PR TITLE
feat: change the default retry strategy

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -133,7 +133,7 @@ export interface ZWaveOptions {
 		/** How long to wait for a callback from the host for a SendData[Multicast]Request */
 		sendDataCallback: number; // >=10000, default: 65000 ms
 		/** How much time a node gets to process a request and send a response */
-		report: number; // [1000...40000], default: 1600 ms
+		report: number; // [1000...40000], default: 10000 ms
 		/** How long generated nonces are valid */
 		nonce: number; // [3000...20000], default: 5000 ms
 		/** How long a node is assumed to be awake after the last communication with it */
@@ -145,6 +145,8 @@ export interface ZWaveOptions {
 		controller: number; // [1...3], default: 3
 		/** How often the driver should try sending SendData commands before giving up */
 		sendData: number; // [1...5], default: 3
+		/** Whether a command should be retried when a node acknowledges the receipt but no response is received */
+		retryAfterTransmitReport: boolean; // default: false
 		/**
 		 * How many attempts should be made for each node interview before giving up
 		 */
@@ -177,7 +179,7 @@ const defaultOptions: ZWaveOptions = {
 		ack: 1000,
 		byte: 150,
 		response: 1600,
-		report: 1600,
+		report: 10000,
 		nonce: 5000,
 		sendDataCallback: 65000, // as defined in INS13954
 		nodeAwake: 10000,
@@ -185,6 +187,7 @@ const defaultOptions: ZWaveOptions = {
 	attempts: {
 		controller: 3,
 		sendData: 3,
+		retryAfterTransmitReport: false,
 		nodeInterview: 5,
 	},
 	skipInterview: false,


### PR DESCRIPTION
This PR updates the default strategy for retrying SendData commands. For details see #997

fixes: #997 