### PR TITLE
fix(config): change LZW31 indicator color value size to 2

### DIFF
--- a/packages/config/config/devices/0x031e/lzw31-bsd.json
+++ b/packages/config/config/devices/0x031e/lzw31-bsd.json
@@ -148,7 +148,7 @@
 		},
 		"13": {
 			"label": "LED Indicator Color",
-			"valueSize": 1,
+			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 170,

--- a/packages/config/config/devices/0x031e/lzw31-sn.json
+++ b/packages/config/config/devices/0x031e/lzw31-sn.json
@@ -148,7 +148,7 @@
 		},
 		"13": {
 			"label": "LED Indicator Color",
-			"valueSize": 1,
+			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 170,


### PR DESCRIPTION
Fix for Inovelli Red (lzw31-sn)  and Black (lzw31-bsd) series dimmers LED Color Indicator.  Despite documentation from Inovelli, it appears the parameter 13 valueSize should be 2 bytes.  With the current size of 1, value updates do not work.  With a value size of 2 value updates will work.  This also appears to match the openzwave configuration which I used previously before migrating to this library.

Fixes #1581