### PR TITLE
feat(config): add Inovelli NZW30T manufactured by NIE Technology

### DIFF
--- a/packages/config/config/devices/0x0312/nzw30t.json
+++ b/packages/config/config/devices/0x0312/nzw30t.json
@@ -41,7 +41,7 @@
 		"5": {
 			"label": "Countdown",
 			"description": "Countdown to shutoff",
-			"unit": "Seconds",
+			"unit": "seconds",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 32767,

--- a/packages/config/config/devices/0x0312/nzw30t.json
+++ b/packages/config/config/devices/0x0312/nzw30t.json
@@ -1,0 +1,54 @@
+// NIE Technology Co., Ltd. NZW30T
+// Inovelli In-Wall Switch (On/Off) Scene Enabled
+{
+	"manufacturer": "NIE Technology Co., Ltd.",
+	"manufacturerId": "0x0312",
+	"label": "NZW30T",
+	"description": "Inovelli In-Wall Switch (On/Off) Scene Enabled",
+	"devices": [
+		{
+			"productType": "0x1e02",
+			"productId": "0x1e02"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"supportsZWavePlus": true,
+	"paramInformation": {
+		"4": {
+			"label": "Invert",
+			"description": "Change the top of the switch to OFF and the bottom of the switch to ON.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Default",
+					"value": 0
+				},
+				{
+					"label": "Inverted",
+					"value": 1
+				}
+			]
+		},
+		"5": {
+			"label": "Countdown",
+			"description": "Countdown to shutoff",
+			"unit": "Seconds",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 32767,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		}
+	}
+}

--- a/packages/config/config/devices/0x0312/nzw30t.json
+++ b/packages/config/config/devices/0x0312/nzw30t.json
@@ -1,10 +1,10 @@
 // NIE Technology Co., Ltd. NZW30T
 // Inovelli In-Wall Switch (On/Off) Scene Enabled
 {
-	"manufacturer": "NIE Technology Co., Ltd.",
+	"manufacturer": "Inovelli",
 	"manufacturerId": "0x0312",
 	"label": "NZW30T",
-	"description": "Inovelli In-Wall Switch (On/Off) Scene Enabled",
+	"description": "In-Wall Switch (On/Off) Scene Enabled",
 	"devices": [
 		{
 			"productType": "0x1e02",


### PR DESCRIPTION
While some of the NZW30T switches were manufactured by Willis, mine appear to be manufactured by NIE since the json dump from the server shows:

"manufacturerId": 786, "productId": 7682, "productType": 7682,