### PR TITLE
feat: add pollValue API to perform get request for a specific ValueID

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -68,6 +68,26 @@ This method automatically figures out which commands to send to the node, so you
 
 <!-- TODO: Check what happens if the CC is not supported by the node -->
 
+### `pollValue`
+
+```ts
+async pollValue<T>(valueId: ValueID): Promise<T | undefined>
+```
+
+Polls a value from the node. The `valueId` parameter specifies which value to poll. You can define the expected return type by passing it as the type parameter `T`.
+
+This method automatically figures out which commands to send to the node, so you don't have to use the specific commands yourself. The returned promise resolves to the current value reported by the node or `undefined` if there was no response. It will be **rejected** if any of the following conditions are met:
+
+-   The `pollValue` API is not implemented in the required Command Class
+-   The required Command Class is not implemented in this library yet
+-   The API for the required Command Class is not implemented in this library yet
+
+> [!WARNING]
+> Polling can impose a heavy load on the network and should not be done too frequently.
+
+> [!WARNING]
+> Some value IDs share a command, so make sure not to blindly call this for every property. Otherwise you'll end up with multiple duplicate requests.
+
 ### `refreshValues`
 
 ```ts

--- a/maintenance/implemented_ccs.ts
+++ b/maintenance/implemented_ccs.ts
@@ -16,6 +16,8 @@ const setValueApiRegex = /^\tprotected \[SET_VALUE\]/m;
 const noSetValueApiRegex = /^\/\/ @noSetValueAPI/m; // This comment marks a CC that needs no setValue API
 const interviewRegex = /^\tpublic async interview/m;
 const noInterviewRegex = /^\/\/ @noInterview/m; // This comment marks a CC that needs no interview procedure
+const pollValueApiRegex = /^\tprotected \[POLL_VALUE\]/m;
+const noPollValueApiRegex = /^\/\/ @noPollValueAPI/m; // This comment marks a CC that needs no pollValue API
 
 const onlyIncomplete = !!yargs.argv.onlyIncomplete;
 
@@ -31,6 +33,7 @@ interface CCInfo {
 	version: number;
 	API: boolean;
 	setValue: boolean;
+	pollValue: boolean;
 	interview: boolean;
 }
 
@@ -49,7 +52,13 @@ interface CCInfo {
 			.filter((cc) => Number.isNaN(+cc))
 			.map((name) => [
 				name,
-				{ version: 0, API: false, setValue: false, interview: false },
+				{
+					version: 0,
+					API: false,
+					setValue: false,
+					pollValue: false,
+					interview: false,
+				},
 			]),
 	);
 
@@ -64,6 +73,10 @@ interface CCInfo {
 				(hasAPI && setValueApiRegex.test(fileContent)) ||
 				noApiRegex.test(fileContent) ||
 				noSetValueApiRegex.test(fileContent);
+			const pollValue =
+				(hasAPI && pollValueApiRegex.test(fileContent)) ||
+				noApiRegex.test(fileContent) ||
+				noPollValueApiRegex.test(fileContent);
 			const interview =
 				interviewRegex.test(fileContent) ||
 				noInterviewRegex.test(fileContent);
@@ -71,6 +84,7 @@ interface CCInfo {
 				version: ccVersion,
 				API: hasAPI,
 				setValue,
+				pollValue,
 				interview,
 			});
 		} catch {
@@ -85,12 +99,13 @@ interface CCInfo {
 		"Interview?",
 		"API?",
 		"setValue?",
+		"pollValue?",
 	];
 	const rows: string[][] = [];
 
 	for (const [
 		name,
-		{ version, interview, API, setValue },
+		{ version, interview, API, setValue, pollValue },
 	] of allCCs.entries()) {
 		const { version: latest, deprecated, obsolete } = getLatestVersion(
 			name,
@@ -124,6 +139,7 @@ interface CCInfo {
 		const hasInterview = interview ? c.green(" ✔ ") : c.red(" ❌ ");
 		const hasAPI = API ? c.green(" ✔ ") : c.red(" ❌ ");
 		const hasSetValue = setValue ? c.green(" ✔ ") : c.red(" ❌ ");
+		const hasPollValue = pollValue ? c.green(" ✔ ") : c.red(" ❌ ");
 		const prefix =
 			implementationStatus === "done"
 				? "✔"
@@ -139,6 +155,7 @@ interface CCInfo {
 				hasInterview,
 				hasAPI,
 				hasSetValue,
+				hasPollValue,
 			]);
 		}
 	}

--- a/packages/zwave-js/src/lib/commandclass/API.ts
+++ b/packages/zwave-js/src/lib/commandclass/API.ts
@@ -21,6 +21,12 @@ export type SetValueImplementation = (
 	value: unknown,
 ) => Promise<void>;
 
+/** Used to identify the method on the CC API class that handles polling values from nodes */
+export const POLL_VALUE: unique symbol = Symbol.for("CCAPI_POLL_VALUE");
+export type PollValueImplementation<T extends unknown = unknown> = (
+	property: Pick<ValueID, "property" | "propertyKey">,
+) => Promise<T | undefined>;
+
 // Since the setValue API is called from a point with very generic parameters,
 // we must do narrowing inside the API calls. These three methods are for convenience
 export function throwUnsupportedProperty(
@@ -91,6 +97,15 @@ export class CCAPI {
 	public get setValue(): SetValueImplementation | undefined {
 		// wotan-disable-next-line no-restricted-property-access
 		return this[SET_VALUE];
+	}
+
+	protected [POLL_VALUE]: PollValueImplementation | undefined;
+	/**
+	 * Can be used on supported CC APIs to poll a CC value by property name (and optionally the property key)
+	 */
+	public get pollValue(): PollValueImplementation | undefined {
+		// wotan-disable-next-line no-restricted-property-access
+		return this[POLL_VALUE];
 	}
 
 	/**

--- a/packages/zwave-js/src/lib/commandclass/BasicCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BasicCC.ts
@@ -16,6 +16,8 @@ import { MessagePriority } from "../message/Constants";
 import {
 	CCAPI,
 	ignoreTimeout,
+	PollValueImplementation,
+	POLL_VALUE,
 	SetValueImplementation,
 	SET_VALUE,
 	throwUnsupportedProperty,
@@ -88,6 +90,19 @@ export class BasicCCAPI extends CCAPI {
 			throwWrongValueType(this.ccId, property, "number", typeof value);
 		}
 		await this.set(value);
+	};
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+	}): Promise<unknown> => {
+		switch (property) {
+			case "currentValue":
+			case "targetValue":
+			case "duration":
+				return (await this.get())?.[property];
+			default:
+				throwUnsupportedProperty(this.ccId, property);
+		}
 	};
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types

--- a/packages/zwave-js/src/lib/commandclass/BatteryCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BatteryCC.ts
@@ -14,7 +14,13 @@ import {
 import { getEnumMemberName } from "@zwave-js/shared";
 import type { Driver } from "../driver/Driver";
 import { MessagePriority } from "../message/Constants";
-import { ignoreTimeout, PhysicalCCAPI } from "./API";
+import {
+	ignoreTimeout,
+	PhysicalCCAPI,
+	PollValueImplementation,
+	POLL_VALUE,
+	throwUnsupportedProperty,
+} from "./API";
 import {
 	API,
 	CCCommand,
@@ -65,6 +71,31 @@ export class BatteryCCAPI extends PhysicalCCAPI {
 		}
 		return super.supportsCommand(cmd);
 	}
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+	}): Promise<unknown> => {
+		switch (property) {
+			case "level":
+			case "isLow":
+			case "chargingStatus":
+			case "rechargeable":
+			case "backup":
+			case "overheating":
+			case "lowFluid":
+			case "rechargeOrReplace":
+			case "lowTemperatureStatus":
+			case "disconnected":
+				return (await this.get())?.[property];
+
+			case "maximumCapacity":
+			case "temperature":
+				return (await this.getHealth())?.[property];
+
+			default:
+				throwUnsupportedProperty(this.ccId, property);
+		}
+	};
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	public async get() {

--- a/packages/zwave-js/src/lib/commandclass/BinarySensorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySensorCC.ts
@@ -12,7 +12,13 @@ import {
 import { getEnumMemberName } from "@zwave-js/shared";
 import type { Driver } from "../driver/Driver";
 import { MessagePriority } from "../message/Constants";
-import { ignoreTimeout, PhysicalCCAPI } from "./API";
+import {
+	ignoreTimeout,
+	PhysicalCCAPI,
+	PollValueImplementation,
+	POLL_VALUE,
+	throwUnsupportedProperty,
+} from "./API";
 import {
 	API,
 	CCCommand,
@@ -95,6 +101,18 @@ export class BinarySensorCCAPI extends PhysicalCCAPI {
 		}
 		return super.supportsCommand(cmd);
 	}
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+	}): Promise<unknown> => {
+		if (typeof property === "string") {
+			const sensorType = (BinarySensorType as any)[property] as
+				| BinarySensorType
+				| undefined;
+			if (sensorType) return this.get(sensorType);
+		}
+		throwUnsupportedProperty(this.ccId, property);
+	};
 
 	/**
 	 * Retrieves the current value from this sensor

--- a/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
@@ -16,6 +16,8 @@ import type { Driver } from "../driver/Driver";
 import { MessagePriority } from "../message/Constants";
 import {
 	CCAPI,
+	PollValueImplementation,
+	POLL_VALUE,
 	SetValueImplementation,
 	SET_VALUE,
 	throwUnsupportedProperty,
@@ -141,6 +143,19 @@ export class BinarySwitchCCAPI extends CCAPI {
 			throwWrongValueType(this.ccId, property, "boolean", typeof value);
 		}
 		await this.set(value);
+	};
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+	}): Promise<unknown> => {
+		switch (property) {
+			case "currentValue":
+			case "targetValue":
+			case "duration":
+				return (await this.get())?.[property];
+			default:
+				throwUnsupportedProperty(this.ccId, property);
+		}
 	};
 }
 

--- a/packages/zwave-js/src/lib/commandclass/CentralSceneCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/CentralSceneCC.ts
@@ -20,6 +20,8 @@ import { MessagePriority } from "../message/Constants";
 import {
 	CCAPI,
 	ignoreTimeout,
+	PollValueImplementation,
+	POLL_VALUE,
 	SetValueImplementation,
 	SET_VALUE,
 	throwUnsupportedProperty,
@@ -161,6 +163,15 @@ export class CentralSceneCCAPI extends CCAPI {
 			throwWrongValueType(this.ccId, property, "boolean", typeof value);
 		}
 		await this.setConfiguration(value);
+	};
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+	}): Promise<unknown> => {
+		if (property === "slowRefresh") {
+			return (await this.getConfiguration())?.[property];
+		}
+		throwUnsupportedProperty(this.ccId, property);
 	};
 }
 

--- a/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
@@ -21,6 +21,8 @@ import { MessagePriority } from "../message/Constants";
 import {
 	CCAPI,
 	ignoreTimeout,
+	PollValueImplementation,
+	POLL_VALUE,
 	SetValueImplementation,
 	SET_VALUE,
 	throwMissingPropertyKey,
@@ -346,6 +348,28 @@ export class ColorSwitchCCAPI extends CCAPI {
 			await this.set({ hexColor: value });
 		} else {
 			throwUnsupportedProperty(this.ccId, property);
+		}
+	};
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+		propertyKey,
+	}): Promise<unknown> => {
+		if (propertyKey == undefined) {
+			throwMissingPropertyKey(this.ccId, property);
+		} else if (typeof propertyKey !== "number") {
+			throwUnsupportedPropertyKey(this.ccId, property, propertyKey);
+		}
+
+		switch (property) {
+			case "currentColor":
+				return (await this.get(propertyKey))?.currentValue;
+			case "targetColor":
+				return (await this.get(propertyKey))?.targetValue;
+			case "duration":
+				return (await this.get(propertyKey))?.duration;
+			default:
+				throwUnsupportedProperty(this.ccId, property);
 		}
 	};
 }

--- a/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
@@ -30,6 +30,8 @@ import { MessagePriority } from "../message/Constants";
 import {
 	ignoreTimeout,
 	PhysicalCCAPI,
+	PollValueImplementation,
+	POLL_VALUE,
 	SetValueImplementation,
 	SET_VALUE,
 	throwUnsupportedProperty,
@@ -223,6 +225,21 @@ export class ConfigurationCCAPI extends PhysicalCCAPI {
 		void this.get(property).catch(() => {
 			/* ignore */
 		});
+	};
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+		propertyKey,
+	}): Promise<unknown> => {
+		// Config parameters are addressed with numeric properties/keys
+		if (typeof property !== "number") {
+			throwUnsupportedProperty(this.ccId, property);
+		}
+		if (propertyKey != undefined && typeof propertyKey !== "number") {
+			throwUnsupportedPropertyKey(this.ccId, property, propertyKey);
+		}
+
+		return this.get(property, { valueBitMask: propertyKey });
 	};
 
 	/**

--- a/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
@@ -21,6 +21,8 @@ import { MessagePriority } from "../message/Constants";
 import {
 	ignoreTimeout,
 	PhysicalCCAPI,
+	PollValueImplementation,
+	POLL_VALUE,
 	SetValueImplementation,
 	SET_VALUE,
 	throwUnsupportedProperty,
@@ -165,6 +167,36 @@ export class DoorLockCCAPI extends PhysicalCCAPI {
 			await this.setConfiguration(config);
 		} else {
 			throwUnsupportedProperty(this.ccId, property);
+		}
+	};
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+	}): Promise<unknown> => {
+		switch (property) {
+			case "currentMode":
+			case "targetMode":
+			case "duration":
+			case "outsideHandlesCanOpenDoor":
+			case "insideHandlesCanOpenDoor":
+			case "latchStatus":
+			case "boltStatus":
+			case "doorStatus":
+			case "lockTimeout":
+				return (await this.get())?.[property];
+
+			case "operationType":
+			case "outsideHandlesCanOpenDoorConfiguration":
+			case "insideHandlesCanOpenDoorConfiguration":
+			case "lockTimeoutConfiguration":
+			case "autoRelockTime":
+			case "holdAndReleaseTime":
+			case "twistAssist":
+			case "blockToBlock":
+				return (await this.getConfiguration())?.[property];
+
+			default:
+				throwUnsupportedProperty(this.ccId, property);
 		}
 	};
 

--- a/packages/zwave-js/src/lib/commandclass/IndicatorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/IndicatorCC.ts
@@ -19,6 +19,8 @@ import { MessagePriority } from "../message/Constants";
 import {
 	CCAPI,
 	ignoreTimeout,
+	PollValueImplementation,
+	POLL_VALUE,
 	SetValueImplementation,
 	SET_VALUE,
 	throwUnsupportedProperty,
@@ -233,6 +235,17 @@ export class IndicatorCCAPI extends CCAPI {
 		} else {
 			throwUnsupportedProperty(this.ccId, property);
 		}
+	};
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+	}): Promise<unknown> => {
+		if (property === "value") return this.get();
+		if (typeof property === "number") {
+			return this.get(property);
+		}
+
+		throwUnsupportedProperty(this.ccId, property);
 	};
 
 	public async get(

--- a/packages/zwave-js/src/lib/commandclass/LockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/LockCC.ts
@@ -10,6 +10,8 @@ import type { Driver } from "../driver/Driver";
 import { MessagePriority } from "../message/Constants";
 import {
 	PhysicalCCAPI,
+	PollValueImplementation,
+	POLL_VALUE,
 	SetValueImplementation,
 	SET_VALUE,
 	throwUnsupportedProperty,
@@ -90,6 +92,13 @@ export class LockCCAPI extends PhysicalCCAPI {
 			throwWrongValueType(this.ccId, property, "boolean", typeof value);
 		}
 		await this.set(value);
+	};
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+	}): Promise<unknown> => {
+		if (property === "locked") return this.get();
+		throwUnsupportedProperty(this.ccId, property);
 	};
 }
 

--- a/packages/zwave-js/src/lib/commandclass/ManufacturerProprietaryCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ManufacturerProprietaryCC.ts
@@ -9,6 +9,8 @@ import { isArray } from "alcalzone-shared/typeguards";
 import type { Driver } from "../driver/Driver";
 import {
 	CCAPI,
+	PollValueImplementation,
+	POLL_VALUE,
 	SetValueImplementation,
 	SET_VALUE,
 	throwUnsupportedProperty,
@@ -123,6 +125,18 @@ export class ManufacturerProprietaryCCAPI extends CCAPI {
 		}
 		// Refresh the current value
 		await this.fibaroVenetianBlindsGet();
+	};
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+	}): Promise<unknown> => {
+		switch (property) {
+			case "position":
+			case "tilt":
+				return (await this.fibaroVenetianBlindsGet())?.[property];
+			default:
+				throwUnsupportedProperty(this.ccId, property);
+		}
 	};
 }
 

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -16,6 +16,8 @@ import type { Driver } from "../driver/Driver";
 import { MessagePriority } from "../message/Constants";
 import {
 	CCAPI,
+	PollValueImplementation,
+	POLL_VALUE,
 	SetValueImplementation,
 	SET_VALUE,
 	throwUnsupportedProperty,
@@ -376,6 +378,19 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 			}
 		} else {
 			throwUnsupportedProperty(this.ccId, property);
+		}
+	};
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+	}): Promise<unknown> => {
+		switch (property) {
+			case "currentValue":
+			case "targetValue":
+			case "duration":
+				return (await this.get())?.[property];
+			default:
+				throwUnsupportedProperty(this.ccId, property);
 		}
 	};
 }

--- a/packages/zwave-js/src/lib/commandclass/NodeNamingCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/NodeNamingCC.ts
@@ -4,6 +4,8 @@ import type { Driver } from "../driver/Driver";
 import { MessagePriority } from "../message/Constants";
 import {
 	PhysicalCCAPI,
+	PollValueImplementation,
+	POLL_VALUE,
 	SetValueImplementation,
 	SET_VALUE,
 	throwUnsupportedProperty,
@@ -82,6 +84,19 @@ export class NodeNamingAndLocationCCAPI extends PhysicalCCAPI {
 				await this.setLocation(value);
 				// Refresh the current value
 				await this.getLocation();
+		}
+	};
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+	}): Promise<unknown> => {
+		switch (property) {
+			case "name":
+				return this.getName();
+			case "location":
+				return this.getLocation();
+			default:
+				throwUnsupportedProperty(this.ccId, property);
 		}
 	};
 

--- a/packages/zwave-js/src/lib/commandclass/ProtectionCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ProtectionCC.ts
@@ -21,6 +21,8 @@ import type { Driver } from "../driver/Driver";
 import { MessagePriority } from "../message/Constants";
 import {
 	CCAPI,
+	PollValueImplementation,
+	POLL_VALUE,
 	SetValueImplementation,
 	SET_VALUE,
 	throwUnsupportedProperty,
@@ -198,6 +200,20 @@ export class ProtectionCCAPI extends CCAPI {
 			await this.setExclusiveControl(value);
 		} else {
 			throwUnsupportedProperty(this.ccId, property);
+		}
+	};
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+	}): Promise<unknown> => {
+		switch (property) {
+			case "local":
+			case "rf":
+				return (await this.get())?.[property];
+			case "exclusiveControlNodeId":
+				return this.getExclusiveControl();
+			default:
+				throwUnsupportedProperty(this.ccId, property);
 		}
 	};
 

--- a/packages/zwave-js/src/lib/commandclass/SoundSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SoundSwitchCC.ts
@@ -16,6 +16,8 @@ import { MessagePriority } from "../message/Constants";
 import {
 	CCAPI,
 	ignoreTimeout,
+	PollValueImplementation,
+	POLL_VALUE,
 	SetValueImplementation,
 	SET_VALUE,
 	throwUnsupportedProperty,
@@ -274,6 +276,23 @@ export class SoundSwitchCCAPI extends CCAPI {
 			}
 		} else {
 			throwUnsupportedProperty(this.ccId, property);
+		}
+	};
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+	}): Promise<unknown> => {
+		switch (property) {
+			case "defaultToneId":
+			case "defaultVolume":
+				return (await this.getConfiguration())?.[property];
+
+			case "toneId":
+			case "volume":
+				return (await this.getPlaying())?.[property];
+
+			default:
+				throwUnsupportedProperty(this.ccId, property);
 		}
 	};
 }

--- a/packages/zwave-js/src/lib/commandclass/ThermostatModeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatModeCC.ts
@@ -19,6 +19,8 @@ import { MessagePriority } from "../message/Constants";
 import {
 	CCAPI,
 	ignoreTimeout,
+	PollValueImplementation,
+	POLL_VALUE,
 	SetValueImplementation,
 	SET_VALUE,
 	throwUnsupportedProperty,
@@ -93,6 +95,18 @@ export class ThermostatModeCCAPI extends CCAPI {
 			throwWrongValueType(this.ccId, property, "number", typeof value);
 		}
 		await this.set(value);
+	};
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+	}): Promise<unknown> => {
+		switch (property) {
+			case "mode":
+				return (await this.get())?.[property];
+
+			default:
+				throwUnsupportedProperty(this.ccId, property);
+		}
 	};
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types

--- a/packages/zwave-js/src/lib/commandclass/ThermostatOperatingStateCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatOperatingStateCC.ts
@@ -8,7 +8,12 @@ import {
 import { getEnumMemberName } from "@zwave-js/shared";
 import type { Driver } from "../driver/Driver";
 import { MessagePriority } from "../message/Constants";
-import { PhysicalCCAPI } from "./API";
+import {
+	PhysicalCCAPI,
+	PollValueImplementation,
+	POLL_VALUE,
+	throwUnsupportedProperty,
+} from "./API";
 import {
 	API,
 	CCCommand,
@@ -63,6 +68,17 @@ export class ThermostatOperatingStateCCAPI extends PhysicalCCAPI {
 		}
 		return super.supportsCommand(cmd);
 	}
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+	}): Promise<unknown> => {
+		switch (property) {
+			case "state":
+				return this.get();
+			default:
+				throwUnsupportedProperty(this.ccId, property);
+		}
+	};
 
 	public async get(): Promise<ThermostatOperatingState> {
 		this.assertSupportsCommand(

--- a/packages/zwave-js/src/lib/commandclass/ThermostatSetbackCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatSetbackCC.ts
@@ -14,7 +14,12 @@ import {
 	encodeSetbackState,
 	SetbackState,
 } from "../values/SetbackState";
-import { CCAPI } from "./API";
+import {
+	CCAPI,
+	PollValueImplementation,
+	POLL_VALUE,
+	throwUnsupportedProperty,
+} from "./API";
 import {
 	API,
 	CCCommand,
@@ -58,6 +63,19 @@ export class ThermostatSetbackCCAPI extends CCAPI {
 		}
 		return super.supportsCommand(cmd);
 	}
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+	}): Promise<unknown> => {
+		switch (property) {
+			case "setbackType":
+			case "setbackState":
+				return (await this.get())?.[property];
+
+			default:
+				throwUnsupportedProperty(this.ccId, property);
+		}
+	};
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	public async get() {

--- a/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
@@ -17,6 +17,8 @@ import { MessagePriority } from "../message/Constants";
 import {
 	CCAPI,
 	ignoreTimeout,
+	PollValueImplementation,
+	POLL_VALUE,
 	SetValueImplementation,
 	SET_VALUE,
 	throwUnsupportedProperty,
@@ -177,6 +179,27 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 				getSetpointScaleValueID(this.endpoint.index, propertyKey),
 			);
 		await this.set(propertyKey, value, preferredScale ?? 0);
+	};
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+		propertyKey,
+	}): Promise<unknown> => {
+		switch (property) {
+			case "setpoint":
+				if (typeof propertyKey !== "number") {
+					throw new ZWaveError(
+						`${
+							CommandClasses[this.ccId]
+						}: "${property}" must be further specified by a numeric property key`,
+						ZWaveErrorCodes.Argument_Invalid,
+					);
+				}
+
+				return (await this.get(propertyKey))?.value;
+			default:
+				throwUnsupportedProperty(this.ccId, property);
+		}
 	};
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types

--- a/packages/zwave-js/src/lib/commandclass/TimeParametersCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/TimeParametersCC.ts
@@ -10,6 +10,8 @@ import { MessagePriority } from "../message/Constants";
 import type { Endpoint } from "../node/Endpoint";
 import {
 	CCAPI,
+	PollValueImplementation,
+	POLL_VALUE,
 	SetValueImplementation,
 	SET_VALUE,
 	throwUnsupportedProperty,
@@ -122,6 +124,17 @@ export class TimeParametersCCAPI extends CCAPI {
 			throwWrongValueType(this.ccId, property, "date", typeof value);
 		}
 		await this.set(value);
+	};
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+	}): Promise<unknown> => {
+		switch (property) {
+			case "dateAndTime":
+				return this.get();
+			default:
+				throwUnsupportedProperty(this.ccId, property);
+		}
 	};
 
 	public async get(): Promise<Date> {

--- a/packages/zwave-js/src/lib/commandclass/UserCodeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/UserCodeCC.ts
@@ -22,6 +22,8 @@ import {
 import {
 	ignoreTimeout,
 	PhysicalCCAPI,
+	PollValueImplementation,
+	POLL_VALUE,
 	SetValueImplementation,
 	SET_VALUE,
 	throwMissingPropertyKey,
@@ -413,6 +415,33 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 			await this.set(propertyKey, userIdStatus as any, value);
 		} else {
 			throwUnsupportedProperty(this.ccId, property);
+		}
+	};
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+		propertyKey,
+	}): Promise<unknown> => {
+		switch (property) {
+			case "keypadMode":
+				return this.getKeypadMode();
+			case "masterCode":
+				return this.getMasterCode();
+			case "userIdStatus":
+			case "userCode": {
+				if (propertyKey == undefined) {
+					throwMissingPropertyKey(this.ccId, property);
+				} else if (typeof propertyKey !== "number") {
+					throwUnsupportedPropertyKey(
+						this.ccId,
+						property,
+						propertyKey,
+					);
+				}
+				return (await this.get(propertyKey))?.[property];
+			}
+			default:
+				throwUnsupportedProperty(this.ccId, property);
 		}
 	};
 

--- a/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
@@ -13,6 +13,8 @@ import { NodeStatus } from "../node/Types";
 import {
 	CCAPI,
 	ignoreTimeout,
+	PollValueImplementation,
+	POLL_VALUE,
 	SetValueImplementation,
 	SET_VALUE,
 	throwUnsupportedProperty,
@@ -75,6 +77,17 @@ export class WakeUpCCAPI extends CCAPI {
 			throwWrongValueType(this.ccId, property, "number", typeof value);
 		}
 		await this.setInterval(value, this.driver.controller.ownNodeId ?? 1);
+	};
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+	}): Promise<unknown> => {
+		switch (property) {
+			case "wakeUpInterval":
+				return (await this.getInterval())?.[property];
+			default:
+				throwUnsupportedProperty(this.ccId, property);
+		}
 	};
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -707,9 +707,10 @@ export class ZWaveNode extends Endpoint {
 
 	/**
 	 * Requests a value for a given property of a given CommandClass by polling the node.
+	 * **Warning:** Some value IDs share a command, so make sure not to blindly call this for every property
 	 */
 	// wotan-disable-next-line no-misused-generics
-	public async pollValue<T extends unknown = unknown>(
+	public pollValue<T extends unknown = unknown>(
 		valueId: ValueID,
 	): Promise<T | undefined> {
 		// Try to retrieve the corresponding CC API
@@ -735,6 +736,7 @@ export class ZWaveNode extends Endpoint {
 			);
 		}
 		// And call it
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
 		return (api.pollValue as PollValueImplementation<T>)({
 			property: valueId.property,
 			propertyKey: valueId.propertyKey,

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -36,7 +36,11 @@ import { padStart } from "alcalzone-shared/strings";
 import { isArray, isObject } from "alcalzone-shared/typeguards";
 import { randomBytes } from "crypto";
 import { EventEmitter } from "events";
-import { CCAPI, ignoreTimeout } from "../commandclass/API";
+import {
+	CCAPI,
+	ignoreTimeout,
+	PollValueImplementation,
+} from "../commandclass/API";
 import { getHasLifelineValueId } from "../commandclass/AssociationCC";
 import {
 	BasicCC,
@@ -699,6 +703,42 @@ export class ZWaveNode extends Endpoint {
 			}
 			throw e;
 		}
+	}
+
+	/**
+	 * Requests a value for a given property of a given CommandClass by polling the node.
+	 */
+	// wotan-disable-next-line no-misused-generics
+	public async pollValue<T extends unknown = unknown>(
+		valueId: ValueID,
+	): Promise<T | undefined> {
+		// Try to retrieve the corresponding CC API
+		const endpointInstance = this.getEndpoint(valueId.endpoint || 0);
+		if (!endpointInstance) {
+			throw new ZWaveError(
+				`Endpoint ${valueId.endpoint} does not exist on Node ${this.id}`,
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+
+		const api = (endpointInstance.commandClasses as any)[
+			valueId.commandClass
+		] as CCAPI;
+
+		// Check if the pollValue method is implemented
+		if (!api.pollValue) {
+			throw new ZWaveError(
+				`The pollValue API is not implemented for CC ${getCCName(
+					valueId.commandClass,
+				)}!`,
+				ZWaveErrorCodes.CC_NoAPI,
+			);
+		}
+		// And call it
+		return (api.pollValue as PollValueImplementation<T>)({
+			property: valueId.property,
+			propertyKey: valueId.propertyKey,
+		});
 	}
 
 	public get endpointCountIsDynamic(): boolean | undefined {


### PR DESCRIPTION
This PR adds a `pollValue` method on the `ZWaveNode` class to perform `GET` requests for a specific value ID - similar to what `setValue` is for `SET` commands.

We still need to ensure that no redundant commands are queued, but that is something for another PR.