### PR TITLE
feat(ci): auto-release nightly versions of @zwave-js/config

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,1 @@
+-P ubuntu-latest=nektos/act-environments-ubuntu:18.04

--- a/.github/workflows/nightly-config-publish.yml
+++ b/.github/workflows/nightly-config-publish.yml
@@ -1,0 +1,95 @@
+name: Publish nightly configuration updates
+
+on:
+  schedule:
+    - cron: 0 2 * * * # Every day at 02:00
+
+jobs:
+  publish-config:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Detect changes (git)
+      run: |
+        LAST_TAG=$(git describe --abbrev=0)
+        echo "Checking for changes since last tag $LAST_TAG"
+
+        # Check if there were any config file changes
+        if [[ $(git diff "$LAST_TAG" --name-only | grep -E "packages\/config\/config\/(.*\/)?.+\.json") != 0 ]]; then
+          echo "🔸 No config file changes since latest version, aborting..."
+          exit 0
+        fi
+
+        # Check if there were changes except config files and .gitignore
+        if [[ $(git diff "$LAST_TAG" --name-only | grep -E -v "packages\/config\/config\/(.*\/)?.+\.json" | grep -v ".gitignore") = 0 ]]; then
+          echo "❌ Found non-config changes, aborting..."
+          exit 0
+        else
+          echo "✔ Changes are limited to config files"
+        fi
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install yarn
+      run: npm i -g yarn
+
+    - name: Install dependencies
+      run: yarn install --frozen-lockfile
+
+    - name: Double-check changes with lerna
+      run: |
+        # Verify that only @zwave-js/config and zwave-js are changed
+        LERNA_CHANGED=$(npx lerna changed)
+        if [[ $(echo -e "@zwave-js/config\nzwave-js") != "$LERNA_CHANGED" ]]; then
+          echo "❌ Lerna detected unexpected package changes, aborting..."
+          echo "These packages are changed:"
+          echo "$LERNA_CHANGED"
+          exit 0
+        fi
+
+    - name: Create a clean build
+      run: npx lerna run build --scope=@zwave-js/config
+
+    - name: Lint config files
+      run: npx lerna run lint:config
+
+    - name: Bump the version and publish
+      run: |
+        cd packages/config
+        npm config set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
+        npm whoami
+
+        # Figure out next version
+        cat > ./script.js << 'EOF'
+        const semver = require("semver");
+        let v = require("../config/package.json").version;
+        const now = new Date();
+        const today = new Date(now.getTime() - now.getTimezoneOffset()*60000);
+        const dateStr = today.toISOString().split("T")[0].replace(/-/g, "");
+
+        // Figure out the version increase with the least priority
+        // 1.0.0 < 1.0.1-20210101 < 1.0.1-alpha.0 < 1.0.1-alpha.0.20200101 < 1.0.1-alpha.1
+        if (semver.parse(v).prerelease.length) {
+          // This is a prerelease, append the config identifier
+          v += "." + dateStr;
+        } else {
+          // This is not a prerelease, patch-bump and then append the config (pre)identifier
+          v = semver.inc(v, "patch") + "-" + datestr;
+        }
+        console.log(v);
+        EOF
+
+        VERSION=$(node script.js)
+        echo "Next version is $VERSION"
+        npm version "$VERSION" --ignore-scripts --no-git-tag-version
+        npm publish


### PR DESCRIPTION
With this PR, we automatically release a new prerelease version of @zwave-js/config every night at 02:00 if the following conditions are met:
1. There are config file changes
2. There are no non-config file changes (except .gitignore)
3. `lerna` tells us that only `@zwave-js/config` and `zwave-js` (because of the dependency) would be published
4. The `lint:config` script succeeds
5. Building `@zwave-js/config` succeeds.

The action does not mirror the version back to git, but chooses a version increase with the least specifity:
`1.0.0 < 1.0.1-20210101 < 1.0.1-alpha.0 < 1.0.1-alpha.0.20200101 < 1.0.1-alpha.1`

This way, versions that are manually released later will always have precedence.

fixes: #1267