### PR TITLE
style: fix minor spelling issues

### DIFF
--- a/packages/config/config/devices/0x0208/hkzw-so01.json
+++ b/packages/config/config/devices/0x0208/hkzw-so01.json
@@ -40,7 +40,7 @@
 			"allowManualEntry": true
 		},
 		"24": {
-			"label": "Notifcation on Load Change",
+			"label": "Notification on Load Change",
 			"description": "Smart Plug can send notifications to association device load state changes.",
 			"valueSize": 1,
 			"minValue": 0,

--- a/packages/config/config/devices/0x0208/pid15654.json
+++ b/packages/config/config/devices/0x0208/pid15654.json
@@ -40,7 +40,7 @@
 			"allowManualEntry": true
 		},
 		"24": {
-			"label": "Notifcation on Load Change",
+			"label": "Notification on Load Change",
 			"description": "Smart Plug can send notifications to association device load state changes.",
 			"valueSize": 1,
 			"minValue": 0,

--- a/packages/config/config/devices/0x0260/dx1cg-z.json
+++ b/packages/config/config/devices/0x0260/dx1cg-z.json
@@ -22,7 +22,7 @@
 			"isLifeline": true
 		},
 		"2": {
-			"label": "Root Device group (Notifcation)",
+			"label": "Root Device group (Notification)",
 			"maxNodes": 5
 		}
 	}

--- a/packages/core/src/error/ZWaveError.ts
+++ b/packages/core/src/error/ZWaveError.ts
@@ -126,7 +126,7 @@ export enum ZWaveErrorCodes {
 }
 
 /**
- * Errors thrown in this libary are of this type. The `code` property identifies what went wrong.
+ * Errors thrown in this library are of this type. The `code` property identifies what went wrong.
  */
 export class ZWaveError extends Error {
 	public constructor(

--- a/packages/zwave-js/src/lib/commandclass/VersionCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/VersionCC.ts
@@ -394,7 +394,7 @@ export class VersionCCReport extends VersionCC {
 	@ccValue()
 	@ccValueMetadata({
 		...ValueMetadata.ReadOnly,
-		label: "Libary type",
+		label: "Library type",
 	})
 	public get libraryType(): ZWaveLibraryTypes {
 		return this._libraryType;


### PR DESCRIPTION
Fixes two minor spelling issues/typos found in the codebase:

Notifcation -> Notification
Libary -> Library