### PR TITLE
fix(bot): apply pre-created patch instead of running npm scripts for lint

### DIFF
--- a/.github/bot-scripts/fixLintFeedback.js
+++ b/.github/bot-scripts/fixLintFeedback.js
@@ -14,7 +14,7 @@ async function main(param) {
 
 	let feedbackText;
 	if (process.env.FEEDBACK === "error") {
-		feedbackText = `🔨 I tried my best, but unfortunately some lint errors require manual attention.`;
+		feedbackText = `🔨 I tried my best, but something went wrong.`;
 	} else if (process.env.FEEDBACK === "unchanged") {
 		feedbackText = `😕 Sorry, I couldn't do anything here.`;
 	} else {

--- a/.github/bot-scripts/fixLintFeedback.js
+++ b/.github/bot-scripts/fixLintFeedback.js
@@ -13,7 +13,9 @@ async function main(param) {
 	};
 
 	let feedbackText;
-	if (process.env.FEEDBACK === "error") {
+	if (process.env.PENDING) {
+		feedbackText = `⏳ Please wait for the lint check to complete, then try again.`;
+	} else if (process.env.FEEDBACK === "error") {
 		feedbackText = `🔨 I tried my best, but something went wrong.`;
 	} else if (process.env.FEEDBACK === "unchanged") {
 		feedbackText = `😕 Sorry, I couldn't do anything here.`;

--- a/.github/bot-scripts/fixLintFeedback.js
+++ b/.github/bot-scripts/fixLintFeedback.js
@@ -14,9 +14,9 @@ async function main(param) {
 
 	let feedbackText;
 	if (process.env.PENDING) {
-		feedbackText = `⏳ Please wait for the lint check to complete, then try again.`;
+		feedbackText = `🐌 Please wait for the lint check to complete, then try again.`;
 	} else if (process.env.FEEDBACK === "error") {
-		feedbackText = `🔨 I tried my best, but something went wrong.`;
+		feedbackText = `❌ I tried my best, but something went wrong.`;
 	} else if (process.env.FEEDBACK === "unchanged") {
 		feedbackText = `😕 Sorry, I couldn't do anything here.`;
 	} else {

--- a/.github/bot-scripts/getFixLintInfo.js
+++ b/.github/bot-scripts/getFixLintInfo.js
@@ -1,0 +1,56 @@
+/// <reference path="types.d.ts" />
+// @ts-check
+
+/**
+ * @param {{github: Github, context: Context}} param
+ */
+async function main(param) {
+	const { github, context } = param;
+
+	const options = {
+		owner: context.repo.owner,
+		repo: context.repo.repo,
+	};
+
+	// Get PR info
+	const { data: pull } = await github.pulls.get({
+		...options,
+		pull_number: context.issue.number,
+	});
+	const { data: checks } = await github.checks.listForRef({
+		...options,
+		ref: pull.head.sha,
+	});
+	// Find the correct check
+	const lintCheck = checks.check_runs.find(
+		(r) => r.conclusion === "failure" && r.name.startsWith("lint"),
+	);
+	if (!lintCheck) return undefined;
+
+	const { data: job } = await github.actions.getJobForWorkflowRun({
+		...options,
+		job_id: lintCheck.id,
+	});
+	const {
+		data: { artifacts },
+	} = await github.actions.listWorkflowRunArtifacts({
+		...options,
+		// @ts-expect-error for some reason job is `never`
+		run_id: job.run_id,
+	});
+
+	if (!artifacts.length) return undefined;
+
+	const { url } = await github.actions.downloadArtifact({
+		...options,
+		artifact_id: artifacts[0].id,
+		archive_format: "zip",
+	});
+
+	return {
+		repoName: pull.head.repo.full_name,
+		headRef: pull.head.sha,
+		patchUrl: url,
+	};
+}
+module.exports = main;

--- a/.github/bot-scripts/getFixLintInfo.js
+++ b/.github/bot-scripts/getFixLintInfo.js
@@ -49,7 +49,7 @@ async function main(param) {
 
 	return {
 		repoName: pull.head.repo.full_name,
-		headRef: pull.head.sha,
+		headRef: pull.head.ref,
 		patchUrl: url,
 	};
 }

--- a/.github/bot-scripts/index.js
+++ b/.github/bot-scripts/index.js
@@ -1,6 +1,7 @@
 module.exports = {
 	checkAuthorized: (...args) => require("./checkAuthorized")(...args),
 	fixLintFeedback: (...args) => require("./fixLintFeedback")(...args),
+	getFixLintInfo: (...args) => require("./getFixLintInfo")(...args),
 	rebaseFeedback: (...args) => require("./rebaseFeedback")(...args),
 	renameCommitGetPRInfo: (...args) =>
 		require("./renameCommitGetPRInfo")(...args),

--- a/.github/workflows/zwave-js-bot_comment.yml
+++ b/.github/workflows/zwave-js-bot_comment.yml
@@ -113,13 +113,15 @@ jobs:
             core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
             const result = await bot.getFixLintInfo({github, context});
             console.dir(result);
-            return result;
+            return result ?? {pending: true};
           } catch (err) {
             core.setFailed(`Request failed with error ${err}`)
           }
 
     - name: Download Lint patch
-      if: steps.check-permissions.outputs.result == 'true'
+      if: |
+        steps.check-permissions.outputs.result == 'true' &&
+        !fromJSON(steps.pr-info.outputs.result).pending
       env:
         PATCH_URL: ${{ fromJSON(steps.pr-info.outputs.result).patchUrl }}
       run: |
@@ -129,7 +131,9 @@ jobs:
         unzip patch.zip
 
     - name: Checkout pull request side by side
-      if: steps.check-permissions.outputs.result == 'true'
+      if: |
+        steps.check-permissions.outputs.result == 'true' &&
+        !fromJSON(steps.pr-info.outputs.result).pending
       uses: actions/checkout@v2
       with:
         token: ${{secrets.BOT_TOKEN}}
@@ -138,7 +142,9 @@ jobs:
         path: untrusted
 
     - name: Do the lint fix
-      if: steps.check-permissions.outputs.result == 'true'
+      if: |
+        steps.check-permissions.outputs.result == 'true' &&
+        !fromJSON(steps.pr-info.outputs.result).pending
       working-directory: ./untrusted
       id: fix
       run: |
@@ -168,6 +174,7 @@ jobs:
       uses: actions/github-script@v3
       env:
         FEEDBACK: ${{ steps.fix.outputs.result }}
+        PENDING: ${{ fromJSON(steps.pr-info.outputs.result).pending }}
       with:
         github-token: ${{secrets.BOT_TOKEN}}
         script: |

--- a/.github/workflows/zwave-js-bot_comment.yml
+++ b/.github/workflows/zwave-js-bot_comment.yml
@@ -104,84 +104,49 @@ jobs:
     # These steps only run if the check was successful
     - name: Retrieve PR information
       if: steps.check-permissions.outputs.result == 'true'
-      id: get-pr
+      id: pr-info
       uses: actions/github-script@v3
       with:
         script: |
-          const request = {
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            pull_number: context.issue.number
-          }
-          core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
+          const bot = require(`${process.env.GITHUB_WORKSPACE}/trusted/.github/bot-scripts/index.js`);
           try {
-            const result = await github.pulls.get(request)
-            return result.data
+            core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
+            const result = await bot.getFixLintInfo({github, context});
+            console.dir(result);
+            return result;
           } catch (err) {
             core.setFailed(`Request failed with error ${err}`)
           }
+
+    - name: Download Lint patch
+      if: steps.check-permissions.outputs.result == 'true'
+      env:
+        PATCH_URL: ${{ fromJSON(steps.pr-info.outputs.result).patchUrl }}
+      run: |
+        mkdir -p patch
+        cd patch
+        curl "$PATCH_URL" -o patch.zip
+        unzip patch.zip
 
     - name: Checkout pull request side by side
       if: steps.check-permissions.outputs.result == 'true'
       uses: actions/checkout@v2
       with:
         token: ${{secrets.BOT_TOKEN}}
-        repository: ${{ fromJSON(steps.get-pr.outputs.result).head.repo.full_name }}
-        ref: ${{ fromJSON(steps.get-pr.outputs.result).head.ref }}
+        repository: ${{ fromJSON(steps.pr-info.outputs.result).repoName }}
+        ref: ${{ fromJSON(steps.pr-info.outputs.result).headRef }}
         path: untrusted
-
-    - name: Use Node.js ${{ matrix.node-version }}
-      if: steps.check-permissions.outputs.result == 'true'
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-
-    - name: Get Yarn cache directory
-      if: steps.check-permissions.outputs.result == 'true'
-      id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
-
-    - name: Use Yarn cache
-      if: steps.check-permissions.outputs.result == 'true'
-      uses: actions/cache@v2
-      id: yarn-cache
-      with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('trusted/**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
-
-    - name: Install dependencies
-      if: steps.check-permissions.outputs.result == 'true'
-      working-directory: ./trusted
-      run: yarn install --prefer-offline --frozen-lockfile
-
-    - name: Copy sources from untrusted repo
-      if: steps.check-permissions.outputs.result == 'true'
-      run: |
-        rm -rf ./trusted/packages
-        cp -r ./untrusted/packages/ ./trusted
-
-      # We need this or the linter will complain about other stuff than the checks
-    - name: Compile TypeScript code
-      if: steps.check-permissions.outputs.result == 'true'
-      working-directory: ./trusted
-      run: yarn run build
 
     - name: Do the lint fix
       if: steps.check-permissions.outputs.result == 'true'
-      working-directory: ./trusted
+      working-directory: ./untrusted
       id: fix
       run: |
-        # Run all lint commands and remember if one fails
-        LINT_RESULT=0
-        if ! yarn run lint:ts --fix ; then LINT_RESULT=1 ; fi
-        if ! yarn run lint:wotan --fix ; then LINT_RESULT=1 ; fi
-        if ! yarn run lint:configjson -w ; then LINT_RESULT=1 ; fi
-
-        # Copy potentially fixed sources back
-        rm -rf ../untrusted/packages
-        cp -r ./packages/ ../untrusted
+        # Apply the patch
+        if ! git apply ../patch/fix.patch ; then
+          echo "::set-output name=result::error"
+          exit 0
+        fi
 
         # Check if something changed in the untrusted repo
         cd ../untrusted
@@ -192,15 +157,10 @@ jobs:
           git reset -- .github
           git commit -m "style: fix lint"
           git push
+          echo "::set-output name=result::ok"
         else
           echo "::set-output name=result::unchanged"
           exit 0
-        fi
-
-        if [[ $LINT_RESULT == 0 ]] ; then
-          echo "::set-output name=result::ok"
-        else
-          echo "::set-output name=result::error"
         fi
 
     - name: Give feedback

--- a/.github/workflows/zwave-js-bot_comment.yml
+++ b/.github/workflows/zwave-js-bot_comment.yml
@@ -77,8 +77,7 @@ jobs:
     if: |
       contains(github.event.issue.html_url, '/pull/') &&
       contains(github.event.comment.body, '@zwave-js-bot fix lint') &&
-      (github.event.comment.user.login != 'zwave-js-bot' && github.event.comment.user.login != 'zwave-js-assistant[bot]') &&
-      (github.event.comment.user.login == 'AlCalzone')
+      (github.event.comment.user.login != 'zwave-js-bot' && github.event.comment.user.login != 'zwave-js-assistant[bot]')
 
     runs-on: [ubuntu-latest]
     strategy:
@@ -184,8 +183,7 @@ jobs:
     if: |
       contains(github.event.issue.html_url, '/pull/') &&
       contains(github.event.comment.body, '@zwave-js-bot rebase') &&
-      (github.event.comment.user.login != 'zwave-js-bot' && github.event.comment.user.login != 'zwave-js-assistant[bot]') &&
-      (github.event.comment.user.login == 'AlCalzone')
+      (github.event.comment.user.login != 'zwave-js-bot' && github.event.comment.user.login != 'zwave-js-assistant[bot]')
 
     runs-on: [ubuntu-latest]
     strategy:
@@ -283,8 +281,7 @@ jobs:
     if: |
       contains(github.event.issue.html_url, '/pull/') &&
       contains(github.event.comment.body, '@zwave-js-bot rename commit') &&
-      (github.event.comment.user.login != 'zwave-js-bot' && github.event.comment.user.login != 'zwave-js-assistant[bot]') &&
-      (github.event.comment.user.login == 'AlCalzone')
+      (github.event.comment.user.login != 'zwave-js-bot' && github.event.comment.user.login != 'zwave-js-assistant[bot]')
 
     runs-on: [ubuntu-latest]
     strategy:
@@ -374,8 +371,7 @@ jobs:
     if: |
       contains(github.event.issue.html_url, '/issues/') &&
       contains(github.event.comment.body, '@zwave-js-bot import config') &&
-      (github.event.comment.user.login != 'zwave-js-bot' && github.event.comment.user.login != 'zwave-js-assistant[bot]') &&
-      (github.event.comment.user.login == 'AlCalzone')
+      (github.event.comment.user.login != 'zwave-js-bot' && github.event.comment.user.login != 'zwave-js-assistant[bot]')
 
     runs-on: [ubuntu-latest]
     strategy:

--- a/.github/workflows/zwave-js-bot_comment.yml
+++ b/.github/workflows/zwave-js-bot_comment.yml
@@ -109,14 +109,9 @@ jobs:
       with:
         script: |
           const bot = require(`${process.env.GITHUB_WORKSPACE}/trusted/.github/bot-scripts/index.js`);
-          try {
-            core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
-            const result = await bot.getFixLintInfo({github, context});
-            console.dir(result);
-            return result ?? {pending: true};
-          } catch (err) {
-            core.setFailed(`Request failed with error ${err}`)
-          }
+          const result = await bot.getFixLintInfo({github, context});
+          console.dir(result);
+          return result || {pending: true};
 
     - name: Download Lint patch
       if: |


### PR DESCRIPTION
This PR is step 2 of 2 in enabling contributors to use the bot again. When a user comments `fix lint`, the action now tries to download the previously uploaded patch and applies it to the untrusted code without executing npm or build scripts.

Followup to: #1633