### PR TITLE
fix(config): change manufacturer Jasco Products to GE/Jasco

### DIFF
--- a/packages/config/config/devices/0x0063/12718.json
+++ b/packages/config/config/devices/0x0063/12718.json
@@ -1,7 +1,7 @@
-// Jasco Products 12718
+// GE/Jasco 12718
 // Smart Dimmer
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "12718",
 	"description": "Smart Dimmer",

--- a/packages/config/config/devices/0x0063/12727.json
+++ b/packages/config/config/devices/0x0063/12727.json
@@ -1,7 +1,7 @@
-// Jasco Products 12727
+// GE/Jasco 12727
 // GE 12727 Z-Wave Wireless Lighting Control Smart Toggle Switch
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "12727",
 	"description": "GE 12727 Z-Wave Wireless Lighting Control Smart Toggle Switch",

--- a/packages/config/config/devices/0x0063/12729.json
+++ b/packages/config/config/devices/0x0063/12729.json
@@ -1,7 +1,7 @@
-// Jasco Products 12729
+// GE/Jasco 12729
 // In-Wall Smart Dimmer
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "12729",
 	"description": "In-Wall Smart Dimmer",

--- a/packages/config/config/devices/0x0063/14288.json
+++ b/packages/config/config/devices/0x0063/14288.json
@@ -1,7 +1,7 @@
-// Jasco Products 14288
+// GE/Jasco 14288
 // In-Wall Outlet
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "14288",
 	"description": "In-Wall Outlet",

--- a/packages/config/config/devices/0x0063/26931_zw4006.json
+++ b/packages/config/config/devices/0x0063/26931_zw4006.json
@@ -1,7 +1,7 @@
-// Jasco Products 26931/ZW4006
+// GE/Jasco 26931/ZW4006
 // In-Wall Smart Motion Switch
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "26931/ZW4006",
 	"description": "In-Wall Smart Motion Switch",

--- a/packages/config/config/devices/0x0063/28177.json
+++ b/packages/config/config/devices/0x0063/28177.json
@@ -1,7 +1,7 @@
-// Jasco Products 28177
+// GE/Jasco 28177
 // GE Z-Wave Plus Wireless Smart Lighting Control Appliance Module
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "28177",
 	"description": "GE Z-Wave Plus Wireless Smart Lighting Control Appliance Module",

--- a/packages/config/config/devices/0x0063/32563.json
+++ b/packages/config/config/devices/0x0063/32563.json
@@ -1,7 +1,7 @@
-// Jasco Products 32563
+// GE/Jasco 32563
 // Smart Door Sensor
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "32563",
 	"description": "Smart Door Sensor",

--- a/packages/config/config/devices/0x0063/35931.json
+++ b/packages/config/config/devices/0x0063/35931.json
@@ -1,7 +1,7 @@
-// Jasco Products 35931
+// GE/Jasco 35931
 // Enbrighten 60W Dimmable Light Bulb
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "35931",
 	"description": "Enbrighten 60W Dimmable Light Bulb",

--- a/packages/config/config/devices/0x0063/45603.json
+++ b/packages/config/config/devices/0x0063/45603.json
@@ -1,7 +1,7 @@
-// Jasco Products 45603
+// GE/Jasco 45603
 // Fluorescent Light & Appliance Module
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "45603",
 	"description": "Fluorescent Light & Appliance Module",

--- a/packages/config/config/devices/0x0063/45604.json
+++ b/packages/config/config/devices/0x0063/45604.json
@@ -1,7 +1,7 @@
-// Jasco Products 45604
+// GE/Jasco 45604
 // Outdoor Lighting Control Module
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "45604",
 	"description": "Outdoor Lighting Control Module",

--- a/packages/config/config/devices/0x0063/45605.json
+++ b/packages/config/config/devices/0x0063/45605.json
@@ -1,7 +1,7 @@
-// Jasco Products 45605
+// GE/Jasco 45605
 // Duplex receptacle
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "45605",
 	"description": "Duplex receptacle",

