### PR TITLE
feat(config): add support for Linear/Nortek/GoControl WT00Z5-1

### DIFF
--- a/packages/config/config/devices/0x014f/wt00z5-1.json
+++ b/packages/config/config/devices/0x014f/wt00z5-1.json
@@ -1,0 +1,75 @@
+{
+	"manufacturer": "Linear (Nortek Security Control LLC)",
+	"manufacturerId": "0x014f",
+	"label": "WT00Z5-1",
+	"description": "3-Way Wall Accessory Switch",
+	"devices": [
+		{
+			"productType": "0x5754",
+			"productId": "0x3530"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"supportsZWavePlus": true,
+	"paramInformation": {
+		"3": {
+			"label": "Night Light",
+			"description": "By default, the LED on the WT00Z5-1 will turn OFF when the Associated device is turned ON.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 4,
+			"defaultValue": 0,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "LED OFF when the load is on",
+					"value": 0
+				},
+				{
+					"label": "LED ON when the load is on",
+					"value": 1
+				},
+				{
+					"label": "LED is always ON",
+					"value": 2
+				},
+				{
+					"label": "LED is always OFF",
+					"value": 3
+				},
+				{
+					"label": "LED blinks during RF transmissions",
+					"value": 4
+				}
+			]
+		},
+		"4": {
+			"label": "Invert Switch",
+			"description": "Change the top of the switch to OFF and the bottom of the switch to ON.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "false",
+					"value": 0
+				},
+				{
+					"label": "true",
+					"value": 1
+				}
+			]
+		}
+	}
+}


### PR DESCRIPTION
Adds support for the Linear/Nortek/GoControl WT00Z5-1 accessory switch.

Config was imported from OpenHAB and compared to similar WD500Z5-1 switch.