### PR TITLE
feat(config): add Aeotec ZWA009 aerQ Temperature and Humidity Sensor

### DIFF
--- a/packages/config/config/devices/0x0371/zwa009.json
+++ b/packages/config/config/devices/0x0371/zwa009.json
@@ -1,0 +1,210 @@
+// Aeotec ZWA009
+// aerQ Temperature and Humidity Sensor
+{
+  "_approved": true,
+  "manufacturer": "Aeotec Ltd.",
+  "manufacturerId": "0x0371",
+  "label": "ZWA009",
+  "description": "aerQ Temperature and Humidity Sensor",
+  "devices": [
+    {
+      "productType": "0x0002",
+      "productId": "0x0009"
+    }
+  ],
+  "firmwareVersion": {
+    "min": "0.0",
+    "max": "255.255"
+  },
+  "supportsZWavePlus": true,
+  "paramInformation": {
+    "1": {
+      "label": "Minimum Temperature change to report",
+      "description": "This value defines the minimum change of temperature to cause an unsolicited report of humidity to the central controller using Lifeline. If the value is set to 0, there will be no reports sent to the controller, when the temperature changes. However, periodic reports, managed by configuration parameter 4, may still be active. Valid values are 0-100. Unit is 1/10 degree. Default: 20.",
+      "unsigned": true,
+      "valueSize": 1,
+      "minValue": 0,
+      "maxValue": 100,
+      "defaultValue": 20,
+      "readOnly": false,
+      "writeOnly": false,
+      "allowManualEntry": true
+    },
+    "2": {
+      "label": "Minimum humidity change to report",
+      "description": "This value defines the minimum change of humidity to cause an unsolicited report of humidity to the central controller using Lifeline. If the value is set to 0, there will be no reports sent to the controller, when the humidity changes. However, periodic reports, managed by configuration parameter 4, may still be active. Valid values are 0-20. Unit is %. Default: 5.",
+      "unsigned": true,
+      "valueSize": 1,
+      "minValue": 0,
+      "maxValue": 20,
+      "defaultValue": 5,
+      "readOnly": false,
+      "writeOnly": false,
+      "allowManualEntry": true
+    },
+    "4": {
+      "label": "Periodic Reports",
+      "description": "This parameter defines the time interval to send an unsolicited report. If the value is set to 0, there will be no periodic reports sent to the controller. However, reports on temperature/humidity changes, managed by configuration parameters 1 and 2, may still be active. Valid values are 0, 900-65535. Unit is seconds. Default: 43200",
+      "unsigned": true,
+      "valueSize": 2,
+      "minValue": 0,
+      "maxValue": 65535,
+      "defaultValue": 43200,
+      "readOnly": false,
+      "writeOnly": false,
+      "allowManualEntry": true
+    },
+    "5": {
+      "label": "Temperature Upper Watermark value",
+      "description": "This parameter defines a temperature. If the measured temperature surpasses this watermark a BASIC command is sent into Association Group 2. Valid values are 0-1000. 0 means disabled. Unit is 1/10 degree. Default: 0",
+      "unsigned": true,
+      "valueSize": 2,
+      "minValue": 0,
+      "maxValue": 1000,
+      "defaultValue": 0,
+      "readOnly": false,
+      "writeOnly": false,
+      "allowManualEntry": true
+    },
+    "6": {
+      "label": "Temperature Lower Watermark value",
+      "description": "This parameter defines a temperature. If the measured temperature drops below this watermark a BASIC command is sent into Association Group 3. Valid values are 0, 200-1000. 0 means disabled. Unit is 1/10 degree. Default: 0",
+      "unsigned": true,
+      "valueSize": 2,
+      "minValue": 0,
+      "maxValue": 1000,
+      "defaultValue": 0,
+      "readOnly": false,
+      "writeOnly": false,
+      "allowManualEntry": true
+    },
+    "7": {
+      "label": "Humidity Upper Watermark value",
+      "description": "This parameter defines a relative humidity. If the measured relative humidity surpasses this watermark a BASIC command is sent into Association Group 4. Valid values are 0-90. 0 means disabled. Unit is %. Default: 0",
+      "unsigned": true,
+      "valueSize": 1,
+      "minValue": 0,
+      "maxValue": 90,
+      "defaultValue": 0,
+      "readOnly": false,
+      "writeOnly": false,
+      "allowManualEntry": true
+    },
+    "8": {
+      "label": "Humidity Lower Watermark value",
+      "description": "This parameter defines a relative humidity. If the measured temperature drops below this relative humidity a BASIC command is sent into Association Group 5. Valid values are 0-90. 0 means disabled. Unit is %. Default: 0",
+      "unsigned": true,
+      "valueSize": 1,
+      "minValue": 0,
+      "maxValue": 90,
+      "defaultValue": 0,
+      "readOnly": false,
+      "writeOnly": false,
+      "allowManualEntry": true
+    },
+    "9": {
+      "label": "Low Temperature Trigger BASIC Set Command Value",
+      "description": "This defines what BASIC command shall be sent out into association group 3. Valid values are 0-255. Default: 255.",
+      "unsigned": true,
+      "valueSize": 1,
+      "minValue": 0,
+      "maxValue": 255,
+      "defaultValue": 255,
+      "readOnly": false,
+      "writeOnly": false,
+      "allowManualEntry": true
+    },
+    "10": {
+      "label": "High Temperature Trigger BASIC Set Command Value",
+      "description": "This defines what BASIC command shall be sent out into association group 2. Valid values are 0-255. Default: 0.",
+      "unsigned": true,
+      "valueSize": 1,
+      "minValue": 0,
+      "maxValue": 255,
+      "defaultValue": 0,
+      "readOnly": false,
+      "writeOnly": false,
+      "allowManualEntry": true
+    },
+    "11": {
+      "label": "Low Humidity Trigger BASIC Set Command Value",
+      "description": "This defines what BASIC command shall be sent out into association group 5. Valid values are 0-255. Default: 255.",
+      "unsigned": true,
+      "valueSize": 1,
+      "minValue": 0,
+      "maxValue": 255,
+      "defaultValue": 255,
+      "readOnly": false,
+      "writeOnly": false,
+      "allowManualEntry": true
+    },
+    "12": {
+      "label": "High Humidity Trigger BASIC Set Command Value",
+      "description": "This defines what BASIC command shall be sent out into association group 4. Valid values are 0-255. Default: 0.",
+      "unsigned": true,
+      "valueSize": 1,
+      "minValue": 0,
+      "maxValue": 255,
+      "defaultValue": 0,
+      "readOnly": false,
+      "writeOnly": false,
+      "allowManualEntry": true
+    },
+    "13": {
+      "label": "Offset value for Mould danger notification",
+      "description": "This value allows to increase the humidity threshold for mould danger notification by max 10%. Valid values are 0-10. Unit is %. Default: 0.",
+      "unsigned": true,
+      "valueSize": 1,
+      "minValue": 0,
+      "maxValue": 10,
+      "defaultValue": 0,
+      "readOnly": false,
+      "writeOnly": false,
+      "allowManualEntry": true
+    },
+    "64": {
+      "label": "Temperature Report Unit",
+      "description": "This value allows to switch between Celcius and Fahrenheit unit of temperature report. Default: Celcius (EU version) or Fahrenheit (US version).",
+      "unsigned": true,
+      "valueSize": 1,
+      "minValue": 0,
+      "maxValue": 10,
+      "defaultValue": 1,
+      "readOnly": false,
+      "writeOnly": false,
+      "allowManualEntry": false,
+      "options": [
+        {
+          "label": "Celcius",
+          "value": 1
+        },
+        {
+          "label": "Fahrenheit",
+          "value": 2
+        }
+      ]
+    },
+    "255": {
+      "label": "Factory Reset",
+      "description": "This parameter helps reset configuration parameters and the device to factory defaults.",
+      "unsigned": true,
+      "valueSize": 4,
+      "minValue": 0,
+      "maxValue": 4294967295,
+      "defaultValue": 0,
+      "readOnly": false,
+      "writeOnly": false,
+      "allowManualEntry": false,
+      "options": [
+        {
+          "label": "Reset all Parameter settings to their default settings.",
+          "value": 1
+        },
+        {
+          "label": "Completely factory reset sensor and send device reset locally notification.",
+          "value": 4294967295
+        }
+      ]
+    }
+  }
+}

