### PR TITLE
chore(config): improve Zooz ZEN23 and ZEN24 toggle switch configs

### DIFF
--- a/packages/config/config/devices/0x027a/zen23_3.0.json
+++ b/packages/config/config/devices/0x027a/zen23_3.0.json
@@ -1,7 +1,6 @@
 // Zooz ZEN23
 // Z-Wave Plus On/Off Toggle Switch V3
 {
-	"revision": 10,
 	"manufacturer": "Zooz",
 	"manufacturerId": "0x027a",
 	"label": "ZEN23",
@@ -35,7 +34,7 @@
 	},
 	"paramInformation": {
 		"1": {
-			"label": "Toggle Control",
+			"label": "Switch behavior",
 			"description": "Determines whether up is on and down is off; or up is off, down is on",
 			"valueSize": 1,
 			"minValue": 0,
@@ -57,7 +56,6 @@
 		},
 		"3": {
 			"label": "Auto Turn-Off Timer",
-			"description": "Use this parameter to enable or disable the auto turn-off timer",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
@@ -67,11 +65,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Auto Turn-Off Timer Disabled",
+					"label": "Disabled",
 					"value": 0
 				},
 				{
-					"label": "Auto Turn-Off Timer Enabled",
+					"label": "Enabled",
 					"value": 1
 				}
 			]
@@ -90,7 +88,6 @@
 		},
 		"5": {
 			"label": "Auto Turn-On Timer",
-			"description": "Use this parameter to enable or disable the auto turn-on timer",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
@@ -100,11 +97,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Auto Turn-On Timer Disabled",
+					"label": "Disabled",
 					"value": 0
 				},
 				{
-					"label": "Auto Turn-On Timer Enabled",
+					"label": "Enabled",
 					"value": 1
 				}
 			]
@@ -122,8 +119,7 @@
 			"allowManualEntry": true
 		},
 		"8": {
-			"label": "On Off Status After Power Failure",
-			"description": "Set the on off status for the switch after power failure",
+			"label": "Status After Power Failure",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 2,
@@ -133,11 +129,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "forced to OFF",
+					"label": "Forced to OFF",
 					"value": 0
 				},
 				{
-					"label": "forced to ON",
+					"label": "Forced to ON",
 					"value": 1
 				},
 				{
@@ -158,18 +154,18 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Disable Scene Control",
+					"label": "Disable",
 					"value": 0
 				},
 				{
-					"label": "Enable Scene Control",
+					"label": "Enable",
 					"value": 1
 				}
 			]
 		},
 		"13": {
-			"label": "Report for Disabled Toggle",
-			"description": "Set reporting behavior for disabled physical control.",
+			"label": "Report status when toggle is disabled",
+			"description": "Report light status when both physical and Z-Wave control are disabled.",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
@@ -179,11 +175,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Switch reports on/off status even if physical and Z-Wave control is disabled (default)",
+					"label": "Yes",
 					"value": 0
 				},
 				{
-					"label": "Switch doesn't report on/off status when physical (and Z-Wave) control is disabled",
+					"label": "No",
 					"value": 1
 				}
 			]

--- a/packages/config/config/devices/0x027a/zen23_4.0.json
+++ b/packages/config/config/devices/0x027a/zen23_4.0.json
@@ -1,7 +1,6 @@
 // Zooz ZEN23
 // Z-Wave Plus On/Off Toggle Switch v4
 {
-	"revision": 1,
 	"manufacturer": "Zooz",
 	"manufacturerId": "0x027a",
 	"label": "ZEN23",
@@ -14,7 +13,7 @@
 	],
 	"firmwareVersion": {
 		"min": "4.0",
-		"max": "4.255"
+		"max": "255.255"
 	},
 	"supportsZWavePlus": true,
 	"associations": {
@@ -31,11 +30,11 @@
 	},
 	"paramInformation": {
 		"1": {
-			"label": "Toggle Control",
+			"label": "Switch behavior",
 			"description": "Determines whether up is on and down is off; or up is off, down is on",
 			"valueSize": 1,
 			"minValue": 0,
-			"maxValue": 1,
+			"maxValue": 2,
 			"defaultValue": 0,
 			"readOnly": false,
 			"writeOnly": false,
@@ -50,14 +49,13 @@
 					"value": 1
 				},
 				{
-					"label": "ANY=Toggle State",
+					"label": "Toggle",
 					"value": 2
 				}
 			]
 		},
 		"3": {
 			"label": "Auto Turn-Off Timer",
-			"description": "Use this parameter to enable or disable the auto turn-off timer",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
@@ -67,11 +65,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Auto Turn-Off Timer Disabled",
+					"label": "Disabled",
 					"value": 0
 				},
 				{
-					"label": "Auto Turn-Off Timer Enabled",
+					"label": "Enabled",
 					"value": 1
 				}
 			]
@@ -90,7 +88,6 @@
 		},
 		"5": {
 			"label": "Auto Turn-On Timer",
-			"description": "Use this parameter to enable or disable the auto turn-on timer",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
@@ -100,11 +97,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Auto Turn-On Timer Disabled",
+					"label": "Disabled",
 					"value": 0
 				},
 				{
-					"label": "Auto Turn-On Timer Enabled",
+					"label": "Enabled",
 					"value": 1
 				}
 			]
@@ -122,8 +119,7 @@
 			"allowManualEntry": true
 		},
 		"8": {
-			"label": "On Off Status After Power Failure",
-			"description": "Set the on off status for the switch after power failure",
+			"label": "Status After Power Failure",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 2,
@@ -133,11 +129,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "forced to OFF",
+					"label": "Forced to OFF",
 					"value": 0
 				},
 				{
-					"label": "forced to ON",
+					"label": "Forced to ON",
 					"value": 1
 				},
 				{
@@ -158,11 +154,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Disable Scene Control",
+					"label": "Disable",
 					"value": 0
 				},
 				{
-					"label": "Enable Scene Control",
+					"label": "Enable",
 					"value": 1
 				}
 			]
