### PR TITLE
feat(cc): add value to set multiple color components at once

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/API.ts
+++ b/packages/zwave-js/src/lib/commandclass/API.ts
@@ -102,6 +102,12 @@ export class CCAPI {
 		return this[SET_VALUE];
 	}
 
+	/** Whether a successful setValue call should imply that the value was successfully updated */
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	public isSetValueOptimistic(valueId: ValueID): boolean {
+		return true;
+	}
+
 	protected [POLL_VALUE]: PollValueImplementation | undefined;
 	/**
 	 * Can be used on supported CC APIs to poll a CC value by property name (and optionally the property key)

--- a/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
@@ -486,7 +486,7 @@ export class ColorSwitchCC extends CommandClass {
 				direction: "outbound",
 			});
 
-			// Create metadata
+			// Create metadata for the separate color channels
 			for (const color of supportedColors) {
 				const colorName = getEnumMemberName(ColorComponent, color);
 				valueDB.setMetadata(
@@ -506,6 +506,16 @@ export class ColorSwitchCC extends CommandClass {
 					},
 				);
 			}
+			// And the compound one
+			valueDB.setMetadata(getCurrentColorValueID(this.endpointIndex), {
+				...ValueMetadata.ReadOnly,
+				label: `Current Color`,
+			});
+			valueDB.setMetadata(getTargetColorValueID(this.endpointIndex), {
+				...ValueMetadata.Any,
+				label: `Target Color`,
+			});
+
 			// Create the collective HEX color values
 			const supportsHex = [
 				ColorComponent.Red,

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -681,8 +681,10 @@ export class ZWaveNode extends Endpoint {
 				},
 				value,
 			);
-			// If the call did not throw, assume that the call was successful and remember the new value
-			this._valueDB.setValue(valueId, value, { noEvent: true });
+			if (api.isSetValueOptimistic(valueId)) {
+				// If the call did not throw, assume that the call was successful and remember the new value
+				this._valueDB.setValue(valueId, value, { noEvent: true });
+			}
 
 			return true;
 		} catch (e: unknown) {


### PR DESCRIPTION
With this PR, the Color Switch CC now has a combined value ID to set multiple color components at once:
```
// reading:
{
	commandClass: CommandClasses["Color Switch"],
	property: "currentColor",
	endpoint: endpointIndex,
}

// writing
{
	commandClass: CommandClasses["Color Switch"],
	property: "targetColor",
	endpoint: endpointIndex,
}
```

It accepts objects of the form
```
{
	warmWhite: /* 0..255 */,
	coldWhite: /* 0..255 */,
	red: /* 0..255 */,
	green: /* 0..255 */,
	blue: /* 0..255 */,
	amber: /* 0..255 */,
	cyan: /* 0..255 */,
	purple: /* 0..255 */,
}
```
where each entry is optional. Partial objects are merged with the existing settings.

fixes: #1526 