### PR TITLE
fix(config): swap ZW080 bitmasks for siren volume and siren sound

### DIFF
--- a/packages/config/config/devices/0x0086/zw080.json
+++ b/packages/config/config/devices/0x0086/zw080.json
@@ -64,7 +64,7 @@
 				}
 			]
 		},
-		"37[0xff]": {
+		"37[0xff00]": {
 			"label": "Siren Sound",
 			"valueSize": 2,
 			"minValue": 0,
@@ -100,7 +100,7 @@
 				}
 			]
 		},
-		"37[0xff00]": {
+		"37[0xff]": {
 			"label": "Siren Volume",
 			"valueSize": 2,
 			"minValue": 0,


### PR DESCRIPTION
swapped hex byte code on siren volume and siren sound as these were reversed