### PR TITLE
fix(config): add compat flags for 14287 GE fan switches.

### DIFF
--- a/packages/config/config/devices/0x0063/zw4002.json
+++ b/packages/config/config/devices/0x0063/zw4002.json
@@ -84,6 +84,6 @@
 		}
 	},
 	"compat": {
-		"disableBasicMapping": true
+		"treatBasicSetAsEvent": true
 	}
 }

--- a/packages/config/config/devices/0x0063/zw4002.json
+++ b/packages/config/config/devices/0x0063/zw4002.json
@@ -1,9 +1,9 @@
-// GE/Jasco ZW4002
+// GE/Jasco 14287 (ZW4002)
 // In-Wall Smart Fan Control
 {
 	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
-	"label": "ZW4002",
+	"label": "14287 (ZW4002)",
 	"description": "In-Wall Smart Fan Control",
 	"devices": [
 		{
@@ -15,6 +15,7 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
+	"supportsZWavePlus": true,
 	"associations": {
 		"1": {
 			"label": "Lifeline",
@@ -81,5 +82,8 @@
 				}
 			]
 		}
+	},
+ 	"compat": {
+ 		"disableBasicMapping": true
 	}
 }

--- a/packages/config/config/devices/0x0063/zw4002.json
+++ b/packages/config/config/devices/0x0063/zw4002.json
@@ -83,7 +83,7 @@
 			]
 		}
 	},
- 	"compat": {
- 		"disableBasicMapping": true
+	"compat": {
+		"disableBasicMapping": true
 	}
 }


### PR DESCRIPTION
Add compat flags and support ZWavePlus for 14287 GE fan switches.

This is for activating the double taps with basic CC that was recently implemented in node-zjs.