### PR TITLE
fix: improve communication with sleeping nodes when WakeUp CC is unsupported or support not yet known

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -2059,10 +2059,12 @@ ${handlers.length} left`,
 			!!node &&
 			// Pings can be used to check if a node is really asleep, so they should be sent regardless
 			!messageIsPing(msg) &&
-			// Nodes that support the Wake Up CC should have their messages queued for wakeup
-			// If a sleeping node is currently awake, we should use the WakeUp priority so the message
-			// get handled immediately
-			node.supportsCC(CommandClasses["Wake Up"]) &&
+			// Nodes that can sleep and support the Wake Up CC should have their messages queued for wakeup
+			node.canSleep &&
+			(node.supportsCC(CommandClasses["Wake Up"]) ||
+				// If we don't know the Wake Up support yet, also change the priority or RequestNodeInfoRequests will get stuck
+				// in front of the queue
+				node.interviewStage < InterviewStage.NodeInfo) &&
 			// If we move multicasts to the wakeup queue, it is unlikely
 			// that there is ever a points where all targets are awake
 			!(msg instanceof SendDataMulticastRequest) &&


### PR DESCRIPTION
This PR implements what was discussed in https://github.com/zwave-js/node-zwave-js/discussions/1537 - meaning that messages to sleeping nodes will now be sent if they don't support the Wake Up CC

Messages to sleeping nodes will now also be added to the wakeup queue if we don't know yet if they support Wake Up.
fixes: #1781 
closes: #1783 