### PR TITLE
fix(config): rename GE 12340 to GE 12730

### DIFF
--- a/packages/config/config/devices/0x0063/ge_12730_zw4002.json
+++ b/packages/config/config/devices/0x0063/ge_12730_zw4002.json
@@ -1,9 +1,9 @@
-// Jasco Products GE 12340 (ZW4002)
+// Jasco Products GE 12730 (ZW4002)
 // In-Wall Smart Fan Control
 {
 	"manufacturer": "Jasco Products",
 	"manufacturerId": "0x0063",
-	"label": "GE 12340 (ZW4002)",
+	"label": "GE 12730 (ZW4002)",
 	"description": "In-Wall Smart Fan Control",
 	"devices": [
 		{


### PR DESCRIPTION
The device is actually a GE 12730 (see [1](https://products.z-wavealliance.org/products/1202?selectedFrequencyId=2), [2](https://opensmarthouse.org/zwavedatabase/932) and [3](https://github.com/OpenZWave/open-zwave/blob/e970295ff320f37135ef4f0dbb8ecf5a3bd3f67d/config/manufacturer_specific.xml#L820)). I was unable find any real reference to a "12340" device.

12340 happens to be the decimal equivalent of the product ID, 0x3034. Perhaps it was accidentally named from that.