### PR TITLE
fix: treat no error as successful command, update currentValue immediately

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/API.ts
+++ b/packages/zwave-js/src/lib/commandclass/API.ts
@@ -125,7 +125,7 @@ export class CCAPI {
 
 	protected scheduledPolls: ObjectKeyMap<ValueIDProperties, NodeJS.Timeout>;
 	/**
-	 * Schedules a value to be polled after a given time. Schedules are eduplicated on a per-property basis.
+	 * Schedules a value to be polled after a given time. Schedules are deduplicated on a per-property basis.
 	 * @returns `true` if the poll was scheduled, `false` otherwise
 	 */
 	protected schedulePoll(

--- a/packages/zwave-js/src/lib/commandclass/BasicCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BasicCC.ts
@@ -90,8 +90,16 @@ export class BasicCCAPI extends CCAPI {
 		}
 		await this.set(value);
 
+		// If the command did not fail, assume that it succeeded and update the currentValue accordingly
+		// so UIs have immediate feedback
 		if (this.isSinglecast()) {
-			// Refresh the current value after a delay
+			const valueDB = this.endpoint.getNodeUnsafe()?.valueDB;
+			valueDB?.setValue(
+				getCurrentValueValueId(this.endpoint.index),
+				value,
+			);
+
+			// and verify the current value after a delay
 			if (this.refreshTimeout) clearTimeout(this.refreshTimeout);
 			setTimeout(async () => {
 				this.refreshTimeout = undefined;
@@ -144,16 +152,6 @@ export class BasicCCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 			targetValue,
 		});
-		if (this.isSinglecast()) {
-			// remember the value in case the device does not respond with a target value
-			this.endpoint
-				.getNodeUnsafe()
-				?.valueDB.setValue(
-					getTargetValueValueId(this.endpoint.index),
-					targetValue,
-					{ noEvent: true },
-				);
-		}
 		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 }

--- a/packages/zwave-js/src/lib/commandclass/BasicCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BasicCC.ts
@@ -100,15 +100,7 @@ export class BasicCCAPI extends CCAPI {
 			);
 
 			// and verify the current value after a delay
-			if (this.refreshTimeout) clearTimeout(this.refreshTimeout);
-			setTimeout(async () => {
-				this.refreshTimeout = undefined;
-				try {
-					await this.get();
-				} catch {
-					/* ignore */
-				}
-			}, this.driver.options.timeouts.refreshValue).unref();
+			this.schedulePoll({ property });
 		}
 	};
 

--- a/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
@@ -135,16 +135,7 @@ export class BinarySwitchCCAPI extends CCAPI {
 			// Verify the current value after a delay
 			// TODO: #1321
 			const duration = undefined as Duration | undefined;
-
-			if (this.refreshTimeout) clearTimeout(this.refreshTimeout);
-			setTimeout(async () => {
-				this.refreshTimeout = undefined;
-				try {
-					await this.get();
-				} catch {
-					/* ignore */
-				}
-			}, duration?.toMilliseconds() ?? 1000).unref();
+			this.schedulePoll({ property }, duration?.toMilliseconds() ?? 1000);
 		}
 	};
 

