### PR TITLE
fix(config): correct device names UFairy ZSE01/ZSE02

### DIFF
--- a/packages/config/config/devices/0x0152/zse01.json
+++ b/packages/config/config/devices/0x0152/zse01.json
@@ -1,10 +1,10 @@
-// Zooz Zooz Indoor Siren
-// ZSE01
+// UFairy G.R. Tech ZSE01
+// Indoor Siren
 {
-	"manufacturer": "Zooz",
+	"manufacturer": "UFairy G.R. Tech",
 	"manufacturerId": "0x0152",
-	"label": "Zooz Indoor Siren",
-	"description": "ZSE01",
+	"label": "ZSE01",
+	"description": "Indoor Siren",
 	"devices": [
 		{
 			"productType": "0x0003",

--- a/packages/config/config/devices/0x0152/zse02.json
+++ b/packages/config/config/devices/0x0152/zse02.json
@@ -1,10 +1,10 @@
-// Zooz ZSE02
-// Zooz Z‑Wave Plus Motion Sensor
+// UFairy G.R. Tech ZSE02
+// Z‑Wave Plus Motion Sensor
 {
-	"manufacturer": "Zooz",
+	"manufacturer": "UFairy G.R. Tech",
 	"manufacturerId": "0x0152",
 	"label": "ZSE02",
-	"description": "Zooz Z‑Wave Plus Motion Sensor",
+	"description": "Z‑Wave Plus Motion Sensor",
 	"devices": [
 		{
 			"productType": "0x0500",


### PR DESCRIPTION
Correct devices names mistakenly changed to Zooz. Renames device file for consistency.

@marcus-j-davies 