### PR TITLE
fix(config): move product Type/Id from CT100 to CT101

### DIFF
--- a/packages/config/config/devices/0x0098/ct100.json
+++ b/packages/config/config/devices/0x0098/ct100.json
@@ -30,10 +30,6 @@
 			"productType": "0x6401",
 			"productId": "0x01fd"
 		},
-		{
-			"productType": "0x6501",
-			"productId": "0x000b"
-		}
 	],
 	"firmwareVersion": {
 		"min": "0.0",

--- a/packages/config/config/devices/0x0098/ct100.json
+++ b/packages/config/config/devices/0x0098/ct100.json
@@ -29,7 +29,7 @@
 		{
 			"productType": "0x6401",
 			"productId": "0x01fd"
-		},
+		}
 	],
 	"firmwareVersion": {
 		"min": "0.0",

--- a/packages/config/config/devices/0x0098/ct101.json
+++ b/packages/config/config/devices/0x0098/ct101.json
@@ -14,7 +14,7 @@
 		{
 			"productType": "0x6501",
 			"productId": "0x000b"
-		},		
+		},
 		{
 			"productType": "0x6501",
 			"productId": "0x000c"

--- a/packages/config/config/devices/0x0098/ct101.json
+++ b/packages/config/config/devices/0x0098/ct101.json
@@ -14,7 +14,7 @@
 		{
 			"productType": "0x6501",
 			"productId": "0x000b"
-		}		
+		},		
 		{
 			"productType": "0x6501",
 			"productId": "0x000c"

--- a/packages/config/config/devices/0x0098/ct101.json
+++ b/packages/config/config/devices/0x0098/ct101.json
@@ -13,6 +13,10 @@
 		},
 		{
 			"productType": "0x6501",
+			"productId": "0x000b"
+		}		
+		{
+			"productType": "0x6501",
 			"productId": "0x000c"
 		},
 		{


### PR DESCRIPTION
One of my 3 CT101 thermostats is incorrectly identified as a CT100. This device is correctly identified in OZW Admin.

fixes: #1664 