--- a/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
@@ -119,19 +119,6 @@ export class BinarySwitchCCAPI extends CCAPI {
 				);
 		}
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		if (this.isSinglecast()) {
-			// Refresh the current value after a delay
-			if (this.refreshTimeout) clearTimeout(this.refreshTimeout);
-			setTimeout(async () => {
-				this.refreshTimeout = undefined;
-				try {
-					await this.get();
-				} catch {
-					/* ignore */
-				}
-			}, duration?.toMilliseconds() ?? 1000).unref();
-		}
 	}
 
 	protected [SET_VALUE]: SetValueImplementation = async (
@@ -145,6 +132,22 @@ export class BinarySwitchCCAPI extends CCAPI {
 			throwWrongValueType(this.ccId, property, "boolean", typeof value);
 		}
 		await this.set(value);
+
+		if (this.isSinglecast()) {
+			// Refresh the current value after a delay
+			// TODO: #1321
+			const duration = undefined as Duration | undefined;
+
+			if (this.refreshTimeout) clearTimeout(this.refreshTimeout);
+			setTimeout(async () => {
+				this.refreshTimeout = undefined;
+				try {
+					await this.get();
+				} catch {
+					/* ignore */
+				}
+			}, duration?.toMilliseconds() ?? 1000).unref();
+		}
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({

--- a/packages/zwave-js/src/lib/commandclass/CentralSceneCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/CentralSceneCC.ts
@@ -146,11 +146,6 @@ export class CentralSceneCCAPI extends CCAPI {
 			slowRefresh,
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		if (this.isSinglecast()) {
-			// Refresh the current value
-			await this.getConfiguration();
-		}
 	}
 
 	protected [SET_VALUE]: SetValueImplementation = async (
@@ -164,6 +159,12 @@ export class CentralSceneCCAPI extends CCAPI {
 			throwWrongValueType(this.ccId, property, "boolean", typeof value);
 		}
 		await this.setConfiguration(value);
+
+		if (this.isSinglecast()) {
+			// Refresh the current value
+			// TODO: #1521
+			await this.getConfiguration();
+		}
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({

--- a/packages/zwave-js/src/lib/commandclass/CentralSceneCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/CentralSceneCC.ts
@@ -159,12 +159,6 @@ export class CentralSceneCCAPI extends CCAPI {
 			throwWrongValueType(this.ccId, property, "boolean", typeof value);
 		}
 		await this.setConfiguration(value);
-
-		if (this.isSinglecast()) {
-			// Refresh the current value
-			// TODO: #1521
-			await this.getConfiguration();
-		}
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({

--- a/packages/zwave-js/src/lib/commandclass/ClimateControlScheduleCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ClimateControlScheduleCC.ts
@@ -85,11 +85,6 @@ export class ClimateControlScheduleCCAPI extends CCAPI {
 			switchPoints,
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		if (this.isSinglecast()) {
-			// Refresh the current value
-			await this.get(weekday);
-		}
 	}
 
 	public async get(
@@ -168,11 +163,6 @@ export class ClimateControlScheduleCCAPI extends CCAPI {
 			overrideState: state,
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		if (this.isSinglecast()) {
-			// Refresh the current value
-			await this.getOverride();
-		}
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/ClockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ClockCC.ts
@@ -89,11 +89,6 @@ export class ClockCCAPI extends CCAPI {
 			weekday: weekday ?? Weekday.Unknown,
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		if (this.isSinglecast()) {
-			// Refresh the current value
-			await this.get();
-		}
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
@@ -331,6 +331,7 @@ export class ColorSwitchCCAPI extends CCAPI {
 
 			if (this.isSinglecast()) {
 				// Refresh the current value
+				// TODO: #1521, #1321
 				await this.get(propertyKey);
 			}
 		} else if (property === "hexColor") {

--- a/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
@@ -224,7 +224,9 @@ export class ColorSwitchCCAPI extends CCAPI {
 
 		await this.driver.sendCommand(cc, this.commandOptions);
 
-		// Assume it worked and update currentColor
+		// If the command did not fail, assume that it succeeded and update the values accordingly
+		// TODO: The API methods should not modify the value DB directly, but to do so
+		// this requires a nicer way of synchronizing hexColor with the others
 		if (this.isSinglecast()) {
 			const valueDB = this.endpoint.getNodeUnsafe()?.valueDB;
 			if (valueDB) {

--- a/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
@@ -332,9 +332,13 @@ export class ColorSwitchCCAPI extends CCAPI {
 			await this.set({ [propertyKey]: value });
 
 			if (this.isSinglecast()) {
-				// Refresh the current value
-				// TODO: #1521, #1321
-				await this.get(propertyKey);
+				// Verify the current value after a delay
+				// TODO: #1321
+				const duration = undefined as Duration | undefined;
+				this.schedulePoll(
+					{ property, propertyKey },
+					duration?.toMilliseconds(),
+				);
 			}
 		} else if (property === "hexColor") {
 			// No property key, this is the hex color #rrggbb

--- a/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
@@ -222,6 +222,7 @@ export class ConfigurationCCAPI extends PhysicalCCAPI {
 		await this.set(property, targetValue, valueSize as any);
 
 		// Refresh the current value and ignore potential timeouts
+		// TODO: #1321, #1521
 		void this.get(property).catch(() => {
 			/* ignore */
 		});

--- a/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
@@ -221,11 +221,8 @@ export class ConfigurationCCAPI extends PhysicalCCAPI {
 
 		await this.set(property, targetValue, valueSize as any);
 
-		// Refresh the current value and ignore potential timeouts
-		// TODO: #1321, #1521
-		void this.get(property).catch(() => {
-			/* ignore */
-		});
+		// Verify the current value after a delay
+		this.schedulePoll({ property, propertyKey }, 1000);
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({

--- a/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
@@ -131,17 +131,8 @@ export class DoorLockCCAPI extends PhysicalCCAPI {
 			}
 			await this.set(value);
 
-			// Refresh the current value after a delay
-			// TODO: #1321, #1521
-			if (this.refreshTimeout) clearTimeout(this.refreshTimeout);
-			setTimeout(async () => {
-				this.refreshTimeout = undefined;
-				try {
-					await this.get();
-				} catch {
-					/* ignore */
-				}
-			}, this.driver.options.timeouts.refreshValue).unref();
+			// Verify the current value after a delay
+			this.schedulePoll({ property });
 		} else if (
 			typeof property === "string" &&
 			configurationSetParameters.includes(property as any)

--- a/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
@@ -130,6 +130,18 @@ export class DoorLockCCAPI extends PhysicalCCAPI {
 				);
 			}
 			await this.set(value);
+
+			// Refresh the current value after a delay
+			// TODO: #1321, #1521
+			if (this.refreshTimeout) clearTimeout(this.refreshTimeout);
+			setTimeout(async () => {
+				this.refreshTimeout = undefined;
+				try {
+					await this.get();
+				} catch {
+					/* ignore */
+				}
+			}, this.driver.options.timeouts.refreshValue).unref();
 		} else if (
 			typeof property === "string" &&
 			configurationSetParameters.includes(property as any)
@@ -164,6 +176,10 @@ export class DoorLockCCAPI extends PhysicalCCAPI {
 			}
 
 			await this.setConfiguration(config);
+
+			// Refresh the current value
+			// TODO: #1321, #1521
+			await this.getConfiguration();
 		} else {
 			throwUnsupportedProperty(this.ccId, property);
 		}
@@ -275,17 +291,6 @@ export class DoorLockCCAPI extends PhysicalCCAPI {
 			mode,
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		// Refresh the current value after a delay
-		if (this.refreshTimeout) clearTimeout(this.refreshTimeout);
-		setTimeout(async () => {
-			this.refreshTimeout = undefined;
-			try {
-				await this.get();
-			} catch {
-				/* ignore */
-			}
-		}, this.driver.options.timeouts.refreshValue).unref();
 	}
 
 	public async setConfiguration(
@@ -302,9 +307,6 @@ export class DoorLockCCAPI extends PhysicalCCAPI {
 			...configuration,
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		// Refresh the current value
-		await this.getConfiguration();
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types

--- a/packages/zwave-js/src/lib/commandclass/IndicatorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/IndicatorCC.ts
@@ -203,6 +203,9 @@ export class IndicatorCCAPI extends CCAPI {
 				);
 			}
 			await this.set(value);
+
+			// Refresh the current value
+			await this.get();
 		} else if (
 			typeof property === "number" &&
 			typeof propertyKey === "number"
@@ -231,6 +234,9 @@ export class IndicatorCCAPI extends CCAPI {
 					value: value as any,
 				},
 			]);
+
+			// Refresh the current value
+			await this.get(property);
 		} else {
 			throwUnsupportedProperty(this.ccId, property);
 		}
@@ -275,15 +281,6 @@ export class IndicatorCCAPI extends CCAPI {
 			...(typeof value === "number" ? { value } : { values: value }),
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		if (this.isSinglecast()) {
-			// Refresh the current value
-			if (typeof value === "number") {
-				await this.get();
-			} else {
-				await this.get(value[0]?.indicatorId);
-			}
-		}
 	}
 
 	public async getSupported(

--- a/packages/zwave-js/src/lib/commandclass/IndicatorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/IndicatorCC.ts
@@ -203,9 +203,6 @@ export class IndicatorCCAPI extends CCAPI {
 				);
 			}
 			await this.set(value);
-
-			// Refresh the current value
-			await this.get();
 		} else if (
 			typeof property === "number" &&
 			typeof propertyKey === "number"
@@ -234,9 +231,6 @@ export class IndicatorCCAPI extends CCAPI {
 					value: value as any,
 				},
 			]);
-
-			// Refresh the current value
-			await this.get(property);
 		} else {
 			throwUnsupportedProperty(this.ccId, property);
 		}

--- a/packages/zwave-js/src/lib/commandclass/LanguageCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/LanguageCC.ts
@@ -71,11 +71,6 @@ export class LanguageCCAPI extends CCAPI {
 			country,
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		if (this.isSinglecast()) {
-			// Refresh the current value
-			await this.get();
-		}
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/LockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/LockCC.ts
@@ -90,8 +90,8 @@ export class LockCCAPI extends PhysicalCCAPI {
 		}
 		await this.set(value);
 
-		// Refresh the current value
-		await this.get();
+		// Verify the current value after a delay
+		this.schedulePoll({ property });
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({

--- a/packages/zwave-js/src/lib/commandclass/LockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/LockCC.ts
@@ -76,9 +76,6 @@ export class LockCCAPI extends PhysicalCCAPI {
 			locked,
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		// Refresh the current value
-		await this.get();
 	}
 
 	protected [SET_VALUE]: SetValueImplementation = async (
@@ -92,6 +89,9 @@ export class LockCCAPI extends PhysicalCCAPI {
 			throwWrongValueType(this.ccId, property, "boolean", typeof value);
 		}
 		await this.set(value);
+
+		// Refresh the current value
+		await this.get();
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({

--- a/packages/zwave-js/src/lib/commandclass/ManufacturerProprietaryCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ManufacturerProprietaryCC.ts
@@ -122,8 +122,9 @@ export class ManufacturerProprietaryCCAPI extends CCAPI {
 			// unsupported property key, ignore...
 			return;
 		}
-		// Refresh the current value
-		await this.fibaroVenetianBlindsGet();
+
+		// Verify the current value after a delay
+		this.schedulePoll({ property });
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -325,18 +325,9 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 						.getNodeUnsafe()
 						?.supportsCC(CommandClasses.Supervision)
 				) {
-					if (this.refreshTimeout) clearTimeout(this.refreshTimeout);
 					// TODO: #1321
 					const duration = undefined as Duration | undefined;
-
-					setTimeout(async () => {
-						this.refreshTimeout = undefined;
-						try {
-							await this.get();
-						} catch {
-							/* ignore */
-						}
-					}, duration?.toMilliseconds() ?? this.driver.options.timeouts.refreshValue).unref();
+					this.schedulePoll({ property }, duration?.toMilliseconds());
 				}
 			}
 		} else if (switchTypeProperties.includes(property as string)) {

--- a/packages/zwave-js/src/lib/commandclass/NodeNamingCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/NodeNamingCC.ts
@@ -77,13 +77,10 @@ export class NodeNamingAndLocationCCAPI extends PhysicalCCAPI {
 		switch (property) {
 			case "name":
 				await this.setName(value);
-				// Refresh the current value
-				await this.getName();
 				break;
 			case "location":
 				await this.setLocation(value);
-				// Refresh the current value
-				await this.getLocation();
+				break;
 		}
 	};
 

--- a/packages/zwave-js/src/lib/commandclass/ProtectionCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ProtectionCC.ts
@@ -174,6 +174,11 @@ export class ProtectionCCAPI extends CCAPI {
 				getRFStateValueID(this.endpoint.index),
 			);
 			await this.set(value, rf);
+
+			if (this.isSinglecast()) {
+				// Refresh the current value
+				await this.get();
+			}
 		} else if (property === "rf") {
 			if (typeof value !== "number") {
 				throwWrongValueType(
@@ -188,6 +193,11 @@ export class ProtectionCCAPI extends CCAPI {
 				getLocalStateValueID(this.endpoint.index),
 			);
 			await this.set(local ?? LocalProtectionState.Unprotected, value);
+
+			if (this.isSinglecast()) {
+				// Refresh the current value
+				await this.get();
+			}
 		} else if (property === "exclusiveControlNodeId") {
 			if (typeof value !== "number") {
 				throwWrongValueType(
@@ -198,6 +208,11 @@ export class ProtectionCCAPI extends CCAPI {
 				);
 			}
 			await this.setExclusiveControl(value);
+
+			if (this.isSinglecast()) {
+				// Refresh the status
+				await this.getExclusiveControl();
+			}
 		} else {
 			throwUnsupportedProperty(this.ccId, property);
 		}
@@ -247,11 +262,6 @@ export class ProtectionCCAPI extends CCAPI {
 			rf,
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		if (this.isSinglecast()) {
-			// Refresh the current value
-			await this.get();
-		}
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -308,11 +318,6 @@ export class ProtectionCCAPI extends CCAPI {
 			exclusiveControlNodeId: nodeId,
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		if (this.isSinglecast()) {
-			// Refresh the status
-			await this.getExclusiveControl();
-		}
 	}
 
 	public async getTimeout(): Promise<Timeout | undefined> {
@@ -344,11 +349,6 @@ export class ProtectionCCAPI extends CCAPI {
 			timeout,
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		if (this.isSinglecast()) {
-			// Refresh the status
-			await this.getTimeout();
-		}
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/ProtectionCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ProtectionCC.ts
@@ -174,11 +174,6 @@ export class ProtectionCCAPI extends CCAPI {
 				getRFStateValueID(this.endpoint.index),
 			);
 			await this.set(value, rf);
-
-			if (this.isSinglecast()) {
-				// Refresh the current value
-				await this.get();
-			}
 		} else if (property === "rf") {
 			if (typeof value !== "number") {
 				throwWrongValueType(
@@ -193,11 +188,6 @@ export class ProtectionCCAPI extends CCAPI {
 				getLocalStateValueID(this.endpoint.index),
 			);
 			await this.set(local ?? LocalProtectionState.Unprotected, value);
-
-			if (this.isSinglecast()) {
-				// Refresh the current value
-				await this.get();
-			}
 		} else if (property === "exclusiveControlNodeId") {
 			if (typeof value !== "number") {
 				throwWrongValueType(
@@ -208,11 +198,6 @@ export class ProtectionCCAPI extends CCAPI {
 				);
 			}
 			await this.setExclusiveControl(value);
-
-			if (this.isSinglecast()) {
-				// Refresh the status
-				await this.getExclusiveControl();
-			}
 		} else {
 			throwUnsupportedProperty(this.ccId, property);
 		}

--- a/packages/zwave-js/src/lib/commandclass/SoundSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SoundSwitchCC.ts
@@ -141,11 +141,6 @@ export class SoundSwitchCCAPI extends CCAPI {
 			defaultVolume,
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		if (this.isSinglecast()) {
-			// Refresh the current value
-			await this.getConfiguration();
-		}
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -188,11 +183,6 @@ export class SoundSwitchCCAPI extends CCAPI {
 			volume,
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		if (this.isSinglecast()) {
-			// Refresh the current value
-			await this.getPlaying();
-		}
 	}
 
 	public async stopPlaying(): Promise<void> {
@@ -208,11 +198,6 @@ export class SoundSwitchCCAPI extends CCAPI {
 			volume: 0x00,
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		if (this.isSinglecast()) {
-			// Refresh the current value
-			await this.getPlaying();
-		}
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -249,6 +234,11 @@ export class SoundSwitchCCAPI extends CCAPI {
 				);
 			}
 			await this.setConfiguration(value, 0xff /* keep current volume */);
+
+			if (this.isSinglecast()) {
+				// Refresh the current value
+				await this.getConfiguration();
+			}
 		} else if (property === "defaultVolume") {
 			if (typeof value !== "number") {
 				throwWrongValueType(
@@ -259,6 +249,11 @@ export class SoundSwitchCCAPI extends CCAPI {
 				);
 			}
 			await this.setConfiguration(0x00 /* keep current tone */, value);
+
+			if (this.isSinglecast()) {
+				// Refresh the current value
+				await this.getConfiguration();
+			}
 		} else if (property === "toneId") {
 			if (typeof value !== "number") {
 				throwWrongValueType(
@@ -276,6 +271,11 @@ export class SoundSwitchCCAPI extends CCAPI {
 				await this.play(value, volume);
 			} else {
 				await this.stopPlaying();
+			}
+
+			if (this.isSinglecast()) {
+				// Refresh the current value
+				await this.getPlaying();
 			}
 		} else {
 			throwUnsupportedProperty(this.ccId, property);

--- a/packages/zwave-js/src/lib/commandclass/SoundSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SoundSwitchCC.ts
@@ -234,11 +234,6 @@ export class SoundSwitchCCAPI extends CCAPI {
 				);
 			}
 			await this.setConfiguration(value, 0xff /* keep current volume */);
-
-			if (this.isSinglecast()) {
-				// Refresh the current value
-				await this.getConfiguration();
-			}
 		} else if (property === "defaultVolume") {
 			if (typeof value !== "number") {
 				throwWrongValueType(
@@ -249,11 +244,6 @@ export class SoundSwitchCCAPI extends CCAPI {
 				);
 			}
 			await this.setConfiguration(0x00 /* keep current tone */, value);
-
-			if (this.isSinglecast()) {
-				// Refresh the current value
-				await this.getConfiguration();
-			}
 		} else if (property === "toneId") {
 			if (typeof value !== "number") {
 				throwWrongValueType(
@@ -272,10 +262,9 @@ export class SoundSwitchCCAPI extends CCAPI {
 			} else {
 				await this.stopPlaying();
 			}
-
 			if (this.isSinglecast()) {
-				// Refresh the current value
-				await this.getPlaying();
+				// Verify the current value after a delay
+				this.schedulePoll({ property });
 			}
 		} else {
 			throwUnsupportedProperty(this.ccId, property);

--- a/packages/zwave-js/src/lib/commandclass/ThermostatModeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatModeCC.ts
@@ -96,8 +96,8 @@ export class ThermostatModeCCAPI extends CCAPI {
 		await this.set(value);
 
 		if (this.isSinglecast()) {
-			// Refresh the current value
-			await this.get();
+			// Verify the current value after a delay
+			this.schedulePoll({ property });
 		}
 	};
 

--- a/packages/zwave-js/src/lib/commandclass/ThermostatModeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatModeCC.ts
@@ -94,6 +94,11 @@ export class ThermostatModeCCAPI extends CCAPI {
 			throwWrongValueType(this.ccId, property, "number", typeof value);
 		}
 		await this.set(value);
+
+		if (this.isSinglecast()) {
+			// Refresh the current value
+			await this.get();
+		}
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({
@@ -155,11 +160,6 @@ export class ThermostatModeCCAPI extends CCAPI {
 			manufacturerData: manufacturerData as any,
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		if (this.isSinglecast()) {
-			// Refresh the current value
-			await this.get();
-		}
 	}
 
 	public async getSupportedModes(): Promise<

--- a/packages/zwave-js/src/lib/commandclass/ThermostatSetbackCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatSetbackCC.ts
@@ -113,11 +113,6 @@ export class ThermostatSetbackCCAPI extends CCAPI {
 			setbackState,
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		if (this.isSinglecast()) {
-			// Refresh the current value
-			await this.get();
-		}
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
@@ -178,6 +178,11 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 				getSetpointScaleValueID(this.endpoint.index, propertyKey),
 			);
 		await this.set(propertyKey, value, preferredScale ?? 0);
+
+		if (this.isSinglecast()) {
+			// Refresh the current value
+			await this.get(propertyKey);
+		}
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({
@@ -246,11 +251,6 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 			scale,
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		if (this.isSinglecast()) {
-			// Refresh the current value
-			await this.get(setpointType);
-		}
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types

--- a/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
@@ -180,8 +180,8 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 		await this.set(propertyKey, value, preferredScale ?? 0);
 
 		if (this.isSinglecast()) {
-			// Refresh the current value
-			await this.get(propertyKey);
+			// Verify the current value after a delay
+			this.schedulePoll({ property, propertyKey });
 		}
 	};
 

--- a/packages/zwave-js/src/lib/commandclass/TimeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/TimeCC.ts
@@ -102,11 +102,6 @@ export class TimeCCAPI extends CCAPI {
 			dstEnd: timezone.endDate,
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		if (this.isSinglecast()) {
-			// Refresh the current value
-			await this.getTimezone();
-		}
 	}
 
 	public async getTimezone(): Promise<DSTInfo | undefined> {

--- a/packages/zwave-js/src/lib/commandclass/TimeParametersCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/TimeParametersCC.ts
@@ -124,11 +124,6 @@ export class TimeParametersCCAPI extends CCAPI {
 			throwWrongValueType(this.ccId, property, "date", typeof value);
 		}
 		await this.set(value);
-
-		if (this.isSinglecast()) {
-			// Refresh the current value
-			await this.get();
-		}
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({

--- a/packages/zwave-js/src/lib/commandclass/TimeParametersCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/TimeParametersCC.ts
@@ -124,6 +124,11 @@ export class TimeParametersCCAPI extends CCAPI {
 			throwWrongValueType(this.ccId, property, "date", typeof value);
 		}
 		await this.set(value);
+
+		if (this.isSinglecast()) {
+			// Refresh the current value
+			await this.get();
+		}
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({
@@ -166,11 +171,6 @@ export class TimeParametersCCAPI extends CCAPI {
 			dateAndTime,
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		if (this.isSinglecast()) {
-			// Refresh the current value
-			await this.get();
-		}
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/UserCodeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/UserCodeCC.ts
@@ -349,9 +349,6 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 				);
 			}
 			await this.setKeypadMode(value);
-
-			// Refresh the current value
-			await this.getKeypadMode();
 		} else if (property === "masterCode") {
 			if (typeof value !== "string") {
 				throwWrongValueType(
@@ -362,9 +359,6 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 				);
 			}
 			await this.setMasterCode(value);
-
-			// Refresh the current value
-			await this.getMasterCode();
 		} else if (property === "userIdStatus") {
 			if (propertyKey == undefined) {
 				throwMissingPropertyKey(this.ccId, property);
@@ -391,9 +385,6 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 				);
 				await this.set(propertyKey, value, userCode!);
 			}
-
-			// Refresh the current value
-			await this.get(propertyKey);
 		} else if (property === "userCode") {
 			if (propertyKey == undefined) {
 				throwMissingPropertyKey(this.ccId, property);
@@ -421,12 +412,12 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 				userIdStatus = UserIDStatus.Enabled;
 			}
 			await this.set(propertyKey, userIdStatus as any, value);
-
-			// Refresh the current value
-			await this.get(propertyKey);
 		} else {
 			throwUnsupportedProperty(this.ccId, property);
 		}
+
+		// Verify the current value after a delay
+		this.schedulePoll({ property, propertyKey });
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({

--- a/packages/zwave-js/src/lib/commandclass/UserCodeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/UserCodeCC.ts
@@ -349,6 +349,9 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 				);
 			}
 			await this.setKeypadMode(value);
+
+			// Refresh the current value
+			await this.getKeypadMode();
 		} else if (property === "masterCode") {
 			if (typeof value !== "string") {
 				throwWrongValueType(
@@ -359,6 +362,9 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 				);
 			}
 			await this.setMasterCode(value);
+
+			// Refresh the current value
+			await this.getMasterCode();
 		} else if (property === "userIdStatus") {
 			if (propertyKey == undefined) {
 				throwMissingPropertyKey(this.ccId, property);
@@ -385,6 +391,9 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 				);
 				await this.set(propertyKey, value, userCode!);
 			}
+
+			// Refresh the current value
+			await this.get(propertyKey);
 		} else if (property === "userCode") {
 			if (propertyKey == undefined) {
 				throwMissingPropertyKey(this.ccId, property);
@@ -412,6 +421,9 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 				userIdStatus = UserIDStatus.Enabled;
 			}
 			await this.set(propertyKey, userIdStatus as any, value);
+
+			// Refresh the current value
+			await this.get(propertyKey);
 		} else {
 			throwUnsupportedProperty(this.ccId, property);
 		}
@@ -539,9 +551,6 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 		});
 
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		// Refresh the current value
-		await this.get(userId);
 	}
 
 	/** Configures multiple user codes */
@@ -579,9 +588,6 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 			});
 			await this.driver.sendCommand(cc, this.commandOptions);
 		}
-
-		// Refresh the current value
-		await this.get(userId);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -643,9 +649,6 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 		});
 
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		// Refresh the current value
-		await this.getKeypadMode();
 	}
 
 	public async getMasterCode(): Promise<string | undefined> {
@@ -678,9 +681,6 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 		});
 
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		// Refresh the current value
-		await this.getMasterCode();
 	}
 
 	public async getUserCodeChecksum(): Promise<number | undefined> {

--- a/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
@@ -79,8 +79,8 @@ export class WakeUpCCAPI extends CCAPI {
 		await this.setInterval(value, this.driver.controller.ownNodeId ?? 1);
 
 		if (this.isSinglecast()) {
-			// Refresh the current value
-			await this.getInterval();
+			// Verify the current value after a delay
+			this.schedulePoll({ property });
 		}
 	};
 

--- a/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
@@ -77,6 +77,11 @@ export class WakeUpCCAPI extends CCAPI {
 			throwWrongValueType(this.ccId, property, "number", typeof value);
 		}
 		await this.setInterval(value, this.driver.controller.ownNodeId ?? 1);
+
+		if (this.isSinglecast()) {
+			// Refresh the current value
+			await this.getInterval();
+		}
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({
@@ -145,11 +150,6 @@ export class WakeUpCCAPI extends CCAPI {
 			controllerNodeId,
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
-
-		if (this.isSinglecast()) {
-			// Refresh the current value
-			await this.getInterval();
-		}
 	}
 
 	public async sendNoMoreInformation(): Promise<void> {

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -671,6 +671,9 @@ export class ZWaveNode extends Endpoint {
 				},
 				value,
 			);
+			// If the call did not throw, assume that the call was successful and remember the new value
+			this._valueDB.setValue(valueId, value, { noEvent: true });
+
 			return true;
 		} catch (e: unknown) {
 			// Define which errors during setValue are expected and won't crash


### PR DESCRIPTION
With this PR, we no longer refresh or update values in the lower level `commandClasses` APIs. Instead this now happens in the `SET_VALUE` API if the low-level command succeeded. A few non-critical CCs (like name/location) no longer automatically poll and instead just assume it worked.

Also, we now update `currentValue` immediately where applicable and we update the newly set value in the value DB if the command was successful, so UIs should no longer flicker between different states.

Fixes: #1519
Fixes: #1521