### PR TITLE
feat(config): track file hash in device index and regenerate on demand

### DIFF
--- a/packages/config/src/ConfigManager.ts
+++ b/packages/config/src/ConfigManager.ts
@@ -449,12 +449,8 @@ export class ConfigManager {
 		productId: number,
 		firmwareVersion?: string | false,
 	): Promise<DeviceConfig | undefined> {
-		if (!this.index) {
-			throw new ZWaveError(
-				"The config has not been loaded yet!",
-				ZWaveErrorCodes.Driver_NotReady,
-			);
-		}
+		// Load/regenerate the index if necessary
+		if (!this.index) await this.loadDeviceIndex();
 
 		// Look up the device in the index
 		let indexEntry: DeviceConfigIndexEntry | undefined;
@@ -465,11 +461,11 @@ export class ConfigManager {
 				productType,
 				productId,
 			);
-			indexEntry = this.index.find(
+			indexEntry = this.index!.find(
 				(e) => e.firmwareVersion === false && predicate(e),
 			);
 		} else {
-			indexEntry = this.index.find(
+			indexEntry = this.index!.find(
 				getDeviceEntryPredicate(
 					manufacturerId,
 					productType,


### PR DESCRIPTION
With this PR, we hash the existing config files and store that hash in the index to detect if it needs to be regenerated. This should make it easier to add, lint and test new configurations because the index.json no longer needs to be regenerated manually.