### PR TITLE
fix(config): add missing config parameters to IDLock 150

### DIFF
--- a/packages/config/config/devices/0x0373/id-150_1.6.json
+++ b/packages/config/config/devices/0x0373/id-150_1.6.json
@@ -229,7 +229,7 @@
 			"defaultValue": 0,
 			"readOnly": false,
 			"writeOnly": false,
-			"allowManualEntry": false
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disabled (no sound)",
@@ -239,7 +239,7 @@
 					"label": "Enabled (no sound)",
 					"value": 1
 				},
-			    {
+				{
 					"label": "Disabled",
 					"value": 2
 				},
@@ -248,7 +248,7 @@
 					"value": 3
 				}
 			]
-		},		
+		},
 		"9": {
 			"label": "Master PIN Unlock Mode",
 			"description": "Configures if the Master PIN can unlock",
@@ -258,7 +258,7 @@
 			"defaultValue": 1,
 			"readOnly": false,
 			"writeOnly": false,
-			"allowManualEntry": false
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disabled",

--- a/packages/config/config/devices/0x0373/id-150_1.6.json
+++ b/packages/config/config/devices/0x0373/id-150_1.6.json
@@ -184,6 +184,14 @@
 					"value": 4
 				},
 				{
+					"label": "Generate Random PIN 1x use",
+					"value": 5
+				},
+				{
+					"label": "Generate Random PIN 24h use",
+					"value": 6
+				},
+				{
 					"label": "Always Valid",
 					"value": 7
 				},
@@ -211,6 +219,56 @@
 			"readOnly": true,
 			"writeOnly": false,
 			"allowManualEntry": true
+		},
+		"8": {
+			"label": "Updater Mode",
+			"description": "Enables use of the Updater app",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 0,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false
+			"options": [
+				{
+					"label": "Disabled (no sound)",
+					"value": 0
+				},
+				{
+					"label": "Enabled (no sound)",
+					"value": 1
+				},
+			    {
+					"label": "Disabled",
+					"value": 2
+				},
+				{
+					"label": "Enabled",
+					"value": 3
+				}
+			]
+		},		
+		"9": {
+			"label": "Master PIN Unlock Mode",
+			"description": "Configures if the Master PIN can unlock",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false
+			"options": [
+				{
+					"label": "Disabled",
+					"value": 0
+				},
+				{
+					"label": "Enabled",
+					"value": 1
+				}
+			]
 		}
 	},
 	"compat": {


### PR DESCRIPTION
Added some parameters lacking.

Docs:
https://idlock.no/wp-content/uploads/2020/08/User-manual-Z-Wave-modul_EN_1.1.pdf