### PR TITLE
fix(build): export ZWaveNodeValueNotificationArgs

### DIFF
--- a/packages/zwave-js/src/Values.ts
+++ b/packages/zwave-js/src/Values.ts
@@ -16,6 +16,7 @@ export type {
 	TranslatedValueID,
 	ZWaveNodeMetadataUpdatedArgs,
 	ZWaveNodeValueAddedArgs,
+	ZWaveNodeValueNotificationArgs,
 	ZWaveNodeValueRemovedArgs,
 	ZWaveNodeValueUpdatedArgs,
 } from "./lib/node/Types";


### PR DESCRIPTION
@robertsLando this means you can replace
```
 * @param {import('zwave-js/build/lib/node/Types').ZWaveNodeValueNotificationArgs} args
```
with
```
 * @param {import('zwave-js').ZWaveNodeValueNotificationArgs} args
```
since you shouldn't count on the internal structure to stay like it is.