### PR TITLE
chore(config): check if param description contains unnecessary stuff

### DIFF
--- a/packages/config/maintenance/lintConfigFiles.ts
+++ b/packages/config/maintenance/lintConfigFiles.ts
@@ -71,40 +71,6 @@ async function lintDevices(): Promise<void> {
 
 		// Validate that the file is semantically correct
 
-		// These checks seem to be wrong
-		// 		// Validate associations
-		// 		if (config.associations?.size) {
-		// 			// Real lifeline associations (as per the Z-Wave+ specs) only have a single node
-		// 			// If there is a 2nd lifeline with more nodes, that is most likely wrong
-		// 			const lifelines = [...config.associations.values()].filter(
-		// 				(assoc) => assoc.isLifeline,
-		// 			);
-		// 			if (
-		// 				lifelines.length > 1 &&
-		// 				lifelines.find((l) => l.maxNodes === 1) &&
-		// 				lifelines.find((l) => l.maxNodes > 1)
-		// 			) {
-		// 				addWarning(
-		// 					file,
-		// 					`A lifeline with 1 node plus another one with more nodes found!
-		// This is likely an error!`,
-		// 				);
-		// 			}
-		// 			if (
-		// 				lifelines.some(
-		// 					(l) =>
-		// 						l.label === "Lifeline" &&
-		// 						l.groupId === 1 &&
-		// 						l.maxNodes > 1,
-		// 				)
-		// 			) {
-		// 				addWarning(
-		// 					file,
-		// 					`Found an association that looks like a Z-Wave+ lifeline but has more than 1 max nodes!`,
-		// 				);
-		// 			}
-		// 		}
-
 		if (config.paramInformation?.size) {
 			for (const [
 				{ parameter },
@@ -433,6 +399,31 @@ Did you mean to use ${opt.value >>> shiftAmount}?`,
 						} is incompatible with the bit mask ${num2hex(
 							key.valueBitMask,
 						)}!`,
+					);
+				}
+			}
+
+			// Check if there are descriptions with common errors
+			for (const [
+				{ parameter },
+				value,
+			] of config.paramInformation.entries()) {
+				if (!value.description) continue;
+
+				if (/default:?\s+\d+/i.test(value.description)) {
+					addWarning(
+						file,
+						`Parameter #${parameter}: The description mentions a default value which should be handled by the "defaultValue" property instead!`,
+					);
+				}
+				if (
+					/seconds|minutes|hours|percent(age)?|kwh|watts/i.test(
+						value.description,
+					)
+				) {
+					addWarning(
+						file,
+						`Parameter #${parameter}: The description mentions a unit which should be moved by the "unit" property instead!`,
 					);
 				}
 			}


### PR DESCRIPTION
@robertsLando Like we talked about. This found a ton of warnings - I could use some help here:
```Found 0 errors and 470 warnings!```

@blhoward2 do you have a script to clean the descriptions?