### PR TITLE
feat(config): add support for Zooz ZEN71

### DIFF
--- a/packages/config/config/devices/0x027a/zen71.json
+++ b/packages/config/config/devices/0x027a/zen71.json
@@ -39,7 +39,7 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Upper paddle turns the light on, lower paddle turns it off (default)",
+					"label": "Upper paddle turns the light on, lower paddle turns it off",
 					"value": 0
 				},
 				{
@@ -64,7 +64,7 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "LED indicator is on when switch is off, otherwise off (default)",
+					"label": "LED indicator is on when switch is off, otherwise off",
 					"value": 0
 				},
 				{
@@ -91,7 +91,7 @@
 			"defaultValue": 0,
 			"readOnly": false,
 			"writeOnly": false,
-			"allowManualEntry": false
+			"allowManualEntry": true
 		},
 		"5": {
 			"label": "Auto Turn-On Timer (Minutes)",
@@ -102,7 +102,7 @@
 			"defaultValue": 0,
 			"readOnly": false,
 			"writeOnly": false,
-			"allowManualEntry": false
+			"allowManualEntry": true
 		},
 		"8": {
 			"label": "On Off Status After Power Failure",
@@ -124,7 +124,7 @@
 					"value": 1
 				},
 				{
-					"label": "Remembers and restores on/off status after power failure (default)",
+					"label": "Remembers and restores on/off status after power failure",
 					"value": 2
 				}
 			]
@@ -141,7 +141,7 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Scene control disabled (default)",
+					"label": "Scene control disabled",
 					"value": 0
 				},
 				{
@@ -166,7 +166,7 @@
 					"value": 0
 				},
 				{
-					"label": "Physical paddle control enabled (default)",
+					"label": "Physical paddle control enabled",
 					"value": 1
 				},
 				{
@@ -187,7 +187,7 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Regular mechanical 3-way on/off switch (default)",
+					"label": "Regular mechanical 3-way on/off switch",
 					"value": 0
 				},
 				{
@@ -208,7 +208,7 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Switch always reports status and changes LED state (default)",
+					"label": "Switch always reports status and changes LED state",
 					"value": 0
 				},
 				{
@@ -233,7 +233,7 @@
 					"value": 0
 				},
 				{
-					"label": "Blue (default)",
+					"label": "Blue",
 					"value": 1
 				},
 				{
@@ -262,7 +262,7 @@
 					"value": 0
 				},
 				{
-					"label": "Medium (60%) (default)",
+					"label": "Medium (60%)",
 					"value": 1
 				},
 				{
@@ -287,7 +287,7 @@
 					"value": 0
 				},
 				{
-					"label": "Z-Wave control and paddle control = binary (default)",
+					"label": "Z-Wave control and paddle control = binary",
 					"value": 1
 				}
 			]

