### PR TITLE
fix(cc): binary sensor supported bitmask starts at 0

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/BinarySensorCC.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySensorCC.test.ts
@@ -101,8 +101,8 @@ describe("lib/commandclass/BinarySensorCC => ", () => {
 		const ccData = buildCCBuffer(
 			Buffer.from([
 				BinarySensorCommand.SupportedReport, // CC Command
-				0b01010101,
-				1,
+				0b10101010,
+				0b10,
 			]),
 		);
 		const cc = new BinarySensorCCSupportedReport(fakeDriver, {

--- a/packages/zwave-js/src/lib/commandclass/BinarySensorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySensorCC.ts
@@ -381,7 +381,11 @@ export class BinarySensorCCSupportedReport extends BinarySensorCC {
 		super(driver, options);
 
 		validatePayload(this.payload.length >= 1);
-		this._supportedSensorTypes = parseBitMask(this.payload);
+		// The enumeration starts at 1, but the first (reserved) bit is included
+		// in the report
+		this._supportedSensorTypes = parseBitMask(this.payload, 0).filter(
+			(t) => t !== 0,
+		);
 		this.persistValues();
 	}
 


### PR DESCRIPTION
found in https://github.com/zwave-js/node-zwave-js/issues/1257
The manuals mentioned "Tilt", we interpreted it as "Motion"