### PR TITLE
feat: export controller event callback types

### DIFF
--- a/packages/zwave-js/src/Controller.ts
+++ b/packages/zwave-js/src/Controller.ts
@@ -1,6 +1,6 @@
 export type {
+	ControllerEvents,
 	HealNodeStatus,
 	ZWaveController,
-	ControllerEvents,
 } from "./lib/controller/Controller";
 export type { ZWaveLibraryTypes } from "./lib/controller/ZWaveLibraryTypes";

--- a/packages/zwave-js/src/Controller.ts
+++ b/packages/zwave-js/src/Controller.ts
@@ -1,5 +1,6 @@
 export type {
 	HealNodeStatus,
 	ZWaveController,
+	ControllerEvents,
 } from "./lib/controller/Controller";
 export type { ZWaveLibraryTypes } from "./lib/controller/ZWaveLibraryTypes";

--- a/packages/zwave-js/src/Node.ts
+++ b/packages/zwave-js/src/Node.ts
@@ -6,4 +6,5 @@ export {
 	InterviewStage,
 	NodeInterviewFailedEventArgs,
 	NodeStatus,
+	ZWaveNodeEvents,
 } from "./lib/node/Types";

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -123,7 +123,7 @@ interface ControllerEventCallbacks {
 	"heal network done": (result: ReadonlyMap<number, HealNodeStatus>) => void;
 }
 
-type ControllerEvents = Extract<keyof ControllerEventCallbacks, string>;
+export type ControllerEvents = Extract<keyof ControllerEventCallbacks, string>;
 
 export interface ZWaveController {
 	on<TEvent extends ControllerEvents>(


### PR DESCRIPTION
This exports the controller event callback types so we can use the types in Z-Wave JS Server here https://github.com/zwave-js/zwave-js-server/blob/master/src/lib/forward.ts#L6