--- a/packages/config/config/devices/0x0063/45606.json
+++ b/packages/config/config/devices/0x0063/45606.json
@@ -1,7 +1,7 @@
-// Jasco Products 45606
+// GE/Jasco 45606
 // 2-Way Dimmer Switch
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "45606",
 	"description": "2-Way Dimmer Switch",

--- a/packages/config/config/devices/0x0063/45607.json
+++ b/packages/config/config/devices/0x0063/45607.json
@@ -1,7 +1,7 @@
-// Jasco Products 45607
+// GE/Jasco 45607
 // 2-Way Dimmer Switch
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "45607",
 	"description": "2-Way Dimmer Switch",

--- a/packages/config/config/devices/0x0063/45609.json
+++ b/packages/config/config/devices/0x0063/45609.json
@@ -1,7 +1,7 @@
-// Jasco Products 45609
+// GE/Jasco 45609
 // On/Off Relay Switch
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "45609",
 	"description": "On/Off Relay Switch",

--- a/packages/config/config/devices/0x0063/46201.json
+++ b/packages/config/config/devices/0x0063/46201.json
@@ -1,7 +1,7 @@
-// Jasco Products 46201
+// GE/Jasco 46201
 // GE Quick-fit Smart In-Wall Paddle Switch
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "46201",
 	"description": "GE Quick-fit Smart In-Wall Paddle Switch",

