### PR TITLE
fix: ignore duplicate NonceGet instead of aborting previous transmission

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
@@ -205,14 +205,6 @@ export class SecurityCCAPI extends PhysicalCCAPI {
 				...this.commandOptions,
 				priority: MessagePriority.Handshake,
 			});
-			if (keepUntilNext) {
-				// The nonce was received. If we are talking to a device with the keepS0NonceUntilNext compat option,
-				// we now may expire all other nonces
-				this.driver.securityManager.deleteAllNoncesForReceiver(
-					cc.nodeId,
-					nonceId,
-				);
-			}
 		} catch (e) {
 			if (
 				e instanceof ZWaveError &&
@@ -228,6 +220,13 @@ export class SecurityCCAPI extends PhysicalCCAPI {
 				// Pass other errors through
 				throw e;
 			}
+		} finally {
+			// The nonce was either received or could not be sent.
+			// Either the device will now use the new nonce or we'll ignore the messages
+			this.driver.securityManager.deleteAllNoncesForReceiver(
+				cc.nodeId,
+				nonceId,
+			);
 		}
 		return true;
 	}

--- a/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
@@ -221,8 +221,8 @@ export class SecurityCCAPI extends PhysicalCCAPI {
 				throw e;
 			}
 		} finally {
-			// The nonce was either received or could not be sent.
-			// Either the device will now use the new nonce or we'll ignore the messages
+			// We transmitted a new nonce - whether it was received by the target node
+			// or not, the old ones should not be used anymore
 			this.driver.securityManager.deleteAllNoncesForReceiver(
 				cc.nodeId,
 				nonceId,

--- a/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
@@ -223,10 +223,13 @@ export class SecurityCCAPI extends PhysicalCCAPI {
 		} finally {
 			// We transmitted a new nonce - whether it was received by the target node
 			// or not, the old ones should not be used anymore
-			this.driver.securityManager.deleteAllNoncesForReceiver(
-				cc.nodeId,
-				nonceId,
-			);
+			const expireDelay = keepUntilNext ? 500 : 0; // avoid timing issues with those bugged devices
+			setTimeout(() => {
+				this.driver.securityManager!.deleteAllNoncesForReceiver(
+					cc.nodeId,
+					nonceId,
+				);
+			}, expireDelay);
 		}
 		return true;
 	}

--- a/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
@@ -223,13 +223,10 @@ export class SecurityCCAPI extends PhysicalCCAPI {
 		} finally {
 			// We transmitted a new nonce - whether it was received by the target node
 			// or not, the old ones should not be used anymore
-			const expireDelay = keepUntilNext ? 500 : 0; // avoid timing issues with those bugged devices
-			setTimeout(() => {
-				this.driver.securityManager!.deleteAllNoncesForReceiver(
-					cc.nodeId,
-					nonceId,
-				);
-			}, expireDelay);
+			this.driver.securityManager.deleteAllNoncesForReceiver(
+				cc.nodeId,
+				nonceId,
+			);
 		}
 		return true;
 	}

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1808,11 +1808,11 @@ version:               ${this.version}`;
 			return;
 		}
 
-		// Delete all previous nonces we sent the node since they
+		// Delete all previous nonces we sent the node, since they
 		// should no longer be used - except if a config flag forbids it
 		// Devices using this flag may only delete the old nonce after the new one was acknowledged
 		const keepUntilNext = !!this.deviceConfig?.compat?.keepS0NonceUntilNext;
-		if (keepUntilNext) {
+		if (!keepUntilNext) {
 			this.driver.securityManager.deleteAllNoncesForReceiver(this.id);
 		}
 


### PR DESCRIPTION
In order to fix #1059 we aborted the ongoing NonceReport transmissions if a device requested a new one. This causes #1402 however. The more logical fix seems to be **not** to reply to duplicate requests while the transmission of a nonce is ongoing.

fixes: #1402 