### PR TITLE
feat(cc): map Notification CC (un)lock operations to (Door) Lock CC

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
@@ -98,54 +98,6 @@ function getOperationTypeValueId(endpoint: number): ValueID {
 	};
 }
 
-function getLatchSupportedValueId(endpoint: number): ValueID {
-	return {
-		commandClass: CommandClasses["Door Lock"],
-		endpoint,
-		property: "latchSupported",
-	};
-}
-
-function getBoltSupportedValueId(endpoint: number): ValueID {
-	return {
-		commandClass: CommandClasses["Door Lock"],
-		endpoint,
-		property: "boltSupported",
-	};
-}
-
-function getDoorSupportedValueId(endpoint: number): ValueID {
-	return {
-		commandClass: CommandClasses["Door Lock"],
-		endpoint,
-		property: "doorSupported",
-	};
-}
-
-function getLatchStatusValueId(endpoint: number): ValueID {
-	return {
-		commandClass: CommandClasses["Door Lock"],
-		endpoint,
-		property: "latchStatus",
-	};
-}
-
-function getBoltStatusValueId(endpoint: number): ValueID {
-	return {
-		commandClass: CommandClasses["Door Lock"],
-		endpoint,
-		property: "boltStatus",
-	};
-}
-
-function getDoorStatusValueId(endpoint: number): ValueID {
-	return {
-		commandClass: CommandClasses["Door Lock"],
-		endpoint,
-		property: "doorStatus",
-	};
-}
-
 const configurationSetParameters = [
 	"operationType",
 	"outsideHandlesCanOpenDoorConfiguration",
@@ -534,43 +486,6 @@ latch status:       ${status.latchStatus}`;
 
 		// Remember that the interview is complete
 		if (!hadCriticalTimeout) this.interviewComplete = true;
-	}
-
-	public handleLockOperationNotification(isLocked: boolean): void {
-		const node = this.getNode()!;
-		const endpoint = this.getEndpoint()!;
-		const api = endpoint.commandClasses["Door Lock"].withOptions({
-			priority: MessagePriority.NodeQuery,
-		});
-
-		const valueDB = node.valueDB;
-		valueDB.setValue(
-			getCurrentModeValueId(this.endpointIndex),
-			isLocked ? DoorLockMode.Secured : DoorLockMode.Unsecured,
-		);
-		if (valueDB.getValue(getDoorSupportedValueId(this.endpointIndex))) {
-			valueDB.setValue(
-				getDoorStatusValueId(this.endpointIndex),
-				isLocked ? "closed" : "open",
-			);
-		}
-		if (valueDB.getValue(getBoltSupportedValueId(this.endpointIndex))) {
-			valueDB.setValue(
-				getBoltStatusValueId(this.endpointIndex),
-				isLocked ? "locked" : "unlocked",
-			);
-		}
-		if (valueDB.getValue(getLatchSupportedValueId(this.endpointIndex))) {
-			valueDB.setValue(
-				getLatchStatusValueId(this.endpointIndex),
-				isLocked ? "closed" : "open",
-			);
-		}
-
-		// And since we're really not sure about all these statuses, verify :)
-		api.get().catch(() => {
-			/* ignore */
-		});
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
@@ -98,6 +98,54 @@ function getOperationTypeValueId(endpoint: number): ValueID {
 	};
 }
 
+function getLatchSupportedValueId(endpoint: number): ValueID {
+	return {
+		commandClass: CommandClasses["Door Lock"],
+		endpoint,
+		property: "latchSupported",
+	};
+}
+
+function getBoltSupportedValueId(endpoint: number): ValueID {
+	return {
+		commandClass: CommandClasses["Door Lock"],
+		endpoint,
+		property: "boltSupported",
+	};
+}
+
+function getDoorSupportedValueId(endpoint: number): ValueID {
+	return {
+		commandClass: CommandClasses["Door Lock"],
+		endpoint,
+		property: "doorSupported",
+	};
+}
+
+function getLatchStatusValueId(endpoint: number): ValueID {
+	return {
+		commandClass: CommandClasses["Door Lock"],
+		endpoint,
+		property: "latchStatus",
+	};
+}
+
+function getBoltStatusValueId(endpoint: number): ValueID {
+	return {
+		commandClass: CommandClasses["Door Lock"],
+		endpoint,
+		property: "boltStatus",
+	};
+}
+
+function getDoorStatusValueId(endpoint: number): ValueID {
+	return {
+		commandClass: CommandClasses["Door Lock"],
+		endpoint,
+		property: "doorStatus",
+	};
+}
+
 const configurationSetParameters = [
 	"operationType",
 	"outsideHandlesCanOpenDoorConfiguration",
@@ -486,6 +534,43 @@ latch status:       ${status.latchStatus}`;
 
 		// Remember that the interview is complete
 		if (!hadCriticalTimeout) this.interviewComplete = true;
+	}
+
+	public handleLockOperationNotification(isLocked: boolean): void {
+		const node = this.getNode()!;
+		const endpoint = this.getEndpoint()!;
+		const api = endpoint.commandClasses["Door Lock"].withOptions({
+			priority: MessagePriority.NodeQuery,
+		});
+
+		const valueDB = node.valueDB;
+		valueDB.setValue(
+			getCurrentModeValueId(this.endpointIndex),
+			isLocked ? DoorLockMode.Secured : DoorLockMode.Unsecured,
+		);
+		if (valueDB.getValue(getDoorSupportedValueId(this.endpointIndex))) {
+			valueDB.setValue(
+				getDoorStatusValueId(this.endpointIndex),
+				isLocked ? "closed" : "open",
+			);
+		}
+		if (valueDB.getValue(getBoltSupportedValueId(this.endpointIndex))) {
+			valueDB.setValue(
+				getBoltStatusValueId(this.endpointIndex),
+				isLocked ? "locked" : "unlocked",
+			);
+		}
+		if (valueDB.getValue(getLatchSupportedValueId(this.endpointIndex))) {
+			valueDB.setValue(
+				getLatchStatusValueId(this.endpointIndex),
+				isLocked ? "closed" : "open",
+			);
+		}
+
+		// And since we're really not sure about all these statuses, verify :)
+		api.get().catch(() => {
+			/* ignore */
+		});
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
@@ -74,11 +74,19 @@ export enum DoorLockOperationType {
 // @publicAPI
 export type DoorHandleStatus = [boolean, boolean, boolean, boolean];
 
-function getTargetModeValueId(endpoint: number): ValueID {
+export function getTargetModeValueId(endpoint: number): ValueID {
 	return {
 		commandClass: CommandClasses["Door Lock"],
 		endpoint,
 		property: "targetMode",
+	};
+}
+
+export function getCurrentModeValueId(endpoint: number): ValueID {
+	return {
+		commandClass: CommandClasses["Door Lock"],
+		endpoint,
+		property: "currentMode",
 	};
 }
 

--- a/packages/zwave-js/src/lib/commandclass/LockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/LockCC.ts
@@ -143,11 +143,6 @@ export class LockCC extends CommandClass {
 		// Remember that the interview is complete
 		this.interviewComplete = true;
 	}
-
-	public handleLockOperationNotification(isLocked: boolean): void {
-		const valueDB = this.getNode()!.valueDB;
-		valueDB.setValue(getLockedValueId(this.endpointIndex), isLocked);
-	}
 }
 
 interface LockCCSetOptions extends CCCommandOptions {

--- a/packages/zwave-js/src/lib/commandclass/LockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/LockCC.ts
@@ -143,6 +143,11 @@ export class LockCC extends CommandClass {
 		// Remember that the interview is complete
 		this.interviewComplete = true;
 	}
+
+	public handleLockOperationNotification(isLocked: boolean): void {
+		const valueDB = this.getNode()!.valueDB;
+		valueDB.setValue(getLockedValueId(this.endpointIndex), isLocked);
+	}
 }
 
 interface LockCCSetOptions extends CCCommandOptions {

--- a/packages/zwave-js/src/lib/commandclass/LockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/LockCC.ts
@@ -1,4 +1,4 @@
-import type { Maybe, MessageOrCCLogEntry } from "@zwave-js/core";
+import type { Maybe, MessageOrCCLogEntry, ValueID } from "@zwave-js/core";
 import {
 	CommandClasses,
 	validatePayload,
@@ -36,6 +36,14 @@ export enum LockCommand {
 	Set = 0x01,
 	Get = 0x02,
 	Report = 0x03,
+}
+
+export function getLockedValueId(endpoint: number): ValueID {
+	return {
+		commandClass: CommandClasses.Lock,
+		endpoint,
+		property: "locked",
+	};
 }
 
 @API(CommandClasses.Lock)

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -52,10 +52,7 @@ import {
 } from "../commandclass/CentralSceneCC";
 import { ClockCCReport } from "../commandclass/ClockCC";
 import { CommandClass, getCCValueMetadata } from "../commandclass/CommandClass";
-import {
-	DoorLockMode,
-	getCurrentModeValueId as getCurrentLockModeValueId,
-} from "../commandclass/DoorLockCC";
+import { DoorLockCC } from "../commandclass/DoorLockCC";
 import {
 	FirmwareUpdateMetaDataCC,
 	FirmwareUpdateMetaDataCCGet,
@@ -65,7 +62,7 @@ import {
 } from "../commandclass/FirmwareUpdateMetaDataCC";
 import { HailCC } from "../commandclass/HailCC";
 import { isCommandClassContainer } from "../commandclass/ICommandClassContainer";
-import { getLockedValueId } from "../commandclass/LockCC";
+import { LockCC } from "../commandclass/LockCC";
 import {
 	getManufacturerIdValueId,
 	getProductIdValueId,
@@ -2417,16 +2414,16 @@ version:               ${this.version}`;
 
 			// Update the current lock status
 			if (this.supportsCC(CommandClasses["Door Lock"])) {
-				this.valueDB.setValue(
-					getCurrentLockModeValueId(command.endpointIndex),
-					isLocked ? DoorLockMode.Secured : DoorLockMode.Unsecured,
-				);
+				const instance = this.getEndpoint(
+					command.endpointIndex,
+				)?.createCCInstanceInternal(DoorLockCC);
+				instance?.handleLockOperationNotification(isLocked);
 			}
 			if (this.supportsCC(CommandClasses.Lock)) {
-				this.valueDB.setValue(
-					getLockedValueId(command.endpointIndex),
-					isLocked,
-				);
+				const instance = this.getEndpoint(
+					command.endpointIndex,
+				)?.createCCInstanceInternal(LockCC);
+				instance?.handleLockOperationNotification(isLocked);
 			}
 		}
 	}

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -52,7 +52,10 @@ import {
 } from "../commandclass/CentralSceneCC";
 import { ClockCCReport } from "../commandclass/ClockCC";
 import { CommandClass, getCCValueMetadata } from "../commandclass/CommandClass";
-import { DoorLockCC } from "../commandclass/DoorLockCC";
+import {
+	DoorLockMode,
+	getCurrentModeValueId as getCurrentLockModeValueId,
+} from "../commandclass/DoorLockCC";
 import {
 	FirmwareUpdateMetaDataCC,
 	FirmwareUpdateMetaDataCCGet,
@@ -62,7 +65,7 @@ import {
 } from "../commandclass/FirmwareUpdateMetaDataCC";
 import { HailCC } from "../commandclass/HailCC";
 import { isCommandClassContainer } from "../commandclass/ICommandClassContainer";
-import { LockCC } from "../commandclass/LockCC";
+import { getLockedValueId } from "../commandclass/LockCC";
 import {
 	getManufacturerIdValueId,
 	getProductIdValueId,
@@ -2414,16 +2417,16 @@ version:               ${this.version}`;
 
 			// Update the current lock status
 			if (this.supportsCC(CommandClasses["Door Lock"])) {
-				const instance = this.getEndpoint(
-					command.endpointIndex,
-				)?.createCCInstanceInternal(DoorLockCC);
-				instance?.handleLockOperationNotification(isLocked);
+				this.valueDB.setValue(
+					getCurrentLockModeValueId(command.endpointIndex),
+					isLocked ? DoorLockMode.Secured : DoorLockMode.Unsecured,
+				);
 			}
 			if (this.supportsCC(CommandClasses.Lock)) {
-				const instance = this.getEndpoint(
-					command.endpointIndex,
-				)?.createCCInstanceInternal(LockCC);
-				instance?.handleLockOperationNotification(isLocked);
+				this.valueDB.setValue(
+					getLockedValueId(command.endpointIndex),
+					isLocked,
+				);
 			}
 		}
 	}

--- a/packages/zwave-js/src/lib/test/cc/mapNotificationDoorLock.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/mapNotificationDoorLock.test.ts
@@ -1,0 +1,66 @@
+import { CommandClasses } from "@zwave-js/core";
+import {
+	DoorLockMode,
+	getCurrentModeValueId as getCurrentLockModeValueId,
+} from "../../commandclass/DoorLockCC";
+import { NotificationCCReport } from "../../commandclass/NotificationCC";
+import type { ThrowingMap } from "../../controller/Controller";
+import type { Driver } from "../../driver/Driver";
+import { ZWaveNode } from "../../node/Node";
+import { createAndStartDriver } from "../utils";
+
+describe("map Notification CC to Door Lock CC", () => {
+	let driver: Driver;
+	process.env.LOGLEVEL = "debug";
+
+	beforeEach(async () => {
+		({ driver } = await createAndStartDriver());
+
+		driver["_controller"] = {
+			ownNodeId: 1,
+			isFunctionSupported: () => true,
+			nodes: new Map(),
+		} as any;
+		await driver.configManager.loadNotifications();
+	});
+
+	afterEach(async () => {
+		await driver.destroy();
+		driver.removeAllListeners();
+	});
+
+	it("When receiving a NotificationCC::Report with a lock operation, the current value for Door Lock CC should be updated accordingly", () => {
+		const node = new ZWaveNode(1, driver);
+		node.addCC(CommandClasses["Door Lock"], {
+			isSupported: true,
+		});
+		node.addCC(CommandClasses.Notification, {
+			isSupported: true,
+			version: 8,
+		});
+		(driver.controller.nodes as ThrowingMap<number, ZWaveNode>).set(
+			node.id,
+			node,
+		);
+
+		const valueId = getCurrentLockModeValueId(0);
+
+		let cmd = new NotificationCCReport(driver, {
+			nodeId: node.id,
+			notificationType: 0x06, // Access Control,
+			notificationEvent: 0x01, // Manual Lock Operation
+		});
+		node.handleCommand(cmd);
+
+		expect(node.getValue(valueId)).toEqual(DoorLockMode.Secured);
+
+		cmd = new NotificationCCReport(driver, {
+			nodeId: node.id,
+			notificationType: 0x06, // Access Control,
+			notificationEvent: 0x06, // Keypad Unlock Operation
+		});
+		node.handleCommand(cmd);
+
+		expect(node.getValue(valueId)).toEqual(DoorLockMode.Unsecured);
+	});
+});


### PR DESCRIPTION
With this PR, we handle manual (un)lock operations reported through Notification CC and set the current lock status for (Door) Lock CC accordingly.

fixes: #1602