### PR TITLE
feat: distinguish between stateful and notification-type values

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -100,5 +100,6 @@
 	],
 	"files.participants.timeout": 10000,
 	"typescript.preferences.importModuleSpecifier": "project-relative",
-	"jest.autoEnable": false
+	"jest.autoEnable": false,
+	"jest.runAllTestsFirst": false
 }

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -553,6 +553,21 @@ The event arguments have the shape of [`TranslatedValueID`](api/valueid.md) with
 -   `prevValue` - The previous value (before the change). Only present in the `"updated"` and `"removed"` events.
 -   `newValue` - The new value (after the change). Only present in the `"added"` and `"updated"` events.
 
+### `"value notification"`
+
+Some values (like `Central Scene` notifications) are stateless, meaning their value only has significance **the moment** it is received. These stateless values are not persisted in the value DB in order to avoid triggering automations when restoring the network from the cache.
+
+To distinguish them from the statful values, the `"value notification"` event is used. The callback takes the node itself and an argument detailing the change:
+
+```ts
+(node: ZWaveNode, args: ZWaveNodeValueNotificationArgs) => void;
+```
+
+The event argument has the shape of [`TranslatedValueID`](api/valueid.md) with an additional `value` property containing the current value at the time of the event.
+
+> [!NOTE]
+> If these values are displayed in a UI somehow, it is advised to perform some kind of auto-invalidation, e.g. after a fixed short time interval.
+
 ### `"metadata updated"`
 
 The metadata for one of this node's values was added or updated.