@@ -204,18 +200,18 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Regular mechanical 3-way on/off switch, use the connected 3-way switch to turn the light on or off (default)",
+					"label": "3-way on/off switch",
 					"value": 0
 				},
 				{
-					"label": "Momentary switch, click once to change status (light on or off)",
+					"label": "Momentary switch",
 					"value": 1
 				}
 			]
 		},
 		"13": {
-			"label": "Report for Disabled Toggle",
-			"description": "Set reporting behavior for disabled physical control.",
+			"label": "Report status when toggle is disabled",
+			"description": "Report light status when both physical and Z-Wave control are disabled.",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
@@ -225,11 +221,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Switch reports on/off status even if physical and Z-Wave control is disabled (default)",
+					"label": "Yes",
 					"value": 0
 				},
 				{
-					"label": "Switch doesn't report on/off status when physical (and Z-Wave) control is disabled",
+					"label": "No",
 					"value": 1
 				}
 			]

--- a/packages/config/config/devices/0x027a/zen23_4.0.json
+++ b/packages/config/config/devices/0x027a/zen23_4.0.json
@@ -1,24 +1,20 @@
 // Zooz ZEN23
-// Z-Wave Plus On/Off Toggle Switch V3
+// Z-Wave Plus On/Off Toggle Switch v4
 {
-	"revision": 10,
+	"revision": 1,
 	"manufacturer": "Zooz",
 	"manufacturerId": "0x027a",
 	"label": "ZEN23",
-	"description": "Z-Wave Plus On/Off Toggle Switch V3",
+	"description": "Z-Wave Plus On/Off Toggle Switch v4",
 	"devices": [
-		{
-			"productType": "0x1111",
-			"productId": "0x1e1c"
-		},
 		{
 			"productType": "0xb111",
 			"productId": "0x251c"
 		}
 	],
 	"firmwareVersion": {
-		"min": "3.0",
-		"max": "3.255"
+		"min": "4.0",
+		"max": "4.255"
 	},
 	"supportsZWavePlus": true,
 	"associations": {
@@ -52,6 +48,10 @@
 				{
 					"label": "UP=Off, DOWN=On",
 					"value": 1
+				},
+				{
+					"label": "ANY=Toggle State",
+					"value": 2
 				}
 			]
 		},
@@ -163,6 +163,52 @@
 				},
 				{
 					"label": "Enable Scene Control",
+					"value": 1
+				}
+			]
+		},
+		"11": {
+			"label": "Smart Bulb Mode (Disable Physical Switch)",
+			"description": "Enable/Disable Toggle / Z-Wave Control. NOTE: tap the upper paddle 10 times quickly to change this mode.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 2,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Physical switch disabled",
+					"value": 0
+				},
+				{
+					"label": "Physical switch enabled",
+					"value": 1
+				},
+				{
+					"label": "Physical switch and Z-Wave control disabled",
+					"value": 2
+				}
+			]
+		},
+		"12": {
+			"label": "3-Way Switch Type",
+			"description": "Choose the type of 3-way switch you want to use with this dimmer in a 3-way set-up.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Regular mechanical 3-way on/off switch, use the connected 3-way switch to turn the light on or off (default)",
+					"value": 0
+				},
+				{
+					"label": "Momentary switch, click once to change status (light on or off)",
 					"value": 1
 				}
 			]

--- a/packages/config/config/devices/0x027a/zen24_3.0-3.255.json
+++ b/packages/config/config/devices/0x027a/zen24_3.0-3.255.json
@@ -232,11 +232,11 @@
 					"value": 0
 				},
 				{
-					"label": "DT Disabled, Single Tap last brightness",
+					"label": "Double Tap Disabled, Single Tap to Last Brightness",
 					"value": 1
 				},
 				{
-					"label": "DT Disabled, Single Tap to Full",
+					"label": "Double Tap Disabled, Single Tap to Full Brightness",
 					"value": 2
 				}
 			]

--- a/packages/config/config/devices/0x027a/zen24_3.0-3.255.json
+++ b/packages/config/config/devices/0x027a/zen24_3.0-3.255.json
@@ -1,7 +1,6 @@
 // Zooz ZEN24
 // Z-Wave Plus On/Off Toggle Dimmer v3
 {
-	"revision": 4,
 	"manufacturer": "Zooz",
 	"manufacturerId": "0x027a",
 	"label": "ZEN24",
@@ -31,7 +30,7 @@
 	},
 	"paramInformation": {
 		"1": {
-			"label": "Toggle Control",
+			"label": "Switch behavior",
 			"description": "Determines whether up is on and down is off; or up is off, down is on",
 			"valueSize": 1,
 			"minValue": 0,
@@ -53,7 +52,6 @@
 		},
 		"3": {
 			"label": "Auto Turn-Off Timer",
-			"description": "Use this parameter to enable or disable the auto turn-off timer",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
@@ -63,11 +61,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Auto Turn-Off Timer Disabled",
+					"label": "Disabled",
 					"value": 0
 				},
 				{
-					"label": "Auto Turn-Off Timer Enabled",
+					"label": "Enabled",
 					"value": 1
 				}
 			]
@@ -86,7 +84,6 @@
 		},
 		"5": {
 			"label": "Auto Turn-On Timer",
-			"description": "Use this parameter to enable or disable the auto turn-on timer",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
@@ -96,11 +93,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Auto Turn-On Timer Disabled",
+					"label": "Disabled",
 					"value": 0
 				},
 				{
-					"label": "Auto Turn-On Timer Enabled",
+					"label": "Enabled",
 					"value": 1
 				}
 			]
