### PR TITLE
feat(config): add support for HomeSeer HS-FLS100-G2

### DIFF
--- a/packages/config/config/devices/0x000c/hs-fls100-g2.json
+++ b/packages/config/config/devices/0x000c/hs-fls100-g2.json
@@ -1,4 +1,4 @@
-// HomeSeer Technologies HS-FLS100+
+// HomeSeer Technologies HS-FLS100-G2
 // Floodlight Sensor
 {
 	"manufacturer": "HomeSeer Technologies",
@@ -18,7 +18,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"1": {
-			"label": "PIR Trigger Off Period",
+			"label": "PIR trigger off period",
 			"description": "Period to send Trigger Off command after PIR is triggered.",
 			"unit": "Seconds",
 			"valueSize": 2,
@@ -53,7 +53,7 @@
 			"allowManualEntry": true
 		},
 		"4": {
-			"label": "PIR Trigger alert",
+			"label": "PIR trigger alert",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
@@ -73,7 +73,7 @@
 			]
 		},
 		"5": {
-			"label": "Floodlight Control Mode",
+			"label": "Floodlight control mode",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
@@ -83,17 +83,17 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "floodlight is controlled by Z wave controller directly, regardless of PIR trigger or LUX level",
+					"label": "controlled by Z wave controller only",
 					"value": 0
 				},
 				{
-					"label": "floodlight is controlled by PIR trigger and Lux level, or by Z wave controller",
+					"label": "controlled by PIR trigger and Lux level, or by Z wave controller",
 					"value": 1
 				}
 			]
 		},
 		"6": {
-			"label": "Lux Sensor",
+			"label": "Lux sensor",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
@@ -107,13 +107,13 @@
 					"value": 0
 				},
 				{
-					"label": "lighting control via Lux level only, regardless of PIR trigger",
+					"label": "floodlight is controlled by Lux level only, regardless of PIR trigger",
 					"value": 1
 				}
 			]
 		},
 		"7": {
-			"label": "Mesured Temperature Offset",
+			"label": "Mesured temperature offset",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 127,

--- a/packages/config/config/devices/0x000c/hs-fls100-g2.json
+++ b/packages/config/config/devices/0x000c/hs-fls100-g2.json
@@ -20,7 +20,7 @@
 		"1": {
 			"label": "PIR trigger off period",
 			"description": "Period to send Trigger Off command after PIR is triggered.",
-			"unit": "Seconds",
+			"unit": "seconds",
 			"valueSize": 2,
 			"minValue": 8,
 			"maxValue": 720,
@@ -30,8 +30,9 @@
 			"allowManualEntry": true
 		},
 		"2": {
-			"label": "Lux sensor threshold",
+			"label": "Illuminance sensor threshold",
 			"description": "Lux level to activate the PIR",
+			"unit": "lux",
 			"valueSize": 2,
 			"minValue": 10,
 			"maxValue": 900,
@@ -42,8 +43,7 @@
 		},
 		"3": {
 			"label": "Auto Report luminance and temperature interval",
-			"description": "set the interval of periodic lux level report and temperature report to the controller",
-			"unit": "min",
+			"unit": "minutes",
 			"valueSize": 2,
 			"minValue": 1,
 			"maxValue": 1440,
@@ -63,11 +63,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "disable alert",
+					"label": "Disable alert",
 					"value": 0
 				},
 				{
-					"label": "enable alert",
+					"label": "Enable alert",
 					"value": 1
 				}
 			]
@@ -83,17 +83,17 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "controlled by Z wave controller only",
+					"label": "Controlled by Z-wave controller only",
 					"value": 0
 				},
 				{
-					"label": "controlled by PIR trigger and Lux level, or by Z wave controller",
+					"label": "Controlled by PIR trigger and Lux level, or by Z-wave controller",
 					"value": 1
 				}
 			]
 		},
 		"6": {
-			"label": "Lux sensor",
+			"label": "Floodlight triggers",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
@@ -103,20 +103,21 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "floodlight is controlled by Lux level and PIR trigger",
+					"label": "Floodlight is controlled by Lux level and PIR trigger",
 					"value": 0
 				},
 				{
-					"label": "floodlight is controlled by Lux level only, regardless of PIR trigger",
+					"label": "Floodlight is controlled by Lux level only, regardless of PIR trigger",
 					"value": 1
 				}
 			]
 		},
 		"7": {
-			"label": "Mesured temperature offset",
+			"label": "Measured temperature offset",
+			"unit": "0.1 °C"
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 127,
+			"minValue": -100,
+			"maxValue": 100,
 			"defaultValue": 0,
 			"readOnly": false,
 			"writeOnly": false,
@@ -133,15 +134,15 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "low level, approx. 6m distance",
+					"label": "Low level, approx. 6m distance",
 					"value": 0
 				},
 				{
-					"label": "mid level, approx. 10m distance",
+					"label": "Mid level, approx. 10m distance",
 					"value": 1
 				},
 				{
-					"label": "high level, approx. 20m distance",
+					"label": "High level, approx. 20m distance",
 					"value": 2
 				}
 			]

