### PR TITLE
feat(driver): allow sending unimplemented CCs

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -13,6 +13,10 @@
     -   [Endpoint](api/endpoint.md)
     -   [ValueID](api/valueid.md)
 
+-   Advanced usage
+
+    -   [Send custom messages](usage/custom.md)
+
 -   Development
     -   [Introduction](development/intro.md)
     -   [Device configuration files](development/config-files.md)

--- a/docs/usage/custom.md
+++ b/docs/usage/custom.md
@@ -1,0 +1,40 @@
+# Send custom messages
+
+It may be necessary to send messages or commands that aren't implemented yet. For these cases, `zwave-js` provides means to send "raw" messages or commands.
+The only downside is that you won't necessarily receive any responses that would normally be mapped to the call.
+
+## Send a custom message to the controller
+
+Here's an example how to turn off the LED on a **Aeotec Gen 5 stick**.
+
+```ts
+const turnLEDOff = new Message(driver, {
+	type: MessageType.Request,
+	functionType: 0xF2,
+	payload: Buffer.from("5101000501", "hex"),
+});
+await driver.sendMessage(turnLEDOff, {
+	priority: MessagePriority.Controller,
+	supportCheck: false, // This line is necessary to send commands a device does not advertise support for
+});
+```
+
+> [!NOTE]
+> This will send the raw buffer `0x010800F2510100050151` to the serialport.
+> The protocol bytes `SOF (0x01)`, length (`0x08`) and the checksum (`0x51`) are automatically added at the start and end of the serial message.
+
+## Send a custom command to a node
+
+This example sends an `Anti-theft Get` command (which is currently unsupported) to node 2:
+
+```ts
+const cc = new CommandClass(driver, {
+	nodeId: 2,
+	ccId: CommandClasses["Anti-theft"], // or 0x5d
+	ccCommand: 0x02,
+});
+await driver.sendCommand(cc);
+```
+
+> [!NOTE]
+> Sending unimplemented get-type commands does not actually make sense since the response will silently be dropped.

--- a/packages/zwave-js/maintenance/generateCCExports.ts
+++ b/packages/zwave-js/maintenance/generateCCExports.ts
@@ -95,8 +95,7 @@ function findExports() {
 							sourceFile.fileName,
 							node.name.text,
 							ts.isTypeAliasDeclaration(node) ||
-								ts.isInterfaceDeclaration(node) ||
-								ts.isClassDeclaration(node),
+								ts.isInterfaceDeclaration(node),
 						);
 					}
 				}

--- a/packages/zwave-js/src/lib/commandclass/CommandClass.ts
+++ b/packages/zwave-js/src/lib/commandclass/CommandClass.ts
@@ -5,6 +5,7 @@ import {
 	deserializeCacheValue,
 	getCCName,
 	MessageOrCCLogEntry,
+	MessageRecord,
 	NODE_ID_BROADCAST,
 	parseCCId,
 	serializeCacheValue,
@@ -18,6 +19,7 @@ import {
 } from "@zwave-js/core";
 import {
 	buffer2hex,
+	getEnumMemberName,
 	JSONObject,
 	num2hex,
 	staticExtends,
@@ -332,12 +334,23 @@ export class CommandClass {
 
 	/** Generates a representation of this CC for the log */
 	public toLogEntry(): MessageOrCCLogEntry {
+		let tag = this.constructor.name;
+		const message: MessageRecord = {};
+		if (this.constructor === CommandClass) {
+			tag = `${getEnumMemberName(
+				CommandClasses,
+				this.ccId,
+			)} CC (not implemented)`;
+			if (this.ccCommand != undefined) {
+				message.command = num2hex(this.ccCommand);
+			}
+		}
+		if (this.payload.length > 0) {
+			message.payload = buffer2hex(this.payload);
+		}
 		return {
-			tags: [this.constructor.name],
-			message:
-				this.payload.length > 0
-					? { payload: buffer2hex(this.payload) }
-					: undefined,
+			tags: [tag],
+			message,
 		};
 	}
 

--- a/packages/zwave-js/src/lib/commandclass/CommandClass.ts
+++ b/packages/zwave-js/src/lib/commandclass/CommandClass.ts
@@ -60,6 +60,7 @@ export interface CCCommandOptions {
 }
 
 interface CommandClassCreationOptions extends CCCommandOptions {
+	ccId?: number; // Used to overwrite the declared CC ID
 	ccCommand?: number; // undefined = NoOp
 	payload?: Buffer;
 }
@@ -77,8 +78,9 @@ export class CommandClass {
 	// empty constructor to parse messages
 	public constructor(driver: Driver, options: CommandClassOptions) {
 		this.driver = driver;
-		// Extract the cc from declared metadata if not provided
-		this.ccId = getCommandClass(this);
+		// Extract the cc from declared metadata if not provided by the CC constructor
+		this.ccId =
+			("ccId" in options && options.ccId) || getCommandClass(this);
 		// Default to the root endpoint - Inherited classes may override this behavior
 		this.endpointIndex =
 			("endpoint" in options ? options.endpoint : undefined) ?? 0;

--- a/packages/zwave-js/src/lib/commandclass/index.ts
+++ b/packages/zwave-js/src/lib/commandclass/index.ts
@@ -14,7 +14,7 @@ for (const file of definedCCs) {
 // explicitly export specific things from the CCs
 export { AlarmSensorType } from "./AlarmSensorCC";
 export type { AlarmSensorValueMetadata } from "./AlarmSensorCC";
-export type { CCAPI } from "./API";
+export { CCAPI } from "./API";
 export { AssociationGroupInfoProfile } from "./AssociationGroupInfoCC";
 export type { AssociationGroup } from "./AssociationGroupInfoCC";
 export { BatteryChargingStatus, BatteryReplacementStatus } from "./BatteryCC";
@@ -25,7 +25,7 @@ export { ScheduleOverrideType } from "./ClimateControlScheduleCC";
 export { Weekday } from "./ClockCC";
 export { ColorComponent } from "./ColorSwitchCC";
 export type { ColorTable } from "./ColorSwitchCC";
-export type { CommandClass } from "./CommandClass";
+export { CommandClass } from "./CommandClass";
 export type { ConfigValue } from "./ConfigurationCC";
 export { DoorLockMode, DoorLockOperationType } from "./DoorLockCC";
 export type { DoorHandleStatus } from "./DoorLockCC";

--- a/test/run.ts
+++ b/test/run.ts
@@ -11,6 +11,14 @@ const driver = new Driver("COM4", {
 })
 	.on("error", console.error)
 	.once("driver ready", async () => {
+		// const cc = new CommandClass(driver, {
+		// 	nodeId: 24,
+		// 	ccId: 0x5d,
+		// 	ccCommand: 0x02,
+		// 	payload: Buffer.from([1, 2, 3]),
+		// });
+		// await driver.sendCommand(cc);
+		// console.log("OK");
 		// const node = driver.controller.nodes.get(21)!;
 		// node.keepAwake = true;
 		// node.once("interview completed", async () => {


### PR DESCRIPTION
With this PR, we str now able to send unimplemented (raw) commands in an easy way.

@smitt04, please test if this allows you to get information about the Anti-Theft status:
```ts
const cc = new CommandClass(driver, {
	nodeId: 2,
	ccId: CommandClasses["Anti-theft"], // or 0x5d
	ccCommand: 0x02,
});
await driver.sendCommand(cc);
```

fixes: #1253