### PR TITLE
feat: specify why security-encapsulated command is dropped

### DIFF
--- a/packages/core/src/util/misc.test.ts
+++ b/packages/core/src/util/misc.test.ts
@@ -89,6 +89,13 @@ describe("lib/util/misc", () => {
 				});
 			}
 		});
+
+		it("The error message should contain the rejection reason", () => {
+			assertZWaveError(() => validatePayload.withReason("NOPE")(false), {
+				errorCode: ZWaveErrorCodes.PacketFormat_InvalidPayload,
+				context: "NOPE",
+			});
+		});
 	});
 
 	describe("getMinimumShiftForBitMask", () => {

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1438,7 +1438,11 @@ export class Driver extends EventEmitter {
 
 				case ZWaveErrorCodes.PacketFormat_InvalidPayload:
 					this.driverLog.print(
-						`Message with invalid data received. Dropping it:
+						`Dropping message with invalid data${
+							typeof e.context === "string"
+								? ` (Reason: ${e.context})`
+								: ""
+						}:
 0x${data.toString("hex")}`,
 						"warn",
 					);


### PR DESCRIPTION
This should help us debug quicker why the driver doesn't accept some security-encapsulated commands.