### PR TITLE
fix(config): remove unsupported parameter in GE 14294

### DIFF
--- a/packages/config/config/devices/0x0063/ge_14294_zw3005.json
+++ b/packages/config/config/devices/0x0063/ge_14294_zw3005.json
@@ -80,27 +80,6 @@
 				}
 			]
 		},
-		"5": {
-			"label": "Ignore Start-Level (Receiving)",
-			"description": "This dimmer will start dimming from its current level.",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"readOnly": false,
-			"writeOnly": false,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "No",
-					"value": 0
-				},
-				{
-					"label": "Yes",
-					"value": 1
-				}
-			]
-		},
 		"7": {
 			"label": "On/Off Command Dim Step",
 			"description": "Indicates how many levels the dimmer will change per step.",


### PR DESCRIPTION
Parameter 5 is not supported on this model, and does not exist in any version of the device manual

http://manual.zwave.eu/backend/make.php?lang=en&sku=14294%20(ZW3005)&cert=ZC10-15080015