### PR TITLE
fix: refactor test for securely included nodes

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
@@ -317,13 +317,22 @@ export class SecurityCC extends CommandClass {
 
 			const resp = await api.getSupportedCommands();
 			if (!resp) {
-				this.driver.controllerLog.logNode(node.id, {
-					endpoint: this.endpointIndex,
-					message:
-						"Querying securely supported commands timed out, skipping interview...",
-					level: "warn",
-				});
-				// TODO: Abort interview?
+				if (node.isSecure === true) {
+					this.driver.controllerLog.logNode(node.id, {
+						endpoint: this.endpointIndex,
+						message:
+							"Querying securely supported commands timed out, skipping Security interview...",
+						level: "warn",
+					});
+					// TODO: Abort interview?
+				} else {
+					// We didn't know if the node was secure, assume that it is not actually included securely
+					this.driver.controllerLog.logNode(
+						node.id,
+						`The node is not included securely. Continuing interview non-securely.`,
+					);
+					node.isSecure = false;
+				}
 				return;
 			}
 
@@ -355,6 +364,15 @@ export class SecurityCC extends CommandClass {
 					isControlled: true,
 					secure: true,
 				});
+			}
+
+			// We know for sure that the node is included securely
+			if (node.isSecure !== true) {
+				node.isSecure = true;
+				this.driver.controllerLog.logNode(
+					node.id,
+					`The node is included securely.`,
+				);
 			}
 
 			// Remember that the interview is complete

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1361,30 +1361,7 @@ version:               ${this.version}`;
 					this._hasEmittedNoNetworkKeyError = true;
 				}
 			} else {
-				const action = await interviewEndpoint(
-					this,
-					CommandClasses.Security,
-				);
-				if (this._isSecure === true && action === false) {
-					// The node is definitely included securely, but we got no response to the interview question
-					return false;
-				} else if (action === false || action === "continue") {
-					// Assume that the node is not actually included securely
-					this.driver.controllerLog.logNode(
-						this.nodeId,
-						`The node is not included securely. Continuing interview non-securely.`,
-					);
-					this._isSecure = false;
-				} else {
-					// We got a response, so we know the node is included securely
-					if (this._isSecure !== true) {
-						this.driver.controllerLog.logNode(
-							this.nodeId,
-							`The node is included securely.`,
-						);
-					}
-					this._isSecure = true;
-				}
+				await interviewEndpoint(this, CommandClasses.Security);
 			}
 		} else if (
 			!this.supportsCC(CommandClasses.Security) &&


### PR DESCRIPTION
After #1522 our logic to test if a node was included securely was broken, since the interview method no longer aborts with a timeout. This PR corrects the logic to detect secure nodes.