### PR TITLE
feat(config): add checks for partial parameters

### DIFF
--- a/docs/development/config-files.md
+++ b/docs/development/config-files.md
@@ -132,8 +132,8 @@ defines 4 partial parameters that each switch a single bit of parameter #40. Usi
 
 Partial parameters must follow these rules:
 
-1. Each partial parameter must have the same `valueSize`
-1. Each bit mask must fit into the configured `valueSize` of the parameter.
+1. The `valueSize` must be the actual size of the parameter, as defined in the device manual (not just the part of the bitmask). Each partial parameter must have the same `valueSize`.
+1. Each bitmask must fit into the configured `valueSize` of the parameter.
 1. The `minValue`, `maxValue` and `defaultValue` as well as options values are relative to the lowest bit the bit mask. If the bit mask is `0xC` (binary `1100`), these properties must be in the range 0...3 (2 bits). Any required bit shifts are automatically done.
 
 ## `compat`

--- a/packages/config/config/devices/0x0005/pe653_3.4-3.4.json
+++ b/packages/config/config/devices/0x0005/pe653_3.4-3.4.json
@@ -1,70 +1,70 @@
 // Intermatic PE653
 // Pool Control
 {
-    "_approved": true,
-    "manufacturer": "Intermatic",
-    "manufacturerId": "0x0005",
-    "label": "PE653",
-    "description": "Pool Control",
-    "devices": [
-        {
-            "productType": "0x5045",
-            "productId": "0x0653"
-        }
-    ],
-    "firmwareVersion": {
-        "min": "3.4",
-        "max": "3.4"
-    },
-    "paramInformation": {
-        "2": {
-            "label": "Fireman Timeout",
-            "description": "Minutes that pump will continue to run after heater shutoff",
-            "unit": "Minutes",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 255,
-            "defaultValue": 0,
-            "unsigned": true,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "22": {
-            "label": "Pool - Spa Mode",
-            "description": "Controller Mode",
-            "unit": "Decimal",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 2,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "1[0xff]": {
-            "label": "Booster/Cleaner Pump Operation Mode",
-            "description": "Which circuit the booster/cleaner pump resides on",
-            "unit": "Decimal",
-            "valueSize": 2,
-            "minValue": 1,
-            "maxValue": 6,
-            "defaultValue": 1,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "1[0xff00]": {
-            "label": "Pump Type Operation Mode",
-            "description": "Which type of pump is being used",
-            "unit": "Decimal",
-            "valueSize": 2,
-            "minValue": 0,
-            "maxValue": 7,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        }
-    }
+	"_approved": true,
+	"manufacturer": "Intermatic",
+	"manufacturerId": "0x0005",
+	"label": "PE653",
+	"description": "Pool Control",
+	"devices": [
+		{
+			"productType": "0x5045",
+			"productId": "0x0653"
+		}
+	],
+	"firmwareVersion": {
+		"min": "3.4",
+		"max": "3.4"
+	},
+	"paramInformation": {
+		"2": {
+			"label": "Fireman Timeout",
+			"description": "Minutes that pump will continue to run after heater shutoff",
+			"unit": "Minutes",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"22": {
+			"label": "Pool - Spa Mode",
+			"description": "Controller Mode",
+			"unit": "Decimal",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 2,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"1[0xff]": {
+			"label": "Booster/Cleaner Pump Operation Mode",
+			"description": "Which circuit the booster/cleaner pump resides on",
+			"unit": "Decimal",
+			"valueSize": 2,
+			"minValue": 1,
+			"maxValue": 6,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"1[0xff00]": {
+			"label": "Pump Type Operation Mode",
+			"description": "Which type of pump is being used",
+			"unit": "Decimal",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 7,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		}
+	}
 }

--- a/packages/config/config/devices/0x001d/914trl.json
+++ b/packages/config/config/devices/0x001d/914trl.json
@@ -1,108 +1,108 @@
 // Leviton 914TRL
 // Touchpad Electronic Deadbolt
 {
-    "_approved": false,
-    "manufacturer": "Leviton",
-    "manufacturerId": "0x001d",
-    "label": "914TRL",
-    "description": "Touchpad Electronic Deadbolt",
-    "devices": [
-        {
-            "productType": "0x0001",
-            "productId": "0x0001"
-        }
-    ],
-    "firmwareVersion": {
-        "min": "0.0",
-        "max": "255.255"
-    },
-    "associations": {
-        "1": {
-            "label": "Group 1",
-            "maxNodes": 5,
-            "isLifeline": true
-        }
-    },
-    "paramInformation": {
-        "40": {
-            "label": "Factory Default",
-            "description": "Reset to factory default settings.",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": true,
-            "allowManualEntry": true,
-            "options": [
-                {
-                    "label": "Factory Default",
-                    "value": 1
-                }
-            ]
-        },
-        "31[0x100000]": {
-            "label": "Auto Buzzer",
-            "description": "Beeping sound enabled.",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 1,
-            "readOnly": true,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "OFF",
-                    "value": 0
-                },
-                {
-                    "label": "ON",
-                    "value": 1
-                }
-            ]
-        },
-        "31[0x01000000]": {
-            "label": "Auto Lock",
-            "description": "Automatically re-locks door 30 seconds after unlocking.",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 0,
-            "readOnly": true,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "OFF",
-                    "value": 0
-                },
-                {
-                    "label": "ON",
-                    "value": 1
-                }
-            ]
-        },
-        "31[0x10000000]": {
-            "label": "Lock LED Status",
-            "description": "Door lock status LED blinks every 6 seconds.",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 1,
-            "readOnly": true,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "OFF",
-                    "value": 0
-                },
-                {
-                    "label": "ON",
-                    "value": 1
-                }
-            ]
-        }
-    }
+	"_approved": false,
+	"manufacturer": "Leviton",
+	"manufacturerId": "0x001d",
+	"label": "914TRL",
+	"description": "Touchpad Electronic Deadbolt",
+	"devices": [
+		{
+			"productType": "0x0001",
+			"productId": "0x0001"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Group 1",
+			"maxNodes": 5,
+			"isLifeline": true
+		}
+	},
+	"paramInformation": {
+		"40": {
+			"label": "Factory Default",
+			"description": "Reset to factory default settings.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": true,
+			"allowManualEntry": true,
+			"options": [
+				{
+					"label": "Factory Default",
+					"value": 1
+				}
+			]
+		},
+		"31[0x100000]": {
+			"label": "Auto Buzzer",
+			"description": "Beeping sound enabled.",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"readOnly": true,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "OFF",
+					"value": 0
+				},
+				{
+					"label": "ON",
+					"value": 1
+				}
+			]
+		},
+		"31[0x01000000]": {
+			"label": "Auto Lock",
+			"description": "Automatically re-locks door 30 seconds after unlocking.",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": true,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "OFF",
+					"value": 0
+				},
+				{
+					"label": "ON",
+					"value": 1
+				}
+			]
+		},
+		"31[0x10000000]": {
+			"label": "Lock LED Status",
+			"description": "Door lock status LED blinks every 6 seconds.",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"readOnly": true,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "OFF",
+					"value": 0
+				},
+				{
+					"label": "ON",
+					"value": 1
+				}
+			]
+		}
+	}
 }

--- a/packages/config/config/devices/0x0086/dsd31.json
+++ b/packages/config/config/devices/0x0086/dsd31.json
@@ -18,18 +18,6 @@
 	},
 	"supportsZWavePlus": true,
 	"paramInformation": {
-		"37": {
-			"label": "Sirensound and Volume",
-			"description": "Sets the sound type and volume",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 65535,
-			"defaultValue": 13,
-			"unsigned": true,
-			"readOnly": false,
-			"writeOnly": false,
-			"allowManualEntry": true
-		},
 		"80": {
 			"label": "Send Notifications",
 			"description": "send notifications to associated devices",

--- a/packages/config/config/devices/0x0086/zw096.json
+++ b/packages/config/config/devices/0x0086/zw096.json
@@ -149,28 +149,6 @@
 				}
 			]
 		},
-		"83": {
-			"label": "Color in night light mode",
-			"valueSize": 3,
-			"minValue": 0,
-			"maxValue": 16777215,
-			"defaultValue": 0,
-			"unsigned": true,
-			"readOnly": false,
-			"writeOnly": false,
-			"allowManualEntry": true
-		},
-		"84": {
-			"label": "Color in energy mode",
-			"valueSize": 3,
-			"minValue": 0,
-			"maxValue": 16777215,
-			"defaultValue": 0,
-			"unsigned": true,
-			"readOnly": false,
-			"writeOnly": false,
-			"allowManualEntry": true
-		},
 		"90": {
 			"label": "Enable items 91 and 92",
 			"description": "Enables/disables parameter 91 and 92",

--- a/packages/config/config/devices/0x0086/zw100_1.10.json
+++ b/packages/config/config/devices/0x0086/zw100_1.10.json
@@ -130,18 +130,6 @@
 			"writeOnly": false,
 			"allowManualEntry": true
 		},
