### PR TITLE
fix(config): fix zen30 latest firmware config

### DIFF
--- a/packages/config/config/devices/0x027a/zen30_1.4.json
+++ b/packages/config/config/devices/0x027a/zen30_1.4.json
@@ -13,7 +13,7 @@
 		}
 	],
 	"firmwareVersion": {
-		"min": "1.5",
+		"min": "1.4",
 		"max": "255.255"
 	},
 	"associations": {


### PR DESCRIPTION
The Zen30 firmware changed in 1.4 and has identical parameters to the latest 1.5 that currently exists in the repo.  The file should be changed to min 1.4 and max 255.255.  This is a very minor change so 1.4 firmwares have the appropriate parameters.