--- a/packages/config/config/devices/0x0371/zwa009.json
+++ b/packages/config/config/devices/0x0371/zwa009.json
@@ -43,7 +43,6 @@
       "label": "Air Temperature",
       "description": "A multilevel sensor report is sent to the nodes in this group",
       "maxNodes": 5,
-      "isLifeline": true
     }
   },
   "paramInformation": {

--- a/packages/config/config/devices/0x0371/zwa009.json
+++ b/packages/config/config/devices/0x0371/zwa009.json
@@ -21,6 +21,7 @@
     "1": {
       "label": "Minimum Temperature change to report",
       "description": "This value defines the minimum change of temperature to cause an unsolicited report of humidity to the central controller using Lifeline. If the value is set to 0, there will be no reports sent to the controller, when the temperature changes. However, periodic reports, managed by configuration parameter 4, may still be active. Valid values are 0-100. Unit is 1/10 degree. Default: 20.",
+      "unit": "1/10 degree",
       "unsigned": true,
       "valueSize": 1,
       "minValue": 0,
@@ -33,6 +34,7 @@
     "2": {
       "label": "Minimum humidity change to report",
       "description": "This value defines the minimum change of humidity to cause an unsolicited report of humidity to the central controller using Lifeline. If the value is set to 0, there will be no reports sent to the controller, when the humidity changes. However, periodic reports, managed by configuration parameter 4, may still be active. Valid values are 0-20. Unit is %. Default: 5.",
+      "unit": "%",
       "unsigned": true,
       "valueSize": 1,
       "minValue": 0,
@@ -45,6 +47,7 @@
     "4": {
       "label": "Periodic Reports",
       "description": "This parameter defines the time interval to send an unsolicited report. If the value is set to 0, there will be no periodic reports sent to the controller. However, reports on temperature/humidity changes, managed by configuration parameters 1 and 2, may still be active. Valid values are 0, 900-65535. Unit is seconds. Default: 43200",
+      "unit": "seconds",
       "unsigned": true,
       "valueSize": 2,
       "minValue": 0,
@@ -57,6 +60,7 @@
     "5": {
       "label": "Temperature Upper Watermark value",
       "description": "This parameter defines a temperature. If the measured temperature surpasses this watermark a BASIC command is sent into Association Group 2. Valid values are 0-1000. 0 means disabled. Unit is 1/10 degree. Default: 0",
+      "unit": "1/10 degree",
       "unsigned": true,
       "valueSize": 2,
       "minValue": 0,
@@ -69,6 +73,7 @@
     "6": {
       "label": "Temperature Lower Watermark value",
       "description": "This parameter defines a temperature. If the measured temperature drops below this watermark a BASIC command is sent into Association Group 3. Valid values are 0, 200-1000. 0 means disabled. Unit is 1/10 degree. Default: 0",
+      "unit": "1/10 degree",
       "unsigned": true,
       "valueSize": 2,
       "minValue": 0,
@@ -81,6 +86,7 @@
     "7": {
       "label": "Humidity Upper Watermark value",
       "description": "This parameter defines a relative humidity. If the measured relative humidity surpasses this watermark a BASIC command is sent into Association Group 4. Valid values are 0-90. 0 means disabled. Unit is %. Default: 0",
+      "unit": "%",
       "unsigned": true,
       "valueSize": 1,
       "minValue": 0,
@@ -93,6 +99,7 @@
     "8": {
       "label": "Humidity Lower Watermark value",
       "description": "This parameter defines a relative humidity. If the measured temperature drops below this relative humidity a BASIC command is sent into Association Group 5. Valid values are 0-90. 0 means disabled. Unit is %. Default: 0",
+      "unit": "%",
       "unsigned": true,
       "valueSize": 1,
       "minValue": 0,
@@ -153,6 +160,7 @@
     "13": {
       "label": "Offset value for Mould danger notification",
       "description": "This value allows to increase the humidity threshold for mould danger notification by max 10%. Valid values are 0-10. Unit is %. Default: 0.",
+      "unit": "%",
       "unsigned": true,
       "valueSize": 1,
       "minValue": 0,

--- a/packages/config/config/devices/0x0371/zwa009.json
+++ b/packages/config/config/devices/0x0371/zwa009.json
@@ -27,19 +27,19 @@
       "label": "High Temperature Notification",
       "maxNodes": 5
     },
-    "35": {
+    "3": {
       "label": "Low Temperature Notification",
       "maxNodes": 5
     },
-    "45": {
+    "4": {
       "label": "High Humidity Notification",
       "maxNodes": 5
     },
-    "55": {
+    "5": {
       "label": "Low Humidity Notification",
       "maxNodes": 5
     },
-    "65": {
+    "6": {
       "label": "Air Temperature",
       "description": "A multilevel sensor report is sent to the nodes in this group",
       "maxNodes": 5

--- a/packages/config/config/devices/0x0371/zwa009.json
+++ b/packages/config/config/devices/0x0371/zwa009.json
@@ -17,6 +17,34 @@
     "max": "255.255"
   },
   "supportsZWavePlus": true,
+  "associations": {
+    "1": {
+      "label": "Lifeline",
+      "maxNodes": 5,
+      "isLifeline": true
+    },
+    "2": {
+      "label": "High Temperature Notification",
+      "maxNodes": 5
+    },
+    "35": {
+      "label": "Low Temperature Notification",
+      "maxNodes": 5
+    },
+    "45": {
+      "label": "High Humidity Notification",
+      "maxNodes": 5
+    },
+    "55": {
+      "label": "Low Humidity Notification",
+      "maxNodes": 5
+    },
+    "65": {
+      "label": "Air Temperature",
+      "description": "A multilevel sensor report is sent to the nodes in this group",
+      "maxNodes": 5
+    }
+  },
   "paramInformation": {
     "1": {
       "label": "Minimum Temperature change to report",
@@ -175,8 +203,8 @@
       "description": "This value allows to switch between Celcius and Fahrenheit unit of temperature report. Default: Celcius (EU version) or Fahrenheit (US version).",
       "unsigned": true,
       "valueSize": 1,
-      "minValue": 0,
-      "maxValue": 10,
+      "minValue": 1,
+      "maxValue": 2,
       "defaultValue": 1,
       "readOnly": false,
       "writeOnly": false,

--- a/packages/config/config/devices/0x0371/zwa009.json
+++ b/packages/config/config/devices/0x0371/zwa009.json
@@ -42,7 +42,8 @@
     "6": {
       "label": "Air Temperature",
       "description": "A multilevel sensor report is sent to the nodes in this group",
-      "maxNodes": 5
+      "maxNodes": 5,
+      "isLifeline": true
     }
   },
   "paramInformation": {

--- a/packages/config/config/devices/index.json
+++ b/packages/config/config/devices/index.json
@@ -14982,6 +14982,16 @@
     },
     {
         "manufacturerId": "0x0371",
+        "productType": "0x0002",
+        "productId": "0x0009",
+        "firmwareVersion": {
+            "min": "0.0",
+            "max": "255.255"
+        },
+        "filename": "0x0371/zwa009.json"
+    },
+    {
+        "manufacturerId": "0x0371",
         "productType": "0x0103",
         "productId": "0x0002",
         "firmwareVersion": {


### PR DESCRIPTION
Add Aeotec ZWA009 aerQ Temperature and Humidity Sensor. 

<img width="1758" alt="Screenshot 2021-01-02 at 13 46 07" src="https://user-images.githubusercontent.com/64238/103457612-18202d00-4d01-11eb-91fb-6e5c1e5af4ad.png">


<img width="1556" alt="Screenshot 2021-01-02 at 13 44 34" src="https://user-images.githubusercontent.com/64238/103457610-16ef0000-4d01-11eb-9e9a-42aa807908cf.png">


[ES - AërQ Temperature _ Humidity Sensor.pdf](https://github.com/zwave-js/node-zwave-js/files/5760248/ES.-.AerQ.Temperature._.Humidity.Sensor.pdf)

https://aeotec.freshdesk.com/support/solutions/articles/6000227918-a%C3%ABrq-temperature-and-humidity-sensor-user-guide-


https://aeotec.freshdesk.com/support/solutions/articles/6000227919-a%C3%ABrq-temperature-and-humidity-sensor-technical-specification-