--- a/packages/zwave-js/src/lib/commandclass/CommandClass.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/CommandClass.test.ts
@@ -126,12 +126,12 @@ describe("lib/commandclass/CommandClass => ", () => {
 	describe("persistValues()", () => {
 		let node2: ZWaveNode;
 
-		beforeAll(() => {
+		beforeEach(() => {
 			node2 = new ZWaveNode(2, fakeDriver as any);
 			(fakeDriver.controller.nodes as any).set(2, node2);
 		});
 
-		afterAll(() => {
+		afterEach(() => {
 			node2.destroy();
 			(fakeDriver.controller.nodes as any).delete(2);
 		});
@@ -174,11 +174,11 @@ describe("lib/commandclass/CommandClass => ", () => {
 			node2.on("value updated", spyA);
 			await node2.handleCommand(cc);
 
+			expect(spyA).not.toBeCalled();
 			expect(spyN).toBeCalled();
 			expect(spyN.mock.calls[0][1].value).toBe(
 				CentralSceneKeys.KeyPressed,
 			);
-			expect(spyA).not.toBeCalled();
 
 			// and not persist the value in the DB
 			expect(

--- a/packages/zwave-js/src/lib/commandclass/CommandClass.ts
+++ b/packages/zwave-js/src/lib/commandclass/CommandClass.ts
@@ -568,6 +568,19 @@ export class CommandClass {
 		return false;
 	}
 
+	/** Determines if the given value should be persisted or represents an event */
+	public isStatefulValue(property: keyof this): boolean {
+		const ccValueDefinition = getCCValueDefinitions(this).get(
+			property as string,
+		);
+		if (ccValueDefinition?.stateful === false) return false;
+		const ccKeyValuePairDefinition = getCCKeyValuePairDefinitions(this).get(
+			property as string,
+		);
+		if (ccKeyValuePairDefinition?.stateful === false) return false;
+		return true;
+	}
+
 	/** Persists all values on the given node into the value. Returns true if the process succeeded, false otherwise */
 	public persistValues(valueNames?: (keyof this)[]): boolean {
 		// In order to avoid cluttering applications with heaps of unsupported properties,
@@ -660,7 +673,11 @@ export class CommandClass {
 				};
 				// Avoid overwriting existing values with undefined if forceCreation is true
 				if (sourceValue != undefined || !db.hasValue(valueId)) {
-					db.setValue(valueId, sourceValue);
+					// Tell the value DB if this is a stateful value
+					const stateful = this.isStatefulValue(
+						variable as keyof this,
+					);
+					db.setValue(valueId, sourceValue, { stateful });
 				}
 			}
 		}
@@ -1220,6 +1237,10 @@ export interface CCValueOptions {
 	 * Whether this value should always be created/persisted, even if it is undefined. Default: false
 	 */
 	forceCreation?: boolean;
+	/**
+	 * Whether this value represents a state (`true`) or a notification/event (`false`). Default: `true`
+	 */
+	stateful?: boolean;
 }
 
 /**

--- a/packages/zwave-js/src/lib/log/Controller.ts
+++ b/packages/zwave-js/src/lib/log/Controller.ts
@@ -10,6 +10,7 @@ import {
 	tagify,
 	ValueAddedArgs,
 	ValueID,
+	ValueNotificationArgs,
 	ValueRemovedArgs,
 	ValueUpdatedArgs,
 	ZWaveLogger,
@@ -116,6 +117,7 @@ const valueEventPrefixes = Object.freeze({
 	added: "+",
 	updated: "~",
 	removed: "-",
+	notification: "!",
 });
 
 function formatValue(value: any): string {
@@ -139,7 +141,11 @@ export function value(
 	args: LogValueArgs<ValueRemovedArgs>,
 ): void;
 export function value(
-	change: "added" | "updated" | "removed",
+	change: "notification",
+	args: LogValueArgs<ValueNotificationArgs>,
+): void;
+export function value(
+	change: "added" | "updated" | "removed" | "notification",
 	args: LogValueArgs<ValueID>,
 ): void {
 	if (!isValueLogVisible()) return;
@@ -177,6 +183,11 @@ export function value(
 			message += ` (was ${formatValue(
 				((args as unknown) as ValueRemovedArgs).prevValue,
 			)})`;
+			break;
+		case "notification":
+			message += `: ${formatValue(
+				((args as unknown) as ValueNotificationArgs).value,
+			)}`;
 			break;
 	}
 	getLogger().log({

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -181,6 +181,7 @@ export class ZWaveNode extends Endpoint {
 			"value added",
 			"value updated",
 			"value removed",
+			"value notification",
 			"metadata updated",
 		] as const) {
 			this._valueDB.on(event, this.translateValueEvent.bind(this, event));
@@ -1862,7 +1863,7 @@ version:               ${this.version}`;
 			key: CentralSceneKeys,
 		): void => {
 			const valueId = getSceneValueId(sceneNumber);
-			this.valueDB.setValue(valueId, key);
+			this.valueDB.setValue(valueId, key, { stateful: false });
 		};
 
 		const forceKeyUp = (): void => {

--- a/packages/zwave-js/src/lib/node/Types.ts
+++ b/packages/zwave-js/src/lib/node/Types.ts
@@ -2,6 +2,7 @@ import type {
 	MetadataUpdatedArgs,
 	ValueAddedArgs,
 	ValueID,
+	ValueNotificationArgs,
 	ValueRemovedArgs,
 	ValueUpdatedArgs,
 } from "@zwave-js/core";
@@ -30,8 +31,12 @@ export type NodeInterviewFailedEventArgs = {
 export type ZWaveNodeValueAddedArgs = ValueAddedArgs & TranslatedValueID;
 export type ZWaveNodeValueUpdatedArgs = ValueUpdatedArgs & TranslatedValueID;
 export type ZWaveNodeValueRemovedArgs = ValueRemovedArgs & TranslatedValueID;
+export type ZWaveNodeValueNotificationArgs = ValueNotificationArgs &
+	TranslatedValueID;
+
 export type ZWaveNodeMetadataUpdatedArgs = MetadataUpdatedArgs &
 	TranslatedValueID;
+
 export type ZWaveNodeValueAddedCallback = (
 	node: ZWaveNode,
 	args: ZWaveNodeValueAddedArgs,
@@ -43,6 +48,10 @@ export type ZWaveNodeValueUpdatedCallback = (
 export type ZWaveNodeValueRemovedCallback = (
 	node: ZWaveNode,
 	args: ZWaveNodeValueRemovedArgs,
+) => void;
+export type ZWaveNodeValueNotificationCallback = (
+	node: ZWaveNode,
+	args: ZWaveNodeValueNotificationArgs,
 ) => void;
 export type ZWaveNodeMetadataUpdatedCallback = (
 	node: ZWaveNode,
@@ -77,6 +86,7 @@ export interface ZWaveNodeValueEventCallbacks {
 	"value updated": ZWaveNodeValueUpdatedCallback;
 	"value removed": ZWaveNodeValueRemovedCallback;
 	"metadata updated": ZWaveNodeMetadataUpdatedCallback;
+	"value notification": ZWaveNodeValueNotificationCallback;
 }
 
 export interface ZWaveNodeEventCallbacks extends ZWaveNodeValueEventCallbacks {


### PR DESCRIPTION
This PR adds a new value event `"value notification"` which is exclusively used for values that are not stateful, like `Central Scene CC`'s scene values, which only have a meaning the instant they are received. 
For these non-stateful values, the value added/updated/removed events are no longer used and they aren't stored in the value DB anymore.

For now, I've only identified the values mentioned above as non-stateful. `Notification CC` would also fall into this category, but it has its own event.

fixes: #1213