### PR TITLE
fix: do not assume that a node falls asleep

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -71,7 +71,6 @@ import {
 import { BridgeApplicationCommandRequest } from "../controller/BridgeApplicationCommandRequest";
 import { ZWaveController } from "../controller/Controller";
 import {
-	isTransmitReport,
 	MAX_SEND_ATTEMPTS,
 	SendDataAbort,
 	SendDataMulticastRequest,
@@ -128,8 +127,6 @@ export interface ZWaveOptions {
 		report: number; // [1000...40000], default: 10000 ms
 		/** How long generated nonces are valid */
 		nonce: number; // [3000...20000], default: 5000 ms
-		/** How long a node is assumed to be awake after the last communication with it */
-		nodeAwake: number; // [1000...30000], default: 10000 ms
 	};
 
 	attempts: {
@@ -184,7 +181,6 @@ const defaultOptions: ZWaveOptions = {
 		report: 10000,
 		nonce: 5000,
 		sendDataCallback: 65000, // as defined in INS13954
-		nodeAwake: 10000,
 	},
 	attempts: {
 		controller: 3,
@@ -259,15 +255,6 @@ function checkOptions(options: ZWaveOptions): void {
 	if (options.timeouts.sendDataCallback < 10000) {
 		throw new ZWaveError(
 			`The Send Data Callback timeout must be at least 10000 milliseconds!`,
-			ZWaveErrorCodes.Driver_InvalidOptions,
-		);
-	}
-	if (
-		options.timeouts.nodeAwake < 1000 ||
-		options.timeouts.nodeAwake > 30000
-	) {
-		throw new ZWaveError(
-			`The Node awake timeout must be between 1000 and 30000 milliseconds!`,
 			ZWaveErrorCodes.Driver_InvalidOptions,
 		);
 	}
@@ -1354,12 +1341,6 @@ export class Driver extends EventEmitter {
 
 				// Assemble partial CCs on the driver level. Only forward complete messages to the send thread machine
 				if (!this.assemblePartialCCs(msg)) return;
-			} else if (isTransmitReport(msg) && msg.isOK()) {
-				// The node acknowledged a message so it must be awake - refresh its awake timer (GH#1068)
-				const node = msg.getNodeUnsafe();
-				if (node && node.supportsCC(CommandClasses["Wake Up"])) {
-					node.refreshAwakeTimer();
-				}
 			}
 
 			this.driverLog.logMessage(msg, { direction: "inbound" });
@@ -2059,8 +2040,6 @@ ${handlers.length} left`,
 			if (expirationTimeout) clearTimeout(expirationTimeout);
 			if (node) {
 				if (node.supportsCC(CommandClasses["Wake Up"])) {
-					// The node responded, refresh its awake timer
-					node.refreshAwakeTimer();
 					// If the node is not meant to be kept awake, try to send it back to sleep
 					if (!node.keepAwake) {
 						this.debounceSendNodeToSleep(node);

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -198,20 +198,7 @@ export class ZWaveNode extends Endpoint {
 		for (const cc of controlledCCs) this.addCC(cc, { isControlled: true });
 
 		// Create and hook up the status machine
-		this.statusMachine = interpretEx(
-			createNodeStatusMachine(
-				this,
-				{
-					notifyAwakeTimeoutElapsed: () => {
-						this.driver.driverLog.print(
-							`The awake timeout for node ${this.id} has elapsed. Assuming it is asleep.`,
-							"verbose",
-						);
-					},
-				},
-				driver.options.timeouts,
-			),
-		);
+		this.statusMachine = interpretEx(createNodeStatusMachine(this));
 		this.statusMachine.onTransition((state) => {
 			if (state.changed) {
 				this.onStatusChange(
@@ -417,14 +404,6 @@ export class ZWaveNode extends Endpoint {
 	 */
 	public markAsAwake(): void {
 		this.statusMachine.send("AWAKE");
-	}
-
-	/**
-	 * @internal
-	 * Call this whenever a node responds to an active request to refresh the time it is assumed awake
-	 */
-	public refreshAwakeTimer(): void {
-		this.statusMachine.send("TRANSACTION_COMPLETE");
 	}
 
 	// The node is only ready when the interview has been completed

--- a/packages/zwave-js/src/lib/node/NodeStatusMachine.test.ts
+++ b/packages/zwave-js/src/lib/node/NodeStatusMachine.test.ts
@@ -1,6 +1,5 @@
 import { CommandClasses } from "@zwave-js/core";
 import { interpret, Interpreter } from "xstate";
-import { SimulatedClock } from "xstate/lib/SimulatedClock";
 // import { SimulatedClock } from "xstate/lib/SimulatedClock";
 import {
 	createNodeStatusMachine,
@@ -22,12 +21,6 @@ const testNodeWakeup = {
 	},
 } as any;
 
-const defaultImplementations = {
-	notifyAwakeTimeoutElapsed() {},
-};
-
-const timeoutConfig = { nodeAwake: 10000 };
-
 describe("lib/driver/NodeStatusMachine", () => {
 	let service:
 		| undefined
@@ -39,11 +32,7 @@ describe("lib/driver/NodeStatusMachine", () => {
 
 	describe("default status changes", () => {
 		it(`The node should start in the unknown state`, () => {
-			const testMachine = createNodeStatusMachine(
-				undefined as any,
-				defaultImplementations,
-				timeoutConfig,
-			);
+			const testMachine = createNodeStatusMachine(undefined as any);
 
 			service = interpret(testMachine).start();
 			expect(service.state.value).toBe("unknown");
@@ -190,11 +179,7 @@ describe("lib/driver/NodeStatusMachine", () => {
 						? testNodeWakeup
 						: testNodeNoWakeup;
 
-				const testMachine = createNodeStatusMachine(
-					testNode,
-					defaultImplementations,
-					timeoutConfig,
-				);
+				const testMachine = createNodeStatusMachine(testNode);
 				testMachine.initial = test.start;
 
 				service = interpret(testMachine).start();
@@ -203,49 +188,9 @@ describe("lib/driver/NodeStatusMachine", () => {
 			});
 		}
 	});
-
-	describe("Asleep timeouts", () => {
-		it(`The node should go into the asleep state when the awake timer elapses`, () => {
-			const testMachine = createNodeStatusMachine(
-				testNodeWakeup,
-				defaultImplementations,
-				timeoutConfig,
-			);
-			const clock = new SimulatedClock();
-			service = interpret(testMachine, { clock }).start();
-
-			service.send("AWAKE");
-			clock.increment(10000);
-			expect(service.state.value).toBe("asleep");
-		});
-
-		it(`The awake timer should be refreshed when a transaction is completed`, () => {
-			const testMachine = createNodeStatusMachine(
-				testNodeWakeup,
-				defaultImplementations,
-				timeoutConfig,
-			);
-			const clock = new SimulatedClock();
-			service = interpret(testMachine, { clock }).start();
-
-			service.send("AWAKE");
-			clock.increment(9999);
-			expect(service.state.value).toBe("awake");
-			service.send("TRANSACTION_COMPLETE");
-			clock.increment(1);
-			expect(service.state.value).toBe("awake");
-			clock.increment(9999);
-			expect(service.state.value).toBe("asleep");
-		});
-	});
-
 	describe("WakeUp CC support", () => {
 		it("A transition from unknown to awake should not happen if the node does not support the Wake Up CC", () => {
-			const testMachine = createNodeStatusMachine(
-				testNodeNoWakeup,
-				defaultImplementations,
-				timeoutConfig,
-			);
+			const testMachine = createNodeStatusMachine(testNodeNoWakeup);
 
 			service = interpret(testMachine).start();
 			service.send("AWAKE");
@@ -253,11 +198,7 @@ describe("lib/driver/NodeStatusMachine", () => {
 		});
 
 		it("A transition from unknown to asleep should not happen if the node does not support the Wake Up CC", () => {
-			const testMachine = createNodeStatusMachine(
-				testNodeNoWakeup,
-				defaultImplementations,
-				timeoutConfig,
-			);
+			const testMachine = createNodeStatusMachine(testNodeNoWakeup);
 
 			service = interpret(testMachine).start();
 			service.send("ASLEEP");
@@ -265,11 +206,7 @@ describe("lib/driver/NodeStatusMachine", () => {
 		});
 
 		it("A transition from unknown to alive should not happen if the node supports the Wake Up CC", () => {
-			const testMachine = createNodeStatusMachine(
-				testNodeWakeup,
-				defaultImplementations,
-				timeoutConfig,
-			);
+			const testMachine = createNodeStatusMachine(testNodeWakeup);
 
 			service = interpret(testMachine).start();
 			service.send("ALIVE");
@@ -277,11 +214,7 @@ describe("lib/driver/NodeStatusMachine", () => {
 		});
 
 		it("A transition from unknown to dead should not happen if the node supports the Wake Up CC", () => {
-			const testMachine = createNodeStatusMachine(
-				testNodeWakeup,
-				defaultImplementations,
-				timeoutConfig,
-			);
+			const testMachine = createNodeStatusMachine(testNodeWakeup);
 
 			service = interpret(testMachine).start();
 			service.send("DEAD");

--- a/packages/zwave-js/src/lib/test/mocks.ts
+++ b/packages/zwave-js/src/lib/test/mocks.ts
@@ -90,7 +90,6 @@ export function createEmptyMockDriver() {
 				report: 1600,
 				nonce: 5000,
 				sendDataCallback: 65000,
-				nodeAwake: 10000,
 			},
 			attempts: {
 				sendData: 3,


### PR DESCRIPTION
We have a feature which often causes the communication with battery-powered nodes to seemingly get stuck. After 10s without communication, we assume nodes to be asleep. This is not always correct and causes the node's messages to be moved to the wakeup queue until the next time the node announces that it is awake.

This PR entirely removes this feature.