@@ -118,8 +115,7 @@
 			"allowManualEntry": true
 		},
 		"8": {
-			"label": "On Off Status After Power Failure",
-			"description": "Set the on off status for the switch after power failure",
+			"label": "Status After Power Failure",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 2,
@@ -129,11 +125,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "forced to OFF",
+					"label": "Forced to OFF",
 					"value": 0
 				},
 				{
-					"label": "forced to ON",
+					"label": "Forced to ON",
 					"value": 1
 				},
 				{
@@ -144,7 +140,7 @@
 		},
 		"9": {
 			"label": "Ramp Rate Control",
-			"description": "Adjust the physical ramp rate for your dimmer (fade-in / fade-out effect for on / off operation). Values correspond to the number of seconds it take for the dimmer to reach full brightness or turn off when operated manually. This setting is for physical taps only, see parameter 17 to adjust Z-Wave ramp rate.",
+			"description": "Adjust the physical ramp rate for your dimmer (fade-in / fade-out effect for on / off operation).",
 			"unit": "seconds",
 			"valueSize": 1,
 			"minValue": 1,
@@ -157,7 +153,7 @@
 		"10": {
 			"label": "Minimum Brightness",
 			"description": "Set the minimum brightness level (in %) for your dimmer. You won’t be able to dim the light below the set value.",
-			"unit": "percent",
+			"unit": "%",
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 99,
@@ -169,7 +165,7 @@
 		"11": {
 			"label": "Maximum Brightness",
 			"description": "Set the maximum brightness level (in %) for your dimmer. You won’t be able to add brightness to the light beyond the set value. Note: if Parameter 12 is set to value 0, Parameter 11 is automatically disabled.",
-			"unit": "percent",
+			"unit": "%",
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 99,
@@ -194,7 +190,7 @@
 					"value": 0
 				},
 				{
-					"label": "Maximum Brightness Level (Parameter 11)",
+					"label": "Custom Brightness Level",
 					"value": 1
 				}
 			]
@@ -211,11 +207,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Scene Control Disabled",
+					"label": "Disabled",
 					"value": 0
 				},
 				{
-					"label": "Scene Control Enabled",
+					"label": "Enabled",
 					"value": 1
 				}
 			]
@@ -240,7 +236,7 @@
 					"value": 1
 				},
 				{
-					"label": "DT Disabled, Single Tap to Full / Max Brightness",
+					"label": "DT Disabled, Single Tap to Full",
 					"value": 2
 				}
 			]
@@ -250,7 +246,7 @@
 			"description": "Enable or disable manual on/off control. If enabled, you’ll only be able to control the connected light via Z-Wave. Scenes and other functionality will still be available through the physical switch.",
 			"valueSize": 1,
 			"minValue": 0,
-			"maxValue": 1,
+			"maxValue": 2,
 			"defaultValue": 1,
 			"readOnly": false,
 			"writeOnly": false,
@@ -272,7 +268,7 @@
 		},
 		"16": {
 			"label": "Physical Dimming Speed",
-			"description": "Set the time it takes to get from 0% to 100% brightness when pressing and holding the toggle (physical dimming). The number entered as value corresponds to the number of seconds.",
+			"description": "Set the time it takes to get from 0% to 100% brightness when pressing and holding the toggle.",
 			"unit": "seconds",
 			"valueSize": 1,
 			"minValue": 1,
@@ -294,11 +290,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Z-Wave ramp rate matches the physical ramp rate set in parameter 9 (default)",
+					"label": "Match Physical",
 					"value": 0
 				},
 				{
-					"label": "Z-Wave ramp rate is set independently using appropriate Z-Wave commands",
+					"label": "Independent",
 					"value": 1
 				}
 			]
@@ -306,7 +302,7 @@
 		"18": {
 			"label": "Custom Brightness On",
 			"description": "Set the custom brightness level (instead of the last set brightness level) you want the dimmer to come on to when you toggle the switch up once. 0 Means last brightness level.",
-			"unit": "percent",
+			"unit": "%",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 99,
@@ -317,7 +313,7 @@
 		},
 		"19": {
 			"label": "3-Way Switch Type",
-			"description": "Choose the type of 3-way switch you want to use with this dimmer in a 3-way set-up. Changing this setting can allow you to control brightness and dim the light from both 3-way locations. Use a regular momentary switch (like the Zooz ZAC99 accessory switch) if value is set to 2.",
+			"description": "Choose the type of 3-way switch you want to use with this dimmer in a 3-way set-up. Changing this setting can allow you to control brightness and dim the light from both 3-way locations. Use a regular momentary switch (like the Zooz ZAC99 accessory switch) if value is set to 2. See Zooz website for details.",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 3,
@@ -327,19 +323,19 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Toggle switch, use the connected 3-way switch to turn the light off or on to the last brightness level, dimming only available from the Zooz Z-Wave dimmer and from the hub (or through voice control if smart speaker is integrated with your Z-Wave hub)",
+					"label": "Toggle switch, On/Off Only",
 					"value": 0
 				},
 				{
-					"label": "Toggle switch, toggle up or down once to change state (light on or off), toggle twice quickly to turn light on to full brightness, toggle 3 times quickly to enable a dimming sequence (the light will start dimming up and down in a loop) and toggle the switch again to set the selected brightness level",
+					"label": "Toggle switch, Dimming Sequence",
 					"value": 1
 				},
 				{
-					"label": "Momentary switch, click once to change status (light on or off), click twice quickly to turn light on to full brightness, press and hold to adjust brightness (dim up / dim down in sequence)",
+					"label": "Momentary switch",
 					"value": 2
 				},
 				{
-					"label": "Momentary switch, click once to change status (light on or off), click twice quickly to turn light on to full brightness, press and hold to adjust brightness (dim up / dim down in sequence but always reduce brightness after double click)",
+					"label": "Momentary switch (variant)",
 					"value": 3
 				}
 			]
