### PR TITLE
feat(config): do not map Basic CC for GE switches and dimmers, define new switch 46202

### DIFF
--- a/packages/config/config/devices/0x0063/46202.json
+++ b/packages/config/config/devices/0x0063/46202.json
@@ -1,14 +1,14 @@
-// Jasco Products 46201
-// GE Quick-fit Smart In-Wall Paddle Switch
+// Jasco Products GE 46202
+// GE Enbrighten Z-Wave Plus Smart Switch
 {
 	"manufacturer": "Jasco Products",
 	"manufacturerId": "0x0063",
-	"label": "46201",
-	"description": "GE Quick-fit Smart In-Wall Paddle Switch",
+	"label": "GE 46202",
+	"description": "GE Enbrighten Z-Wave Plus Smart Switch",
 	"devices": [
 		{
 			"productType": "0x4952",
-			"productId": "0x3135"
+			"productId": "0x3137"
 		}
 	],
 	"firmwareVersion": {
@@ -34,29 +34,24 @@
 		}
 	},
 	"paramInformation": {
-		"3": {
-			"label": "Blue LED Night Light",
-			"description": "Blue LED Night Light",
+		"4": {
+			"label": "Invert Switch",
+			"description": "Invert Switch",
 			"valueSize": 1,
 			"minValue": 0,
-			"maxValue": 255,
+			"maxValue": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"readOnly": false,
 			"writeOnly": false,
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "LED ON when switch is OFF",
+					"label": "Normal Switch Install",
 					"value": 0
 				},
 				{
-					"label": "LED ON when switch is ON",
+					"label": "Inverted Switch Install",
 					"value": 1
-				},
-				{
-					"label": "LED always OFF",
-					"value": 2
 				}
 			]
 		}

--- a/packages/config/config/devices/0x0063/46203.json
+++ b/packages/config/config/devices/0x0063/46203.json
@@ -16,6 +16,23 @@
 		"max": "255.255"
 	},
 	"supportsZWavePlus": true,
+	"associations": {
+		// One entry for each association group
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "Basic - Local Load",
+			"maxNodes": 5
+		},
+		"3": {
+			"label": "Basic - Double Tap", // required
+			"maxNodes": 5,
+			"isLifeline": true
+		}
+	},
 	"paramInformation": {
 		"3": {
 			"label": "LED Status",
@@ -38,5 +55,8 @@
 			"writeOnly": false,
 			"allowManualEntry": true
 		}
+	},
+	"compat": {
+		"disableBasicMapping": true
 	}
 }

--- a/packages/config/config/devices/0x0063/ge_14291_zw4005.json
+++ b/packages/config/config/devices/0x0063/ge_14291_zw4005.json
@@ -20,6 +20,23 @@
 		"max": "255.255"
 	},
 	"supportsZWavePlus": true,
+	"associations": {
+		// One entry for each association group
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "Basic - Local Load",
+			"maxNodes": 5
+		},
+		"3": {
+			"label": "Basic - Double Tap", // required
+			"maxNodes": 5,
+			"isLifeline": true
+		}
+	},
 	"paramInformation": {
 		"3": {
 			"label": "Night Light",
@@ -69,5 +86,8 @@
 				}
 			]
 		}
+	},
+	"compat": {
+		"disableBasicMapping": true
 	}
 }

--- a/packages/config/config/devices/0x0063/ge_14292.json
+++ b/packages/config/config/devices/0x0063/ge_14292.json
@@ -16,6 +16,23 @@
 		"max": "255.255"
 	},
 	"supportsZWavePlus": true,
+	"associations": {
+		// One entry for each association group
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "Basic - Local Load",
+			"maxNodes": 5
+		},
+		"3": {
+			"label": "Basic - Double Tap", // required
+			"maxNodes": 5,
+			"isLifeline": true
+		}
+	},
 	"paramInformation": {
 		"4": {
 			"label": "Invert Switch",
@@ -38,5 +55,8 @@
 				}
 			]
 		}
+	},
+	"compat": {
+		"disableBasicMapping": true
 	}
 }

--- a/packages/config/config/devices/0x0063/ge_14294_zw3005.json
+++ b/packages/config/config/devices/0x0063/ge_14294_zw3005.json
@@ -16,6 +16,23 @@
 		"max": "255.255"
 	},
 	"supportsZWavePlus": true,
+	"associations": {
+		// One entry for each association group
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "Basic - Local Load",
+			"maxNodes": 5
+		},
+		"3": {
+			"label": "Basic - Double Tap", // required
+			"maxNodes": 5,
+			"isLifeline": true
+		}
+	},
 	"paramInformation": {
 		"3": {
 			"label": "Night Light",
@@ -150,5 +167,8 @@
 			"writeOnly": false,
 			"allowManualEntry": true
 		}
+	},
+	"compat": {
+		"disableBasicMapping": true
 	}
 }

--- a/packages/config/config/devices/0x0063/ge_14295.json
+++ b/packages/config/config/devices/0x0063/ge_14295.json
@@ -16,6 +16,23 @@
 		"max": "255.255"
 	},
 	"supportsZWavePlus": true,
+	"associations": {
+		// One entry for each association group
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "Basic - Local Load",
+			"maxNodes": 5
+		},
+		"3": {
+			"label": "Basic - Double Tap", // required
+			"maxNodes": 5,
+			"isLifeline": true
+		}
+	},
 	"paramInformation": {
 		"4": {
 			"label": "Invert Switch",
@@ -104,5 +121,8 @@
 			"writeOnly": false,
 			"allowManualEntry": true
 		}
+	},
+	"compat": {
+		"disableBasicMapping": true
 	}
 }

--- a/packages/config/config/devices/0x0063/ge_jasco_14299.json
+++ b/packages/config/config/devices/0x0063/ge_jasco_14299.json
@@ -129,5 +129,8 @@
 			"writeOnly": false,
 			"allowManualEntry": true
 		}
+	},
+	"compat": {
+		"disableBasicMapping": true
 	}
 }


### PR DESCRIPTION
These changes implement the device file changes necessary for #1277. I'm unsure why it shows the whole thing as a deletion/insertion, but these:
- Add compat flags for GE switches and dimmers
- Define association groups and make group 3 a lifeline (necessary for the controller to receive the BasicCC events)
- Define a new switch for model 46202

I've tested these on models 14291, 14294, 46201, 46202, and 46203. The others I confirmed support double tap in the same manner and should function fine. 

The 46X series support Central Scene but these changes result in both a central scene and a BasicCC being sent. That gives the user the option as many people with these switches own multiple generations (like me) and would want to use the same automation for each.