### PR TITLE
feat(config): add support for Yale YRM276 lock

### DIFF
--- a/packages/config/config/devices/0x0129/yrm276.json
+++ b/packages/config/config/devices/0x0129/yrm276.json
@@ -1,0 +1,298 @@
+{
+	"manufacturer": "Assa Abloy",
+	"manufacturerId": "0x0129",
+	"label": "YRM276",
+	"description": "Yale Assure Lock for Andersen Patio Doors",
+	"devices": [
+		{
+			"productType": "0x8014",
+			"productId": "0x1604"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"supportsZWavePlus": true,
+	"paramInformation": {
+		"1": {
+			"label": "Volume Mode",
+			"description": "Default is Low Volume",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 3,
+			"defaultValue": 2,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "High Volume",
+					"value": 1
+				},
+				{
+					"label": "Low Volume",
+					"value": 2
+				},
+				{
+					"label": "Silent",
+					"value": 3
+				}
+			]
+		},
+		"2": {
+			"label": "Auto Relock",
+			"description": "Default is Off",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Off",
+					"value": 0
+				},
+				{
+					"label": "On",
+					"value": 255
+				}
+			]
+		},
+		"3": {
+			"label": "Auto Relock Time",
+			"description": "1 to 180 seconds (default is 30)",
+			"valueSize": 1,
+			"unit": "seconds",
+			"minValue": 1,
+			"maxValue": 180,
+			"defaultValue": 30,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"4": {
+			"label": "Wrong Code Entry Limit",
+			"description": "3 to 10 (default is 5)",
+			"valueSize": 1,
+			"minValue": 3,
+			"maxValue": 10,
+			"defaultValue": 5,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"5": {
+			"label": "Language",
+			"description": "Default is English",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 3,
+			"defaultValue": 2,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "English",
+					"value": 1
+				},
+				{
+					"label": "Spanish",
+					"value": 2
+				},
+				{
+					"label": "French",
+					"value": 3
+				}
+			]
+		},
+		"7": {
+			"label": "Shutdown Time (after wrong code entries)",
+			"description": "10 to 180 seconds (default is 60)",
+			"valueSize": 1,
+			"unit": "seconds",
+			"minValue": 10,
+			"maxValue": 180,
+			"defaultValue": 60,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"8": {
+			"label": "Operating Mode",
+			"description": "Normal (default)\nVacation = keypad lockout\nPrivacy = no keypad, RF Unlock will work",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 2,
+			"defaultValue": 0,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Normal",
+					"value": 0
+				},
+				{
+					"label": "Vacation",
+					"value": 1
+				},
+				{
+					"label": "Privacy",
+					"value": 2
+				}
+			]
+		},
+		"11": {
+			"label": "One Touch Locking",
+			"description": "Default is On",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 255,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Off",
+					"value": 0
+				},
+				{
+					"label": "On",
+					"value": 255
+				}
+			]
+		},
+		"12": {
+			"label": "Privacy Button",
+			"description": "Default is Off",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Off",
+					"value": 0
+				},
+				{
+					"label": "On",
+					"value": 255
+				}
+			]
+		},
+		"13": {
+			"label": "Lock Status LED",
+			"description": "Default is Off",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Off",
+					"value": 0
+				},
+				{
+					"label": "On",
+					"value": 255
+				}
+			]
+		},
+		"15": {
+			"label": "Reset To Factory Defaults",
+			"description": "No default value",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Lock will execute Reset To Factory",
+					"value": 1
+				}
+			]
+		},
+		"18": {
+			"label": "Door Propped Timer**",
+			"description": "10 to 2540 second. This value is represented as seconds X 10 (ie a value of 4 would mean a door propped timer of 40 seconds). Set to 0 to disable (default).\n\n**Optional Door Position Switch must hvae been installed with the lock.",
+			"valueSize": 1,
+			"unit": "seconds",
+			"minValue": 0,
+			"maxValue": 254,
+			"defaultValue": 0,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"19": {
+			"label": "DPS Alarms**",
+			"description": "Used to enable/disable door condition alarms for locks that support a door position sensor. Any lock that does not support DPS will always report Off. Default is Off\n\n**Optional Door Position Switch must hvae been installed with the lock.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Off",
+					"value": 0
+				},
+				{
+					"label": "On",
+					"value": 255
+				}
+			]
+		},
+		"24": {
+			"label": "DPS Locking Protection**",
+			"description": "Off (default) = The lock will always lock regardless of DPSstate\nOn = Check DPS before motorized lock function\n\n**Optional Door Position Switch must hvae been installed with the lock.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Off",
+					"value": 0
+				},
+				{
+					"label": "On",
+					"value": 255
+				}
+			]
+		}
+	}
+}