@@ -356,18 +352,18 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Report each brightness level to hub when physical / Z-Wave control is disabled for physical dimming (final level only reported if physical / Z-Wave control is enabled)",
+					"label": "All Levels",
 					"value": 0
 				},
 				{
-					"label": "Report final brightness level only for physical dimming, regardless of the physical / Z-Wave control mode.",
+					"label": "Final Level Only",
 					"value": 1
 				}
 			]
 		},
 		"21": {
-			"label": "Report for Disabled Toggle",
-			"description": "Set reporting behavior for disabled physical control.",
+			"label": "Report status when toggle is disabled",
+			"description": "Report light status when both physical and Z-Wave control are disabled.",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
@@ -377,11 +373,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Switch reports on/off status even if physical and Z-Wave control is disabled (default)",
+					"label": "Yes",
 					"value": 0
 				},
 				{
-					"label": "Switch doesn't report on/off status when physical (and Z-Wave) control is disabled",
+					"label": "No",
 					"value": 1
 				}
 			]

--- a/packages/config/config/devices/0x027a/zen24_3.0-3.255.json
+++ b/packages/config/config/devices/0x027a/zen24_3.0-3.255.json
@@ -1,0 +1,401 @@
+// Zooz ZEN24
+// Z-Wave Plus On/Off Toggle Dimmer v3
+{
+	"revision": 4,
+	"manufacturer": "Zooz",
+	"manufacturerId": "0x027a",
+	"label": "ZEN24",
+	"description": "Z-Wave Plus On/Off Toggle Dimmer v3",
+	"devices": [
+		{
+			"productType": "0xb112",
+			"productId": "0x261c"
+		}
+	],
+	"firmwareVersion": {
+		"min": "3.0",
+		"max": "3.255"
+	},
+	"supportsZWavePlus": true,
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 1,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "Group 2",
+			"description": "BASIC Command Set",
+			"maxNodes": 5
+		}
+	},
+	"paramInformation": {
+		"1": {
+			"label": "Toggle Control",
+			"description": "Determines whether up is on and down is off; or up is off, down is on",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "UP=On, DOWN=Off",
+					"value": 0
+				},
+				{
+					"label": "UP=Off, DOWN=On",
+					"value": 1
+				}
+			]
+		},
+		"3": {
+			"label": "Auto Turn-Off Timer",
+			"description": "Use this parameter to enable or disable the auto turn-off timer",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Auto Turn-Off Timer Disabled",
+					"value": 0
+				},
+				{
+					"label": "Auto Turn-Off Timer Enabled",
+					"value": 1
+				}
+			]
+		},
+		"4": {
+			"label": "Auto Turn-Off Timer Time",
+			"description": "Time after which the switch automatically turns off",
+			"unit": "minutes",
+			"valueSize": 4,
+			"minValue": 1,
+			"maxValue": 65535,
+			"defaultValue": 60,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"5": {
+			"label": "Auto Turn-On Timer",
+			"description": "Use this parameter to enable or disable the auto turn-on timer",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Auto Turn-On Timer Disabled",
+					"value": 0
+				},
+				{
+					"label": "Auto Turn-On Timer Enabled",
+					"value": 1
+				}
+			]
+		},
+		"6": {
+			"label": "Auto Turn-On Timer Time",
+			"description": "Set the time after which the switch automatically turns on",
+			"unit": "minutes",
+			"valueSize": 4,
+			"minValue": 1,
+			"maxValue": 65535,
+			"defaultValue": 60,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"8": {
+			"label": "On Off Status After Power Failure",
+			"description": "Set the on off status for the switch after power failure",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 2,
+			"defaultValue": 2,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "forced to OFF",
+					"value": 0
+				},
+				{
+					"label": "forced to ON",
+					"value": 1
+				},
+				{
+					"label": "Restore Previous Status",
+					"value": 2
+				}
+			]
+		},
+		"9": {
+			"label": "Ramp Rate Control",
+			"description": "Adjust the physical ramp rate for your dimmer (fade-in / fade-out effect for on / off operation). Values correspond to the number of seconds it take for the dimmer to reach full brightness or turn off when operated manually. This setting is for physical taps only, see parameter 17 to adjust Z-Wave ramp rate.",
+			"unit": "seconds",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 99,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"10": {
+			"label": "Minimum Brightness",
+			"description": "Set the minimum brightness level (in %) for your dimmer. You won’t be able to dim the light below the set value.",
+			"unit": "percent",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 99,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"11": {
+			"label": "Maximum Brightness",
+			"description": "Set the maximum brightness level (in %) for your dimmer. You won’t be able to add brightness to the light beyond the set value. Note: if Parameter 12 is set to value 0, Parameter 11 is automatically disabled.",
+			"unit": "percent",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 99,
+			"defaultValue": 99,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"12": {
+			"label": "Double Tap Function",
+			"description": "Choose if you want the dimmer to turn on to full brightness or custom brightness level after you toggle the switch up twice quickly.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Full Brightness",
+					"value": 0
+				},
+				{
+					"label": "Maximum Brightness Level (Parameter 11)",
+					"value": 1
+				}
+			]
+		},
+		"13": {
+			"label": "Scene Control Enable",
+			"description": "Enable or disable scene control functionality for quick double tap triggers.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Scene Control Disabled",
+					"value": 0
+				},
+				{
+					"label": "Scene Control Enabled",
+					"value": 1
+				}
+			]
+		},
+		"14": {
+			"label": "Double & Single Tap Enable",
+			"description": "Enable or disable the double tap function and assign brightness level to single tap.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 2,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Double Tap Enabled",
+					"value": 0
+				},
+				{
+					"label": "DT Disabled, Single Tap last brightness",
+					"value": 1
+				},
+				{
+					"label": "DT Disabled, Single Tap to Full / Max Brightness",
+					"value": 2
+				}
+			]
+		},
+		"15": {
+			"label": "Local Toggle Control",
+			"description": "Enable or disable manual on/off control. If enabled, you’ll only be able to control the connected light via Z-Wave. Scenes and other functionality will still be available through the physical switch.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Physical switch disabled",
+					"value": 0
+				},
+				{
+					"label": "Physical switch enabled",
+					"value": 1
+				},
+				{
+					"label": "Physical switch and Z-Wave control disabled",
+					"value": 2
+				}
+			]
+		},
+		"16": {
+			"label": "Physical Dimming Speed",
+			"description": "Set the time it takes to get from 0% to 100% brightness when pressing and holding the toggle (physical dimming). The number entered as value corresponds to the number of seconds.",
+			"unit": "seconds",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 99,
+			"defaultValue": 4,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"17": {
+			"label": "Z-Wave Ramp Rate Control",
+			"description": "Choose if you want to set the Z-Wave ramp rate independently of the physical ramp rate (using an appropriate command in your hub) or if you want them to match.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Z-Wave ramp rate matches the physical ramp rate set in parameter 9 (default)",
+					"value": 0
+				},
+				{
+					"label": "Z-Wave ramp rate is set independently using appropriate Z-Wave commands",
+					"value": 1
+				}
+			]
+		},
+		"18": {
+			"label": "Custom Brightness On",
+			"description": "Set the custom brightness level (instead of the last set brightness level) you want the dimmer to come on to when you toggle the switch up once. 0 Means last brightness level.",
+			"unit": "percent",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 99,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"19": {
+			"label": "3-Way Switch Type",
+			"description": "Choose the type of 3-way switch you want to use with this dimmer in a 3-way set-up. Changing this setting can allow you to control brightness and dim the light from both 3-way locations. Use a regular momentary switch (like the Zooz ZAC99 accessory switch) if value is set to 2.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 3,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Toggle switch, use the connected 3-way switch to turn the light off or on to the last brightness level, dimming only available from the Zooz Z-Wave dimmer and from the hub (or through voice control if smart speaker is integrated with your Z-Wave hub)",
+					"value": 0
+				},
+				{
+					"label": "Toggle switch, toggle up or down once to change state (light on or off), toggle twice quickly to turn light on to full brightness, toggle 3 times quickly to enable a dimming sequence (the light will start dimming up and down in a loop) and toggle the switch again to set the selected brightness level",
+					"value": 1
+				},
+				{
+					"label": "Momentary switch, click once to change status (light on or off), click twice quickly to turn light on to full brightness, press and hold to adjust brightness (dim up / dim down in sequence)",
+					"value": 2
+				},
+				{
+					"label": "Momentary switch, click once to change status (light on or off), click twice quickly to turn light on to full brightness, press and hold to adjust brightness (dim up / dim down in sequence but always reduce brightness after double click)",
+					"value": 3
+				}
+			]
+		},
+		"20": {
+			"label": "Report for Holding PhysicalToggle",
+			"description": "Choose how you'd like the dimmer to report when the toggle is held and physical / Z-Wave control is enabled or disabled.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Report each brightness level to hub when physical / Z-Wave control is disabled for physical dimming (final level only reported if physical / Z-Wave control is enabled)",
+					"value": 0
+				},
+				{
+					"label": "Report final brightness level only for physical dimming, regardless of the physical / Z-Wave control mode.",
+					"value": 1
+				}
+			]
+		},
+		"21": {
+			"label": "Report for Disabled Toggle",
+			"description": "Set reporting behavior for disabled physical control.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Switch reports on/off status even if physical and Z-Wave control is disabled (default)",
+					"value": 0
+				},
+				{
+					"label": "Switch doesn't report on/off status when physical (and Z-Wave) control is disabled",
+					"value": 1
+				}
+			]
+		},
+		"22": {
+			"label": "Night Light Mode",
+			"description": "Set the brightness level the dimmer will turn on to when off and when lower toggle is held DOWN for a second. 0 Means feature is disabled.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 99,
+			"defaultValue": 20,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		}
+	}
+}

