### PR TITLE
feat(driver): add ready and allNodesReady indicators

### DIFF
--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -209,6 +209,22 @@ Once the `"driver ready"` event was emitted, this property provides access to th
 > [!WARNING]
 > Don't use it before the driver is ready!
 
+### `ready`
+
+```ts
+readonly ready: boolean
+```
+
+Returns `true` after the `"driver ready"` event has been emitted. This is useful for client-server setups where listeners might not be set up while the driver is initializing.
+
+### `allNodesReady`
+
+```ts
+readonly allNodesReady: boolean
+```
+
+Returns `true` after the `"all nodes ready"` event has been emitted. This is useful for client-server setups where listeners might not be set up while the driver is initializing.
+
 ## Driver events
 
 The `Driver` class inherits from the Node.js [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) and thus also supports its methods like `on`, `removeListener`, etc. The following events are implemented:

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -725,6 +725,12 @@ export class Driver extends EventEmitter {
 	private _controllerInterviewed: boolean = false;
 	private _nodesReady = new Set<number>();
 	private _nodesReadyEventEmitted: boolean = false;
+
+	/** Indicates whether all nodes are ready, i.e. the "all nodes ready" event has been emitted */
+	public get allNodesReady(): boolean {
+		return this._nodesReadyEventEmitted;
+	}
+
 	/**
 	 * Initializes the variables for controller and nodes,
 	 * adds event handlers and starts the interview process.
@@ -1223,6 +1229,16 @@ export class Driver extends EventEmitter {
 				ZWaveErrorCodes.Driver_NotReady,
 			);
 		}
+	}
+
+	/** Indicates whether the driver is ready, i.e. the "driver ready" event was emitted */
+	public get ready(): boolean {
+		return (
+			this._wasStarted &&
+			this._isOpen &&
+			!this._wasDestroyed &&
+			this._controllerInterviewed
+		);
 	}
 
 	private _cleanupHandler = (): void => {


### PR DESCRIPTION
This PR adds two properties to the driver class which indicate whether
a) the driver "ready" event has been emitted (`driver.ready`)
b) the "all nodes ready" event has been emitted (`driver.allNodesReady`)

fixes: #1376