### PR TITLE
feat: add ability to get current logging configuration

### DIFF
--- a/packages/core/src/log/shared.ts
+++ b/packages/core/src/log/shared.ts
@@ -143,6 +143,10 @@ export class ZWaveLogContainer extends winston.Container {
 		}
 	}
 
+	public getConfiguration(): LogConfig {
+		return this.logConfig;
+	}
+
 	public getConfiguredTransports(): Transport[] {
 		return this.logConfig.transports;
 	}

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -591,6 +591,11 @@ export class Driver extends EventEmitter {
 		this._logContainer.updateConfiguration(config);
 	}
 
+	/** Returns the current logging configuration. */
+	public getLogConfig(): LogConfig {
+		return this._logContainer.getConfiguration();
+	}
+
 	/** Enumerates all existing serial ports */
 	public static async enumerateSerialPorts(): Promise<string[]> {
 		const ports = await SerialPort.list();


### PR DESCRIPTION
Follow on to https://github.com/zwave-js/node-zwave-js/pull/1754. This will allow us to add support to `zwave-js-server` and we can subsequently expose a way to see and update the logging configuration from the HA frontend.