--- a/packages/config/config/devices/0x027a/zen24_4.0.json
+++ b/packages/config/config/devices/0x027a/zen24_4.0.json
@@ -236,11 +236,11 @@
 					"value": 0
 				},
 				{
-					"label": "DT Disabled, Single Tap last brightness",
+					"label": "Double Tap Disabled, Single Tap to Last Brightness",
 					"value": 1
 				},
 				{
-					"label": "DT Disabled, Single Tap to Full",
+					"label": "Double Tap Disabled, Single Tap to Full Brightness",
 					"value": 2
 				}
 			]

--- a/packages/config/config/devices/0x027a/zen24_4.0.json
+++ b/packages/config/config/devices/0x027a/zen24_4.0.json
@@ -1,7 +1,6 @@
 // Zooz ZEN24
 // Z-Wave Plus On/Off Toggle Dimmer V4
 {
-	"revision": 1,
 	"manufacturer": "Zooz",
 	"manufacturerId": "0x027a",
 	"label": "ZEN24",
@@ -14,7 +13,7 @@
 	],
 	"firmwareVersion": {
 		"min": "4.0",
-		"max": "4.255"
+		"max": "255.255"
 	},
 	"supportsZWavePlus": true,
 	"associations": {
@@ -31,11 +30,11 @@
 	},
 	"paramInformation": {
 		"1": {
-			"label": "Toggle Control",
+			"label": "Switch behavior",
 			"description": "Determines whether up is on and down is off; or up is off, down is on",
 			"valueSize": 1,
 			"minValue": 0,
-			"maxValue": 1,
+			"maxValue": 2,
 			"defaultValue": 0,
 			"readOnly": false,
 			"writeOnly": false,
@@ -50,14 +49,13 @@
 					"value": 1
 				},
 				{
-					"label": "ANY=Toggle State",
+					"label": "Toggle",
 					"value": 2
 				}
 			]
 		},
 		"3": {
 			"label": "Auto Turn-Off Timer",
-			"description": "Use this parameter to enable or disable the auto turn-off timer",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
@@ -67,11 +65,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Auto Turn-Off Timer Disabled",
+					"label": "Disabled",
 					"value": 0
 				},
 				{
-					"label": "Auto Turn-Off Timer Enabled",
+					"label": "Enabled",
 					"value": 1
 				}
 			]
