### PR TITLE
fix: delete "keep until next" nonces AFTER the next one was received

### DIFF
--- a/packages/core/src/security/Manager.test.ts
+++ b/packages/core/src/security/Manager.test.ts
@@ -282,13 +282,28 @@ describe("lib/security/Manager", () => {
 			const nonce3 = man.generateNonce(3, 8);
 			const nonceId3 = man.getNonceId(nonce3);
 
-			man.deleteNonce(nonceId1);
+			man.deleteAllNoncesForReceiver(2);
 			expect(man.getNonce(nonceId1)).toBeUndefined();
 			expect(man.hasNonce(nonceId1)).toBeFalse();
 			expect(man.getNonce(nonceId2)).toBeUndefined();
 			expect(man.hasNonce(nonceId2)).toBeFalse();
 			expect(man.getNonce(nonceId3)).not.toBeUndefined();
 			expect(man.hasNonce(nonceId3)).not.toBeFalse();
+		});
+
+		it("should not delete the nonce with the given nonceId", () => {
+			const man = new SecurityManager(options);
+
+			const nonce1 = man.generateNonce(2, 8);
+			const nonceId1 = man.getNonceId(nonce1);
+			const nonce2 = man.generateNonce(2, 8);
+			const nonceId2 = man.getNonceId(nonce2);
+
+			man.deleteAllNoncesForReceiver(2, nonceId1);
+			expect(man.getNonce(nonceId1)).not.toBeUndefined();
+			expect(man.hasNonce(nonceId1)).not.toBeFalse();
+			expect(man.getNonce(nonceId2)).toBeUndefined();
+			expect(man.hasNonce(nonceId2)).toBeFalse();
 		});
 	});
 

--- a/packages/core/src/security/Manager.ts
+++ b/packages/core/src/security/Manager.ts
@@ -134,10 +134,16 @@ export class SecurityManager {
 		}
 	}
 
-	/** Deletes ALL nonces that were issued for a given node */
-	public deleteAllNoncesForReceiver(receiver: number): void {
+	/** Deletes ALL nonces that were issued for a given node, except the given nonce id */
+	public deleteAllNoncesForReceiver(
+		receiver: number,
+		exceptId?: number,
+	): void {
 		for (const [key, entry] of this._nonceStore) {
-			if (entry.receiver === receiver) {
+			if (
+				entry.receiver === receiver &&
+				this.getNonceId(entry.nonce) !== exceptId
+			) {
 				this.deleteNonceInternal(key);
 			}
 		}

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1782,8 +1782,12 @@ version:               ${this.version}`;
 		);
 
 		// And also delete all previous nonces we sent the node since they
-		// should no longer be used
-		this.driver.securityManager.deleteAllNoncesForReceiver(this.id);
+		// should no longer be used - except if a config flag forbids it
+		// Devices using this flag may only delete the old nonce after the new one was acknowledged
+		const keepUntilNext = !!this.deviceConfig?.compat?.keepS0NonceUntilNext;
+		if (keepUntilNext) {
+			this.driver.securityManager.deleteAllNoncesForReceiver(this.id);
+		}
 
 		// Now send the current nonce
 		try {


### PR DESCRIPTION
Prior to this PR we would expire nonces before sending a new one - which is fine for most devices. However the ID Locks keep using the previous nonce until they have confirmed that they received a new nonce.

Now we only expire the old one after sending the new one was successful.

fixes: #1037 (I hope)