### PR TITLE
chore: speed up CI tests

### DIFF
--- a/.github/actions/zwave-js-bot/main.js
+++ b/.github/actions/zwave-js-bot/main.js
@@ -30,7 +30,7 @@ async function publishPr() {
 	let newVersion;
 	try {
 		// Build it
-		await exec.exec("yarn", ["run", "build"]);
+		await exec.exec("yarn", ["run", "build:full"]);
 
 		// Configure git
 		await exec.exec("git", ["config", "user.email", "bot@zwave.js"]);

--- a/.github/workflows/cc-bot.yml
+++ b/.github/workflows/cc-bot.yml
@@ -24,18 +24,21 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - name: Install yarn
-      run: npm i -g yarn
+    # - name: Get Yarn cache directory
+    #   id: yarn-cache-dir-path
+    #   run: echo "::set-output name=dir::$(yarn cache dir)"
 
-    # # We need npm@7 for the workspaces feature
-    # - name: Update npm to >=7
-    #   run: "[ $(npm -v | cut -d. -f1) -lt 7 ] && npm i -g npm@7"
-
-    # - name: Install dependencies
-    #   run: npm ci
+    # - name: Use Yarn cache
+    #   uses: actions/cache@v2
+    #   id: yarn-cache
+    #   with:
+    #     path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+    #     key: ${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-yarn-
 
     - name: Install dependencies
-      run: rm -rf node_modules && yarn install --frozen-lockfile
+      run: yarn install --prefer-offline --frozen-lockfile
 
     - name: Compile TypeScript code
       run: npx lerna run build

--- a/.github/workflows/cc-bot.yml
+++ b/.github/workflows/cc-bot.yml
@@ -48,7 +48,7 @@ jobs:
           packages/*/build
           packages/*/*.tsbuildinfo
           packages/*/*.js
-        # When dependencies change, we like have to recompile. TS manages the sources itself
+        # When dependencies change, we likely have to recompile. TS manages the sources itself
         key: ts-${{ hashFiles('**/yarn.lock') }}
 
     - name: Compile TypeScript code

--- a/.github/workflows/cc-bot.yml
+++ b/.github/workflows/cc-bot.yml
@@ -40,6 +40,17 @@ jobs:
     - name: Install dependencies
       run: yarn install --prefer-offline --frozen-lockfile
 
+    - name: Use TypeScript build cache
+      uses: actions/cache@v2
+      id: build-cache
+      with:
+        path: |
+          packages/*/build
+          packages/*/*.tsbuildinfo
+          packages/*/*.js
+        # When dependencies change, we like have to recompile. TS manages the sources itself
+        key: ts-${{ hashFiles('**/yarn.lock') }}
+
     - name: Compile TypeScript code
       run: yarn run build
 

--- a/.github/workflows/cc-bot.yml
+++ b/.github/workflows/cc-bot.yml
@@ -24,18 +24,18 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    # - name: Get Yarn cache directory
-    #   id: yarn-cache-dir-path
-    #   run: echo "::set-output name=dir::$(yarn cache dir)"
+    - name: Get Yarn cache directory
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
 
-    # - name: Use Yarn cache
-    #   uses: actions/cache@v2
-    #   id: yarn-cache
-    #   with:
-    #     path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-    #     key: ${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-yarn-
+    - name: Use Yarn cache
+      uses: actions/cache@v2
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
 
     - name: Install dependencies
       run: yarn install --prefer-offline --frozen-lockfile

--- a/.github/workflows/cc-bot.yml
+++ b/.github/workflows/cc-bot.yml
@@ -41,7 +41,7 @@ jobs:
       run: yarn install --prefer-offline --frozen-lockfile
 
     - name: Compile TypeScript code
-      run: npx lerna run build
+      run: yarn run build
 
     # The script will check if there are changes before updating the issue
     - name: Update CC table

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -46,6 +46,17 @@ jobs:
     - name: Install dependencies
       run: yarn install --prefer-offline --frozen-lockfile
 
+    - name: Use TypeScript build cache
+      uses: actions/cache@v2
+      id: build-cache
+      with:
+        path: |
+          packages/*/build
+          packages/*/*.tsbuildinfo
+          packages/*/*.js
+        # When dependencies change, we like have to recompile. TS manages the sources itself
+        key: ts-${{ hashFiles('**/yarn.lock') }}
+
     - name: Compile TypeScript code
       run: yarn run build
 

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -54,7 +54,7 @@ jobs:
           packages/*/build
           packages/*/*.tsbuildinfo
           packages/*/*.js
-        # When dependencies change, we like have to recompile. TS manages the sources itself
+        # When dependencies change, we likely have to recompile. TS manages the sources itself
         key: ts-${{ hashFiles('**/yarn.lock') }}
 
     - name: Compile TypeScript code

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -30,18 +30,8 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - name: Install yarn
-      run: npm i -g yarn
-
-    # # We need npm@7 for the workspaces feature
-    # - name: Update npm to >=7
-    #   run: "[ $(npm -v | cut -d. -f1) -lt 7 ] && npm i -g npm@7"
-
-    # - name: Install dependencies
-    #   run: npm ci
-
     - name: Install dependencies
-      run: rm -rf node_modules && yarn install --frozen-lockfile
+      run: yarn install --prefer-offline --frozen-lockfile
 
     - name: Compile TypeScript code
       run: yarn run build

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -30,6 +30,19 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
+    - name: Get Yarn cache directory
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+
+    - name: Use Yarn cache
+      uses: actions/cache@v2
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
     - name: Install dependencies
       run: yarn install --prefer-offline --frozen-lockfile
 

--- a/.github/workflows/nightly-config-publish.yml
+++ b/.github/workflows/nightly-config-publish.yml
@@ -23,6 +23,17 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
+    - name: Use TypeScript build cache
+      uses: actions/cache@v2
+      id: build-cache
+      with:
+        path: |
+          packages/*/build
+          packages/*/*.tsbuildinfo
+          packages/*/*.js
+        # When dependencies change, we like have to recompile. TS manages the sources itself
+        key: ts-${{ hashFiles('**/yarn.lock') }}
+
     - name: Detect changes (git)
       run: |
         # ===============================

--- a/.github/workflows/nightly-config-publish.yml
+++ b/.github/workflows/nightly-config-publish.yml
@@ -31,7 +31,7 @@ jobs:
           packages/*/build
           packages/*/*.tsbuildinfo
           packages/*/*.js
-        # When dependencies change, we like have to recompile. TS manages the sources itself
+        # When dependencies change, we likely have to recompile. TS manages the sources itself
         key: ts-${{ hashFiles('**/yarn.lock') }}
 
     - name: Detect changes (git)

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -31,6 +31,19 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
+    - name: Get Yarn cache directory
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+
+    - name: Use Yarn cache
+      uses: actions/cache@v2
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
     - name: Install dependencies
       run: yarn install --prefer-offline --frozen-lockfile
 
@@ -63,6 +76,19 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+
+    - name: Get Yarn cache directory
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+
+    - name: Use Yarn cache
+      uses: actions/cache@v2
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
 
     - name: Install dependencies
       run: yarn install --prefer-offline --frozen-lockfile
@@ -105,6 +131,19 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+
+    - name: Get Yarn cache directory
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+
+    - name: Use Yarn cache
+      uses: actions/cache@v2
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
 
     - name: Install dependencies
       run: yarn install --prefer-offline --frozen-lockfile
@@ -161,6 +200,19 @@ jobs:
         BODY="${BODY//$'\n'/'%0A'}"
         BODY="${BODY//$'\r'/'%0D'}"
         echo "::set-output name=BODY::$BODY"
+
+    - name: Get Yarn cache directory
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+
+    - name: Use Yarn cache
+      uses: actions/cache@v2
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
 
     - name: Install dependencies
       run: yarn install --prefer-offline --frozen-lockfile

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -56,6 +56,9 @@ jobs:
     - name: Lint config files
       run: npx lerna run lint:config
 
+    - name: Lint Z-Wave specifics
+      run: npx lerna run lint:zwave
+
   # ===================
 
   # Runs unit tests on all supported node versions and OSes
@@ -102,10 +105,48 @@ jobs:
       env:
         CI: true
 
-    # Test that the main entry point is not broken
+  # ===================
+
+  # Test that the generated packages are ok
+  test-package:
+    if: contains(github.event.head_commit.message, '[skip ci]') == false
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Get Yarn cache directory
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+
+    - name: Use Yarn cache
+      uses: actions/cache@v2
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
+    - name: Install dependencies
+      run: yarn install --prefer-offline --frozen-lockfile
+
+    # Do a full build so the package files are regenerated
+    - name: Compile TypeScript code
+      run: npx lerna run build:full
+
     - name: Import main entry point
       run: node -e 'require("./packages/zwave-js")'
-
 
   # ===================
 
@@ -172,7 +213,7 @@ jobs:
       github.event_name == 'push' &&
       startsWith(github.ref, 'refs/tags/v')
 
-    needs: [lint, unit-tests]
+    needs: [lint, unit-tests, test-package]
 
     runs-on: ubuntu-latest
     strategy:
@@ -218,7 +259,7 @@ jobs:
       run: yarn install --prefer-offline --frozen-lockfile
 
     - name: Create a clean build
-      run: npx lerna run build
+      run: npx lerna run build:full
 
     - name: Publish package to npm
       run: |

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -31,18 +31,8 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - name: Install yarn
-      run: npm i -g yarn
-
-    # # We need npm@7 for the workspaces feature
-    # - name: Update npm to >=7
-    #   run: "[ $(npm -v | cut -d. -f1) -lt 7 ] && npm i -g npm@7"
-
-    # - name: Install dependencies
-    #   run: npm ci
-
     - name: Install dependencies
-      run: rm -rf node_modules && yarn install --frozen-lockfile
+      run: yarn install --prefer-offline --frozen-lockfile
 
     - name: Compile TypeScript code
       run: npx lerna run build
@@ -74,18 +64,8 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - name: Install yarn
-      run: npm i -g yarn
-
-    # # We need npm@7 for the workspaces feature
-    # - name: Update npm to >=7
-    #   run: "[ $(npm -v | cut -d. -f1) -lt 7 ] && npm i -g npm@7"
-
-    # - name: Install dependencies
-    #   run: npm ci
-
     - name: Install dependencies
-      run: rm -rf node_modules && yarn install --frozen-lockfile
+      run: yarn install --prefer-offline --frozen-lockfile
 
     # Compilation is necessary, or the tests won't run
     - name: Compile TypeScript code
@@ -126,18 +106,8 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - name: Install yarn
-      run: npm i -g yarn
-
-    # # We need npm@7 for the workspaces feature
-    # - name: Update npm to >=7
-    #   run: "[ $(npm -v | cut -d. -f1) -lt 7 ] && npm i -g npm@7"
-
-    # - name: Install dependencies
-    #   run: npm ci
-
     - name: Install dependencies
-      run: rm -rf node_modules && yarn install --frozen-lockfile
+      run: yarn install --prefer-offline --frozen-lockfile
 
     # Compilation is necessary, or the tests won't run
     - name: Compile TypeScript code
@@ -179,13 +149,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - name: Install yarn
-      run: npm i -g yarn
-
-    # # We need npm@7 for the workspaces feature
-    # - name: Update npm to >=7
-    #   run: "[ $(npm -v | cut -d. -f1) -lt 7 ] && npm i -g npm@7"
-
     - name: Extract the version and commit body from the tag
       id: extract_release
       # The body may be multiline, therefore we need to escape some characters
@@ -199,11 +162,8 @@ jobs:
         BODY="${BODY//$'\r'/'%0D'}"
         echo "::set-output name=BODY::$BODY"
 
-    # - name: Install dependencies
-    #   run: npm ci
-
     - name: Install dependencies
-      run: rm -rf node_modules && yarn install --frozen-lockfile
+      run: yarn install --prefer-offline --frozen-lockfile
 
     - name: Create a clean build
       run: npx lerna run build

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -47,6 +47,17 @@ jobs:
     - name: Install dependencies
       run: yarn install --prefer-offline --frozen-lockfile
 
+    - name: Use TypeScript build cache
+      uses: actions/cache@v2
+      id: build-cache
+      with:
+        path: |
+          packages/*/build
+          packages/*/*.tsbuildinfo
+          packages/*/*.js
+        # When dependencies change, we like have to recompile. TS manages the sources itself
+        key: ts-${{ hashFiles('**/yarn.lock') }}
+
     - name: Compile TypeScript code
       run: yarn run build
     
@@ -95,6 +106,17 @@ jobs:
 
     - name: Install dependencies
       run: yarn install --prefer-offline --frozen-lockfile
+
+    - name: Use TypeScript build cache
+      uses: actions/cache@v2
+      id: build-cache
+      with:
+        path: |
+          packages/*/build
+          packages/*/*.tsbuildinfo
+          packages/*/*.js
+        # When dependencies change, we like have to recompile. TS manages the sources itself
+        key: ts-${{ hashFiles('**/yarn.lock') }}
 
     # Compilation is necessary, or the tests won't run
     - name: Compile TypeScript code
@@ -188,6 +210,17 @@ jobs:
 
     - name: Install dependencies
       run: yarn install --prefer-offline --frozen-lockfile
+
+    - name: Use TypeScript build cache
+      uses: actions/cache@v2
+      id: build-cache
+      with:
+        path: |
+          packages/*/build
+          packages/*/*.tsbuildinfo
+          packages/*/*.js
+        # When dependencies change, we like have to recompile. TS manages the sources itself
+        key: ts-${{ hashFiles('**/yarn.lock') }}
 
     # Compilation is necessary, or the tests won't run
     - name: Compile TypeScript code

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -55,7 +55,7 @@ jobs:
           packages/*/build
           packages/*/*.tsbuildinfo
           packages/*/*.js
-        # When dependencies change, we like have to recompile. TS manages the sources itself
+        # When dependencies change, we likely have to recompile. TS manages the sources itself
         key: ts-${{ hashFiles('**/yarn.lock') }}
 
     - name: Compile TypeScript code
@@ -115,7 +115,7 @@ jobs:
           packages/*/build
           packages/*/*.tsbuildinfo
           packages/*/*.js
-        # When dependencies change, we like have to recompile. TS manages the sources itself
+        # When dependencies change, we likely have to recompile. TS manages the sources itself
         key: ts-${{ hashFiles('**/yarn.lock') }}
 
     # Compilation is necessary, or the tests won't run
@@ -219,7 +219,7 @@ jobs:
           packages/*/build
           packages/*/*.tsbuildinfo
           packages/*/*.js
-        # When dependencies change, we like have to recompile. TS manages the sources itself
+        # When dependencies change, we likely have to recompile. TS manages the sources itself
         key: ts-${{ hashFiles('**/yarn.lock') }}
 
     # Compilation is necessary, or the tests won't run

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -48,7 +48,7 @@ jobs:
       run: yarn install --prefer-offline --frozen-lockfile
 
     - name: Compile TypeScript code
-      run: npx lerna run build
+      run: yarn run build
     
     - name: Lint TypeScript code
       run: yarn run lint
@@ -98,7 +98,7 @@ jobs:
 
     # Compilation is necessary, or the tests won't run
     - name: Compile TypeScript code
-      run: npx lerna run build
+      run: yarn run build
 
     - name: Run component tests
       run: yarn run test:ci
@@ -143,7 +143,7 @@ jobs:
 
     # Do a full build so the package files are regenerated
     - name: Compile TypeScript code
-      run: npx lerna run build:full
+      run: yarn run build:full
 
     - name: Import main entry point
       run: node -e 'require("./packages/zwave-js")'
@@ -191,7 +191,7 @@ jobs:
 
     # Compilation is necessary, or the tests won't run
     - name: Compile TypeScript code
-      run: npx lerna run build
+      run: yarn run build
 
     - name: Generate coverage
       run: yarn run coverage:ci
@@ -259,7 +259,7 @@ jobs:
       run: yarn install --prefer-offline --frozen-lockfile
 
     - name: Create a clean build
-      run: npx lerna run build:full
+      run: yarn run build:full
 
     - name: Publish package to npm
       run: |

--- a/.github/workflows/to-log-entry-overview.yml
+++ b/.github/workflows/to-log-entry-overview.yml
@@ -24,15 +24,21 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    # # We need npm@7 for the workspaces feature
-    # - name: Update npm to >=7
-    #   run: "[ $(npm -v | cut -d. -f1) -lt 7 ] && npm i -g npm@7"
+    - name: Get Yarn cache directory
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
 
-    # - name: Install dependencies
-    #   run: npm ci
+    - name: Use Yarn cache
+      uses: actions/cache@v2
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
 
     - name: Install dependencies
-      run: rm -rf node_modules && yarn install --frozen-lockfile
+      run: yarn install --prefer-offline --frozen-lockfile
 
     - name: Update overview
       uses: ./.github/actions/toLogEntry

--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     "yargs": "^16.0.3"
   },
   "scripts": {
-    "build": "lerna run build",
+    "build": "lerna run build --scope=zwave-js",
+    "build:full": "lerna run build --scope=@zwave-js/* && lerna run build:full",
     "watch": "lerna run watch --parallel",
     "test:reset": "jest --clear-cache",
     "test:ts": "jest",

--- a/packages/zwave-js/gulpfile.ts
+++ b/packages/zwave-js/gulpfile.ts
@@ -6,11 +6,11 @@ import { lintCCConstructors } from "./maintenance/lintCCConstructor";
 import { lintCCInterview } from "./maintenance/lintCCInterview";
 import { clean, copyIndexFilesToRoot } from "./maintenance/packageStructure";
 
-const prebuild = series(
-	parallel(lintCCInterview, lintCCConstructors),
-	parallel(generateCCAPIInterface, generateCCExports),
-);
+const lint = parallel(lintCCInterview, lintCCConstructors);
+const prebuild = parallel(generateCCAPIInterface, generateCCExports);
 
+// The gulp build task is used to create a "full build" - removing old build artifacts and ensuring the correct directory structure
+// For a quick test build, use the "tsc" way - until https://github.com/ivogabe/gulp-typescript/issues/611 is fixed
 const build = series(clean, prebuild, compile, copyIndexFilesToRoot);
 
-export { clean, prebuild, build, lintCCConstructors, lintCCInterview };
+export { clean, prebuild, build, lintCCConstructors, lintCCInterview, lint };

--- a/packages/zwave-js/package.json
+++ b/packages/zwave-js/package.json
@@ -77,9 +77,11 @@
     "xstate": "^4.12.0"
   },
   "scripts": {
-    "build": "gulp build",
+    "build:full": "gulp build",
+    "build": "tsc -b tsconfig.build.json",
     "clean": "tsc -b tsconfig.build.json --clean",
     "prewatch": "gulp prebuild",
-    "watch": "tsc -b tsconfig.build.json --watch --pretty"
+    "watch": "tsc -b tsconfig.build.json --watch --pretty",
+    "lint:zwave": "gulp lint"
   }
 }


### PR DESCRIPTION
This PR investigates caching strategies to speed up our CI builds:

- [x] yarn cache **minus 20 seconds**
- [x] optimize build process **minus 20-30 seconds**
- [x] cache build artifacts? **no significant change** - might help if we can use this to persist the build artifacts between two jobs