@@ -90,7 +88,6 @@
 		},
 		"5": {
 			"label": "Auto Turn-On Timer",
-			"description": "Use this parameter to enable or disable the auto turn-on timer",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
@@ -100,11 +97,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Auto Turn-On Timer Disabled",
+					"label": "Disabled",
 					"value": 0
 				},
 				{
-					"label": "Auto Turn-On Timer Enabled",
+					"label": "Enabled",
 					"value": 1
 				}
 			]
@@ -122,8 +119,7 @@
 			"allowManualEntry": true
 		},
 		"8": {
-			"label": "On Off Status After Power Failure",
-			"description": "Set the on off status for the switch after power failure",
+			"label": "Status After Power Failure",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 2,
@@ -133,11 +129,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "forced to OFF",
+					"label": "Forced to OFF",
 					"value": 0
 				},
 				{
-					"label": "forced to ON",
+					"label": "Forced to ON",
 					"value": 1
 				},
 				{
@@ -148,7 +144,7 @@
 		},
 		"9": {
 			"label": "Ramp Rate Control",
-			"description": "Adjust the physical ramp rate for your dimmer (fade-in / fade-out effect for on / off operation). Values correspond to the number of seconds it take for the dimmer to reach full brightness or turn off when operated manually. This setting is for physical taps only, see parameter 17 to adjust Z-Wave ramp rate.",
+			"description": "Adjust the physical ramp rate for your dimmer (fade-in / fade-out effect for on / off operation).",
 			"unit": "seconds",
 			"valueSize": 1,
 			"minValue": 1,
@@ -161,7 +157,7 @@
 		"10": {
 			"label": "Minimum Brightness",
 			"description": "Set the minimum brightness level (in %) for your dimmer. You won’t be able to dim the light below the set value.",
-			"unit": "percent",
+			"unit": "%",
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 99,
@@ -173,7 +169,7 @@
 		"11": {
 			"label": "Maximum Brightness",
 			"description": "Set the maximum brightness level (in %) for your dimmer. You won’t be able to add brightness to the light beyond the set value. Note: if Parameter 12 is set to value 0, Parameter 11 is automatically disabled.",
-			"unit": "percent",
+			"unit": "%",
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 99,
@@ -198,7 +194,7 @@
 					"value": 0
 				},
 				{
-					"label": "Maximum Brightness Level (Parameter 11)",
+					"label": "Custom Brightness Level",
 					"value": 1
 				}
 			]
@@ -215,11 +211,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Scene Control Disabled",
+					"label": "Disabled",
 					"value": 0
 				},
 				{
-					"label": "Scene Control Enabled",
+					"label": "Enabled",
 					"value": 1
 				}
 			]
@@ -244,7 +240,7 @@
 					"value": 1
 				},
 				{
-					"label": "DT Disabled, Single Tap to Full / Max Brightness",
+					"label": "DT Disabled, Single Tap to Full",
 					"value": 2
 				}
 			]
@@ -254,7 +250,7 @@
 			"description": "Enable or disable manual on/off control. If enabled, you’ll only be able to control the connected light via Z-Wave. Scenes and other functionality will still be available through the physical switch.",
 			"valueSize": 1,
 			"minValue": 0,
-			"maxValue": 1,
+			"maxValue": 2,
 			"defaultValue": 1,
 			"readOnly": false,
 			"writeOnly": false,
@@ -276,7 +272,7 @@
 		},
 		"16": {
 			"label": "Physical Dimming Speed",
-			"description": "Set the time it takes to get from 0% to 100% brightness when pressing and holding the toggle (physical dimming). The number entered as value corresponds to the number of seconds.",
+			"description": "Set the time it takes to get from 0% to 100% brightness when pressing and holding the toggle.",
 			"unit": "seconds",
 			"valueSize": 1,
 			"minValue": 1,
@@ -298,11 +294,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Z-Wave ramp rate matches the physical ramp rate set in parameter 9 (default)",
+					"label": "Match Physical",
 					"value": 0
 				},
 				{
-					"label": "Z-Wave ramp rate is set independently using appropriate Z-Wave commands",
+					"label": "Independent",
 					"value": 1
 				}
 			]