-		"9": {
-			"label": "Report the current power mode",
-			"description": "Report the current power mode and the product state of battery power mode",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 65535,
-			"defaultValue": 0,
-			"unsigned": true,
-			"readOnly": true,
-			"writeOnly": false,
-			"allowManualEntry": true
-		},
 		"39": {
 			"label": "Low Battery Report",
 			"description": "Report Low Battery if below this value",
@@ -252,28 +240,6 @@
 			"unsigned": true,
 			"readOnly": false,
 			"writeOnly": false,
-			"allowManualEntry": true
-		},
-		"49": {
-			"label": "Upper limit value of temp sensor",
-			"description": "Upper limit value of temperature sensor",
-			"valueSize": 4,
-			"minValue": 0,
-			"maxValue": 0,
-			"defaultValue": 0,
-			"readOnly": false,
-			"writeOnly": true,
-			"allowManualEntry": true
-		},
-		"50": {
-			"label": "Lower limit value of temperature sensor",
-			"description": "Lower limit value of temperature sensor",
-			"valueSize": 4,
-			"minValue": 0,
-			"maxValue": 0,
-			"defaultValue": 0,
-			"readOnly": false,
-			"writeOnly": true,
 			"allowManualEntry": true
 		},
 		"51": {

--- a/packages/config/config/devices/0x0086/zw100_1.7-1.7.json
+++ b/packages/config/config/devices/0x0086/zw100_1.7-1.7.json
@@ -466,17 +466,6 @@
 			"writeOnly": false,
 			"allowManualEntry": true
 		},
-		"201": {
-			"label": "Temperature Calibration",
-			"description": "Temperature calibration in 0.1 deg steps",
-			"valueSize": 2,
-			"minValue": -128,
-			"maxValue": 127,
-			"defaultValue": 0,
-			"readOnly": false,
-			"writeOnly": false,
-			"allowManualEntry": true
-		},
 		"202": {
 			"label": "Humidity Sensor Calibration",
 			"description": "Humidity Sensor Calibration",

--- a/packages/config/config/devices/0x0086/zw100_1.8-1.9.json
+++ b/packages/config/config/devices/0x0086/zw100_1.8-1.9.json
@@ -472,17 +472,6 @@
 			"writeOnly": false,
 			"allowManualEntry": true
 		},
-		"201": {
-			"label": "Temperature Calibration",
-			"description": "Temperature calibration in 0.1 deg steps",
-			"valueSize": 2,
-			"minValue": -128,
-			"maxValue": 127,
-			"defaultValue": 0,
-			"readOnly": false,
-			"writeOnly": false,
-			"allowManualEntry": true
-		},
 		"202": {
 			"label": "Humidity Sensor Calibration",
 			"description": "Humidity Sensor Calibration",

--- a/packages/config/config/devices/0x0086/zw122.json
+++ b/packages/config/config/devices/0x0086/zw122.json
@@ -71,17 +71,6 @@
 			"writeOnly": false,
 			"allowManualEntry": true
 		},
-		"10": {
-			"label": "Alarm time for buzzer",
-			"description": "Set the alarm time for the buzzer when triggered",
-			"valueSize": 4,
-			"minValue": 0,
-			"maxValue": 0,
-			"defaultValue": 0,
-			"readOnly": false,
-			"writeOnly": false,
-			"allowManualEntry": true
-		},
 		"39": {
 			"label": "Low Battery Threshold",
 			"description": "Set the low battery value. (Range: 10% to 50%)",
@@ -114,28 +103,6 @@
 					"value": 1
 				}
 			]
-		},
-		"49": {
-			"label": "Set the upper limit value (overheat)",
-			"description": "Set the upper limit value (overheat)",
-			"valueSize": 4,
-			"minValue": 0,
-			"maxValue": 2147483647,
-			"defaultValue": 0,
-			"readOnly": false,
-			"writeOnly": false,
-			"allowManualEntry": true
-		},
-		"50": {
-			"label": "Set the lower limit value (underheat)",
-			"description": "Set the lower limit value (underheat)",
-			"valueSize": 4,
-			"minValue": 0,
-			"maxValue": 2147483647,
-			"defaultValue": 0,
-			"readOnly": false,
-			"writeOnly": false,
-			"allowManualEntry": true
 		},
 		"64": {
 			"label": "Default Temperature Unit",
@@ -303,17 +270,6 @@
 			"maxValue": 0,
 			"defaultValue": 0,
 			"readOnly": true,
-			"writeOnly": false,
-			"allowManualEntry": true
-		},
-		"201": {
-			"label": "Temperature calibration",
-			"description": "Temperature calibration",
-			"valueSize": 2,
-			"minValue": -128,
-			"maxValue": 127,
-			"defaultValue": 1,
-			"readOnly": false,
 			"writeOnly": false,
 			"allowManualEntry": true
 		},

--- a/packages/config/config/devices/0x0090/ged1800.json
+++ b/packages/config/config/devices/0x0090/ged1800.json
@@ -1,135 +1,135 @@
 // Spectrum Brands GED1800
 // SmartCode 10 Touchpad Electronic Deadbolt
 {
-    "_approved": false,
-    "_errors": [
-        "Overview information is not set",
-        "Command Class \"ASSOCIATION_GROUP_INFO\" in endpoint 0 is duplicated!"
-    ],
-    "_warnings": [
-        "No channels have been assigned even though there are user configurable command classes."
-    ],
-    "manufacturer": "Spectrum Brands",
-    "manufacturerId": "0x0090",
-    "label": "GED1800",
-    "description": "SmartCode 10 Touchpad Electronic Deadbolt",
-    "devices": [
-        {
-            "productType": "0x0006",
-            "productId": "0x0440"
-        }
-    ],
-    "firmwareVersion": {
-        "min": "0.0",
-        "max": "255.255"
-    },
-    "supportsZWavePlus": true,
-    "paramInformation": {
-        "31": {
-            "label": "Buzzer",
-            "description": "Internal Buzzer",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 1,
-            "readOnly": true,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "OFF",
-                    "value": 0
-                },
-                {
-                    "label": "ON",
-                    "value": 1
-                }
-            ]
-        },
-        "33": {
-            "label": "SKU (1st half)",
-            "description": "First 4 byes of SKU",
-            "valueSize": 4,
-            "minValue": 32,
-            "maxValue": 126,
-            "defaultValue": 32,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "34": {
-            "label": "SKU (2nd half)",
-            "description": "Last 4 bytes of SKU",
-            "valueSize": 4,
-            "minValue": 32,
-            "maxValue": 126,
-            "defaultValue": 32,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "40": {
-            "label": "Factory Default",
-            "description": "Reset to factory default settings",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": true,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Don't Reset",
-                    "value": 0
-                },
-                {
-                    "label": "Reset to Factory Defaults",
-                    "value": 1
-                }
-            ]
-        },
-        "31[0x01000000]": {
-            "label": "Auto Lock",
-            "description": "Automatically re-locks door 30 seconds after unlocking.",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 0,
-            "readOnly": true,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "OFF",
-                    "value": 0
-                },
-                {
-                    "label": "ON",
-                    "value": 1
-                }
-            ]
-        },
-        "31[0x10000000]": {
-            "label": "Status LED",
-            "description": "Door lock status LED blinks every 6 seconds",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 1,
-            "readOnly": true,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "OFF",
-                    "value": 0
-                },
-                {
-                    "label": "ON",
-                    "value": 1
-                }
-            ]
-        }
-    }
+	"_approved": false,
+	"_errors": [
+		"Overview information is not set",
+		"Command Class \"ASSOCIATION_GROUP_INFO\" in endpoint 0 is duplicated!"
+	],
+	"_warnings": [
+		"No channels have been assigned even though there are user configurable command classes."
+	],
+	"manufacturer": "Spectrum Brands",
+	"manufacturerId": "0x0090",
+	"label": "GED1800",
+	"description": "SmartCode 10 Touchpad Electronic Deadbolt",
+	"devices": [
+		{
+			"productType": "0x0006",
+			"productId": "0x0440"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"supportsZWavePlus": true,
+	"paramInformation": {
+		"33": {
+			"label": "SKU (1st half)",
+			"description": "First 4 byes of SKU",
+			"valueSize": 4,
+			"minValue": 32,
+			"maxValue": 126,
+			"defaultValue": 32,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"34": {
+			"label": "SKU (2nd half)",
+			"description": "Last 4 bytes of SKU",
+			"valueSize": 4,
+			"minValue": 32,
+			"maxValue": 126,
+			"defaultValue": 32,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"40": {
+			"label": "Factory Default",
+			"description": "Reset to factory default settings",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Don't Reset",
+					"value": 0
+				},
+				{
+					"label": "Reset to Factory Defaults",
+					"value": 1
+				}
+			]
+		},
+		"31[0x100000]": {
+			"label": "Auto Buzzer",
+			"description": "Beeping sound enabled.",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"readOnly": true,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "OFF",
+					"value": 0
+				},
+				{
+					"label": "ON",
+					"value": 1
+				}
+			]
+		},
+		"31[0x01000000]": {
+			"label": "Auto Lock",
+			"description": "Automatically re-locks door 30 seconds after unlocking.",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": true,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "OFF",
+					"value": 0
+				},
+				{
+					"label": "ON",
+					"value": 1
+				}
+			]
+		},
+		"31[0x10000000]": {
+			"label": "Status LED",
+			"description": "Door lock status LED blinks every 6 seconds",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"readOnly": true,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "OFF",
+					"value": 0
+				},
+				{
+					"label": "ON",
+					"value": 1
+				}
+			]
+		}
+	}
 }

