### PR TITLE
fix: assume non-listening nodes to be asleep on startup, don't ping

### DIFF
--- a/packages/zwave-js/src/lib/node/Node.test.ts
+++ b/packages/zwave-js/src/lib/node/Node.test.ts
@@ -257,33 +257,25 @@ describe("lib/node/Node", () => {
 				expect(node.interviewStage).toBe(InterviewStage.ProtocolInfo);
 			});
 
-			it("if the node is a sleeping device, assume that it is awake", async () => {
-				for (const {
-					isListening,
-					isFrequentListening,
-					supportsWakeup,
-				} of [
+			it("if the node is a sleeping device, assume that it is asleep", async () => {
+				for (const { isListening, isFrequentListening } of [
 					// Test 1-3: not sleeping
 					{
 						isListening: true,
 						isFrequentListening: true,
-						supportsWakeup: false,
 					},
 					{
 						isListening: false,
 						isFrequentListening: true,
-						supportsWakeup: false,
 					},
 					{
 						isListening: true,
 						isFrequentListening: false,
-						supportsWakeup: false,
 					},
 					// Test 4: sleeping
 					{
 						isListening: false,
 						isFrequentListening: false,
-						supportsWakeup: true,
 					},
 				]) {
 					Object.assign(expected, {
@@ -292,10 +284,9 @@ describe("lib/node/Node", () => {
 					});
 					await node["queryProtocolInfo"]();
 
-					// expect(node.isAwake()).toBeTrue();
-					expect(node.supportsCC(CommandClasses["Wake Up"])).toBe(
-						supportsWakeup,
-					);
+					if (node.canSleep) {
+						expect(node.status).toBe(NodeStatus.Asleep);
+					}
 				}
 			});
 		});

--- a/packages/zwave-js/src/lib/node/NodeStatusMachine.test.ts
+++ b/packages/zwave-js/src/lib/node/NodeStatusMachine.test.ts
@@ -19,11 +19,22 @@ describe("lib/driver/NodeStatusMachine", () => {
 	});
 
 	describe("default status changes", () => {
-		it(`The node should start in the unknown state`, () => {
-			const testMachine = createNodeStatusMachine(undefined as any);
+		it(`The node should start in the unknown state if it maybe cannot sleep`, () => {
+			const testMachine = createNodeStatusMachine({
+				canSleep: false,
+			} as any);
 
 			service = interpret(testMachine).start();
 			expect(service.state.value).toBe("unknown");
+		});
+
+		it(`The node should start in the asleep state if it can definitely sleep`, () => {
+			const testMachine = createNodeStatusMachine({
+				canSleep: true,
+			} as any);
+
+			service = interpret(testMachine).start();
+			expect(service.state.value).toBe("asleep");
 		});
 
 		const transitions: {
@@ -186,22 +197,6 @@ describe("lib/driver/NodeStatusMachine", () => {
 
 			service = interpret(testMachine).start();
 			service.send("ASLEEP");
-			expect(service.state.value).toBe("unknown");
-		});
-
-		it("A transition from unknown to alive should not happen if the node can sleep", () => {
-			const testMachine = createNodeStatusMachine(testNodeSleeping);
-
-			service = interpret(testMachine).start();
-			service.send("ALIVE");
-			expect(service.state.value).toBe("unknown");
-		});
-
-		it("A transition from unknown to dead should not happen if the node can sleep", () => {
-			const testMachine = createNodeStatusMachine(testNodeSleeping);
-
-			service = interpret(testMachine).start();
-			service.send("DEAD");
 			expect(service.state.value).toBe("unknown");
 		});
 	});


### PR DESCRIPTION
With this PR we no longer waste time on startup with pinging non-listening ("sleeping") nodes. It is very unlikely that they are actually awake at that point. For the same reason, we immediately assume them to be in the `Asleep` status, so no messages are transmitted until they notify us about waking up.