@@ -310,7 +306,7 @@
 		"18": {
 			"label": "Custom Brightness On",
 			"description": "Set the custom brightness level (instead of the last set brightness level) you want the dimmer to come on to when you toggle the switch up once. 0 Means last brightness level.",
-			"unit": "percent",
+			"unit": "%",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 99,
@@ -321,7 +317,7 @@
 		},
 		"19": {
 			"label": "3-Way Switch Type",
-			"description": "Choose the type of 3-way switch you want to use with this dimmer in a 3-way set-up. Changing this setting can allow you to control brightness and dim the light from both 3-way locations. Use a regular momentary switch (like the Zooz ZAC99 accessory switch) if value is set to 2.",
+			"description": "Choose the type of 3-way switch you want to use with this dimmer in a 3-way set-up. Changing this setting can allow you to control brightness and dim the light from both 3-way locations. Use a regular momentary switch (like the Zooz ZAC99 accessory switch) if value is set to 2. See Zooz website for details.",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 3,
@@ -331,19 +327,19 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Toggle switch, use the connected 3-way switch to turn the light off or on to the last brightness level, dimming only available from the Zooz Z-Wave dimmer and from the hub (or through voice control if smart speaker is integrated with your Z-Wave hub)",
+					"label": "Toggle switch, On/Off Only",
 					"value": 0
 				},
 				{
-					"label": "Toggle switch, toggle up or down once to change state (light on or off), toggle twice quickly to turn light on to full brightness, toggle 3 times quickly to enable a dimming sequence (the light will start dimming up and down in a loop) and toggle the switch again to set the selected brightness level",
+					"label": "Toggle switch, Dimming Sequence",
 					"value": 1
 				},
 				{
-					"label": "Momentary switch, click once to change status (light on or off), click twice quickly to turn light on to full brightness, press and hold to adjust brightness (dim up / dim down in sequence)",
+					"label": "Momentary switch",
 					"value": 2
 				},
 				{
-					"label": "Momentary switch, click once to change status (light on or off), click twice quickly to turn light on to full brightness, press and hold to adjust brightness (dim up / dim down in sequence but always reduce brightness after double click)",
+					"label": "Momentary switch (variant)",
 					"value": 3
 				}
 			]
@@ -360,18 +356,18 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Report each brightness level to hub when physical / Z-Wave control is disabled for physical dimming (final level only reported if physical / Z-Wave control is enabled)",
+					"label": "All Levels",
 					"value": 0
 				},
 				{
-					"label": "Report final brightness level only for physical dimming, regardless of the physical / Z-Wave control mode.",
+					"label": "Final Level Only",
 					"value": 1
 				}
 			]
 		},
 		"21": {
-			"label": "Report for Disabled Toggle",
-			"description": "Set reporting behavior for disabled physical control.",
+			"label": "Report status when toggle is disabled",
+			"description": "Report light status when both physical and Z-Wave control are disabled.",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
@@ -381,11 +377,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Switch reports on/off status even if physical and Z-Wave control is disabled (default)",
+					"label": "Yes",
 					"value": 0
 				},
 				{
-					"label": "Switch doesn't report on/off status when physical (and Z-Wave) control is disabled",
+					"label": "No",
 					"value": 1
 				}
 			]