--- a/packages/config/config/devices/0x0063/46202.json
+++ b/packages/config/config/devices/0x0063/46202.json
@@ -1,9 +1,9 @@
-// Jasco Products GE 46202
+// GE/Jasco 46202
 // GE Enbrighten Z-Wave Plus Smart Switch
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
-	"label": "GE 46202",
+	"label": "46202",
 	"description": "GE Enbrighten Z-Wave Plus Smart Switch",
 	"devices": [
 		{

--- a/packages/config/config/devices/0x0063/46203.json
+++ b/packages/config/config/devices/0x0063/46203.json
@@ -1,7 +1,7 @@
-// Jasco Products 46203
+// GE/Jasco 46203
 // GE Enbrighten Z-Wave Plus Smart Dimmer
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "46203",
 	"description": "GE Enbrighten Z-Wave Plus Smart Dimmer",

--- a/packages/config/config/devices/0x0063/ge_12725.json
+++ b/packages/config/config/devices/0x0063/ge_12725.json
@@ -1,9 +1,9 @@
-// Jasco Products GE 12725
+// GE/Jasco 12725
 // In-Wall Dimmer
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
-	"label": "GE 12725",
+	"label": "12725",
 	"description": "In-Wall Dimmer",
 	"devices": [
 		{

--- a/packages/config/config/devices/0x0063/ge_12730_zw4002.json
+++ b/packages/config/config/devices/0x0063/ge_12730_zw4002.json
@@ -1,9 +1,9 @@
-// Jasco Products GE 12730 (ZW4002)
+// GE/Jasco 12730 (ZW4002)
 // In-Wall Smart Fan Control
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
-	"label": "GE 12730 (ZW4002)",
+	"label": "12730 (ZW4002)",
 	"description": "In-Wall Smart Fan Control",
 	"devices": [
 		{

--- a/packages/config/config/devices/0x0063/ge_14289_zw3009.json
+++ b/packages/config/config/devices/0x0063/ge_14289_zw3009.json
@@ -1,9 +1,9 @@
-// Jasco Products GE 14289 (ZW3009)
+// GE/Jasco 14289 (ZW3009)
 // In-Wall Touch Sensing Dimmer
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
-	"label": "GE 14289 (ZW3009)",
+	"label": "14289 (ZW3009)",
 	"description": "In-Wall Touch Sensing Dimmer",
 	"devices": [
 		{

--- a/packages/config/config/devices/0x0063/ge_14291_zw4005.json
+++ b/packages/config/config/devices/0x0063/ge_14291_zw4005.json
@@ -1,9 +1,9 @@
-// Jasco Products GE 14291 (ZW4005)
+// GE/Jasco 14291 (ZW4005)
 // In-Wall Paddle Switch
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
-	"label": "GE 14291 (ZW4005)",
+	"label": "14291 (ZW4005)",
 	"description": "In-Wall Paddle Switch",
 	"devices": [
 		{

--- a/packages/config/config/devices/0x0063/ge_14292.json
+++ b/packages/config/config/devices/0x0063/ge_14292.json
@@ -1,9 +1,9 @@
-// Jasco Products GE 14292
+// GE/Jasco 14292
 // In-Wall Toggle Switch
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
-	"label": "GE 14292",
+	"label": "14292",
 	"description": "In-Wall Toggle Switch",
 	"devices": [
 		{

--- a/packages/config/config/devices/0x0063/ge_14294_zw3005.json
+++ b/packages/config/config/devices/0x0063/ge_14294_zw3005.json
@@ -1,9 +1,9 @@
-// Jasco Products GE 14294 (ZW3005)
+// GE/Jasco 14294 (ZW3005)
 // In-Wall Dimmer Switch
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
-	"label": "GE 14294 (ZW3005)",
+	"label": "14294 (ZW3005)",
 	"description": "In-Wall Dimmer Switch",
 	"devices": [
 		{

--- a/packages/config/config/devices/0x0063/ge_14295.json
+++ b/packages/config/config/devices/0x0063/ge_14295.json
@@ -1,9 +1,9 @@
-// Jasco Products GE 14295
+// GE/Jasco 14295
 // In-Wall Dimmer Switch
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
-	"label": "GE 14295",
+	"label": "14295",
 	"description": "In-Wall Dimmer Switch",
 	"devices": [
 		{

--- a/packages/config/config/devices/0x0063/ge_28167_zw3104.json
+++ b/packages/config/config/devices/0x0063/ge_28167_zw3104.json
@@ -1,9 +1,9 @@
-// Jasco Products GE 28167 (ZW3104)
+// GE/Jasco 28167 (ZW3104)
 // Plug-In Smart Dimmer
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
-	"label": "GE 28167 (ZW3104)",
+	"label": "28167 (ZW3104)",
 	"description": "Plug-In Smart Dimmer",
 	"devices": [
 		{

--- a/packages/config/config/devices/0x0063/ge_28169_jasco_28168_0.0-4.9.json
+++ b/packages/config/config/devices/0x0063/ge_28169_jasco_28168_0.0-4.9.json
@@ -1,7 +1,7 @@
-// Jasco Products GE 28169 / Jasco 28168
+// GE/Jasco 28169 / Jasco 28168
 // Plug in Smart Switch
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "GE 28169 / Jasco 28168",
 	"description": "Plug in Smart Switch",

--- a/packages/config/config/devices/0x0063/ge_28169_jasco_28168_5.0.json
+++ b/packages/config/config/devices/0x0063/ge_28169_jasco_28168_5.0.json
@@ -1,7 +1,7 @@
-// Jasco Products GE 28169 / Jasco 28168
+// GE/Jasco 28169 / Jasco 28168
 // Plug in Smart Switch
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "GE 28169 / Jasco 28168",
 	"description": "Plug in Smart Switch",

--- a/packages/config/config/devices/0x0063/ge_28175_zw3106_5.23-5.23.json
+++ b/packages/config/config/devices/0x0063/ge_28175_zw3106_5.23-5.23.json
@@ -1,9 +1,9 @@
-// Jasco Products GE 28175 (ZW3106)
+// GE/Jasco 28175 (ZW3106)
 // Plug-In Dual Smart Dimmer
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
-	"label": "GE 28175 (ZW3106)",
+	"label": "28175 (ZW3106)",
 	"description": "Plug-In Dual Smart Dimmer",
 	"devices": [
 		{

--- a/packages/config/config/devices/0x0063/ge_jasco_14285.json
+++ b/packages/config/config/devices/0x0063/ge_jasco_14285.json
@@ -1,7 +1,7 @@
-// Jasco Products GE/Jasco 14285
+// GE/Jasco/Jasco 14285
 // Direct Wire Indoor/Outdoor Smart Switch
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "GE/Jasco 14285",
 	"description": "Direct Wire Indoor/Outdoor Smart Switch",

--- a/packages/config/config/devices/0x0063/ge_jasco_14299.json
+++ b/packages/config/config/devices/0x0063/ge_jasco_14299.json
@@ -1,7 +1,7 @@
-// Jasco Products GE/Jasco 14299
+// GE/Jasco/Jasco 14299
 // GE/Jasco In-Wall 1000W Incandescent Smart Dimmer
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "GE/Jasco 14299",
 	"description": "GE/Jasco In-Wall 1000W Incandescent Smart Dimmer",

--- a/packages/config/config/devices/0x0063/ge_jasco_14321.json
+++ b/packages/config/config/devices/0x0063/ge_jasco_14321.json
@@ -1,7 +1,7 @@
-// Jasco Products GE/Jasco 14321
+// GE/Jasco/Jasco 14321
 // In-Wall Dimmer
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "GE/Jasco 14321",
 	"description": "In-Wall Dimmer",

--- a/packages/config/config/devices/0x0063/ge_outdoor_switch.json
+++ b/packages/config/config/devices/0x0063/ge_outdoor_switch.json
@@ -1,9 +1,9 @@
-// Jasco Products GE Outdoor Switch
+// GE/Jasco Outdoor Switch
 // Weather Resistant Outdoor Switch
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
-	"label": "GE Outdoor Switch",
+	"label": "Outdoor Switch",
 	"description": "Weather Resistant Outdoor Switch",
 	"devices": [
 		{

--- a/packages/config/config/devices/0x0063/ge_plug_in_smart_switch.json
+++ b/packages/config/config/devices/0x0063/ge_plug_in_smart_switch.json
@@ -1,9 +1,9 @@
-// Jasco Products GE Plug in Smart Switch
+// GE/Jasco Plug in Smart Switch
 // GE Plug in Smart Switch Zwave Plus
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
-	"label": "GE Plug in Smart Switch",
+	"label": "Plug in Smart Switch",
 	"description": "GE Plug in Smart Switch Zwave Plus",
 	"devices": [
 		{

--- a/packages/config/config/devices/0x0063/ge_zw4004.json
+++ b/packages/config/config/devices/0x0063/ge_zw4004.json
@@ -1,9 +1,9 @@
-// Jasco Products GE ZW4004
+// GE/Jasco ZW4004
 // GE Z-Wave Wireless Smart Lighting and Appliance Control - 40 Amp
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
-	"label": "GE ZW4004",
+	"label": "ZW4004",
 	"description": "GE Z-Wave Wireless Smart Lighting and Appliance Control - 40 Amp",
 	"devices": [
 		{

--- a/packages/config/config/devices/0x0063/in-wall_smart_motion_dimmer.json
+++ b/packages/config/config/devices/0x0063/in-wall_smart_motion_dimmer.json
@@ -1,7 +1,7 @@
-// Jasco Products In-Wall Smart Motion Dimmer
+// GE/Jasco In-Wall Smart Motion Dimmer
 // 26932/26933/ZW3008 In-Wall Smart Motion Dimmer
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "In-Wall Smart Motion Dimmer",
 	"description": "26932/26933/ZW3008 In-Wall Smart Motion Dimmer",

--- a/packages/config/config/devices/0x0063/jasco_14318.json
+++ b/packages/config/config/devices/0x0063/jasco_14318.json
@@ -1,7 +1,7 @@
-// Jasco Products Jasco 14318
+// GE/Jasco Jasco 14318
 // Jasco 3-way Light Switch
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "Jasco 14318",
 	"description": "Jasco 3-way Light Switch",

--- a/packages/config/config/devices/0x0063/zw1001.json
+++ b/packages/config/config/devices/0x0063/zw1001.json
@@ -1,7 +1,7 @@
-// Jasco Products ZW1001
+// GE/Jasco ZW1001
 // Smart Outlet
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "ZW1001",
 	"description": "Smart Outlet",

--- a/packages/config/config/devices/0x0063/zw3003_ge_12724.json
+++ b/packages/config/config/devices/0x0063/zw3003_ge_12724.json
@@ -1,7 +1,7 @@
-// Jasco Products ZW3003, GE 12724
+// GE/Jasco ZW3003, GE 12724
 // In-Wall Dimmer
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "ZW3003, GE 12724",
 	"description": "In-Wall Dimmer",

--- a/packages/config/config/devices/0x0063/zw3101.json
+++ b/packages/config/config/devices/0x0063/zw3101.json
@@ -1,7 +1,7 @@
-// Jasco Products ZW3101
+// GE/Jasco ZW3101
 // Lamp Module
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "ZW3101",
 	"description": "Lamp Module",

--- a/packages/config/config/devices/0x0063/zw3102.json
+++ b/packages/config/config/devices/0x0063/zw3102.json
@@ -1,7 +1,7 @@
-// Jasco Products ZW3102
+// GE/Jasco ZW3102
 // Jasco Energy Monitoring Lamp Dimmer
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "ZW3102",
 	"description": "Jasco Energy Monitoring Lamp Dimmer",

--- a/packages/config/config/devices/0x0063/zw3107_ge_14280.json
+++ b/packages/config/config/devices/0x0063/zw3107_ge_14280.json
@@ -1,7 +1,7 @@
-// Jasco Products ZW3107 / GE 14280
+// GE/Jasco ZW3107 / GE 14280
 // Plug-In Smart Dimmer (Dual Linked Outlets)
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "ZW3107 / GE 14280",
 	"description": "Plug-In Smart Dimmer (Dual Linked Outlets)",

--- a/packages/config/config/devices/0x0063/zw4002.json
+++ b/packages/config/config/devices/0x0063/zw4002.json
@@ -1,7 +1,7 @@
-// Jasco Products ZW4002
+// GE/Jasco ZW4002
 // In-Wall Smart Fan Control
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "ZW4002",
 	"description": "In-Wall Smart Fan Control",

--- a/packages/config/config/devices/0x0063/zw4005_12722.json
+++ b/packages/config/config/devices/0x0063/zw4005_12722.json
@@ -1,7 +1,7 @@
-// Jasco Products ZW4005, 12722
+// GE/Jasco ZW4005, 12722
 // On/Off Relay Switch
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "ZW4005, 12722",
 	"description": "On/Off Relay Switch",

--- a/packages/config/config/devices/0x0063/zw4101.json
+++ b/packages/config/config/devices/0x0063/zw4101.json
@@ -1,7 +1,7 @@
-// Jasco Products ZW4101
+// GE/Jasco ZW4101
 // Fluorescent Light & Appliance Module
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "ZW4101",
 	"description": "Fluorescent Light & Appliance Module",

--- a/packages/config/config/devices/0x0063/zw4102.json
+++ b/packages/config/config/devices/0x0063/zw4102.json
@@ -1,7 +1,7 @@
-// Jasco Products ZW4102
+// GE/Jasco ZW4102
 // Energy Monitoring Appliance Module
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
 	"label": "ZW4102",
 	"description": "Energy Monitoring Appliance Module",

--- a/packages/config/config/manufacturers.json
+++ b/packages/config/config/manufacturers.json
@@ -98,7 +98,7 @@
 	"0x0060": "Everspring",
 	"0x0061": "Impact Technologies BV",
 	"0x0062": "LVI Produkter AB",
-	"0x0063": "Jasco Products",
+	"0x0063": "GE/Jasco",
 	"0x0064": "Reitz-Group.de",
 	"0x0065": "RS Scene Automation",
 	"0x0066": "TrickleStar",


### PR DESCRIPTION
We currently label GE devices as Jasco, as Jasco makes them for GE. This could be confusing for users as Jasco sells very few devices under its own branding and all other major projects (and the Zwave Alliance) list these solely under GE's name.