### PR TITLE
fix(test): regenerate device index once before all tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,6 +17,7 @@ module.exports = {
 		"^@zwave-js/shared(.*)": "<rootDir>/packages/shared/src$1",
 		"^@zwave-js/testing(.*)": "<rootDir>/packages/testing/src$1",
 	},
+	globalSetup: "./test/jest.globalSetup.ts",
 	setupFilesAfterEnv: ["jest-extended"],
 	setupFiles: ["reflect-metadata", "./test/jest.setup.js"],
 	extraGlobals: ["Reflect"],

--- a/packages/config/src/Devices.regression.test.ts
+++ b/packages/config/src/Devices.regression.test.ts
@@ -2,14 +2,8 @@ import { ConfigManager } from "./ConfigManager";
 
 describe("lib/config/Devices", () => {
 	describe("lookupDevice (regression tests)", () => {
-		let configManager: ConfigManager;
-
-		beforeAll(async () => {
-			configManager = new ConfigManager();
-			await configManager.loadDeviceIndex();
-		}, 60000);
-
 		it("Z-TRM3 with commandClasses.add compat should work", async () => {
+			const configManager = new ConfigManager();
 			const config = await configManager.lookupDevice(
 				0x019b,
 				0x0003,

--- a/test/jest.globalSetup.ts
+++ b/test/jest.globalSetup.ts
@@ -1,0 +1,8 @@
+import { ConfigManager } from "../packages/config/src/ConfigManager";
+
+export default function setup(): Promise<void> {
+	// Regenerate the device index before all tests to avoid race conditions and
+	// failing tests due to an outdated index
+	const configManager = new ConfigManager();
+	return configManager.loadDeviceIndex();
+}


### PR DESCRIPTION
We've been having flaky tests recently which seems to be due to the device index being regenerated in many tests at once.
This PR addresses the problem by regenerating the device index once before all tests run.