--- a/packages/config/config/devices/0x0098/ct110.json
+++ b/packages/config/config/devices/0x0098/ct110.json
@@ -351,7 +351,7 @@
 		"10[0xffff]": {
 			"label": "Temperature Reporting Filter (lower bound)",
 			"description": "Temperature Reporting Filter (lower bound)",
-			"valueSize": 2,
+			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 124,
 			"defaultValue": 124,
@@ -362,7 +362,7 @@
 		"10[0x0fff0000]": {
 			"label": "Temperature Reporting Filter  (upper bound)",
 			"description": "Temperature Reporting Filter  (upper bound)",
-			"valueSize": 2,
+			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 124,
 			"defaultValue": 124,

--- a/packages/config/config/devices/0x0108/dch-z110.json
+++ b/packages/config/config/devices/0x0108/dch-z110.json
@@ -1,302 +1,285 @@
 // D-Link DCH-Z110
 // Door & Window Sensor
 {
-    "_approved": true,
-    "manufacturer": "D-Link",
-    "manufacturerId": "0x0108",
-    "label": "DCH-Z110",
-    "description": "Door & Window Sensor",
-    "devices": [
-        {
-            "productType": "0x0002",
-            "productId": "0x000e"
-        }
-    ],
-    "firmwareVersion": {
-        "min": "0.0",
-        "max": "255.255"
-    },
-    "supportsZWavePlus": true,
-    "paramInformation": {
-        "2": {
-            "label": "Basic Set Level",
-            "description": "Setting the BASIC command value to turn on the light.",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 100,
-            "defaultValue": 255,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true,
-            "options": [
-                {
-                    "label": "Off",
-                    "value": 0
-                },
-                {
-                    "label": "On",
-                    "value": 255
-                }
-            ]
-        },
-        "3": {
-            "label": "PIR Sensitivity",
-            "description": "Set the sensitivity for the PIR (Passive Infrared Sensor).",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 99,
-            "defaultValue": 70,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true,
-            "options": [
-                {
-                    "label": "Disable",
-                    "value": 0
-                }
-            ]
-        },
-        "4": {
-            "label": "Light Threshold",
-            "description": "Set the illumination threshold to turn on the light.",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 100,
-            "defaultValue": 100,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true,
-            "options": [
-                {
-                    "label": "Disable",
-                    "value": 0
-                }
-            ]
-        },
-        "5": {
-            "label": "Operation Mode",
-            "description": "Operation Mode",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 127,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true,
-            "options": [
-                {
-                    "label": "Preset: Celsius and LED on = Bits: 00001010 = 10",
-                    "value": 10
-                }
-            ]
-        },
-        "6": {
-            "label": "Multi-Sensor Function Switch",
-            "description": "Multi-Sensor Function Switch",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 127,
-            "defaultValue": 4,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "7": {
-            "label": "Customer Function",
-            "description": "Parameter to set the Customer Function.",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 127,
-            "defaultValue": 4,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true,
-            "options": [
-                {
-                    "label": "Enable PIR Super Sensitivity and Binary Report",
-                    "value": 20
-                }
-            ]
-        },
-        "8": {
-            "label": "PIR Re-Detect Interval Time",
-            "description": "PIR Re-Detect Interval Time",
-            "valueSize": 1,
-            "minValue": 1,
-            "maxValue": 127,
-            "defaultValue": 3,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "9": {
-            "label": "Turn Off Light Time",
-            "description": "Turn Off Light Time",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 127,
-            "defaultValue": 4,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "10": {
-            "label": "Auto Report Battery Time",
-            "description": "Auto Report Battery Time",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 127,
-            "defaultValue": 12,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "11": {
-            "label": "Auto Report Door/Window State Time",
-            "description": "Auto Report Door/Window State Time",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 127,
-            "defaultValue": 12,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "12": {
-            "label": "Auto Report Illumination Time",
-            "description": "Auto Report Illumination Time",
-            "valueSize": 1,
-            "minValue": 1,
-            "maxValue": 127,
-            "defaultValue": 12,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "13": {
-            "label": "Auto Report Temperature Time",
-            "description": "Auto Report Temperature Time",
-            "valueSize": 1,
-            "minValue": 1,
-            "maxValue": 127,
-            "defaultValue": 12,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "20": {
-            "label": "Auto Report Tick Interval",
-            "description": "Auto Report Tick Interval",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 255,
-            "defaultValue": 30,
-            "unsigned": true,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "21": {
-            "label": "Temperature Differential Report",
-            "description": "Temperature Differential Report",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 127,
-            "defaultValue": 1,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "22": {
-            "label": "Illumination Differential Report",
-            "description": "Illumination Differential Report",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 99,
-            "defaultValue": 1,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "7[0x08]": {
-            "label": "Disable send of BASIC OFF after door closed",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 1,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Enable",
-                    "value": 0
-                },
-                {
-                    "label": "Disable",
-                    "value": 1
-                }
-            ]
-        },
-        "7[0x10]": {
-            "label": "Notification Type",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Notification Report",
-                    "value": 0
-                },
-                {
-                    "label": "Sensor Binary Report",
-                    "value": 1
-                }
-            ]
-        },
-        "7[0x20]": {
-            "label": "Disable Multi CC in auto report",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Enable",
-                    "value": 0
-                },
-                {
-                    "label": "Disable",
-                    "value": 1
-                }
-            ]
-        },
-        "7[0x40]": {
-            "label": "Disable to report battery state",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Enable",
-                    "value": 0
-                },
-                {
-                    "label": "Disable",
-                    "value": 1
-                }
-            ]
-        }
-    }
+	"_approved": true,
+	"manufacturer": "D-Link",
+	"manufacturerId": "0x0108",
+	"label": "DCH-Z110",
+	"description": "Door & Window Sensor",
+	"devices": [
+		{
+			"productType": "0x0002",
+			"productId": "0x000e"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"supportsZWavePlus": true,
+	"paramInformation": {
+		"2": {
+			"label": "Basic Set Level",
+			"description": "Setting the BASIC command value to turn on the light.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 100,
+			"defaultValue": 255,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true,
+			"options": [
+				{
+					"label": "Off",
+					"value": 0
+				},
+				{
+					"label": "On",
+					"value": 255
+				}
+			]
+		},
+		"3": {
+			"label": "PIR Sensitivity",
+			"description": "Set the sensitivity for the PIR (Passive Infrared Sensor).",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 99,
+			"defaultValue": 70,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
+		},
+		"4": {
+			"label": "Light Threshold",
+			"description": "Set the illumination threshold to turn on the light.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 100,
+			"defaultValue": 100,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
+		},
+		"5": {
+			"label": "Operation Mode",
+			"description": "Operation Mode",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 127,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true,
+			"options": [
+				{
+					"label": "Preset: Celsius and LED on = Bits: 00001010 = 10",
+					"value": 10
+				}
+			]
+		},
+		"6": {
+			"label": "Multi-Sensor Function Switch",
+			"description": "Multi-Sensor Function Switch",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 127,
+			"defaultValue": 4,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"8": {
+			"label": "PIR Re-Detect Interval Time",
+			"description": "PIR Re-Detect Interval Time",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 127,
+			"defaultValue": 3,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"9": {
+			"label": "Turn Off Light Time",
+			"description": "Turn Off Light Time",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 127,
+			"defaultValue": 4,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"10": {
+			"label": "Auto Report Battery Time",
+			"description": "Auto Report Battery Time",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 127,
+			"defaultValue": 12,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"11": {
+			"label": "Auto Report Door/Window State Time",
+			"description": "Auto Report Door/Window State Time",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 127,
+			"defaultValue": 12,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"12": {
+			"label": "Auto Report Illumination Time",
+			"description": "Auto Report Illumination Time",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 127,
+			"defaultValue": 12,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"13": {
+			"label": "Auto Report Temperature Time",
+			"description": "Auto Report Temperature Time",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 127,
+			"defaultValue": 12,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"20": {
+			"label": "Auto Report Tick Interval",
+			"description": "Auto Report Tick Interval",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 30,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"21": {
+			"label": "Temperature Differential Report",
+			"description": "Temperature Differential Report",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 127,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"22": {
+			"label": "Illumination Differential Report",
+			"description": "Illumination Differential Report",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 99,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"7[0x08]": {
+			"label": "Disable send of BASIC OFF after door closed",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Enable",
+					"value": 0
+				},
+				{
+					"label": "Disable",
+					"value": 1
+				}
+			]
+		},
+		"7[0x10]": {
+			"label": "Notification Type",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Notification Report",
+					"value": 0
+				},
+				{
+					"label": "Sensor Binary Report",
+					"value": 1
+				}
+			]
+		},
+		"7[0x20]": {
+			"label": "Disable Multi CC in auto report",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Enable",
+					"value": 0
+				},
+				{
+					"label": "Disable",
+					"value": 1
+				}
+			]
+		},
+		"7[0x40]": {
+			"label": "Disable to report battery state",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Enable",
+					"value": 0
+				},
+				{
+					"label": "Disable",
+					"value": 1
+				}
+			]
+		}
+	}
 }

--- a/packages/config/config/devices/0x0108/dch-z120.json
+++ b/packages/config/config/devices/0x0108/dch-z120.json
@@ -1,319 +1,308 @@
 // D-Link DCH-Z120
 // Battery Motion Sensor
 {
-    "_approved": true,
-    "manufacturer": "D-Link",
-    "manufacturerId": "0x0108",
-    "label": "DCH-Z120",
-    "description": "Battery Motion Sensor",
-    "devices": [
-        {
-            "productType": "0x0002",
-            "productId": "0x000d"
-        }
-    ],
-    "firmwareVersion": {
-        "min": "0.0",
-        "max": "255.255"
-    },
-    "associations": {
-        "1": {
-            "label": "Reports",
-            "maxNodes": 8,
-            "isLifeline": true
-        },
-        "2": {
-            "label": "Light Control",
-            "maxNodes": 8
-        }
-    },
-    "paramInformation": {
-        "2": {
-            "label": "Basic Set Level",
-            "description": "Setting the BASIC command value to turn on the light.",
-            "valueSize": 1,
-            "minValue": 1,
-            "maxValue": 100,
-            "defaultValue": 255,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true,
-            "options": [
-                {
-                    "label": "Off",
-                    "value": 0
-                },
-                {
-                    "label": "On",
-                    "value": 255
-                }
-            ]
-        },
-        "3": {
-            "label": "PIR Sensitivity",
-            "description": "Set the sensitivity for the PIR (Passive Infrared Sensor).",
-            "valueSize": 1,
-            "minValue": 1,
-            "maxValue": 99,
-            "defaultValue": 80,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true,
-            "options": [
-                {
-                    "label": "Disable",
-                    "value": 0
-                }
-            ]
-        },
-        "4": {
-            "label": "Light Threshold",
-            "description": "Set the illumination threshold to turn on the light.",
-            "valueSize": 1,
-            "minValue": 1,
-            "maxValue": 99,
-            "defaultValue": 99,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true,
-            "options": [
-                {
-                    "label": "Disable, Light OFF",
-                    "value": 0
-                },
-                {
-                    "label": "Disable, Light ON",
-                    "value": 100
-                }
-            ]
-        },
-        "5": {
-            "label": "Operation Mode",
-            "description": "Parameter to set the Operation Mode.",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 255,
-            "defaultValue": 0,
-            "unsigned": true,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "6": {
-            "label": "Multi-Sensor Function Switch",
-            "description": "Parameter to set the sensor functions.",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 63,
-            "defaultValue": 4,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "7": {
-            "label": "Customer Function",
-            "description": "Parameter to set the Customer Function.",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 127,
-            "defaultValue": 4,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "8": {
-            "label": "PIR Re-Detect Interval Time",
-            "description": "Set re-detect time after PIR motion triggered",
-            "valueSize": 1,
-            "minValue": 1,
-            "maxValue": 127,
-            "defaultValue": 3,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "9": {
-            "label": "Turn Off Light Time",
-            "description": "Set delay time to turn off light after motion triggered.",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 127,
-            "defaultValue": 4,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "10": {
-            "label": "Auto Report Battery Time",
-            "description": "Interval time for auto reporting the battery level",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 127,
-            "defaultValue": 12,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "12": {
-            "label": "Auto Report Illumination Time",
-            "description": "Interval time for auto reporting the illumination.",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 127,
-            "defaultValue": 12,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "13": {
-            "label": "Auto Report Temperature Time",
-            "description": "Interval time for auto reporting the temperature.",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 127,
-            "defaultValue": 12,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "20": {
-            "label": "Auto Report Tick Interval",
-            "description": "Interval time for auto reporting each tick.",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 255,
-            "defaultValue": 30,
-            "unsigned": true,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "21": {
-            "label": "Temperature Differential Report",
-            "description": "The temperature differential to report.",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 127,
-            "defaultValue": 1,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "22": {
-            "label": "Illumination Differential Report",
-            "description": "The illumination differential to report.",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 99,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "7[0x02]": {
-            "label": "Bit1: Enable sending motion OFF report.",
-            "description": "0:Disable, 1:Enable",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Disable",
-                    "value": 0
-                },
-                {
-                    "label": "Enable",
-                    "value": 1
-                }
-            ]
-        },
-        "7[0x04]": {
-            "label": "Bit2: Enable PIR super sensitivity mode.",
-            "description": "0:Disable, 1:Enable",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 1,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Disable",
-                    "value": 0
-                },
-                {
-                    "label": "Enable",
-                    "value": 1
-                }
-            ]
-        },
-        "7[0x10]": {
-            "label": "Bit4: Notification Type",
-            "description": "0: Notification Report. 1: Sensor Binary Report.",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Notification Report",
-                    "value": 0
-                },
-                {
-                    "label": "Sensor Binary Report",
-                    "value": 1
-                }
-            ]
-        },
-        "7[0x20]": {
-            "label": "Bit5: Disable Multi CC in auto report.",
-            "description": "1:Disable, 0:Enable",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Enable",
-                    "value": 0
-                },
-                {
-                    "label": "Disable",
-                    "value": 1
-                }
-            ]
-        },
-        "7[0x40]": {
-            "label": "Bit6: Report battery state when device triggered",
-            "description": "1:Disable, 0 Enable",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Enable",
-                    "value": 0
-                },
-                {
-                    "label": "Disable",
-                    "value": 1
-                }
-            ]
-        }
-    }
+	"_approved": true,
+	"manufacturer": "D-Link",
+	"manufacturerId": "0x0108",
+	"label": "DCH-Z120",
+	"description": "Battery Motion Sensor",
+	"devices": [
+		{
+			"productType": "0x0002",
+			"productId": "0x000d"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Reports",
+			"maxNodes": 8,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "Light Control",
+			"maxNodes": 8
+		}
+	},
+	"paramInformation": {
+		"2": {
+			"label": "Basic Set Level",
+			"description": "Setting the BASIC command value to turn on the light.",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 100,
+			"defaultValue": 255,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true,
+			"options": [
+				{
+					"label": "Off",
+					"value": 0
+				},
+				{
+					"label": "On",
+					"value": 255
+				}
+			]
+		},
+		"3": {
+			"label": "PIR Sensitivity",
+			"description": "Set the sensitivity for the PIR (Passive Infrared Sensor).",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 99,
+			"defaultValue": 80,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
+		},
+		"4": {
+			"label": "Light Threshold",
+			"description": "Set the illumination threshold to turn on the light.",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 99,
+			"defaultValue": 99,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true,
+			"options": [
+				{
+					"label": "Disable, Light OFF",
+					"value": 0
+				},
+				{
+					"label": "Disable, Light ON",
+					"value": 100
+				}
+			]
+		},
+		"5": {
+			"label": "Operation Mode",
+			"description": "Parameter to set the Operation Mode.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"6": {
+			"label": "Multi-Sensor Function Switch",
+			"description": "Parameter to set the sensor functions.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 63,
+			"defaultValue": 4,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"8": {
+			"label": "PIR Re-Detect Interval Time",
+			"description": "Set re-detect time after PIR motion triggered",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 127,
+			"defaultValue": 3,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"9": {
+			"label": "Turn Off Light Time",
+			"description": "Set delay time to turn off light after motion triggered.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 127,
+			"defaultValue": 4,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"10": {
+			"label": "Auto Report Battery Time",
+			"description": "Interval time for auto reporting the battery level",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 127,
+			"defaultValue": 12,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"12": {
+			"label": "Auto Report Illumination Time",
+			"description": "Interval time for auto reporting the illumination.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 127,
+			"defaultValue": 12,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"13": {
+			"label": "Auto Report Temperature Time",
+			"description": "Interval time for auto reporting the temperature.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 127,
+			"defaultValue": 12,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"20": {
+			"label": "Auto Report Tick Interval",
+			"description": "Interval time for auto reporting each tick.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 30,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"21": {
+			"label": "Temperature Differential Report",
+			"description": "The temperature differential to report.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 127,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"22": {
+			"label": "Illumination Differential Report",
+			"description": "The illumination differential to report.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 99,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"7[0x02]": {
+			"label": "Bit1: Enable sending motion OFF report.",
+			"description": "0:Disable, 1:Enable",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		"7[0x04]": {
+			"label": "Bit2: Enable PIR super sensitivity mode.",
+			"description": "0:Disable, 1:Enable",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		"7[0x10]": {
+			"label": "Bit4: Notification Type",
+			"description": "0: Notification Report. 1: Sensor Binary Report.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Notification Report",
+					"value": 0
+				},
+				{
+					"label": "Sensor Binary Report",
+					"value": 1
+				}
+			]
+		},
+		"7[0x20]": {
+			"label": "Bit5: Disable Multi CC in auto report.",
+			"description": "1:Disable, 0:Enable",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Enable",
+					"value": 0
+				},
+				{
+					"label": "Disable",
+					"value": 1
+				}
+			]
+		},
+		"7[0x40]": {
+			"label": "Bit6: Report battery state when device triggered",
+			"description": "1:Disable, 0 Enable",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Enable",
+					"value": 0
+				},
+				{
+					"label": "Disable",
+					"value": 1
+				}
+			]
+		}
+	}
 }

--- a/packages/config/config/devices/0x010f/fgrgbw-442.json
+++ b/packages/config/config/devices/0x010f/fgrgbw-442.json
@@ -314,42 +314,6 @@
 			"writeOnly": false,
 			"allowManualEntry": true
 		},
-		"154": {
-			"label": "ON frame value for single click",
-			"description": "ON frame value for single click",
-			"valueSize": 4,
-			"minValue": 0,
-			"maxValue": 4294967295,
-			"defaultValue": 4294967295,
-			"unsigned": true,
-			"readOnly": false,
-			"writeOnly": false,
-			"allowManualEntry": true
-		},
-		"155": {
-			"label": "OFF frame value for single click",
-			"description": "OFF frame value for single click",
-			"valueSize": 4,
-			"minValue": 0,
-			"maxValue": 4294967295,
-			"defaultValue": 4294967295,
-			"unsigned": true,
-			"readOnly": false,
-			"writeOnly": false,
-			"allowManualEntry": true
-		},
-		"156": {
-			"label": "ON frame value for double click",
-			"description": "ON frame value for double click",
-			"valueSize": 4,
-			"minValue": 0,
-			"maxValue": 4294967295,
-			"defaultValue": 4294967295,
-			"unsigned": true,
-			"readOnly": false,
-			"writeOnly": false,
-			"allowManualEntry": true
-		},
 		"157": {
 			"label": "Start programmed sequence",
 			"description": "Start programmed sequence",

--- a/packages/config/config/devices/0x013c/psp05.json
+++ b/packages/config/config/devices/0x013c/psp05.json
@@ -1,218 +1,207 @@
 // Philio Technology Corp PSP05
 // Motion Sensor
 {
-    "_approved": true,
-    "manufacturer": "Philio Technology Corp",
-    "manufacturerId": "0x013c",
-    "label": "PSP05",
-    "description": "Motion Sensor",
-    "devices": [
-        {
-            "productType": "0x0002",
-            "productId": "0x0050"
-        }
-    ],
-    "firmwareVersion": {
-        "min": "0.0",
-        "max": "255.255"
-    },
-    "supportsZWavePlus": true,
-    "paramInformation": {
-        "2": {
-            "label": "Basic Set Level",
-            "description": "Setting the BASIC command value to turn on the light.",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 255,
-            "defaultValue": 255,
-            "unsigned": true,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "3": {
-            "label": "PIR Sensitivity",
-            "description": "Adjust the PIR Sensitivity",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 99,
-            "defaultValue": 80,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "6": {
-            "label": "Multi-Sensor Function Switch",
-            "description": "Parameter to set the sensor functions.",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 255,
-            "defaultValue": 5,
-            "unsigned": true,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "7": {
-            "label": "Customer Function",
-            "description": "Parameter to set the Customer Function.",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 127,
-            "defaultValue": 4,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "8": {
-            "label": "Re-detection interval",
-            "description": "Multiples of 8 seconds to wait before re-detection",
-            "valueSize": 1,
-            "minValue": 1,
-            "maxValue": 127,
-            "defaultValue": 3,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "9": {
-            "label": "Turn off light time",
-            "description": "Time to wait after lighting has been turned on before turning off again",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 127,
-            "defaultValue": 4,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "10": {
-            "label": "Batery level reporting interval",
-            "description": "How frequently battery status should be reported",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 127,
-            "defaultValue": 12,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "20": {
-            "label": "Tick Interval",
-            "description": "Interval time for sending reports",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 255,
-            "defaultValue": 30,
-            "unsigned": true,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "7[0x02]": {
-            "label": "Bit 1: Motion OFF Reporting",
-            "description": "Sends notification when motion has completed.",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Don't Send Report",
-                    "value": 0
-                },
-                {
-                    "label": "Send Report",
-                    "value": 1
-                }
-            ]
-        },
-        "7[0x04]": {
-            "label": "Bit 2: Enable PIR super sensitivity mode.",
-            "description": "Enable PIR super sensitivity mode",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 1,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Disable",
-                    "value": 0
-                },
-                {
-                    "label": "Enable",
-                    "value": 1
-                }
-            ]
-        },
-        "7[0x10]": {
-            "label": "Bit 4: Notification Type",
-            "description": "Method used to send notifications on motion",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Report Notification",
-                    "value": 0
-                },
-                {
-                    "label": "Binary Sensor",
-                    "value": 1
-                }
-            ]
-        },
-        "7[0x20]": {
-            "label": "Bit 5: Send Multi CC in auto report",
-            "description": "Send Multi CC in auto report",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Enable",
-                    "value": 0
-                },
-                {
-                    "label": "Disable",
-                    "value": 1
-                }
-            ]
-        },
-        "7[0x40]": {
-            "label": "Bit 6: Send Battery Report when Triggered",
-            "description": "Whether or not a battery status report should be sent when triggered",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Enable",
-                    "value": 0
-                },
-                {
-                    "label": "Disable",
-                    "value": 1
-                }
-            ]
-        }
-    }
+	"_approved": true,
+	"manufacturer": "Philio Technology Corp",
+	"manufacturerId": "0x013c",
+	"label": "PSP05",
+	"description": "Motion Sensor",
+	"devices": [
+		{
+			"productType": "0x0002",
+			"productId": "0x0050"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"supportsZWavePlus": true,
+	"paramInformation": {
+		"2": {
+			"label": "Basic Set Level",
+			"description": "Setting the BASIC command value to turn on the light.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 255,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"3": {
+			"label": "PIR Sensitivity",
+			"description": "Adjust the PIR Sensitivity",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 99,
+			"defaultValue": 80,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"6": {
+			"label": "Multi-Sensor Function Switch",
+			"description": "Parameter to set the sensor functions.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 5,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"8": {
+			"label": "Re-detection interval",
+			"description": "Multiples of 8 seconds to wait before re-detection",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 127,
+			"defaultValue": 3,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"9": {
+			"label": "Turn off light time",
+			"description": "Time to wait after lighting has been turned on before turning off again",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 127,
+			"defaultValue": 4,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"10": {
+			"label": "Batery level reporting interval",
+			"description": "How frequently battery status should be reported",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 127,
+			"defaultValue": 12,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"20": {
+			"label": "Tick Interval",
+			"description": "Interval time for sending reports",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 30,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"7[0x02]": {
+			"label": "Bit 1: Motion OFF Reporting",
+			"description": "Sends notification when motion has completed.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Don't Send Report",
+					"value": 0
+				},
+				{
+					"label": "Send Report",
+					"value": 1
+				}
+			]
+		},
+		"7[0x04]": {
+			"label": "Bit 2: Enable PIR super sensitivity mode.",
+			"description": "Enable PIR super sensitivity mode",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		"7[0x10]": {
+			"label": "Bit 4: Notification Type",
+			"description": "Method used to send notifications on motion",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Report Notification",
+					"value": 0
+				},
+				{
+					"label": "Binary Sensor",
+					"value": 1
+				}
+			]
+		},
+		"7[0x20]": {
+			"label": "Bit 5: Send Multi CC in auto report",
+			"description": "Send Multi CC in auto report",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Enable",
+					"value": 0
+				},
+				{
+					"label": "Disable",
+					"value": 1
+				}
+			]
+		},
+		"7[0x40]": {
+			"label": "Bit 6: Send Battery Report when Triggered",
+			"description": "Whether or not a battery status report should be sent when triggered",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Enable",
+					"value": 0
+				},
+				{
+					"label": "Disable",
+					"value": 1
+				}
+			]
+		}
+	}
 }

--- a/packages/config/config/devices/0x016a/ft096.json
+++ b/packages/config/config/devices/0x016a/ft096.json
@@ -136,28 +136,6 @@
 				}
 			]
 		},
-		"83": {
-			"label": "Color in night light mode",
-			"valueSize": 3,
-			"minValue": 0,
-			"maxValue": 16777215,
-			"defaultValue": 0,
-			"unsigned": true,
-			"readOnly": false,
-			"writeOnly": false,
-			"allowManualEntry": true
-		},
-		"84": {
-			"label": "Color in energy mode",
-			"valueSize": 3,
-			"minValue": 0,
-			"maxValue": 16777215,
-			"defaultValue": 0,
-			"unsigned": true,
-			"readOnly": false,
-			"writeOnly": false,
-			"allowManualEntry": true
-		},
 		"90": {
 			"label": "Enable items 91 and 92",
 			"description": "Enables/disables parameter 91 and 92",

--- a/packages/config/config/devices/0x0271/is140-2.json
+++ b/packages/config/config/devices/0x0271/is140-2.json
@@ -1,224 +1,213 @@
 // STEINEL GmbH IS140-2
 // PIR sensor with relay
 {
-    "_approved": true,
-    "manufacturer": "STEINEL GmbH",
-    "manufacturerId": "0x0271",
-    "label": "IS140-2",
-    "description": "PIR sensor with relay",
-    "devices": [
-        {
-            "productType": "0x0002",
-            "productId": "0x1a72"
-        },
-        {
-            "productType": "0x0002",
-            "productId": "0x6770"
-        }
-    ],
-    "firmwareVersion": {
-        "min": "0.0",
-        "max": "255.255"
-    },
-    "supportsZWavePlus": true,
-    "paramInformation": {
-        "1": {
-            "label": "Time",
-            "description": "Duration of light after motion detection",
-            "unit": "s",
-            "valueSize": 2,
-            "minValue": 5,
-            "maxValue": 900,
-            "defaultValue": 180,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "2": {
-            "label": "Light",
-            "description": "Light threshold",
-            "unit": "lx",
-            "valueSize": 2,
-            "minValue": 0,
-            "maxValue": 2000,
-            "defaultValue": 2000,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "5": {
-            "label": "Sensitivity",
-            "description": "Motion Radar Sensitivity",
-            "unit": "Percent",
-            "valueSize": 1,
-            "minValue": 2,
-            "maxValue": 100,
-            "defaultValue": 100,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "8": {
-            "label": "Global_Light",
-            "description": "External ambient light value",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 1,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "9": {
-            "label": "SLAVE_MODE",
-            "description": "Disable local control",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 4,
-            "defaultValue": 2,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "10": {
-            "label": "(OFF_BEHAVIOUR)",
-            "description": "Off behaviour (timeout)",
-            "valueSize": 2,
-            "minValue": 0,
-            "maxValue": 255,
-            "defaultValue": 10,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "11": {
-            "label": "ON_BEHAVIOUR",
-            "description": "On behaviour (timeout)",
-            "valueSize": 2,
-            "minValue": 0,
-            "maxValue": 255,
-            "defaultValue": 255,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "12": {
-            "label": "ON_TIME_OVER",
-            "description": "On behaviour time over (timeout)",
-            "valueSize": 2,
-            "minValue": 0,
-            "maxValue": 255,
-            "defaultValue": 204,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "13": {
-            "label": "ON_OFF_ BEHAVIOUR",
-            "description": "Sequence On-Off behaviour (timeout)",
-            "valueSize": 2,
-            "minValue": 0,
-            "maxValue": 255,
-            "defaultValue": 204,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "14": {
-            "label": "OFF_ON_ BEHAVIOUR",
-            "description": "Sequence Off-On behaviour (timeout)",
-            "valueSize": 2,
-            "minValue": 0,
-            "maxValue": 255,
-            "defaultValue": 204,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "15": {
-            "label": "SEQUENCE_ TIME",
-            "description": "Sequence timing",
-            "valueSize": 1,
-            "minValue": 10,
-            "maxValue": 50,
-            "defaultValue": 10,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "16": {
-            "label": "MOTION_ DISABLE",
-            "description": "Motion Off behaviour (timeout)",
-            "valueSize": 2,
-            "minValue": 0,
-            "maxValue": 255,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "9[0x01]": {
-            "label": "Bit 0: Slave Mode",
-            "description": "0=Disable, 1=Enable",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 1,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Disable",
-                    "value": 0
-                },
-                {
-                    "label": "Enable",
-                    "value": 1
-                }
-            ]
-        },
-        "9[0x02]": {
-            "label": "Bit 1: Central Unit checking",
-            "description": "0=Disable, 1=Enable",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 1,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Disable",
-                    "value": 0
-                },
-                {
-                    "label": "Enable",
-                    "value": 1
-                }
-            ]
-        },
-        "9[0x04]": {
-            "label": "Bit 2: Stupid Mode",
-            "description": "0=Disable, 1=Enable",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Disable",
-                    "value": 0
-                },
-                {
-                    "label": "Enable",
-                    "value": 1
-                }
-            ]
-        }
-    }
+	"_approved": true,
+	"manufacturer": "STEINEL GmbH",
+	"manufacturerId": "0x0271",
+	"label": "IS140-2",
+	"description": "PIR sensor with relay",
+	"devices": [
+		{
+			"productType": "0x0002",
+			"productId": "0x1a72"
+		},
+		{
+			"productType": "0x0002",
+			"productId": "0x6770"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"supportsZWavePlus": true,
+	"paramInformation": {
+		"1": {
+			"label": "Time",
+			"description": "Duration of light after motion detection",
+			"unit": "s",
+			"valueSize": 2,
+			"minValue": 5,
+			"maxValue": 900,
+			"defaultValue": 180,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"2": {
+			"label": "Light",
+			"description": "Light threshold",
+			"unit": "lx",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 2000,
+			"defaultValue": 2000,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"5": {
+			"label": "Sensitivity",
+			"description": "Motion Radar Sensitivity",
+			"unit": "Percent",
+			"valueSize": 1,
+			"minValue": 2,
+			"maxValue": 100,
+			"defaultValue": 100,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"8": {
+			"label": "Global_Light",
+			"description": "External ambient light value",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"10": {
+			"label": "(OFF_BEHAVIOUR)",
+			"description": "Off behaviour (timeout)",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 10,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"11": {
+			"label": "ON_BEHAVIOUR",
+			"description": "On behaviour (timeout)",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 255,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"12": {
+			"label": "ON_TIME_OVER",
+			"description": "On behaviour time over (timeout)",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 204,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"13": {
+			"label": "ON_OFF_ BEHAVIOUR",
+			"description": "Sequence On-Off behaviour (timeout)",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 204,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"14": {
+			"label": "OFF_ON_ BEHAVIOUR",
+			"description": "Sequence Off-On behaviour (timeout)",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 204,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"15": {
+			"label": "SEQUENCE_ TIME",
+			"description": "Sequence timing",
+			"valueSize": 1,
+			"minValue": 10,
+			"maxValue": 50,
+			"defaultValue": 10,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"16": {
+			"label": "MOTION_ DISABLE",
+			"description": "Motion Off behaviour (timeout)",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"9[0x01]": {
+			"label": "Bit 0: Slave Mode",
+			"description": "0=Disable, 1=Enable",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		"9[0x02]": {
+			"label": "Bit 1: Central Unit checking",
+			"description": "0=Disable, 1=Enable",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		"9[0x04]": {
+			"label": "Bit 2: Stupid Mode",
+			"description": "0=Disable, 1=Enable",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		}
+	}
 }

--- a/packages/config/config/devices/0x031e/lzw30-sn.json
+++ b/packages/config/config/devices/0x031e/lzw30-sn.json
@@ -1,501 +1,490 @@
 // Inovelli LZW30-SN
 // Red Series On/Off switch
 {
-    "_approved": false,
-    "manufacturer": "Inovelli",
-    "manufacturerId": "0x031e",
-    "label": "LZW30-SN",
-    "description": "Red Series On/Off switch",
-    "devices": [
-        {
-            "productType": "0x0002",
-            "productId": "0x0001"
-        }
-    ],
-    "firmwareVersion": {
-        "min": "0.0",
-        "max": "255.255"
-    },
-    "supportsZWavePlus": true,
-    "paramInformation": {
-        "1": {
-            "label": "Power On State",
-            "description": "Power On State",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 2,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Prior State",
-                    "value": 0
-                },
-                {
-                    "label": "On",
-                    "value": 1
-                },
-                {
-                    "label": "Off",
-                    "value": 2
-                }
-            ]
-        },
-        "2": {
-            "label": "Invert Switch",
-            "description": "Invert Switch",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 1,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Disabled",
-                    "value": 0
-                },
-                {
-                    "label": "Enabled",
-                    "value": 1
-                }
-            ]
-        },
-        "3": {
-            "label": "Auto Off Timer",
-            "description": "Auto Off Timer",
-            "unit": "seconds",
-            "valueSize": 2,
-            "minValue": 0,
-            "maxValue": 32767,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "4": {
-            "label": "Association Behavior",
-            "description": "Association Behavior",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 15,
-            "defaultValue": 15,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "5": {
-            "label": "LED Indicator Color",
-            "description": "LED Indicator Color",
-            "valueSize": 2,
-            "minValue": 0,
-            "maxValue": 255,
-            "defaultValue": 170,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true,
-            "options": [
-                {
-                    "label": "Red",
-                    "value": 0
-                },
-                {
-                    "label": "Orange",
-                    "value": 21
-                },
-                {
-                    "label": "Yellow",
-                    "value": 42
-                },
-                {
-                    "label": "Green",
-                    "value": 85
-                },
-                {
-                    "label": "Cyan",
-                    "value": 127
-                },
-                {
-                    "label": "Blue",
-                    "value": 170
-                },
-                {
-                    "label": "Violet",
-                    "value": 212
-                },
-                {
-                    "label": "Pink",
-                    "value": 234
-                }
-            ]
-        },
-        "6": {
-            "label": "LED Indicator Intensity",
-            "description": "LED Indicator Intensity",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 10,
-            "defaultValue": 5,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Off",
-                    "value": 0
-                },
-                {
-                    "label": "10%",
-                    "value": 1
-                },
-                {
-                    "label": "20%",
-                    "value": 2
-                },
-                {
-                    "label": "30%",
-                    "value": 3
-                },
-                {
-                    "label": "40%",
-                    "value": 4
-                },
-                {
-                    "label": "50%",
-                    "value": 5
-                },
-                {
-                    "label": "60%",
-                    "value": 6
-                },
-                {
-                    "label": "70%",
-                    "value": 7
-                },
-                {
-                    "label": "80%",
-                    "value": 8
-                },
-                {
-                    "label": "90%",
-                    "value": 9
-                },
-                {
-                    "label": "100%",
-                    "value": 10
-                }
-            ]
-        },
-        "7": {
-            "label": "LED Indicator Intensity (When Off)",
-            "description": "LED Indicator Intensity (When Off)",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 10,
-            "defaultValue": 1,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Off",
-                    "value": 0
-                },
-                {
-                    "label": "10%",
-                    "value": 1
-                },
-                {
-                    "label": "20%",
-                    "value": 2
-                },
-                {
-                    "label": "30%",
-                    "value": 3
-                },
-                {
-                    "label": "40%",
-                    "value": 4
-                },
-                {
-                    "label": "50%",
-                    "value": 5
-                },
-                {
-                    "label": "60%",
-                    "value": 6
-                },
-                {
-                    "label": "70%",
-                    "value": 7
-                },
-                {
-                    "label": "80%",
-                    "value": 8
-                },
-                {
-                    "label": "90%",
-                    "value": 9
-                },
-                {
-                    "label": "100%",
-                    "value": 10
-                }
-            ]
-        },
-        "8": {
-            "label": "LED Strip Effect",
-            "description": "LED Strip Effect",
-            "valueSize": 4,
-            "minValue": 0,
-            "maxValue": 83823359,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "9": {
-            "label": "LED Strip Timeout",
-            "description": "LED Strip Timeout",
-            "unit": "seconds",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 10,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Stay Off",
-                    "value": 0
-                },
-                {
-                    "label": "One Second",
-                    "value": 1
-                },
-                {
-                    "label": "Two Seconds",
-                    "value": 2
-                },
-                {
-                    "label": "Three Seconds",
-                    "value": 3
-                },
-                {
-                    "label": "Four Seconds",
-                    "value": 4
-                },
-                {
-                    "label": "Five Seconds",
-                    "value": 5
-                },
-                {
-                    "label": "Six Seconds",
-                    "value": 6
-                },
-                {
-                    "label": "Seven Seconds",
-                    "value": 7
-                },
-                {
-                    "label": "Eight Seconds",
-                    "value": 8
-                },
-                {
-                    "label": "Nine Seconds",
-                    "value": 9
-                },
-                {
-                    "label": "Ten Seconds",
-                    "value": 10
-                }
-            ]
-        },
-        "10": {
-            "label": "Active Power Reports",
-            "description": "Active Power Reports",
-            "unit": "percent",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 100,
-            "defaultValue": 10,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "11": {
-            "label": "Periodic Power & Energy Reports",
-            "description": "Periodic Power & Energy Reports",
-            "unit": "seconds",
-            "valueSize": 2,
-            "minValue": 0,
-            "maxValue": 32767,
-            "defaultValue": 3600,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "12": {
-            "label": "Energy Reports",
-            "description": "Energy Reports",
-            "unit": "percent",
-            "valueSize": 1,
-            "minValue": 0,
-            "maxValue": 100,
-            "defaultValue": 10,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "8[0xff]": {
-            "label": "LED Strip Effect (Color)",
-            "description": "LED Strip Effect (Color)",
-            "valueSize": 4,
-            "minValue": 0,
-            "maxValue": 255,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true,
-            "options": [
-                {
-                    "label": "Red",
-                    "value": 0
-                },
-                {
-                    "label": "Orange",
-                    "value": 21
-                },
-                {
-                    "label": "Yellow",
-                    "value": 42
-                },
-                {
-                    "label": "Green",
-                    "value": 85
-                },
-                {
-                    "label": "Cyan",
-                    "value": 127
-                },
-                {
-                    "label": "Blue",
-                    "value": 170
-                },
-                {
-                    "label": "Violet",
-                    "value": 212
-                },
-                {
-                    "label": "Pink",
-                    "value": 234
-                }
-            ]
-        },
-        "8[0xff00]": {
-            "label": "LED Strip Effect (Brightness)",
-            "description": "LED Strip Effect (Brightness)",
-            "valueSize": 4,
-            "minValue": 0,
-            "maxValue": 10,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Off",
-                    "value": 0
-                },
-                {
-                    "label": "10%",
-                    "value": 1
-                },
-                {
-                    "label": "20%",
-                    "value": 2
-                },
-                {
-                    "label": "30%",
-                    "value": 3
-                },
-                {
-                    "label": "40%",
-                    "value": 4
-                },
-                {
-                    "label": "50%",
-                    "value": 5
-                },
-                {
-                    "label": "60%",
-                    "value": 6
-                },
-                {
-                    "label": "70%",
-                    "value": 7
-                },
-                {
-                    "label": "80%",
-                    "value": 8
-                },
-                {
-                    "label": "90%",
-                    "value": 9
-                },
-                {
-                    "label": "100%",
-                    "value": 10
-                }
-            ]
-        },
-        "8[0xff0000]": {
-            "label": "LED Strip Effect (Duration)",
-            "description": "LED Strip Effect (Duration)",
-            "valueSize": 4,
-            "minValue": 0,
-            "maxValue": 255,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": true
-        },
-        "8[0x7f000000]": {
-            "label": "LED Strip Effect (Effect)",
-            "description": "LED Strip Effect (Effect)",
-            "valueSize": 4,
-            "minValue": 0,
-            "maxValue": 4,
-            "defaultValue": 0,
-            "readOnly": false,
-            "writeOnly": false,
-            "allowManualEntry": false,
-            "options": [
-                {
-                    "label": "Off",
-                    "value": 0
-                },
-                {
-                    "label": "Solid",
-                    "value": 1
-                },
-                {
-                    "label": "Fast Blink",
-                    "value": 2
-                },
-                {
-                    "label": "Slow Blink",
-                    "value": 3
-                },
-                {
-                    "label": "Pulse",
-                    "value": 4
-                }
-            ]
-        }
-    }
+	"_approved": false,
+	"manufacturer": "Inovelli",
+	"manufacturerId": "0x031e",
+	"label": "LZW30-SN",
+	"description": "Red Series On/Off switch",
+	"devices": [
+		{
+			"productType": "0x0002",
+			"productId": "0x0001"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"supportsZWavePlus": true,
+	"paramInformation": {
+		"1": {
+			"label": "Power On State",
+			"description": "Power On State",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 2,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Prior State",
+					"value": 0
+				},
+				{
+					"label": "On",
+					"value": 1
+				},
+				{
+					"label": "Off",
+					"value": 2
+				}
+			]
+		},
+		"2": {
+			"label": "Invert Switch",
+			"description": "Invert Switch",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disabled",
+					"value": 0
+				},
+				{
+					"label": "Enabled",
+					"value": 1
+				}
+			]
+		},
+		"3": {
+			"label": "Auto Off Timer",
+			"description": "Auto Off Timer",
+			"unit": "seconds",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 32767,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"4": {
+			"label": "Association Behavior",
+			"description": "Association Behavior",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 15,
+			"defaultValue": 15,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"5": {
+			"label": "LED Indicator Color",
+			"description": "LED Indicator Color",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 170,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true,
+			"options": [
+				{
+					"label": "Red",
+					"value": 0
+				},
+				{
+					"label": "Orange",
+					"value": 21
+				},
+				{
+					"label": "Yellow",
+					"value": 42
+				},
+				{
+					"label": "Green",
+					"value": 85
+				},
+				{
+					"label": "Cyan",
+					"value": 127
+				},
+				{
+					"label": "Blue",
+					"value": 170
+				},
+				{
+					"label": "Violet",
+					"value": 212
+				},
+				{
+					"label": "Pink",
+					"value": 234
+				}
+			]
+		},
+		"6": {
+			"label": "LED Indicator Intensity",
+			"description": "LED Indicator Intensity",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 10,
+			"defaultValue": 5,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Off",
+					"value": 0
+				},
+				{
+					"label": "10%",
+					"value": 1
+				},
+				{
+					"label": "20%",
+					"value": 2
+				},
+				{
+					"label": "30%",
+					"value": 3
+				},
+				{
+					"label": "40%",
+					"value": 4
+				},
+				{
+					"label": "50%",
+					"value": 5
+				},
+				{
+					"label": "60%",
+					"value": 6
+				},
+				{
+					"label": "70%",
+					"value": 7
+				},
+				{
+					"label": "80%",
+					"value": 8
+				},
+				{
+					"label": "90%",
+					"value": 9
+				},
+				{
+					"label": "100%",
+					"value": 10
+				}
+			]
+		},
+		"7": {
+			"label": "LED Indicator Intensity (When Off)",
+			"description": "LED Indicator Intensity (When Off)",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 10,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Off",
+					"value": 0
+				},
+				{
+					"label": "10%",
+					"value": 1
+				},
+				{
+					"label": "20%",
+					"value": 2
+				},
+				{
+					"label": "30%",
+					"value": 3
+				},
+				{
+					"label": "40%",
+					"value": 4
+				},
+				{
+					"label": "50%",
+					"value": 5
+				},
+				{
+					"label": "60%",
+					"value": 6
+				},
+				{
+					"label": "70%",
+					"value": 7
+				},
+				{
+					"label": "80%",
+					"value": 8
+				},
+				{
+					"label": "90%",
+					"value": 9
+				},
+				{
+					"label": "100%",
+					"value": 10
+				}
+			]
+		},
+		"9": {
+			"label": "LED Strip Timeout",
+			"description": "LED Strip Timeout",
+			"unit": "seconds",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 10,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Stay Off",
+					"value": 0
+				},
+				{
+					"label": "One Second",
+					"value": 1
+				},
+				{
+					"label": "Two Seconds",
+					"value": 2
+				},
+				{
+					"label": "Three Seconds",
+					"value": 3
+				},
+				{
+					"label": "Four Seconds",
+					"value": 4
+				},
+				{
+					"label": "Five Seconds",
+					"value": 5
+				},
+				{
+					"label": "Six Seconds",
+					"value": 6
+				},
+				{
+					"label": "Seven Seconds",
+					"value": 7
+				},
+				{
+					"label": "Eight Seconds",
+					"value": 8
+				},
+				{
+					"label": "Nine Seconds",
+					"value": 9
+				},
+				{
+					"label": "Ten Seconds",
+					"value": 10
+				}
+			]
+		},
+		"10": {
+			"label": "Active Power Reports",
+			"description": "Active Power Reports",
+			"unit": "percent",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 100,
+			"defaultValue": 10,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"11": {
+			"label": "Periodic Power & Energy Reports",
+			"description": "Periodic Power & Energy Reports",
+			"unit": "seconds",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 32767,
+			"defaultValue": 3600,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"12": {
+			"label": "Energy Reports",
+			"description": "Energy Reports",
+			"unit": "percent",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 100,
+			"defaultValue": 10,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"8[0xff]": {
+			"label": "LED Strip Effect (Color)",
+			"description": "LED Strip Effect (Color)",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true,
+			"options": [
+				{
+					"label": "Red",
+					"value": 0
+				},
+				{
+					"label": "Orange",
+					"value": 21
+				},
+				{
+					"label": "Yellow",
+					"value": 42
+				},
+				{
+					"label": "Green",
+					"value": 85
+				},
+				{
+					"label": "Cyan",
+					"value": 127
+				},
+				{
+					"label": "Blue",
+					"value": 170
+				},
+				{
+					"label": "Violet",
+					"value": 212
+				},
+				{
+					"label": "Pink",
+					"value": 234
+				}
+			]
+		},
+		"8[0xff00]": {
+			"label": "LED Strip Effect (Brightness)",
+			"description": "LED Strip Effect (Brightness)",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 10,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Off",
+					"value": 0
+				},
+				{
+					"label": "10%",
+					"value": 1
+				},
+				{
+					"label": "20%",
+					"value": 2
+				},
+				{
+					"label": "30%",
+					"value": 3
+				},
+				{
+					"label": "40%",
+					"value": 4
+				},
+				{
+					"label": "50%",
+					"value": 5
+				},
+				{
+					"label": "60%",
+					"value": 6
+				},
+				{
+					"label": "70%",
+					"value": 7
+				},
+				{
+					"label": "80%",
+					"value": 8
+				},
+				{
+					"label": "90%",
+					"value": 9
+				},
+				{
+					"label": "100%",
+					"value": 10
+				}
+			]
+		},
+		"8[0xff0000]": {
+			"label": "LED Strip Effect (Duration)",
+			"description": "LED Strip Effect (Duration)",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"8[0x7f000000]": {
+			"label": "LED Strip Effect (Effect)",
+			"description": "LED Strip Effect (Effect)",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 4,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Off",
+					"value": 0
+				},
+				{
+					"label": "Solid",
+					"value": 1
+				},
+				{
+					"label": "Fast Blink",
+					"value": 2
+				},
+				{
+					"label": "Slow Blink",
+					"value": 3
+				},
+				{
+					"label": "Pulse",
+					"value": 4
+				}
+			]
+		}
+	}
 }

--- a/packages/config/maintenance/lintConfigFiles.ts
+++ b/packages/config/maintenance/lintConfigFiles.ts
@@ -266,6 +266,21 @@ Consider converting this parameter to unsigned using ${white(
 				}
 			}
 
+			// Check if there are partial parameters and non-partials with the same number
+			const duplicatedPartials = distinct(
+				partialParams.map(([key]) => key.parameter),
+			).filter((parameter) =>
+				config.paramInformation!.has({ parameter }),
+			);
+			if (duplicatedPartials.length) {
+				addError(
+					file,
+					`The following non-partial parameters need to be removed because partial parameters with the same key exist: ${duplicatedPartials
+						.map((p) => `#${p}`)
+						.join(", ")}!`,
+				);
+			}
+
 			// Check if there are partial parameters with incompatible min/max/default values
 			for (const [key, param] of partialParams) {
 				const bitMask = key.valueBitMask!;


### PR DESCRIPTION
This PR adds three more checks for partial config parameters:
* Is the value size compatible with the bitmask?
* Is the value size of all related partial params the same?
* Is there a (unnecessary) non-partial config parameter with the same property as a partial one?