### PR TITLE
feat(config): add compat option overrideFloatEncoding and use it for Z-TRM3 and AC301

### DIFF
--- a/maintenance/schemas/device-config.json
+++ b/maintenance/schemas/device-config.json
@@ -205,6 +205,22 @@
 				"disableBasicMapping": {
 					"const": true
 				},
+				"overrideFloatEncoding": {
+					"type": "object",
+					"properties": {
+						"size": {
+							"type": "integer",
+							"minimum": 1,
+							"maximum": 4
+						},
+						"precision": {
+							"type": "integer",
+							"minimum": 0
+						}
+					},
+					"minProperties": 1,
+					"additionalProperties": false
+				},
 				"keepS0NonceUntilNext": {
 					"const": true
 				},

--- a/packages/config/config/devices/0x0060/ac301.json
+++ b/packages/config/config/devices/0x0060/ac301.json
@@ -160,5 +160,12 @@
 			"writeOnly": false,
 			"allowManualEntry": true
 		}
+	},
+	"compat": {
+		// This device only accepts Thermostat Setpoint Set commands with a specific float encoding
+		"overrideFloatEncoding": {
+			"precision": 1,
+			"size": 2
+		}
 	}
 }

--- a/packages/config/config/devices/0x019b/z-trm3.json
+++ b/packages/config/config/devices/0x019b/z-trm3.json
@@ -350,6 +350,10 @@
 					}
 				}
 			}
+		},
+		// This device only accepts Thermostat Setpoint Set commands with a size of 2
+		"overrideFloatEncoding": {
+			"size": 2
 		}
 	}
 }

--- a/packages/config/src/CompatConfig.ts
+++ b/packages/config/src/CompatConfig.ts
@@ -115,6 +115,76 @@ error in compat option treatBasicSetAsEvent`,
 			this.treatBasicSetAsEvent = definition.treatBasicSetAsEvent;
 		}
 
+		if (definition.overrideFloatEncoding != undefined) {
+			if (!isObject(definition.overrideFloatEncoding)) {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+error in compat option overrideFloatEncoding`,
+				);
+			}
+
+			this.overrideFloatEncoding = {};
+			if ("precision" in definition.overrideFloatEncoding) {
+				if (
+					typeof definition.overrideFloatEncoding.precision !=
+					"number"
+				) {
+					throwInvalidConfig(
+						"devices",
+						`config/devices/${filename}:
+compat option overrideFloatEncoding.precision must be a number!`,
+					);
+				}
+
+				if (
+					definition.overrideFloatEncoding.precision % 1 !== 0 ||
+					definition.overrideFloatEncoding.precision < 0
+				) {
+					throwInvalidConfig(
+						"devices",
+						`config/devices/${filename}:
+compat option overrideFloatEncoding.precision must be a positive integer!`,
+					);
+				}
+
+				this.overrideFloatEncoding.precision =
+					definition.overrideFloatEncoding.precision;
+			}
+			if ("size" in definition.overrideFloatEncoding) {
+				if (typeof definition.overrideFloatEncoding.size != "number") {
+					throwInvalidConfig(
+						"devices",
+						`config/devices/${filename}:
+compat option overrideFloatEncoding.size must be a number!`,
+					);
+				}
+
+				if (
+					definition.overrideFloatEncoding.size % 1 !== 0 ||
+					definition.overrideFloatEncoding.size < 1 ||
+					definition.overrideFloatEncoding.size > 4
+				) {
+					throwInvalidConfig(
+						"devices",
+						`config/devices/${filename}:
+compat option overrideFloatEncoding.size must be an integer between 1 and 4!`,
+					);
+				}
+
+				this.overrideFloatEncoding.size =
+					definition.overrideFloatEncoding.size;
+			}
+
+			if (Object.keys(this.overrideFloatEncoding).length === 0) {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+error in compat option overrideFloatEncoding: size and/or precision must be specified!`,
+				);
+			}
+		}
+
 		if (definition.commandClasses != undefined) {
 			if (!isObject(definition.commandClasses)) {
 				throwInvalidConfig(
@@ -169,6 +239,10 @@ All values in compat option commandClasses.add must be objects`,
 
 	public readonly addCCs?: ReadonlyMap<CommandClasses, CompatAddCC>;
 	public readonly disableBasicMapping?: boolean;
+	public readonly overrideFloatEncoding?: {
+		size?: number;
+		precision?: number;
+	};
 	public readonly keepS0NonceUntilNext?: boolean;
 	public readonly preserveRootApplicationCCValueIDs?: boolean;
 	public readonly skipConfigurationInfoQuery?: boolean;

--- a/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
@@ -619,9 +619,12 @@ export class ThermostatSetpointCCSet extends ThermostatSetpointCC {
 	public scale: number;
 
 	public serialize(): Buffer {
+		// If a config file overwrites how the float should be encoded, use that information
+		const override = this.getNodeUnsafe()?.deviceConfig?.compat
+			?.overrideFloatEncoding;
 		this.payload = Buffer.concat([
 			Buffer.from([this.setpointType & 0b1111]),
-			encodeFloatWithScale(this.value, this.scale),
+			encodeFloatWithScale(this.value, this.scale, override),
 		]);
 		return super.serialize();
 	}


### PR DESCRIPTION
fixes: #1421
and allows to operate Z-TRM3 without updating to the unofficial firmware.