### PR TITLE
feat(config): add additional product type and id number for Shenzen Neo PD03Z

### DIFF
--- a/packages/config/config/devices/0x0258/pd03z.json
+++ b/packages/config/config/devices/0x0258/pd03z.json
@@ -13,6 +13,10 @@
 		{
 			"productType": "0x0003",
 			"productId": "0x208d"
+		},
+		{
+			"productType": "0x0200",
+			"productId": "0x1031"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
I own a Shenzen Neo PD03Z motion sensor whose product type and id where not supported yet however the sensor itself is.
Therefore, I added the product type and id number to the already existing config file.