### PR TITLE
feat: expose option to throttle FS access

### DIFF
--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -416,12 +416,21 @@ interface ZWaveOptions {
 	 * Optional log configuration
 	 */
 	logConfig?: LogConfig;
-	/**
-	 * Allows you to replace the default file system driver used to store and read the cache
-	 */
-	fs: FileSystem;
-	/** Allows you to specify a different cache directory */
-	cacheDir: string;
+	storage: {
+		/** Allows you to replace the default file system driver used to store and read the cache */
+		driver: FileSystem;
+		/** Allows you to specify a different cache directory */
+		cacheDir: string;
+		/**
+		 * How frequently the values and metadata should be written to the DB files. This is a compromise between data loss
+		 * in cause of a crash and disk wear:
+		 *
+		 * * `"fast"` immediately writes every change to disk
+		 * * `"slow"` writes at most every 5 minutes or after 500 changes - whichever happens first
+		 * * `"normal"` is a compromise between the two options
+		 */
+		throttle: "fast" | "normal" | "slow";
+	};
 
 	/** Specify the network key to use for encryption. This must be a Buffer of exactly 16 bytes. */
 	networkKey?: Buffer;
@@ -434,6 +443,7 @@ The `report` timeout is used by this library to determine how long to wait for a
 
 If your network has connectivity issues, you can increase the number of interview attempts the driver makes before giving up. The default is 5.
 
-For more control over writing the cache file, you can use the `fs` and `cacheDir` options. By default, the cache is located inside `node_modules/zwave-js/cache` and written using Node.js built-in `fs` methods (promisified using `fs-extra`). The replacement file system must adhere to the [`FileSystem`](#FileSystem) interface.
+For more control over writing the cache files, you can use the `storage` options. By default, the cache is located inside `node_modules/zwave-js/cache` and written using Node.js built-in `fs` methods (promisified using `fs-extra`). The replacement file system must adhere to the [`FileSystem`](#FileSystem) interface.
+The `throttle` option allows you to fine-tune the filesystem. The default value `"normal"`
 
 For custom logging options you can use `logConfig`, check [`LogConfig`](#LogConfig) interface for more informations.

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -102,6 +102,7 @@ import {
 	TransactionReducer,
 	TransactionReducerResult,
 } from "./SendThreadMachine";
+import { throttlePresets } from "./ThrottlePresets";
 import { Transaction } from "./Transaction";
 
 // eslint-disable-next-line
@@ -166,12 +167,22 @@ export interface ZWaveOptions {
 	 * @deprecated Use `attempts.nodeInterview` instead.
 	 */
 	nodeInterviewAttempts?: number;
-	/**
-	 * Allows you to replace the default file system driver used to store and read the cache
-	 */
-	fs: FileSystem;
-	/** Allows you to specify a different cache directory */
-	cacheDir: string;
+
+	storage: {
+		/** Allows you to replace the default file system driver used to store and read the cache */
+		driver: FileSystem;
+		/** Allows you to specify a different cache directory */
+		cacheDir: string;
+		/**
+		 * How frequently the values and metadata should be written to the DB files. This is a compromise between data loss
+		 * in cause of a crash and disk wear:
+		 *
+		 * * `"fast"` immediately writes every change to disk
+		 * * `"slow"` writes at most every 5 minutes or after 500 changes - whichever happens first
+		 * * `"normal"` is a compromise between the two options
+		 */
+		throttle: "fast" | "normal" | "slow";
+	};
 
 	/** Specify the network key to use for encryption. This must be a Buffer of exactly 16 bytes. */
 	networkKey?: Buffer;
@@ -194,8 +205,11 @@ const defaultOptions: ZWaveOptions = {
 		nodeInterview: 5,
 	},
 	skipInterview: false,
-	fs: fsExtra,
-	cacheDir: path.resolve(__dirname, "../../..", "cache"),
+	storage: {
+		driver: fsExtra,
+		cacheDir: path.resolve(__dirname, "../../..", "cache"),
+		throttle: "normal",
+	},
 };
 
 /**
@@ -466,7 +480,7 @@ export class Driver extends EventEmitter {
 			updateLogConfig(this.options.logConfig);
 		}
 
-		this.cacheDir = this.options.cacheDir;
+		this.cacheDir = this.options.storage.cacheDir;
 
 		// register some cleanup handlers in case the program doesn't get closed cleanly
 		this._cleanupHandler = this._cleanupHandler.bind(this);
@@ -719,17 +733,7 @@ export class Driver extends EventEmitter {
 			// Always start the value and metadata databases
 			const options: JsonlDBOptions<any> = {
 				ignoreReadErrors: true,
-				autoCompress: {
-					onOpen: true,
-					intervalMs: 60000,
-					intervalMinChanges: 5,
-					sizeFactor: 2,
-					sizeFactorMinimumSize: 20,
-				},
-				throttleFS: {
-					intervalMs: 1000,
-					maxBufferedCommands: 50,
-				},
+				...throttlePresets[this.options.storage.throttle],
 			};
 
 			const valueDBFile = path.join(
@@ -2328,7 +2332,7 @@ ${handlers.length} left`,
 	private async saveNetworkToCacheInternal(): Promise<void> {
 		if (!this._controller || !this.controller.homeId) return;
 
-		await this.options.fs.ensureDir(this.cacheDir);
+		await this.options.storage.driver.ensureDir(this.cacheDir);
 		const cacheFile = path.join(
 			this.cacheDir,
 			this.controller.homeId.toString(16) + ".json",
@@ -2336,7 +2340,11 @@ ${handlers.length} left`,
 
 		const serializedObj = this.controller.serialize();
 		const jsonString = stringify(serializedObj);
-		await this.options.fs.writeFile(cacheFile, jsonString, "utf8");
+		await this.options.storage.driver.writeFile(
+			cacheFile,
+			jsonString,
+			"utf8",
+		);
 	}
 
 	/**
@@ -2378,7 +2386,7 @@ ${handlers.length} left`,
 			this.cacheDir,
 			`${this.controller.homeId.toString(16)}.json`,
 		);
-		if (!(await this.options.fs.pathExists(cacheFile))) return;
+		if (!(await this.options.storage.driver.pathExists(cacheFile))) return;
 
 		try {
 			log.driver.print(
@@ -2386,7 +2394,7 @@ ${handlers.length} left`,
 					this.controller.homeId,
 				)} found, attempting to restore the network from cache...`,
 			);
-			const cacheString = await this.options.fs.readFile(
+			const cacheString = await this.options.storage.driver.readFile(
 				cacheFile,
 				"utf8",
 			);

--- a/packages/zwave-js/src/lib/driver/ThrottlePresets.ts
+++ b/packages/zwave-js/src/lib/driver/ThrottlePresets.ts
@@ -1,0 +1,44 @@
+import type { JsonlDBOptions } from "@alcalzone/jsonl-db";
+import type { ZWaveOptions } from "./Driver";
+
+export const throttlePresets: Record<
+	ZWaveOptions["storage"]["throttle"],
+	JsonlDBOptions<any>
+> = {
+	slow: {
+		autoCompress: {
+			onOpen: true,
+			intervalMs: 60 * 60000, // compress every 60 minutes
+			intervalMinChanges: 100, // if there were at least 100 changes
+			sizeFactor: 3, // only compress large DBs after they have grown 3x
+			sizeFactorMinimumSize: 100,
+		},
+		throttleFS: {
+			intervalMs: 5 * 60000, // write at most every 5 minutes
+			maxBufferedCommands: 500, // or after 500 changes
+		},
+	},
+	normal: {
+		autoCompress: {
+			onOpen: true,
+			intervalMs: 60000,
+			intervalMinChanges: 5,
+			sizeFactor: 2,
+			sizeFactorMinimumSize: 20,
+		},
+		throttleFS: {
+			intervalMs: 1000,
+			maxBufferedCommands: 50,
+		},
+	},
+	fast: {
+		autoCompress: {
+			onOpen: true,
+			intervalMs: 60000,
+			intervalMinChanges: 5,
+			sizeFactor: 2,
+			sizeFactorMinimumSize: 20,
+		},
+		// no throttle :)
+	},
+};


### PR DESCRIPTION
With this PR, we expose a new option to configure throttling of the filesystem access.
The option `storage.throttle` has the following three options:
* `"fast"` - Every change is written to disk immediately, the DB is compressed each minute (if there were 5 changes)
* `"slow"` - Up to 500 changes are buffered for 5 minutes, the DB is compressed every hour (if there were at least 100 changes)
* `"normal"` (default) - Compromise between the two, corresponds to the legacy behavior

To clean up, the `fs` option was renamed to `storage.driver` and the `cacheDir` option was moved into the new `storage` option group.

fixes: #1255