### PR TITLE
fix(config): add Lifeline association to Danfoss MT 2649

### DIFF
--- a/packages/config/config/devices/0x0002/mt_2649.json
+++ b/packages/config/config/devices/0x0002/mt_2649.json
@@ -1,7 +1,6 @@
 // Danfoss MT 2649
 // Room Thermostat
 {
-	"_approved": true,
 	"manufacturer": "Danfoss",
 	"manufacturerId": "0x0002",
 	"label": "MT 2649",
@@ -15,6 +14,13 @@
 	"firmwareVersion": {
 		"min": "0.0",
 		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 1,
+			"isLifeline": true
+		}
 	},
 	"paramInformation": {
 		"1": {


### PR DESCRIPTION
fixes: #1265 