### PR TITLE
fix(cc): ignore newlines before/after ASCII in V1 UserCode reports

### DIFF
--- a/packages/shared/src/strings.ts
+++ b/packages/shared/src/strings.ts
@@ -30,3 +30,7 @@ export function buffer2hex(buffer: Buffer, uppercase: boolean = false): string {
 export function isPrintableASCII(text: string): boolean {
 	return /^[\u0020-\u007e]*$/.test(text);
 }
+
+export function isPrintableASCIIWithNewlines(text: string): boolean {
+	return /^[\r\n]*[\u0020-\u007e]*[\r\n]*$/.test(text);
+}

--- a/packages/zwave-js/src/lib/commandclass/UserCodeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/UserCodeCC.ts
@@ -16,6 +16,7 @@ import {
 	buffer2hex,
 	getEnumMemberName,
 	isPrintableASCII,
+	isPrintableASCIIWithNewlines,
 	num2hex,
 	pick,
 } from "@zwave-js/shared";
@@ -970,6 +971,14 @@ export class UserCodeCCReport extends UserCodeCC {
 			const userCodeString = userCodeBuffer.toString("utf8");
 			if (isPrintableASCII(userCodeString)) {
 				this.userCode = userCodeString;
+			} else if (
+				this.version === 1 &&
+				isPrintableASCIIWithNewlines(userCodeString)
+			) {
+				// Ignore leading and trailing newlines in V1 reports if the rest is ASCII
+				this.userCode = userCodeString
+					.replace(/^[\r\n]*/, "")
+					.replace(/[\r\n]*$/, "");
 			} else {
 				this.userCode = userCodeBuffer;
 			}


### PR DESCRIPTION
fixes: #1642