--- a/packages/config/config/devices/0x027a/zen24_4.0.json
+++ b/packages/config/config/devices/0x027a/zen24_4.0.json
@@ -1,0 +1,405 @@
+// Zooz ZEN24
+// Z-Wave Plus On/Off Toggle Dimmer V4
+{
+	"revision": 1,
+	"manufacturer": "Zooz",
+	"manufacturerId": "0x027a",
+	"label": "ZEN24",
+	"description": "Z-Wave Plus On/Off Toggle Dimmer V4",
+	"devices": [
+		{
+			"productType": "0xb112",
+			"productId": "0x261c"
+		}
+	],
+	"firmwareVersion": {
+		"min": "4.0",
+		"max": "4.255"
+	},
+	"supportsZWavePlus": true,
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 1,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "Group 2",
+			"description": "BASIC Command Set",
+			"maxNodes": 5
+		}
+	},
+	"paramInformation": {
+		"1": {
+			"label": "Toggle Control",
+			"description": "Determines whether up is on and down is off; or up is off, down is on",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "UP=On, DOWN=Off",
+					"value": 0
+				},
+				{
+					"label": "UP=Off, DOWN=On",
+					"value": 1
+				},
+				{
+					"label": "ANY=Toggle State",
+					"value": 2
+				}
+			]
+		},
+		"3": {
+			"label": "Auto Turn-Off Timer",
+			"description": "Use this parameter to enable or disable the auto turn-off timer",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Auto Turn-Off Timer Disabled",
+					"value": 0
+				},
+				{
+					"label": "Auto Turn-Off Timer Enabled",
+					"value": 1
+				}
+			]
+		},
+		"4": {
+			"label": "Auto Turn-Off Timer Time",
+			"description": "Time after which the switch automatically turns off",
+			"unit": "minutes",
+			"valueSize": 4,
+			"minValue": 1,
+			"maxValue": 65535,
+			"defaultValue": 60,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"5": {
+			"label": "Auto Turn-On Timer",
+			"description": "Use this parameter to enable or disable the auto turn-on timer",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Auto Turn-On Timer Disabled",
+					"value": 0
+				},
+				{
+					"label": "Auto Turn-On Timer Enabled",
+					"value": 1
+				}
+			]
+		},
+		"6": {
+			"label": "Auto Turn-On Timer Time",
+			"description": "Set the time after which the switch automatically turns on",
+			"unit": "minutes",
+			"valueSize": 4,
+			"minValue": 1,
+			"maxValue": 65535,
+			"defaultValue": 60,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"8": {
+			"label": "On Off Status After Power Failure",
+			"description": "Set the on off status for the switch after power failure",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 2,
+			"defaultValue": 2,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "forced to OFF",
+					"value": 0
+				},
+				{
+					"label": "forced to ON",
+					"value": 1
+				},
+				{
+					"label": "Restore Previous Status",
+					"value": 2
+				}
+			]
+		},
+		"9": {
+			"label": "Ramp Rate Control",
+			"description": "Adjust the physical ramp rate for your dimmer (fade-in / fade-out effect for on / off operation). Values correspond to the number of seconds it take for the dimmer to reach full brightness or turn off when operated manually. This setting is for physical taps only, see parameter 17 to adjust Z-Wave ramp rate.",
+			"unit": "seconds",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 99,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"10": {
+			"label": "Minimum Brightness",
+			"description": "Set the minimum brightness level (in %) for your dimmer. You won’t be able to dim the light below the set value.",
+			"unit": "percent",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 99,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"11": {
+			"label": "Maximum Brightness",
+			"description": "Set the maximum brightness level (in %) for your dimmer. You won’t be able to add brightness to the light beyond the set value. Note: if Parameter 12 is set to value 0, Parameter 11 is automatically disabled.",
+			"unit": "percent",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 99,
+			"defaultValue": 99,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"12": {
+			"label": "Double Tap Function",
+			"description": "Choose if you want the dimmer to turn on to full brightness or custom brightness level after you toggle the switch up twice quickly.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Full Brightness",
+					"value": 0
+				},
+				{
+					"label": "Maximum Brightness Level (Parameter 11)",
+					"value": 1
+				}
+			]
+		},
+		"13": {
+			"label": "Scene Control Enable",
+			"description": "Enable or disable scene control functionality for quick double tap triggers.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Scene Control Disabled",
+					"value": 0
+				},
+				{
+					"label": "Scene Control Enabled",
+					"value": 1
+				}
+			]
+		},
+		"14": {
+			"label": "Double & Single Tap Enable",
+			"description": "Enable or disable the double tap function and assign brightness level to single tap.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 2,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Double Tap Enabled",
+					"value": 0
+				},
+				{
+					"label": "DT Disabled, Single Tap last brightness",
+					"value": 1
+				},
+				{
+					"label": "DT Disabled, Single Tap to Full / Max Brightness",
+					"value": 2
+				}
+			]
+		},
+		"15": {
+			"label": "Local Toggle Control",
+			"description": "Enable or disable manual on/off control. If enabled, you’ll only be able to control the connected light via Z-Wave. Scenes and other functionality will still be available through the physical switch.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Physical switch disabled",
+					"value": 0
+				},
+				{
+					"label": "Physical switch enabled",
+					"value": 1
+				},
+				{
+					"label": "Physical switch and Z-Wave control disabled",
+					"value": 2
+				}
+			]
+		},
+		"16": {
+			"label": "Physical Dimming Speed",
+			"description": "Set the time it takes to get from 0% to 100% brightness when pressing and holding the toggle (physical dimming). The number entered as value corresponds to the number of seconds.",
+			"unit": "seconds",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 99,
+			"defaultValue": 4,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"17": {
+			"label": "Z-Wave Ramp Rate Control",
+			"description": "Choose if you want to set the Z-Wave ramp rate independently of the physical ramp rate (using an appropriate command in your hub) or if you want them to match.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Z-Wave ramp rate matches the physical ramp rate set in parameter 9 (default)",
+					"value": 0
+				},
+				{
+					"label": "Z-Wave ramp rate is set independently using appropriate Z-Wave commands",
+					"value": 1
+				}
+			]
+		},
+		"18": {
+			"label": "Custom Brightness On",
+			"description": "Set the custom brightness level (instead of the last set brightness level) you want the dimmer to come on to when you toggle the switch up once. 0 Means last brightness level.",
+			"unit": "percent",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 99,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"19": {
+			"label": "3-Way Switch Type",
+			"description": "Choose the type of 3-way switch you want to use with this dimmer in a 3-way set-up. Changing this setting can allow you to control brightness and dim the light from both 3-way locations. Use a regular momentary switch (like the Zooz ZAC99 accessory switch) if value is set to 2.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 3,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Toggle switch, use the connected 3-way switch to turn the light off or on to the last brightness level, dimming only available from the Zooz Z-Wave dimmer and from the hub (or through voice control if smart speaker is integrated with your Z-Wave hub)",
+					"value": 0
+				},
+				{
+					"label": "Toggle switch, toggle up or down once to change state (light on or off), toggle twice quickly to turn light on to full brightness, toggle 3 times quickly to enable a dimming sequence (the light will start dimming up and down in a loop) and toggle the switch again to set the selected brightness level",
+					"value": 1
+				},
+				{
+					"label": "Momentary switch, click once to change status (light on or off), click twice quickly to turn light on to full brightness, press and hold to adjust brightness (dim up / dim down in sequence)",
+					"value": 2
+				},
+				{
+					"label": "Momentary switch, click once to change status (light on or off), click twice quickly to turn light on to full brightness, press and hold to adjust brightness (dim up / dim down in sequence but always reduce brightness after double click)",
+					"value": 3
+				}
+			]
+		},
+		"20": {
+			"label": "Report for Holding PhysicalToggle",
+			"description": "Choose how you'd like the dimmer to report when the toggle is held and physical / Z-Wave control is enabled or disabled.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Report each brightness level to hub when physical / Z-Wave control is disabled for physical dimming (final level only reported if physical / Z-Wave control is enabled)",
+					"value": 0
+				},
+				{
+					"label": "Report final brightness level only for physical dimming, regardless of the physical / Z-Wave control mode.",
+					"value": 1
+				}
+			]
+		},
+		"21": {
+			"label": "Report for Disabled Toggle",
+			"description": "Set reporting behavior for disabled physical control.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Switch reports on/off status even if physical and Z-Wave control is disabled (default)",
+					"value": 0
+				},
+				{
+					"label": "Switch doesn't report on/off status when physical (and Z-Wave) control is disabled",
+					"value": 1
+				}
+			]
+		},
+		"22": {
+			"label": "Night Light Mode",
+			"description": "Set the brightness level the dimmer will turn on to when off and when lower toggle is held DOWN for a second. 0 Means feature is disabled.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 99,
+			"defaultValue": 20,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		}
+	}
+}


### PR DESCRIPTION
- Updates v3 switches with additional params and information from the Zooz website
- Adds missing v3 and v4 configs

I don't have any ZEN21/22 paddle switches, but in theory these changes should be the same for those modules. Hopefully someone else can come along and add those later.