### PR TITLE
feat(config): support Aeotec aerQ ZWA009-A

### DIFF
--- a/packages/config/config/devices/0x0371/zwa009.json
+++ b/packages/config/config/devices/0x0371/zwa009.json
@@ -9,6 +9,10 @@
 		{
 			"productType": "0x0002",
 			"productId": "0x0009"
+		},
+		{
+			"productType": "0x0102",
+			"productId": "0x0009"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
Just added the Product Type ID for the US/Canada/Mexico version.

https://products.z-wavealliance.org/products/3876