--- a/packages/config/config/devices/0x0129/yrm276.json
+++ b/packages/config/config/devices/0x0129/yrm276.json
@@ -123,6 +123,7 @@
 		},
 		"8": {
 			"label": "Operating Mode",
+			"description": "Normal (default)\nVacation = keypad lockout\nPrivacy = no keypad, RF Unlock will work",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 2,

--- a/packages/config/config/devices/0x0129/yrm276.json
+++ b/packages/config/config/devices/0x0129/yrm276.json
@@ -222,7 +222,7 @@
 			"options": [
 				{
 					"label": "Normal Operation",
-					"value": 1
+					"value": 0
 				},
 				{
 					"label": "Reset Device",

--- a/packages/config/config/devices/0x0129/yrm276.json
+++ b/packages/config/config/devices/0x0129/yrm276.json
@@ -252,7 +252,7 @@
 		},
 		"19": {
 			"label": "Enable/Disable Door Position Alarm",
-			"description": "Optional Door Position Switch must have been installed with the lock.",
+			"description": "Note: Optional Door Position Switch must have been installed with the lock.",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 255,

--- a/packages/config/config/devices/0x0129/yrm276.json
+++ b/packages/config/config/devices/0x0129/yrm276.json
@@ -232,7 +232,7 @@
 		},
 		"18": {
 			"label": "Enable/Disable Door Open Timer",
-			"description": "Note: Optional Door Position Switch must hvae been installed with the lock.",
+			"description": "Note: Optional Door Position Switch must have been installed with the lock.",
 			"valueSize": 1,
 			"unit": "10 seconds",
 			"minValue": 0,
@@ -251,7 +251,7 @@
 		},
 		"19": {
 			"label": "Enable/Disable Door Position Alarm",
-			"description": "Optional Door Position Switch must hvae been installed with the lock.",
+			"description": "Optional Door Position Switch must have been installed with the lock.",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 255,
@@ -273,7 +273,7 @@
 		},
 		"24": {
 			"label": "Check Door Position State Before Locking",
-			"description": "Note: Optional Door Position Switch must hvae been installed with the lock.",
+			"description": "Note: Optional Door Position Switch must have been installed with the lock.",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 255,

--- a/packages/config/config/devices/0x0129/yrm276.json
+++ b/packages/config/config/devices/0x0129/yrm276.json
@@ -1,8 +1,8 @@
 {
-	"manufacturer": "Assa Abloy",
+	"manufacturer": "Yale",
 	"manufacturerId": "0x0129",
 	"label": "YRM276",
-	"description": "Yale Assure Lock for Andersen Patio Doors",
+	"description": "Assure Lock for Andersen Patio Doors",
 	"devices": [
 		{
 			"productType": "0x8014",
@@ -17,7 +17,6 @@
 	"paramInformation": {
 		"1": {
 			"label": "Volume Mode",
-			"description": "Default is Low Volume",
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 3,
@@ -42,8 +41,7 @@
 			]
 		},
 		"2": {
-			"label": "Auto Relock",
-			"description": "Default is Off",
+			"label": "Enable/Disable Auto Relock",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 255,
@@ -54,18 +52,17 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Off",
+					"label": "Disable",
 					"value": 0
 				},
 				{
-					"label": "On",
+					"label": "Enable",
 					"value": 255
 				}
 			]
 		},
 		"3": {
 			"label": "Auto Relock Time",
-			"description": "1 to 180 seconds (default is 30)",
 			"valueSize": 1,
 			"unit": "seconds",
 			"minValue": 1,
@@ -78,7 +75,6 @@
 		},
 		"4": {
 			"label": "Wrong Code Entry Limit",
-			"description": "3 to 10 (default is 5)",
 			"valueSize": 1,
 			"minValue": 3,
 			"maxValue": 10,
@@ -90,11 +86,10 @@
 		},
 		"5": {
 			"label": "Language",
-			"description": "Default is English",
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 3,
-			"defaultValue": 2,
+			"defaultValue": 1,
 			"unsigned": true,
 			"readOnly": false,
 			"writeOnly": false,
@@ -115,8 +110,7 @@
 			]
 		},
 		"7": {
-			"label": "Shutdown Time (after wrong code entries)",
-			"description": "10 to 180 seconds (default is 60)",
+			"label": "Wrong Code Lockout Time",
 			"valueSize": 1,
 			"unit": "seconds",
 			"minValue": 10,
@@ -129,7 +123,6 @@
 		},
 		"8": {
 			"label": "Operating Mode",
-			"description": "Normal (default)\nVacation = keypad lockout\nPrivacy = no keypad, RF Unlock will work",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 2,
@@ -155,7 +148,6 @@
 		},
 		"11": {
 			"label": "One Touch Locking",
-			"description": "Default is On",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 255,
@@ -166,18 +158,17 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Off",
+					"label": "Disable",
 					"value": 0
 				},
 				{
-					"label": "On",
+					"label": "Enable",
 					"value": 255
 				}
 			]
 		},
 		"12": {
 			"label": "Privacy Button",
-			"description": "Default is Off",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 255,
@@ -188,18 +179,17 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Off",
+					"label": "Disable",
 					"value": 0
 				},
 				{
-					"label": "On",
+					"label": "Enable",
 					"value": 255
 				}
 			]
 		},
 		"13": {
 			"label": "Lock Status LED",
-			"description": "Default is Off",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 255,
@@ -210,20 +200,19 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Off",
+					"label": "Disable",
 					"value": 0
 				},
 				{
-					"label": "On",
+					"label": "Enable",
 					"value": 255
 				}
 			]
 		},
 		"15": {
 			"label": "Reset To Factory Defaults",
-			"description": "No default value",
 			"valueSize": 1,
-			"minValue": 1,
+			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
 			"unsigned": true,
@@ -232,27 +221,37 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Lock will execute Reset To Factory",
+					"label": "Normal Operation",
+					"value": 1
+				},
+				{
+					"label": "Reset Device",
 					"value": 1
 				}
 			]
 		},
 		"18": {
-			"label": "Door Propped Timer**",
-			"description": "10 to 2540 second. This value is represented as seconds X 10 (ie a value of 4 would mean a door propped timer of 40 seconds). Set to 0 to disable (default).\n\n**Optional Door Position Switch must hvae been installed with the lock.",
+			"label": "Enable/Disable Door Open Timer",
+			"description": "Note: Optional Door Position Switch must hvae been installed with the lock.",
 			"valueSize": 1,
-			"unit": "seconds",
+			"unit": "10 seconds",
 			"minValue": 0,
 			"maxValue": 254,
 			"defaultValue": 0,
 			"unsigned": true,
 			"readOnly": false,
 			"writeOnly": false,
-			"allowManualEntry": true
+			"allowManualEntry": true,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
 		},
 		"19": {
-			"label": "DPS Alarms**",
-			"description": "Used to enable/disable door condition alarms for locks that support a door position sensor. Any lock that does not support DPS will always report Off. Default is Off\n\n**Optional Door Position Switch must hvae been installed with the lock.",
+			"label": "Enable/Disable Door Position Alarm",
+			"description": "Optional Door Position Switch must hvae been installed with the lock.",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 255,
@@ -263,18 +262,18 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Off",
+					"label": "Disable",
 					"value": 0
 				},
 				{
-					"label": "On",
+					"label": "Enable",
 					"value": 255
 				}
 			]
 		},
 		"24": {
-			"label": "DPS Locking Protection**",
-			"description": "Off (default) = The lock will always lock regardless of DPSstate\nOn = Check DPS before motorized lock function\n\n**Optional Door Position Switch must hvae been installed with the lock.",
+			"label": "Check Door Position State Before Locking",
+			"description": "Note: Optional Door Position Switch must hvae been installed with the lock.",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 255,
@@ -285,11 +284,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Off",
+					"label": "Disable",
 					"value": 0
 				},
 				{
-					"label": "On",
+					"label": "Enable",
 					"value": 255
 				}
 			]


### PR DESCRIPTION
Adds support for the Yale Assure Lock for Andersen Patio Doors model YRM276.

Config was imported from OZW file which I had created for that project.