--- a/packages/config/config/devices/0x027a/zen71.json
+++ b/packages/config/config/devices/0x027a/zen71.json
@@ -1,0 +1,296 @@
+// Zooz ZEN71
+// Z-Wave Plus 700 Series S2 ON/OFF Switch
+{
+	"manufacturer": "Zooz",
+	"manufacturerId": "0x027a",
+	"label": "ZEN71",
+	"description": "Z-Wave Plus 700 Series S2 ON/OFF Switch",
+	"devices": [
+		{
+			"productType": "0x7000",
+			"productId": "0xa001"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "On/Off",
+			"maxNodes": 5
+		}
+	},
+	"paramInformation": {
+		"1": {
+			"label": "On/Off Paddle Orientation",
+			"description": "Reverse default on/off operation or set to toggle mode",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 2,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Upper paddle turns the light on, lower paddle turns it off (default)",
+					"value": 0
+				},
+				{
+					"label": "Upper paddle turns the light off, lower paddle turns it on",
+					"value": 1
+				},
+				{
+					"label": "Any paddle turns light on/off",
+					"value": 2
+				}
+			]
+		},
+		"2": {
+			"label": "LED Indicator On/Off",
+			"description": "Adjust LED function",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 3,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "LED indicator is on when switch is off, otherwise off (default)",
+					"value": 0
+				},
+				{
+					"label": "LED indicator is on when switch is on, otherwise off",
+					"value": 1
+				},
+				{
+					"label": "LED indicator is always off",
+					"value": 2
+				},
+				{
+					"label": "LED indicator is always on",
+					"value": 3
+				}
+			]
+		},
+		"3": {
+			"label": "Auto Turn-Off Timer (Minutes)",
+			"description": "How long the switch remains on",
+			"unit": "minutes",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 65535,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false
+		},
+		"5": {
+			"label": "Auto Turn-On Timer (Minutes)",
+			"description": "How long the switch remains off",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 65535,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false
+		},
+		"8": {
+			"label": "On Off Status After Power Failure",
+			"description": "How switch reacts to power failures",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 2,
+			"defaultValue": 2,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Forced to off (regardless of state prior to power outage)",
+					"value": 0
+				},
+				{
+					"label": "Forced to on (regardless of state prior to power outage)",
+					"value": 1
+				},
+				{
+					"label": "Remembers and restores on/off status after power failure (default)",
+					"value": 2
+				}
+			]
+		},
+		"9": {
+			"label": "Enable/Disable Scene Control",
+			"description": "Whether scene control functionality is enabled",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Scene control disabled (default)",
+					"value": 0
+				},
+				{
+					"label": "Scene control enabled",
+					"value": 1
+				}
+			]
+		},
+		"11": {
+			"label": "Smart Bulb Mode: Enable/Disable Paddle",
+			"description": "Allow or disallow local control (paddle)",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 2,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Physical paddle control disabled",
+					"value": 0
+				},
+				{
+					"label": "Physical paddle control enabled (default)",
+					"value": 1
+				},
+				{
+					"label": "Physical paddle and Z-Wave control disabled",
+					"value": 2
+				}
+			]
+		},
+		"12": {
+			"label": "3-Way Switch Type",
+			"description": "Two options for type of 3-way switch",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Regular mechanical 3-way on/off switch (default)",
+					"value": 0
+				},
+				{
+					"label": "Momentary switch, click once to change status (light on or off)",
+					"value": 1
+				}
+			]
+		},
+		"13": {
+			"label": "Reporting Behavior for Smart Bulb Mode",
+			"description": "Set reporting behavior for disabled physical control",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Switch always reports status and changes LED state (default)",
+					"value": 0
+				},
+				{
+					"label": "No status or LED state change when physical control disabled",
+					"value": 1
+				}
+			]
+		},
+		"14": {
+			"label": "LED Indicator Color",
+			"description": "Color of the LED",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 3,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "White",
+					"value": 0
+				},
+				{
+					"label": "Blue (default)",
+					"value": 1
+				},
+				{
+					"label": "Green",
+					"value": 2
+				},
+				{
+					"label": "Red",
+					"value": 3
+				}
+			]
+		},
+		"15": {
+			"label": "LED Indicator Brightness Level",
+			"description": "How bright the LED is",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 2,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Bright (100%)",
+					"value": 0
+				},
+				{
+					"label": "Medium (60%) (default)",
+					"value": 1
+				},
+				{
+					"label": "Low (30%)",
+					"value": 2
+				}
+			]
+		},
+		"16": {
+			"label": "Association Reports",
+			"description": "How the switch reports paddle control",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Z-Wave control = binary; paddle control = basic set",
+					"value": 0
+				},
+				{
+					"label": "Z-Wave control and paddle control = binary (default)",
+					"value": 1
+				}
+			]
+		}
+	}
+}


### PR DESCRIPTION
Adds support for the [Zooz ZEN71](https://www.thesmartesthouse.com/products/zooz-700-series-z-wave-plus-on-off-light-switch-zen71).

Config was imported from [OpenHAB entry](https://opensmarthouse.org/zwavedatabase/1340), and compared against the existing similar [ZEN76](https://github.com/zwave-js/node-zwave-js/blob/master/packages/config/config/devices/0x027a/zen76.json) switch already in zwavejs.