### PR TITLE
fix(config): define additional Association groups for ZW100

### DIFF
--- a/packages/config/config/devices/0x0086/zw100_0.0-1.6.json
+++ b/packages/config/config/devices/0x0086/zw100_0.0-1.6.json
@@ -25,7 +25,7 @@
 	},
 	"associations": {
 		"1": {
-			"label": "Group 1",
+			"label": "Lifeline",
 			"maxNodes": 5,
 			"isLifeline": true
 		},

--- a/packages/config/config/devices/0x0086/zw100_1.10.json
+++ b/packages/config/config/devices/0x0086/zw100_1.10.json
@@ -23,7 +23,21 @@
 		"min": "1.10",
 		"max": "255.255"
 	},
-	"supportsZWavePlus": true,
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "Group 2",
+			"maxNodes": 5
+		},
+		"3": {
+			"label": "Group 3",
+			"maxNodes": 5
+		}
+	},
 	"paramInformation": {
 		"2": {
 			"label": "Stay Awake in Battery Mode",

--- a/packages/config/config/devices/0x0086/zw100_1.7-1.7.json
+++ b/packages/config/config/devices/0x0086/zw100_1.7-1.7.json
@@ -29,7 +29,7 @@
 	},
 	"associations": {
 		"1": {
-			"label": "Group 1",
+			"label": "Lifeline",
 			"maxNodes": 5,
 			"isLifeline": true
 		},

--- a/packages/config/config/devices/0x0086/zw100_1.8-1.9.json
+++ b/packages/config/config/devices/0x0086/zw100_1.8-1.9.json
@@ -23,7 +23,21 @@
 		"min": "1.8",
 		"max": "1.9"
 	},
-	"supportsZWavePlus": true,
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "Group 2",
+			"maxNodes": 5
+		},
+		"3": {
+			"label": "Group 3",
+			"maxNodes": 5
+		}
+	},
 	"paramInformation": {
 		"2": {
 			"label": "Stay Awake in Battery Mode",


### PR DESCRIPTION
Depends on the outcome of #1571 whether this should be merged or not.

The manual and the device only report a single group, but the configuration allows setting the reports for groups 2 and 3 🤷🏻‍♂️