--- a/packages/config/config/devices/0x000c/hs-fls100-g2.json
+++ b/packages/config/config/devices/0x000c/hs-fls100-g2.json
@@ -83,11 +83,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Controlled by Z-wave controller only",
+					"label": "Controlled by Z-Wave controller only",
 					"value": 0
 				},
 				{
-					"label": "Controlled by PIR trigger and Lux level, or by Z-wave controller",
+					"label": "Controlled by PIR trigger and Lux level, or by Z-Wave controller",
 					"value": 1
 				}
 			]

--- a/packages/config/config/devices/0x000c/hs-fls100-g2.json
+++ b/packages/config/config/devices/0x000c/hs-fls100-g2.json
@@ -1,0 +1,150 @@
+// HomeSeer Technologies HS-FLS100+
+// Floodlight Sensor
+{
+	"manufacturer": "HomeSeer Technologies",
+	"manufacturerId": "0x000c",
+	"label": "HS-FLS100-G2",
+	"description": "Floodlight Sensor",
+	"devices": [
+		{
+			"productType": "0x0201",
+			"productId": "0x000c"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"supportsZWavePlus": true,
+	"paramInformation": {
+		"1": {
+			"label": "PIR Trigger Off Period",
+			"description": "Period to send Trigger Off command after PIR is triggered.",
+			"unit": "Seconds",
+			"valueSize": 2,
+			"minValue": 8,
+			"maxValue": 720,
+			"defaultValue": 180,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"2": {
+			"label": "Lux sensor threshold",
+			"description": "Lux level to activate the PIR",
+			"valueSize": 2,
+			"minValue": 10,
+			"maxValue": 900,
+			"defaultValue": 50,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"3": {
+			"label": "Auto Report luminance and temperature interval",
+			"description": "set the interval of periodic lux level report and temperature report to the controller",
+			"unit": "min",
+			"valueSize": 2,
+			"minValue": 1,
+			"maxValue": 1440,
+			"defaultValue": 10,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"4": {
+			"label": "PIR Trigger alert",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "disable alert",
+					"value": 0
+				},
+				{
+					"label": "enable alert",
+					"value": 1
+				}
+			]
+		},
+		"5": {
+			"label": "Floodlight Control Mode",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "floodlight is controlled by Z wave controller directly, regardless of PIR trigger or LUX level",
+					"value": 0
+				},
+				{
+					"label": "floodlight is controlled by PIR trigger and Lux level, or by Z wave controller",
+					"value": 1
+				}
+			]
+		},
+		"6": {
+			"label": "Lux Sensor",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "floodlight is controlled by Lux level and PIR trigger",
+					"value": 0
+				},
+				{
+					"label": "lighting control via Lux level only, regardless of PIR trigger",
+					"value": 1
+				}
+			]
+		},
+		"7": {
+			"label": "Mesured Temperature Offset",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 127,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"8": {
+			"label": "PIR Sensitivity Level",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 2,
+			"defaultValue": 2,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "low level, approx. 6m distance",
+					"value": 0
+				},
+				{
+					"label": "mid level, approx. 10m distance",
+					"value": 1
+				},
+				{
+					"label": "high level, approx. 20m distance",
+					"value": 2
+				}
+			]
+		}
+	}
+}

--- a/packages/config/config/devices/0x000c/hs-fls100-g2.json
+++ b/packages/config/config/devices/0x000c/hs-fls100-g2.json
@@ -114,7 +114,7 @@
 		},
 		"7": {
 			"label": "Measured temperature offset",
-			"unit": "0.1 °C"
+			"unit": "0.1 °C",
 			"valueSize": 1,
 			"minValue": -100,
 			"maxValue": 100,


### PR DESCRIPTION
Adds support for HomeSeer HS-FLS100-G2 floodlight sensor.

Adds temperature and few more config parameters compared to previous device version (HS-FLS100).
Data from product manual and Z-Wave Alliance.