### PR TITLE
fix(perf): improve ValueDB lookup performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,8 @@
     "postversion": "git push && git push --tags",
     "config": "ts-node maintenance/importConfig.ts",
     "docs": "docsify serve docs",
-    "docs:generate": "ts-node -P maintenance/tsconfig.json maintenance/generateTypedDocs.ts"
+    "docs:generate": "ts-node -P maintenance/tsconfig.json maintenance/generateTypedDocs.ts",
+    "perf": "ts-node packages/core/src/values/profile.ts"
   },
   "readme": "README.md",
   "husky": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "config": "ts-node maintenance/importConfig.ts",
     "docs": "docsify serve docs",
     "docs:generate": "ts-node -P maintenance/tsconfig.json maintenance/generateTypedDocs.ts",
-    "perf": "ts-node packages/core/src/values/profile.ts"
+    "perf": "ts-node test/valuedb-perf.ts"
   },
   "readme": "README.md",
   "husky": {

--- a/packages/core/src/values/ValueDB.test.ts
+++ b/packages/core/src/values/ValueDB.test.ts
@@ -486,6 +486,9 @@ describe("lib/node/ValueDB => ", () => {
 				(valueDB as any)._db.set(JSON.stringify(valueId), value);
 			}
 
+			// we're bypassing the index, so we need to fix that
+			valueDB["_index"] = valueDB["buildIndex"]();
+
 			const actual = valueDB.getValues(requestedCC);
 			expect(actual).toHaveLength(expected.length);
 			expect(actual).toContainAllValues(expected);
@@ -604,6 +607,9 @@ describe("lib/node/ValueDB => ", () => {
 			for (const { value, ...valueId } of values) {
 				(valueDB as any)._db.set(JSON.stringify(valueId), value);
 			}
+
+			// we're bypassing the index, so we need to fix that
+			valueDB["_index"] = valueDB["buildIndex"]();
 
 			// The node has nodeID 2
 			const { nodeId, ...expected } = values[1];
@@ -728,6 +734,9 @@ describe("lib/node/ValueDB => ", () => {
 						meta,
 					);
 				}
+
+				// we're bypassing the index, so we need to fix that
+				valueDB["_index"] = valueDB["buildIndex"]();
 
 				const actual = valueDB.getAllMetadata(requestedCC);
 				expect(actual).toHaveLength(expected.length);
@@ -857,6 +866,9 @@ describe("lib/node/ValueDB => ", () => {
 			for (const { meta, ...valueId } of metadata) {
 				(valueDB as any)._metadata.set(JSON.stringify(valueId), meta);
 			}
+
+			// we're bypassing the index, so we need to fix that
+			valueDB["_index"] = valueDB["buildIndex"]();
 
 			// The node has nodeID 2
 			const expectedMeta = metadata[1];

--- a/packages/core/src/values/ValueDB.ts
+++ b/packages/core/src/values/ValueDB.ts
@@ -310,9 +310,9 @@ export class ValueDB extends EventEmitter {
 		});
 
 		oldValues.forEach(([key, prevValue]) => {
-			const { nodeId, ...valueId } = this.dbKeyToValueId(key);
 			this._db.delete(key);
 			if (options.noEvent !== true) {
+				const { nodeId, ...valueId } = this.dbKeyToValueId(key);
 				const cbArg: ValueRemovedArgs = {
 					...valueId,
 					prevValue,
@@ -321,10 +321,10 @@ export class ValueDB extends EventEmitter {
 			}
 		});
 		oldMetadataKeys.forEach((key) => {
-			const { nodeId, ...valueId } = this.dbKeyToValueId(key);
 			this._metadata.delete(key);
 
 			if (options.noEvent !== true) {
+				const { nodeId, ...valueId } = this.dbKeyToValueId(key);
 				const cbArg: MetadataUpdatedArgs = {
 					...valueId,
 					metadata: undefined,

--- a/packages/core/src/values/ValueDB.ts
+++ b/packages/core/src/values/ValueDB.ts
@@ -527,26 +527,28 @@ function compareDBKeyFast(
 	nodeId: number,
 	valueId?: Partial<ValueID>,
 ): boolean {
-	if (!key.includes(`{"nodeId":${nodeId},`)) return false;
+	if (-1 === key.indexOf(`{"nodeId":${nodeId},`)) return false;
 	if (!valueId) return true;
 
 	if ("commandClass" in valueId) {
-		if (!key.includes(`,"commandClass":${valueId.commandClass},`))
+		if (-1 === key.indexOf(`,"commandClass":${valueId.commandClass},`))
 			return false;
 	}
 	if ("endpoint" in valueId) {
-		if (!key.includes(`,"endpoint":${valueId.endpoint},`)) return false;
+		if (-1 === key.indexOf(`,"endpoint":${valueId.endpoint},`))
+			return false;
 	}
 	if (typeof valueId.property === "string") {
-		if (!key.includes(`,"property":"${valueId.property}"`)) return false;
+		if (-1 === key.indexOf(`,"property":"${valueId.property}"`))
+			return false;
 	} else if (typeof valueId.property === "number") {
-		if (!key.includes(`,"property":${valueId.property}`)) return false;
+		if (-1 === key.indexOf(`,"property":${valueId.property}`)) return false;
 	}
 	if (typeof valueId.propertyKey === "string") {
-		if (!key.includes(`,"propertyKey":"${valueId.propertyKey}"`))
+		if (-1 === key.indexOf(`,"propertyKey":"${valueId.propertyKey}"`))
 			return false;
 	} else if (typeof valueId.propertyKey === "number") {
-		if (!key.includes(`,"propertyKey":${valueId.propertyKey}`))
+		if (-1 === key.indexOf(`,"propertyKey":${valueId.propertyKey}`))
 			return false;
 	}
 	return true;

--- a/packages/core/src/values/profile.ts
+++ b/packages/core/src/values/profile.ts
@@ -1,0 +1,48 @@
+import { JsonlDB } from "@alcalzone/jsonl-db";
+import * as fs from "fs-extra";
+import { highResTimestamp } from "../util/date";
+import { ValueDB } from "./ValueDB";
+
+const values: JsonlDB<any> = new JsonlDB("test.values.jsonl");
+const metadata: JsonlDB<any> = new JsonlDB("test.metadata.jsonl");
+const valueDBs = new Map<number, ValueDB>();
+
+(async () => {
+	await values.open();
+	await metadata.open();
+	// add a shitton of values
+	for (let nodeId = 1; nodeId <= 100; nodeId++) {
+		const valueDB = new ValueDB(nodeId, values, metadata);
+		valueDBs.set(nodeId, valueDB);
+		for (let ccId = 1; ccId <= 100; ccId++) {
+			for (let endpoint = 0; endpoint <= 10; endpoint++) {
+				for (const property of ["a", "b", "c", "d", "e"]) {
+					valueDB.setValue(
+						{
+							commandClass: ccId,
+							endpoint,
+							property,
+						},
+						Math.random() * 100,
+					);
+				}
+			}
+		}
+	}
+
+	console.log(`db contains ${values.size} values`);
+	const numRounds = 100;
+	console.log(`calling getValues ${numRounds} times`);
+
+	const start = highResTimestamp();
+	for (let i = 1; i <= numRounds; i++) {
+		valueDBs.get(1)!.getValues(5);
+	}
+	const duration = highResTimestamp() - start;
+	console.log(`took ${(duration / 1e6 / numRounds).toFixed(2)} ms / call`);
+
+	await values.close();
+	await metadata.close();
+	await fs.remove("test.values.jsonl");
+	await fs.remove("test.metadata.jsonl");
+})().catch(() => {});

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -179,11 +179,13 @@ export class ZWaveNode extends Endpoint {
 		deviceClass?: DeviceClass,
 		supportedCCs: CommandClasses[] = [],
 		controlledCCs: CommandClasses[] = [],
+		valueDB?: ValueDB,
 	) {
 		// Define this node's intrinsic endpoint as the root device (0)
 		super(id, driver, 0);
 
-		this._valueDB = new ValueDB(id, driver.valueDB!, driver.metadataDB!);
+		this._valueDB =
+			valueDB ?? new ValueDB(id, driver.valueDB!, driver.metadataDB!);
 		for (const event of [
 			"value added",
 			"value updated",

--- a/test/valuedb-perf.ts
+++ b/test/valuedb-perf.ts
@@ -1,7 +1,7 @@
 import { JsonlDB } from "@alcalzone/jsonl-db";
+import { highResTimestamp } from "@zwave-js/core/src/util/date";
+import { ValueDB } from "@zwave-js/core/src/values/ValueDB";
 import * as fs from "fs-extra";
-import { highResTimestamp } from "../util/date";
-import { ValueDB } from "./ValueDB";
 
 const values: JsonlDB<any> = new JsonlDB("test.values.jsonl");
 const metadata: JsonlDB<any> = new JsonlDB("test.metadata.jsonl");
@@ -45,4 +45,6 @@ const valueDBs = new Map<number, ValueDB>();
 	await metadata.close();
 	await fs.remove("test.values.jsonl");
 	await fs.remove("test.metadata.jsonl");
-})().catch(() => {});
+})().catch(() => {
+	/* ignore */
+});

--- a/test/valuedb-perf.ts
+++ b/test/valuedb-perf.ts
@@ -3,15 +3,20 @@ import { highResTimestamp } from "@zwave-js/core/src/util/date";
 import { ValueDB } from "@zwave-js/core/src/values/ValueDB";
 import * as fs from "fs-extra";
 
-const values: JsonlDB<any> = new JsonlDB("test.values.jsonl");
-const metadata: JsonlDB<any> = new JsonlDB("test.metadata.jsonl");
+const values: JsonlDB<any> = new JsonlDB("test.values.jsonl", {
+	autoCompress: { onClose: false },
+});
+const metadata: JsonlDB<any> = new JsonlDB("test.metadata.jsonl", {
+	autoCompress: { onClose: false },
+});
 const valueDBs = new Map<number, ValueDB>();
 
 (async () => {
 	await values.open();
 	await metadata.open();
 	// add a shitton of values
-	for (let nodeId = 1; nodeId <= 100; nodeId++) {
+	const MAX_NODES = 100;
+	for (let nodeId = 1; nodeId <= MAX_NODES; nodeId++) {
 		const valueDB = new ValueDB(nodeId, values, metadata);
 		valueDBs.set(nodeId, valueDB);
 		for (let ccId = 1; ccId <= 100; ccId++) {
@@ -32,13 +37,23 @@ const valueDBs = new Map<number, ValueDB>();
 
 	console.log(`db contains ${values.size} values`);
 	const numRounds = 100;
+
 	console.log(`calling getValues ${numRounds} times`);
 
-	const start = highResTimestamp();
+	let start = highResTimestamp();
 	for (let i = 1; i <= numRounds; i++) {
 		valueDBs.get(1)!.getValues(5);
 	}
-	const duration = highResTimestamp() - start;
+	let duration = highResTimestamp() - start;
+	console.log(`took ${(duration / 1e6 / numRounds).toFixed(2)} ms / call`);
+
+	console.log(`calling clear for each node (${MAX_NODES})`);
+
+	start = highResTimestamp();
+	for (let nodeID = 1; nodeID <= MAX_NODES; nodeID++) {
+		valueDBs.get(nodeID)!.clear({ noEvent: true });
+	}
+	duration = highResTimestamp() - start;
 	console.log(`took ${(duration / 1e6 / numRounds).toFixed(2)} ms / call`);
 
 	await values.close();

--- a/test/valuedb-perf.ts
+++ b/test/valuedb-perf.ts
@@ -15,6 +15,7 @@ const valueDBs = new Map<number, ValueDB>();
 	await values.open();
 	await metadata.open();
 	// add a shitton of values
+	console.time("create value DB");
 	const MAX_NODES = 100;
 	for (let nodeId = 1; nodeId <= MAX_NODES; nodeId++) {
 		const valueDB = new ValueDB(nodeId, values, metadata);
@@ -34,6 +35,19 @@ const valueDBs = new Map<number, ValueDB>();
 			}
 		}
 	}
+	await values.close();
+	console.timeEnd("create value DB");
+
+	console.time("open value DB");
+	await values.open();
+	console.timeEnd("open value DB");
+
+	console.time("index value DB");
+	for (let nodeId = 1; nodeId <= MAX_NODES; nodeId++) {
+		const valueDB = new ValueDB(nodeId, values, metadata);
+		valueDBs.set(nodeId, valueDB);
+	}
+	console.timeEnd("index value DB");
 
 	console.log(`db contains ${values.size} values`);
 	const numRounds = 100;
@@ -41,11 +55,13 @@ const valueDBs = new Map<number, ValueDB>();
 	console.log(`calling getValues ${numRounds} times`);
 
 	let start = highResTimestamp();
+	let numValues: number;
 	for (let i = 1; i <= numRounds; i++) {
-		valueDBs.get(1)!.getValues(5);
+		numValues = valueDBs.get(1)!.getValues(5).length;
 	}
 	let duration = highResTimestamp() - start;
 	console.log(`took ${(duration / 1e6 / numRounds).toFixed(2)} ms / call`);
+	console.log(`found ${numValues!} values`);
 
 	console.log(`calling clear for each node (${MAX_NODES})`);
 

--- a/test/valuedb-perf.ts
+++ b/test/valuedb-perf.ts
@@ -1,6 +1,6 @@
 import { JsonlDB } from "@alcalzone/jsonl-db";
 import { highResTimestamp } from "@zwave-js/core/src/util/date";
-import { ValueDB } from "@zwave-js/core/src/values/ValueDB";
+import { indexDBsByNode, ValueDB } from "@zwave-js/core/src/values/ValueDB";
 import * as fs from "fs-extra";
 
 const values: JsonlDB<any> = new JsonlDB("test.values.jsonl", {
@@ -43,8 +43,15 @@ const valueDBs = new Map<number, ValueDB>();
 	console.timeEnd("open value DB");
 
 	console.time("index value DB");
+	const indexes = indexDBsByNode([values, metadata]);
+
 	for (let nodeId = 1; nodeId <= MAX_NODES; nodeId++) {
-		const valueDB = new ValueDB(nodeId, values, metadata);
+		const valueDB = new ValueDB(
+			nodeId,
+			values,
+			metadata,
+			indexes.get(nodeId),
+		);
 		valueDBs.set(nodeId, valueDB);
 	}
 	console.timeEnd("index value DB");


### PR DESCRIPTION
This PR attempts to fix the performance issues found in #1493. The Value DB is deliberately huge (550000 values), so we can judge the impact better.

## Step 1:
`dbKeyToValueIdFast` is optimized, but still too slow to be in the hot path. We now filter values using string comparison instead of parsing JSON first and likely discarding the result afterwards.

**Before:**
```
db contains 550000 values
calling getValues 100 times
took 550.62 ms / call
```

**After:**
```
db contains 550000 values
calling getValues 100 times
took 44.97 ms / call
```

**total speedup:** 12x

## Step 2:
The `clear()` methods were parsing the DB keys although the result is only used conditionally. That no longer happens now.
**Before:**
```
calling clear for each node (100)
took 106.55 ms / call
```

**After:**
```
calling clear for each node (100)
took 97.88 ms / call
```

## Step 3:
`indexOf` turns out to be faster, but only if we include the leading `{` and `,`.
**After:**
```
calling getValues 100 times
took 39.94 ms / call
calling clear for each node (100)
took 95.81 ms / call
```

**total speedup:** 13.8x

## Step 4:
Keeping track of the own IDs completely avoids looping altogether. However this adds an upfront cost for the index creation:
**Before:**
```
index value DB: 0.162ms (NO-OP)

calling getValues 100 times
took 40.04 ms / call

calling clear for each node (100)
took 91.89 ms / call
```

**After:**
```
index value DB: 6770.065ms

calling getValues 100 times
took 1.23 ms / call

calling clear for each node (100)
took 12.35 ms / call
```

**total speedup:** 🔥 447x (ignoring the upfront cost)

## Step 5: TODO: Speed up index generation
**After:**
```
index value DB: 122.762ms

calling getValues 100 times
took 1.23 ms / call

calling clear for each node (100)
took 12.31 ms / call
```

**total speedup:** 🔥 447x (with negligible upfront cost 🎉)

---

/cc @marcelveldt
fixes: #1493