### PR TITLE
fix: skip root-to-endpoint mapping if preserveRootApplicationCCValueIDs is set

### DIFF
--- a/packages/config/config/devices/0x0086/dsb28.json
+++ b/packages/config/config/devices/0x0086/dsb28.json
@@ -240,5 +240,9 @@
 				}
 			]
 		}
+	},
+	"compat": {
+		// This device reports cumulative values to the root endpoint
+		"preserveRootApplicationCCValueIDs": true
 	}
 }

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1753,6 +1753,8 @@ version:               ${this.version}`;
 			command.endpointIndex === 0 &&
 			command.constructor.name.endsWith("Report") &&
 			this.getEndpointCount() >= 1 &&
+			// skip the root to endpoint mapping if the root endpoint values are not meant to mirror endpoint 1
+			!this._deviceConfig?.compat?.preserveRootApplicationCCValueIDs &&
 			// Don't check for MCA support or devices without it won't be handled
 			// Instead rely on the version. If MCA is not supported, this will be 0
 			this.getCCVersion(CommandClasses["Multi Channel Association"]) < 3


### PR DESCRIPTION
and enable the flag for Aeon Labs Home Energy Meter G2

fixes: #1573 