### PR TITLE
feat(cc): implement Scene Controller Configuration CC

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/API.ts
+++ b/packages/zwave-js/src/lib/commandclass/API.ts
@@ -315,6 +315,7 @@ export interface CCAPIs {
 	Notification: import("./NotificationCC").NotificationCCAPI;
 	Protection: import("./ProtectionCC").ProtectionCCAPI;
 	"Scene Activation": import("./SceneActivationCC").SceneActivationCCAPI;
+	"Scene Controller Configuration": import("./SceneControllerConfigurationCC").SceneControllerConfigurationCCAPI;
 	Security: import("./SecurityCC").SecurityCCAPI;
 	"Sound Switch": import("./SoundSwitchCC").SoundSwitchCCAPI;
 	Supervision: import("./SupervisionCC").SupervisionCCAPI;

--- a/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.test.ts
@@ -1,0 +1,111 @@
+import { CommandClasses, Duration } from "@zwave-js/core";
+import type { Driver } from "../driver/Driver";
+import { ZWaveNode } from "../node/Node";
+import { createEmptyMockDriver } from "../test/mocks";
+import { getGroupCountValueId } from "./AssociationCC";
+import {
+	SceneControllerConfigurationCC,
+	SceneControllerConfigurationCCGet,
+	SceneControllerConfigurationCCReport,
+	SceneControllerConfigurationCCSet,
+	SceneControllerConfigurationCommand,
+} from "./SceneControllerConfigurationCC";
+
+const fakeGroupCount = 5;
+const groupCountValueId = getGroupCountValueId();
+
+function buildCCBuffer(payload: Buffer): Buffer {
+	return Buffer.concat([
+		Buffer.from([
+			CommandClasses["Scene Controller Configuration"], // CC
+		]),
+		payload,
+	]);
+}
+
+describe("lib/commandclass/SceneControllerConfigurationCC => ", () => {
+	let fakeDriver: Driver;
+	let node2: ZWaveNode;
+
+	beforeAll(() => {
+		fakeDriver = (createEmptyMockDriver() as unknown) as Driver;
+
+		node2 = new ZWaveNode(5, fakeDriver as any);
+		(fakeDriver.controller.nodes as any).set(2, node2);
+		node2.addCC(CommandClasses["Scene Controller Configuration"], {
+			isSupported: true,
+			version: 1,
+		});
+		node2.addCC(CommandClasses.Association, {
+			isSupported: true,
+			version: 3,
+		});
+		node2.valueDB.setValue(groupCountValueId, fakeGroupCount);
+	});
+
+	afterAll(() => {
+		node2.destroy();
+	});
+
+	it("the Get command should serialize correctly", () => {
+		const cc = new SceneControllerConfigurationCCGet(fakeDriver, {
+			nodeId: 1,
+			groupId: 1,
+		});
+		const expected = buildCCBuffer(
+			Buffer.from([
+				SceneControllerConfigurationCommand.Get, // CC Command
+				0b0000_0001,
+			]),
+		);
+		expect(cc.serialize()).toEqual(expected);
+	});
+
+	it("the Set command should serialize correctly", () => {
+		const cc = new SceneControllerConfigurationCCSet(fakeDriver, {
+			nodeId: 2,
+			groupId: 3,
+			sceneId: 240,
+			dimmingDuration: Duration.parseSet(0x05)!,
+		});
+		const expected = buildCCBuffer(
+			Buffer.from([
+				SceneControllerConfigurationCommand.Set, // CC Command
+				3, // groupId
+				240, // sceneId
+				0x05, // dimming duration
+			]),
+		);
+		expect(cc.serialize()).toEqual(expected);
+	});
+
+	it("the Report command (v1) should be deserialized correctly", () => {
+		const ccData = buildCCBuffer(
+			Buffer.from([
+				SceneControllerConfigurationCommand.Report, // CC Command
+				3, // groupId
+				240, // sceneId
+				0x05, // dimming duration
+			]),
+		);
+		const cc = new SceneControllerConfigurationCCReport(fakeDriver, {
+			nodeId: 2,
+			data: ccData,
+		});
+
+		expect(cc.groupId).toBe(3);
+		expect(cc.sceneId).toBe(240);
+		expect(cc.dimmingDuration).toStrictEqual(Duration.parseReport(0x05)!);
+	});
+
+	it("deserializing an unsupported command should return an unspecified version of SceneControllerConfigurationCC", () => {
+		const serializedCC = buildCCBuffer(
+			Buffer.from([255]), // not a valid command
+		);
+		const cc: any = new SceneControllerConfigurationCC(fakeDriver, {
+			nodeId: 1,
+			data: serializedCC,
+		});
+		expect(cc.constructor).toBe(SceneControllerConfigurationCC);
+	});
+});

--- a/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.test.ts
@@ -30,7 +30,7 @@ describe("lib/commandclass/SceneControllerConfigurationCC => ", () => {
 	beforeAll(() => {
 		fakeDriver = (createEmptyMockDriver() as unknown) as Driver;
 
-		node2 = new ZWaveNode(5, fakeDriver as any);
+		node2 = new ZWaveNode(2, fakeDriver as any);
 		(fakeDriver.controller.nodes as any).set(2, node2);
 		node2.addCC(CommandClasses["Scene Controller Configuration"], {
 			isSupported: true,
@@ -49,7 +49,7 @@ describe("lib/commandclass/SceneControllerConfigurationCC => ", () => {
 
 	it("the Get command should serialize correctly", () => {
 		const cc = new SceneControllerConfigurationCCGet(fakeDriver, {
-			nodeId: 1,
+			nodeId: 2,
 			groupId: 1,
 		});
 		const expected = buildCCBuffer(
@@ -59,6 +59,15 @@ describe("lib/commandclass/SceneControllerConfigurationCC => ", () => {
 			]),
 		);
 		expect(cc.serialize()).toEqual(expected);
+	});
+
+	it("the Get command should throw if GroupId > groupCount", () => {
+		expect(() => {
+			new SceneControllerConfigurationCCGet(fakeDriver, {
+				nodeId: 2,
+				groupId: fakeGroupCount + 1,
+			});
+		}).toThrow();
 	});
 
 	it("the Set command should serialize correctly", () => {
@@ -77,6 +86,18 @@ describe("lib/commandclass/SceneControllerConfigurationCC => ", () => {
 			]),
 		);
 		expect(cc.serialize()).toEqual(expected);
+	});
+
+	it("the Set command should throw if GroupId > groupCount", () => {
+		expect(
+			() =>
+				new SceneControllerConfigurationCCSet(fakeDriver, {
+					nodeId: 2,
+					groupId: fakeGroupCount + 1,
+					sceneId: 240,
+					dimmingDuration: Duration.parseSet(0x05)!,
+				}),
+		).toThrow();
 	});
 
 	it("the Report command (v1) should be deserialized correctly", () => {

--- a/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
@@ -300,11 +300,6 @@ export class SceneControllerConfigurationCC extends CommandClass {
 			return;
 		}
 
-		this.driver.controllerLog.logNode(node.id, {
-			endpoint: this.endpointIndex,
-			message: `supports ${groupCount} association groups`,
-			direction: "none",
-		});
 
 		// Always query scene configuration for each association group
 		for (let groupId = 1; groupId <= groupCount; groupId++) {

--- a/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
@@ -313,7 +313,7 @@ export class SceneControllerConfigurationCC extends CommandClass {
 		for (let groupId = 2; groupId <= groupCount; groupId++) {
 			this.driver.controllerLog.logNode(node.id, {
 				endpoint: this.endpointIndex,
-				message: `querying association group #${groupId}...`,
+				message: `querying scene configuration for association group #${groupId}...`,
 				direction: "outbound",
 			});
 			const group = await api.get(groupId);

--- a/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
@@ -318,8 +318,8 @@ export class SceneControllerConfigurationCC extends CommandClass {
 			});
 			const group = await api.get(groupId);
 			if (group != undefined) {
-				const logMessage = `received information for association group #${groupId}:
-scene Id: ${group.sceneId}
+				const logMessage = `received scene configuration for association group #${groupId}:
+scene ID:         ${group.sceneId}
 dimming duration: ${group.dimmingDuration.toString()}`;
 				this.driver.controllerLog.logNode(node.id, {
 					endpoint: this.endpointIndex,

--- a/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
@@ -1,0 +1,491 @@
+import {
+	CommandClasses,
+	Duration,
+	Maybe,
+	MessageOrCCLogEntry,
+	validatePayload,
+	ValueID,
+	ValueMetadata,
+	ZWaveError,
+	ZWaveErrorCodes,
+} from "@zwave-js/core";
+import { pick } from "@zwave-js/shared";
+import type { Driver } from "../driver/Driver";
+import { MessagePriority } from "../message/Constants";
+import {
+	PhysicalCCAPI,
+	PollValueImplementation,
+	POLL_VALUE,
+	SetValueImplementation,
+	SET_VALUE,
+	throwMissingPropertyKey,
+	throwUnsupportedProperty,
+	throwUnsupportedPropertyKey,
+	throwWrongValueType,
+} from "./API";
+import { getGroupCountValueId } from "./AssociationCC";
+import {
+	API,
+	CCCommand,
+	CCCommandOptions,
+	CommandClass,
+	commandClass,
+	CommandClassDeserializationOptions,
+	expectedCCResponse,
+	gotDeserializationOptions,
+	implementedVersion,
+} from "./CommandClass";
+
+// All the supported commands
+export enum SceneControllerConfigurationCommand {
+	Set = 0x01,
+	Get = 0x02,
+	Report = 0x03,
+}
+
+export function getSceneIdValueID(
+	endpoint: number | undefined,
+	groupId: number,
+): ValueID {
+	return {
+		commandClass: CommandClasses["Scene Controller Configuration"],
+		endpoint,
+		property: "sceneId",
+		propertyKey: groupId,
+	};
+}
+
+export function getDimmingDurationValueID(
+	endpoint: number | undefined,
+	groupId: number,
+): ValueID {
+	return {
+		commandClass: CommandClasses["Scene Controller Configuration"],
+		endpoint,
+		property: "dimmingDuration",
+		propertyKey: groupId,
+	};
+}
+
+function persistSceneConfig(
+	this: SceneControllerConfigurationCC,
+	groupId: number,
+	sceneId: number,
+	dimmingDuration: Duration,
+) {
+	const sceneIdValueId = getSceneIdValueID(this.endpointIndex, groupId);
+	const dimmingDurationValueId = getDimmingDurationValueID(
+		this.endpointIndex,
+		groupId,
+	);
+	const valueDB = this.getValueDB();
+
+	if (!valueDB.hasMetadata(sceneIdValueId)) {
+		valueDB.setMetadata(sceneIdValueId, {
+			...ValueMetadata.Number,
+			min: 0,
+			max: 255,
+			label: `Associated Scene ID (${groupId})`,
+		});
+	}
+	if (!valueDB.hasMetadata(dimmingDurationValueId)) {
+		valueDB.setMetadata(dimmingDurationValueId, {
+			...ValueMetadata.Duration,
+			label: `Dimming duration (${groupId})`,
+		});
+	}
+
+	valueDB.setValue(sceneIdValueId, sceneId);
+	valueDB.setValue(dimmingDurationValueId, dimmingDuration);
+
+	return true;
+}
+
+@API(CommandClasses["Scene Controller Configuration"])
+export class SceneControllerConfigurationCCAPI extends PhysicalCCAPI {
+	public supportsCommand(
+		cmd: SceneControllerConfigurationCommand,
+	): Maybe<boolean> {
+		switch (cmd) {
+			case SceneControllerConfigurationCommand.Get:
+			case SceneControllerConfigurationCommand.Set:
+			case SceneControllerConfigurationCommand.Report:
+				return true; // This is mandatory
+		}
+		return super.supportsCommand(cmd);
+	}
+
+	protected [SET_VALUE]: SetValueImplementation = async (
+		{ property, propertyKey },
+		value,
+	): Promise<void> => {
+		if (propertyKey == undefined) {
+			throwMissingPropertyKey(this.ccId, property);
+		} else if (typeof propertyKey !== "number") {
+			throwUnsupportedPropertyKey(this.ccId, property, propertyKey);
+		}
+		if (property === "sceneId") {
+			if (typeof value !== "number") {
+				throwWrongValueType(
+					this.ccId,
+					property,
+					"number",
+					typeof value,
+				);
+			}
+
+			if (value === 0) {
+				// Disable Group ID / Scene ID
+				await this.disable(propertyKey);
+			} else {
+				// We need to set the dimming duration along with
+				const node = this.endpoint.getNodeUnsafe()!;
+				// If duration is missing, we set a default of instant
+				const dimmingDuration =
+					node.getValue<Duration>(
+						getDimmingDurationValueID(
+							this.endpoint.index,
+							propertyKey,
+						),
+					) ?? new Duration(0, "seconds");
+				await this.set(propertyKey, value, dimmingDuration);
+			}
+		} else {
+			// setting dimmingDuration value alone not supported,
+			// because I'm not sure how to handle a Duration value
+			throwUnsupportedProperty(this.ccId, property);
+		}
+
+		// Verify the current value after a delay
+		this.schedulePoll({ property, propertyKey });
+	};
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+		propertyKey,
+	}): Promise<unknown> => {
+		switch (property) {
+			case "sceneId":
+			case "dimmingDuration": {
+				if (propertyKey == undefined) {
+					throwMissingPropertyKey(this.ccId, property);
+				} else if (typeof propertyKey !== "number") {
+					throwUnsupportedPropertyKey(
+						this.ccId,
+						property,
+						propertyKey,
+					);
+				}
+				return (await this.get(propertyKey))?.[property];
+			}
+			default:
+				throwUnsupportedProperty(this.ccId, property);
+		}
+	};
+
+	public async disable(groupId: number): Promise<void> {
+		this.assertSupportsCommand(
+			SceneControllerConfigurationCommand,
+			SceneControllerConfigurationCommand.Set,
+		);
+
+		return this.set(groupId, 0, new Duration(0, "seconds"));
+	}
+
+	public async set(
+		groupId: number,
+		sceneId: number,
+		dimmingDuration: Duration,
+	): Promise<void> {
+		this.assertSupportsCommand(
+			SceneControllerConfigurationCommand,
+			SceneControllerConfigurationCommand.Set,
+		);
+
+		const cc = new SceneControllerConfigurationCCSet(this.driver, {
+			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
+			groupId,
+			sceneId,
+			dimmingDuration,
+		});
+
+		await this.driver.sendCommand(cc, this.commandOptions);
+	}
+
+	public async getLastActivated(): Promise<
+		| {
+				groupId: number;
+				sceneId: number;
+				dimmingDuration: Duration;
+		  }
+		| undefined
+	> {
+		this.assertSupportsCommand(
+			SceneControllerConfigurationCommand,
+			SceneControllerConfigurationCommand.Get,
+		);
+		return this.get(0);
+	}
+
+	public async get(
+		groupId: number,
+	): Promise<
+		| {
+				groupId: number;
+				sceneId: number;
+				dimmingDuration: Duration;
+		  }
+		| undefined
+	> {
+		this.assertSupportsCommand(
+			SceneControllerConfigurationCommand,
+			SceneControllerConfigurationCommand.Get,
+		);
+
+		const cc = new SceneControllerConfigurationCCGet(this.driver, {
+			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
+			groupId,
+		});
+		const response = await this.driver.sendCommand<SceneControllerConfigurationCCReport>(
+			cc,
+			this.commandOptions,
+		);
+		if (response)
+			return pick(response, ["groupId", "sceneId", "dimmingDuration"]);
+	}
+}
+
+@commandClass(CommandClasses["Scene Controller Configuration"])
+@implementedVersion(1)
+export class SceneControllerConfigurationCC extends CommandClass {
+	declare ccCommand: SceneControllerConfigurationCommand;
+
+	public async interview(complete: boolean = true): Promise<void> {
+		const node = this.getNode()!;
+		const endpoint = this.getEndpoint()!;
+		const api = endpoint.commandClasses[
+			"Scene Controller Configuration"
+		].withOptions({
+			priority: MessagePriority.NodeQuery,
+		});
+		const associationApi = endpoint.commandClasses.Association.withOptions({
+			priority: MessagePriority.NodeQuery,
+		});
+
+		this.driver.controllerLog.logNode(node.id, {
+			message: `${this.constructor.name}: doing a ${
+				complete ? "complete" : "partial"
+			} interview...`,
+			direction: "none",
+		});
+
+		let groupCount: number | undefined;
+		if (complete) {
+			groupCount = this.getGroupCountCached();
+			if (groupCount === 0) {
+				this.driver.controllerLog.logNode(node.id, {
+					message: "querying number of association groups...",
+					direction: "outbound",
+				});
+				groupCount = await associationApi.getGroupCount();
+				if (groupCount != undefined) {
+					this.driver.controllerLog.logNode(node.id, {
+						endpoint: this.endpointIndex,
+						message: `supports ${groupCount} association groups`,
+						direction: "inbound",
+					});
+				} else {
+					this.driver.controllerLog.logNode(node.id, {
+						endpoint: this.endpointIndex,
+						message:
+							"Querying association groups timed out, skipping interview...",
+						level: "warn",
+					});
+					return;
+				}
+			}
+		} else {
+			groupCount = this.getGroupCountCached();
+		}
+
+		// Always query scene and dimmer duration for each association group
+		// skipping group #1, which is reserved for Lifeline
+		for (let groupId = 2; groupId <= groupCount; groupId++) {
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message: `querying association group #${groupId}...`,
+				direction: "outbound",
+			});
+			const group = await api.get(groupId);
+			if (group != undefined) {
+				const logMessage = `received information for association group #${groupId}:
+scene Id: ${group.sceneId}
+dimming duration: ${group.dimmingDuration}`;
+				this.driver.controllerLog.logNode(node.id, {
+					endpoint: this.endpointIndex,
+					message: logMessage,
+					direction: "inbound",
+				});
+			}
+		}
+
+		// Remember that the interview is complete
+		this.interviewComplete = true;
+	}
+
+	/**
+	 * Returns the number of association groups reported by the node.
+	 * This only works AFTER the node has been interviewed by this CC
+	 * or the AssociationCC.
+	 */
+	public getGroupCountCached(): number {
+		return this.getValueDB().getValue(getGroupCountValueId()) ?? 0;
+	}
+}
+
+interface SceneControllerConfigurationCCSetOptions extends CCCommandOptions {
+	groupId: number;
+	sceneId: number;
+	dimmingDuration: Duration;
+}
+
+@CCCommand(SceneControllerConfigurationCommand.Set)
+export class SceneControllerConfigurationCCSet extends SceneControllerConfigurationCC {
+	public constructor(
+		driver: Driver,
+		options:
+			| CommandClassDeserializationOptions
+			| SceneControllerConfigurationCCSetOptions,
+	) {
+		super(driver, options);
+		if (gotDeserializationOptions(options)) {
+			// TODO: Deserialize payload
+			throw new ZWaveError(
+				`${this.constructor.name}: deserialization not implemented`,
+				ZWaveErrorCodes.Deserialization_NotImplemented,
+			);
+		} else {
+			const groupCount = this.getGroupCountCached();
+			this.groupId = options.groupId;
+			this.sceneId = options.sceneId;
+			this.dimmingDuration = options.dimmingDuration;
+
+			if (this.groupId < 2 || this.groupId > groupCount) {
+				throw new ZWaveError(
+					`${this.constructor.name}: The user ID must be between 2 and the number of supported groups ${groupCount}.`,
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
+		}
+	}
+
+	public groupId: number;
+
+	public sceneId: number;
+
+	public dimmingDuration: Duration;
+
+	public serialize(): Buffer {
+		this.payload = Buffer.from([
+			this.groupId,
+			this.sceneId,
+			this.dimmingDuration.serializeSet(),
+		]);
+		return super.serialize();
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: {
+				"group id": this.groupId,
+				"scene id": this.sceneId,
+				"dimming duration": this.dimmingDuration.toString(),
+			},
+		};
+	}
+}
+
+@CCCommand(SceneControllerConfigurationCommand.Report)
+export class SceneControllerConfigurationCCReport extends SceneControllerConfigurationCC {
+	public constructor(
+		driver: Driver,
+		options: CommandClassDeserializationOptions,
+	) {
+		super(driver, options);
+		validatePayload(this.payload.length >= 3);
+		this.groupId = this.payload[0];
+		this.sceneId = this.payload[1];
+		this.dimmingDuration =
+			Duration.parseReport(this.payload[2]) ?? new Duration(0, "unknown");
+
+		this.persistValues();
+	}
+
+	public readonly groupId: number;
+	public readonly sceneId: number;
+	public readonly dimmingDuration: Duration;
+
+	public persistValues(): boolean {
+		persistSceneConfig.call(
+			this,
+			this.groupId,
+			this.sceneId,
+			this.dimmingDuration,
+		);
+		return true;
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: {
+				"group id": this.groupId,
+				"scene id": this.sceneId,
+				"dimming duration": this.dimmingDuration.toString(),
+			},
+		};
+	}
+}
+
+interface SceneControllerConfigurationCCGetOptions extends CCCommandOptions {
+	groupId: number;
+}
+
+@CCCommand(SceneControllerConfigurationCommand.Get)
+@expectedCCResponse(SceneControllerConfigurationCCReport)
+export class SceneControllerConfigurationCCGet extends SceneControllerConfigurationCC {
+	public constructor(
+		driver: Driver,
+		options:
+			| CommandClassDeserializationOptions
+			| SceneControllerConfigurationCCGetOptions,
+	) {
+		super(driver, options);
+		if (gotDeserializationOptions(options)) {
+			// TODO: Deserialize payload
+			throw new ZWaveError(
+				`${this.constructor.name}: deserialization not implemented`,
+				ZWaveErrorCodes.Deserialization_NotImplemented,
+			);
+		} else {
+			this.groupId = options.groupId;
+		}
+	}
+
+	public groupId: number;
+
+	public serialize(): Buffer {
+		this.payload = Buffer.from([this.groupId]);
+		return super.serialize();
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: { "group id": this.groupId },
+		};
+	}
+}

--- a/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
@@ -322,7 +322,7 @@ export class SceneControllerConfigurationCC extends CommandClass {
 			if (group != undefined) {
 				const logMessage = `received information for association group #${groupId}:
 scene Id: ${group.sceneId}
-dimming duration: ${group.dimmingDuration}`;
+dimming duration: ${group.dimmingDuration.toString()}`;
 				this.driver.controllerLog.logNode(node.id, {
 					endpoint: this.endpointIndex,
 					message: logMessage,

--- a/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
@@ -138,7 +138,7 @@ export class SceneControllerConfigurationCCAPI extends PhysicalCCAPI {
 				// Disable Group ID / Scene ID
 				await this.disable(propertyKey);
 			} else {
-				// We need to set the dimming duration along with
+				// We need to set the dimming duration along with the scene ID
 				const node = this.endpoint.getNodeUnsafe()!;
 				// If duration is missing, we set a default of instant
 				const dimmingDuration =

--- a/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
@@ -254,8 +254,9 @@ export class SceneControllerConfigurationCCAPI extends PhysicalCCAPI {
 		// Return value includes "groupId", because if get(0) is called
 		// the returned report will include the actual groupId of the
 		// last activated groupId / sceneId
-		if (response)
+		if (response) {
 			return pick(response, ["groupId", "sceneId", "dimmingDuration"]);
+		}
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
@@ -295,11 +295,10 @@ export class SceneControllerConfigurationCC extends CommandClass {
 		if (groupCount === 0) {
 			this.driver.controllerLog.logNode(node.id, {
 				endpoint: this.endpointIndex,
-				message: `soft failing interview (missing association group count)`,
+				message: `skipping Scene Controller Configuration interview because Association group count is unknown`,
 				direction: "none",
+				level: "warn",
 			});
-
-			this.interviewComplete = false;
 			return;
 		}
 

--- a/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
@@ -300,7 +300,6 @@ export class SceneControllerConfigurationCC extends CommandClass {
 			return;
 		}
 
-
 		// Always query scene configuration for each association group
 		for (let groupId = 1; groupId <= groupCount; groupId++) {
 			this.driver.controllerLog.logNode(node.id, {


### PR DESCRIPTION
Here's a draft for the Scene Controller Configuration CC.

I copied what UserCodeCC did for persisting values and setting metadata, but I'm not certain that they're completely alike.  Scene Controller Configuration CC is a little wonky, because it encodes a disabled group / scene assignment with `sceneId = 0`.  I believe this means that `dimming duration` is effectively cleared by setting `sceneId = 0`, but the documentation is 100% clear to me.

I haven't implemented SetValue for `dimmingDuration`, because I don't know how to handle the Duration type here.  If it can be done, this seems like a valuable feature that users would expect.

The interview potentially makes an API call with the Association CC, because that's how to determine the number of supported groups.  I believe that the AssociationCC interview should always happen before the SceneControllerConfigurationCC interview, but I did allow the interview function to do  the actual query if the cached `groupCount` is missing.