### PR TITLE
feat(config): use mtime to detect if index needs to be regenerated

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -92,9 +92,7 @@ jobs:
       run: yarn run build
 
     - name: Lint config files
-      run: |
-        npx lerna run generateDeviceIndex
-        npx lerna run lint:config --no-prefix
+      run: npx lerna run lint:config --no-prefix
 
     - name: Lint Z-Wave specifics
       run: npx lerna run lint:zwave --no-prefix
@@ -140,9 +138,7 @@ jobs:
       run: yarn run build
 
     - name: Run component tests
-      run: |
-        npx lerna run generateDeviceIndex
-        yarn run test:ci
+      run: yarn run test:ci
       env:
         CI: true
 
@@ -235,9 +231,7 @@ jobs:
       run: yarn run build
 
     - name: Generate coverage
-      run: |
-        npx lerna run generateDeviceIndex
-        yarn run coverage:ci
+      run: yarn run coverage:ci
       env:
         CI: true
     - name: Upload to Coveralls

--- a/packages/config/gulpfile.ts
+++ b/packages/config/gulpfile.ts
@@ -1,2 +1,1 @@
-export { generateDeviceIndex } from "./maintenance/generateDeviceIndex";
 export { lintConfigFiles } from "./maintenance/lintConfigFiles";

--- a/packages/config/maintenance/generateDeviceIndex.ts
+++ b/packages/config/maintenance/generateDeviceIndex.ts
@@ -1,5 +1,0 @@
-import { loadDeviceIndexInternal } from "../src/Devices";
-
-export async function generateDeviceIndex(): Promise<void> {
-	await loadDeviceIndexInternal();
-}

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -45,7 +45,6 @@
     "build": "tsc -b tsconfig.build.json",
     "clean": "yarn run build -- --clean",
     "watch": "yarn run build -- --watch --pretty",
-    "lint:config": "gulp lintConfigFiles",
-    "generateDeviceIndex": "gulp generateDeviceIndex"
+    "lint:config": "gulp lintConfigFiles"
   }
 }

--- a/packages/config/src/ConfigManager.ts
+++ b/packages/config/src/ConfigManager.ts
@@ -449,12 +449,8 @@ export class ConfigManager {
 		productId: number,
 		firmwareVersion?: string | false,
 	): Promise<DeviceConfig | undefined> {
-		if (!this.index) {
-			throw new ZWaveError(
-				"The config has not been loaded yet!",
-				ZWaveErrorCodes.Driver_NotReady,
-			);
-		}
+		// Load/regenerate the index if necessary
+		if (!this.index) await this.loadDeviceIndex();
 
 		// Look up the device in the index
 		let indexEntry: DeviceConfigIndexEntry | undefined;
@@ -465,11 +461,11 @@ export class ConfigManager {
 				productType,
 				productId,
 			);
-			indexEntry = this.index.find(
+			indexEntry = this.index!.find(
 				(e) => e.firmwareVersion === false && predicate(e),
 			);
 		} else {
-			indexEntry = this.index.find(
+			indexEntry = this.index!.find(
 				getDeviceEntryPredicate(
 					manufacturerId,
 					productType,

--- a/packages/config/src/ConfigManager.ts
+++ b/packages/config/src/ConfigManager.ts
@@ -413,7 +413,7 @@ export class ConfigManager {
 
 	public async loadDeviceIndex(): Promise<void> {
 		try {
-			this.index = await loadDeviceIndexInternal();
+			this.index = await loadDeviceIndexInternal(this.logger);
 		} catch (e: unknown) {
 			// If the index file is missing or invalid, don't try to find it again
 			if (

--- a/test.ts
+++ b/test.ts
@@ -1,6 +1,0 @@
-import { loadDeviceIndexInternal } from "./packages/config/src/Devices";
-void (async () => {
-	console.time("load");
-	await loadDeviceIndexInternal();
-	console.timeEnd("load");
-})();

--- a/test.ts
+++ b/test.ts
@@ -1,0 +1,6 @@
+import { loadDeviceIndexInternal } from "./packages/config/src/Devices";
+void (async () => {
+	console.time("load");
+	await loadDeviceIndexInternal();
+	console.timeEnd("load");
+})();


### PR DESCRIPTION
With this PR, we compare the `mtime` of the index.json with the maximum `mtime` of the device config directory (recursively) to detect if regenerating the index is necessary.

This means that adding and testing new configuration files is easier because the index is updated automatically.

closes #1492