### PR TITLE
fix(config): delay refreshing the current value after a set command

### DIFF
--- a/.wotanrc.yaml
+++ b/.wotanrc.yaml
@@ -3,4 +3,4 @@ rules:
     return-never-call: off
     prefer-dot-notation: off # this is handled by ESLint and more configurable
     no-uninferred-type-parameter: off # this introduces more noise than it helps
-
+    async-function-assignability: off # this introduces more noise than it helps

--- a/packages/zwave-js/src/lib/commandclass/BasicCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BasicCC.ts
@@ -118,10 +118,14 @@ export class BasicCCAPI extends CCAPI {
 		if (this.isSinglecast()) {
 			// Refresh the current value after a delay
 			if (this.refreshTimeout) clearTimeout(this.refreshTimeout);
-			setTimeout(() => {
+			setTimeout(async () => {
 				this.refreshTimeout = undefined;
-				void this.get().catch();
-			}, this.driver.options.timeouts.refreshValue);
+				try {
+					await this.get();
+				} catch {
+					/* ignore */
+				}
+			}, this.driver.options.timeouts.refreshValue).unref();
 		}
 	}
 }

--- a/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
@@ -119,10 +119,14 @@ export class BinarySwitchCCAPI extends CCAPI {
 		if (this.isSinglecast()) {
 			// Refresh the current value after a delay
 			if (this.refreshTimeout) clearTimeout(this.refreshTimeout);
-			setTimeout(() => {
+			setTimeout(async () => {
 				this.refreshTimeout = undefined;
-				void this.get().catch();
-			}, duration?.toMilliseconds() ?? this.driver.options.timeouts.refreshValue);
+				try {
+					await this.get();
+				} catch {
+					/* ignore */
+				}
+			}, duration?.toMilliseconds() ?? this.driver.options.timeouts.refreshValue).unref();
 		}
 	}
 

--- a/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
@@ -85,6 +85,8 @@ export class BinarySwitchCCAPI extends CCAPI {
 		};
 	}
 
+	private refreshTimeout: NodeJS.Timeout | undefined;
+
 	/**
 	 * Sets the switch to the given value
 	 * @param targetValue The target value to set
@@ -115,8 +117,12 @@ export class BinarySwitchCCAPI extends CCAPI {
 		await this.driver.sendCommand(cc, this.commandOptions);
 
 		if (this.isSinglecast()) {
-			// Refresh the current value
-			await this.get();
+			// Refresh the current value after a delay
+			if (this.refreshTimeout) clearTimeout(this.refreshTimeout);
+			setTimeout(() => {
+				this.refreshTimeout = undefined;
+				void this.get().catch();
+			}, duration?.toMilliseconds() ?? this.driver.options.timeouts.refreshValue);
 		}
 	}
 

--- a/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
@@ -126,7 +126,7 @@ export class BinarySwitchCCAPI extends CCAPI {
 				} catch {
 					/* ignore */
 				}
-			}, duration?.toMilliseconds() ?? this.driver.options.timeouts.refreshValue).unref();
+			}, duration?.toMilliseconds() ?? 1000).unref();
 		}
 	}
 

--- a/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
@@ -243,10 +243,14 @@ export class DoorLockCCAPI extends PhysicalCCAPI {
 
 		// Refresh the current value after a delay
 		if (this.refreshTimeout) clearTimeout(this.refreshTimeout);
-		setTimeout(() => {
+		setTimeout(async () => {
 			this.refreshTimeout = undefined;
-			void this.get().catch();
-		}, this.driver.options.timeouts.refreshValue);
+			try {
+				await this.get();
+			} catch {
+				/* ignore */
+			}
+		}, this.driver.options.timeouts.refreshValue).unref();
 	}
 
 	public async setConfiguration(

--- a/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
@@ -198,6 +198,8 @@ export class DoorLockCCAPI extends PhysicalCCAPI {
 		]);
 	}
 
+	private refreshTimeout: NodeJS.Timeout | undefined;
+
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	public async get() {
 		this.assertSupportsCommand(
@@ -239,8 +241,12 @@ export class DoorLockCCAPI extends PhysicalCCAPI {
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
 
-		// Refresh the current value
-		await this.get();
+		// Refresh the current value after a delay
+		if (this.refreshTimeout) clearTimeout(this.refreshTimeout);
+		setTimeout(() => {
+			this.refreshTimeout = undefined;
+			void this.get().catch();
+		}, this.driver.options.timeouts.refreshValue);
 	}
 
 	public async setConfiguration(

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -152,6 +152,8 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 		};
 	}
 
+	private refreshTimeout: NodeJS.Timeout | undefined;
+
 	/**
 	 * Sets the switch to a new value
 	 * @param targetValue The new target value for the switch
@@ -201,12 +203,15 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 		// Refresh the current value
 		if (
 			!supervisionResult ||
-			supervisionResult.status === SupervisionStatus.Working ||
 			supervisionResult.status === SupervisionStatus.Success
 		) {
 			if (this.isSinglecast()) {
-				// Refresh the current value
-				await this.get();
+				// Refresh the current value after a delay
+				if (this.refreshTimeout) clearTimeout(this.refreshTimeout);
+				setTimeout(() => {
+					this.refreshTimeout = undefined;
+					void this.get().catch();
+				}, duration?.toMilliseconds() ?? this.driver.options.timeouts.refreshValue);
 			}
 		}
 	}

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -208,10 +208,14 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 			if (this.isSinglecast()) {
 				// Refresh the current value after a delay
 				if (this.refreshTimeout) clearTimeout(this.refreshTimeout);
-				setTimeout(() => {
+				setTimeout(async () => {
 					this.refreshTimeout = undefined;
-					void this.get().catch();
-				}, duration?.toMilliseconds() ?? this.driver.options.timeouts.refreshValue);
+					try {
+						await this.get();
+					} catch {
+						/* ignore */
+					}
+				}, duration?.toMilliseconds() ?? this.driver.options.timeouts.refreshValue).unref();
 			}
 		}
 	}

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -127,6 +127,12 @@ export interface ZWaveOptions {
 		report: number; // [1000...40000], default: 10000 ms
 		/** How long generated nonces are valid */
 		nonce: number; // [3000...20000], default: 5000 ms
+
+		/**
+		 * @internal
+		 * How long to wait for a poll after setting a value
+		 */
+		refreshValue: number;
 	};
 
 	attempts: {
@@ -181,6 +187,7 @@ const defaultOptions: ZWaveOptions = {
 		report: 10000,
 		nonce: 5000,
 		sendDataCallback: 65000, // as defined in INS13954
+		refreshValue: 5000, // Default should handle most slow devices until we have a better solution
 	},
 	attempts: {
 		controller: 3,


### PR DESCRIPTION
This PR implements a short-term solution for the incorrect `currentValue` after a set command, which is due to too early polls on devices with a slow transition.

It uses the specified command duration to delay the poll and falls back to a default of 5 seconds if none was given.

I'm going to try and make this a bit smarter and eventually move it out of the driver - but until then this will be the workaround.