### PR TITLE
fix(config): add LED always on to GE 46201

### DIFF
--- a/packages/config/config/devices/0x0063/46201.json
+++ b/packages/config/config/devices/0x0063/46201.json
@@ -56,6 +56,10 @@
 				{
 					"label": "LED always OFF",
 					"value": 2
+				},
+				{
+					"label": "LED always ON",
+					"value": 3
 				}
 			]
 		}


### PR DESCRIPTION
These switches respond to a value of 3 to keep the LED always on.