### PR TITLE
fix(config): change Seconds to seconds for Willis NZW30T

### DIFF
--- a/packages/config/config/devices/0x015d/nzw30t.json
+++ b/packages/config/config/devices/0x015d/nzw30t.json
@@ -45,7 +45,7 @@
 		"5": {
 			"label": "Countdown",
 			"description": "Countdown to shutoff",
-			"unit": "Seconds",
+			"unit": "seconds",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 32767,


### PR DESCRIPTION
Change Seconds to seconds for Willis NZW30T