### PR TITLE
refactor: do not query all values after cache restart

### DIFF
--- a/.vscode/snippets/typescript.json
+++ b/.vscode/snippets/typescript.json
@@ -431,6 +431,20 @@
 			"}"
 		]
 	},
+	"Z-Wave CC Refresh Values": {
+		"prefix": "zwccrefval",
+		"body": [
+			"public async refreshValues(): Promise<void> {",
+			"\tconst node = this.getNode()!;",
+			"\tconst endpoint = this.getEndpoint()!;",
+			"\tconst api = endpoint.commandClasses[\"${1:Basic}\"].withOptions({",
+			"\t\tpriority: MessagePriority.NodeQuery,",
+			"\t});",
+			"",
+			"\t${0:// TODO: Implementation}",
+			"}"
+		]
+	},
 	"Jest test file": {
 		"prefix": "jest",
 		"body": [

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -3,6 +3,7 @@
     -   [Introduction](README.md)
     -   [Quick Start](getting-started/quickstart.md)
     -   [Migrating to v6](getting-started/migrating-to-v6.md)
+    -   [Migrating to v7](getting-started/migrating-to-v7.md)
 
 -   API
 

--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -24,13 +24,13 @@ This starts the driver and opens the underlying serial port and performs an inte
 
 The following table gives you an overview of what happens during the startup process. Note that the promise resolves before the interview process is completed:
 
-| Step | What happens behind the scenes                                          | Library response                                                                                                          |
-| :--: | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-|  1   | Serial port is opened                                                   | `start()` Promise resolves                                                                                                |
-|  2   | Controller interview is performed                                       | `"driver ready"` event is emitted                                                                                         |
-|  3   | Every node is interviewed in the background (This may take a long time) | `"ready"` event is emitted for every node as soon as it can be used                                                       |
-|  4   | -                                                                       | `"all nodes ready"` event is emitted for the driver when all nodes can be used                                            |
-|  5   | -                                                                       | `"interview completed"` event is emitted for every node when its interview is completed and all its values are up to date |
+| Step | What happens behind the scenes                                          | Library response                                                                                                                                                              |
+| :--: | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|  1   | Serial port is opened                                                   | `start()` Promise resolves                                                                                                                                                    |
+|  2   | Controller interview is performed                                       | `"driver ready"` event is emitted                                                                                                                                             |
+|  3   | Every node is interviewed in the background (This may take a long time) | `"ready"` event is emitted for every node as soon as it can be used                                                                                                           |
+|  4   | -                                                                       | `"all nodes ready"` event is emitted for the driver when all nodes can be used                                                                                                |
+|  5   | -                                                                       | `"interview completed"` event is emitted for every node when its interview is completed for the first time. This only gets emitted once, unless the node gets re-interviewed. |
 
 ### `getSupportedCCVersionForEndpoint`
 

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -104,6 +104,17 @@ Refreshes all non-static sensor and actuator values from this node. Although thi
 > [!WARNING]  
 > **DO NOT** use this method too frequently. Depending on the devices, this may generate a lot of traffic.
 
+### `refreshCCValues`
+
+```ts
+refreshCCValues(cc: CommandClasses): Promise<void>
+```
+
+Refreshes all non-static values from the given CC (all endpoints). Although this method returns a `Promise`, it should generally **not** be `await`ed, since the update may take a long time.
+
+> [!WARNING]  
+> **DO NOT** use this method too frequently. Depending on the devices, this may generate a lot of traffic.
+
 ### `getEndpoint`
 
 ```ts

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -310,12 +310,6 @@ enum InterviewStage {
 	NodeInfo,
 
 	/**
-	 * This marks the beginning of re-interviews on application startup.
-	 * RestartFromCache and later stages will be serialized as "Complete" in the cache
-	 */
-	RestartFromCache,
-
-	/**
 	 * Information for all command classes has been queried.
 	 * This includes static information that is requested once as well as dynamic
 	 * information that is requested on every restart.

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -605,7 +605,7 @@ A non-sleeping node has stopped responding or just started responding again. The
 
 ### `"interview completed"`
 
-The interview process for this node was completed. The node is passed as the single argument to the callback:
+The initial interview process for this node was completed. The node is passed as the single argument to the callback:
 
 ```ts
 (node: ZWaveNode) => void
@@ -641,7 +641,7 @@ interface NodeInterviewFailedEventArgs {
 
 ### `"ready"`
 
-This is emitted during the interview process when enough information about the node is known that it can safely be used. The node is passed as the single argument to the callback:
+This is emitted when enough information about the node is known that it can safely be used. The node is passed as the single argument to the callback:
 
 ```ts
 (node: ZWaveNode) => void
@@ -650,7 +650,7 @@ This is emitted during the interview process when enough information about the n
 There are two situations when this event is emitted:
 
 1. The interview of a node is completed for the first time ever.
-2. The driver begins a partial interview of a node that has previously been interviewed completely.
+2. The node that has previously been interviewed completely and it either responds or is asleep.
 
 > [!NOTE]
 > This event does not imply that the node is currently awake or will respond to requests.

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -641,7 +641,11 @@ interface NodeInterviewFailedEventArgs {
 
 ### `"ready"`
 
-This is emitted when enough information about the node is known that it can safely be used. The node is passed as the single argument to the callback:
+This is emitted when enough information about the node is known that it can safely be used. This includes protocol information and supported/controlled CCs.
+
+The driver will also try to identify the node, its CC versions, endpoints, capabilities for each CC, etc. However, this **does not** mean that **all** this information is known to the driver due to potential timeouts, lost messages and/or unresponsive nodes during the interview. Therefore, the driver will do its best to work with what it has.
+
+The node is passed as the single argument to the callback:
 
 ```ts
 (node: ZWaveNode) => void

--- a/docs/getting-started/migrating-to-v7.md
+++ b/docs/getting-started/migrating-to-v7.md
@@ -4,7 +4,8 @@ In version 7.x we got rid of some old habits, leading to several breaking change
 
 ## No automatic query of all node values when restarting from cache
 
-This legacy behavior resulted in a lot of traffic and delays when the driver was restarted, often doing many unnecessary queries. To reduce the strain on battery devices and to keep the network as responsive as possible, we've opted not to do this anymore when a node was previously interviewed.  
+This legacy behavior resulted in a lot of traffic and delays when the driver was restarted, often doing many unnecessary queries. To reduce the strain on battery devices and to keep the network as responsive as possible, we've opted not to do this anymore when a node was previously interviewed. This also means that the `"interview completed"` event is no longer emitted on restart.
+
 If you need to manually update values, you can do that on demand with [`node.refreshValues()`](../api/node.md#refreshValues) or [`node.refreshCCValues()`](../api/node.md#refreshCCValues).
 
 ## Corrected parsing of Node Information Frames (NIF), reworked node properties

--- a/docs/getting-started/migrating-to-v7.md
+++ b/docs/getting-started/migrating-to-v7.md
@@ -2,6 +2,11 @@
 
 In version 7.x we got rid of some old habits, leading to several breaking changes. Follow this guide if you're migrating to v7:
 
+## No automatic query of all node values when restarting from cache
+
+This legacy behavior resulted in a lot of traffic and delays when the driver was restarted, often doing many unnecessary queries. To reduce the strain on battery devices and to keep the network as responsive as possible, we've opted not to do this anymore when a node was previously interviewed.  
+If you need to manually update values, you can do that on demand with [`node.refreshValues()`](../api/node.md#refreshValues) or [`node.refreshCCValues()`](../api/node.md#refreshCCValues).
+
 ## Corrected parsing of Node Information Frames (NIF), reworked node properties
 
 The old parsing code was based on reverse-engineering, best-effort guesses and looking at what OpenZWave did. We've reworked/fixed the parsing code to match the specifications and changed node properties to make more sense:
@@ -12,7 +17,7 @@ The old parsing code was based on reverse-engineering, best-effort guesses and l
 -   The 100kbps data rate is now detected correctly
 -   The `version` property was renamed to `protocolVersion` and had its type changed from `number` to the enum `ProtocolVersion` (the underlying values are still the same).
 
-*   The `isBeaming` property was renamed to `supportsBeaming` to better show its intent
-*   The `supportsSecurity` property was split off from the `isSecure` property because they have a different meaning.
-*   The mutually exclusive `isRoutingSlave` and `isController` properties were merged into the new `nodeType` property.
-*   The old `nodeType` and `roleType` properties were renamed to `zwavePlusNodeType` and `zwavePlusRoleType` to clarify that they refer to Z-Wave+.
+-   The `isBeaming` property was renamed to `supportsBeaming` to better show its intent
+-   The `supportsSecurity` property was split off from the `isSecure` property because they have a different meaning.
+-   The mutually exclusive `isRoutingSlave` and `isController` properties were merged into the new `nodeType` property.
+-   The old `nodeType` and `roleType` properties were renamed to `zwavePlusNodeType` and `zwavePlusRoleType` to clarify that they refer to Z-Wave+.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -36,9 +36,9 @@
             // e.g. add event handlers to all known nodes
         );
 
-        // After a node was interviewed, it is safe to control it
+        // When a node is marked as ready, it is safe to control it
         const node = driver.controller.nodes.get(2);
-        node.once("interview completed", async () => {
+        node.once("ready", async () => {
             // e.g. perform a BasicCC::Set with target value 50
             await node.commandClasses.Basic.set(50);
         });

--- a/packages/zwave-js/src/lib/commandclass/AlarmSensorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/AlarmSensorCC.ts
@@ -156,7 +156,7 @@ export class AlarmSensorCCAPI extends PhysicalCCAPI {
 export class AlarmSensorCC extends CommandClass {
 	declare ccCommand: AlarmSensorCommand;
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 

--- a/packages/zwave-js/src/lib/commandclass/AlarmSensorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/AlarmSensorCC.ts
@@ -177,46 +177,55 @@ export class AlarmSensorCC extends CommandClass {
 
 		this.driver.controllerLog.logNode(node.id, {
 			endpoint: this.endpointIndex,
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
+			message: `Interviewing ${this.ccName}...`,
 			direction: "none",
 		});
 
 		// Find out which sensor types this sensor supports
-		let supportedSensorTypes: readonly AlarmSensorType[] | undefined;
-		if (complete) {
+		this.driver.controllerLog.logNode(node.id, {
+			endpoint: this.endpointIndex,
+			message: "querying supported sensor types...",
+			direction: "outbound",
+		});
+		const supportedSensorTypes = await api.getSupportedSensorTypes();
+		if (supportedSensorTypes) {
+			const logMessage = `received supported sensor types: ${supportedSensorTypes
+				.map((type) => getEnumMemberName(AlarmSensorType, type))
+				.map((name) => `\n· ${name}`)
+				.join("")}`;
 			this.driver.controllerLog.logNode(node.id, {
 				endpoint: this.endpointIndex,
-				message: "querying supported sensor types...",
-				direction: "outbound",
+				message: logMessage,
+				direction: "inbound",
 			});
-			supportedSensorTypes = await api.getSupportedSensorTypes();
-			if (supportedSensorTypes) {
-				const logMessage = `received supported sensor types: ${supportedSensorTypes
-					.map((type) => getEnumMemberName(AlarmSensorType, type))
-					.map((name) => `\n· ${name}`)
-					.join("")}`;
-				this.driver.controllerLog.logNode(node.id, {
-					endpoint: this.endpointIndex,
-					message: logMessage,
-					direction: "inbound",
-				});
-			} else {
-				this.driver.controllerLog.logNode(node.id, {
-					endpoint: this.endpointIndex,
-					message:
-						"Querying supported sensor types timed out, skipping interview...",
-					level: "warn",
-				});
-				return;
-			}
 		} else {
-			supportedSensorTypes =
-				this.getValueDB().getValue(
-					getSupportedSensorTypesValueId(this.endpointIndex),
-				) ?? [];
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message:
+					"Querying supported sensor types timed out, skipping interview...",
+				level: "warn",
+			});
+			return;
 		}
+
+		// Query (all of) the sensor's current value(s)
+		await this.refreshValues();
+
+		// Remember that the interview is complete
+		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
+		const endpoint = this.getEndpoint()!;
+		const api = endpoint.commandClasses["Alarm Sensor"].withOptions({
+			priority: MessagePriority.NodeQuery,
+		});
+
+		const supportedSensorTypes: readonly AlarmSensorType[] =
+			this.getValueDB().getValue(
+				getSupportedSensorTypesValueId(this.endpointIndex),
+			) ?? [];
 
 		// Always query (all of) the sensor's current value(s)
 		for (const type of supportedSensorTypes) {
@@ -246,9 +255,6 @@ duration: ${currentValue.duration}`;
 				});
 			}
 		}
-
-		// Remember that the interview is complete
-		this.interviewComplete = true;
 	}
 
 	protected createMetadataForSensorType(sensorType: AlarmSensorType): void {

--- a/packages/zwave-js/src/lib/commandclass/AssociationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/AssociationCC.ts
@@ -294,7 +294,7 @@ export class AssociationCC extends CommandClass {
 		return ret;
 	}
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses.Association.withOptions({

--- a/packages/zwave-js/src/lib/commandclass/AssociationGroupInfoCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/AssociationGroupInfoCC.ts
@@ -445,7 +445,7 @@ export class AssociationGroupInfoCC extends CommandClass {
 		);
 	}
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses[

--- a/packages/zwave-js/src/lib/commandclass/BarrierOperatorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BarrierOperatorCC.ts
@@ -294,7 +294,7 @@ export class BarrierOperatorCCAPI extends CCAPI {
 export class BarrierOperatorCC extends CommandClass {
 	declare ccCommand: BarrierOperatorCommand;
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses["Barrier Operator"].withOptions({

--- a/packages/zwave-js/src/lib/commandclass/BarrierOperatorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BarrierOperatorCC.ts
@@ -302,9 +302,8 @@ export class BarrierOperatorCC extends CommandClass {
 		});
 
 		this.driver.controllerLog.logNode(node.id, {
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
+			endpoint: this.endpointIndex,
+			message: `Interviewing ${this.ccName}...`,
 			direction: "none",
 		});
 
@@ -321,34 +320,41 @@ export class BarrierOperatorCC extends CommandClass {
 			});
 		}
 
-		let supportedSubsystems: readonly SubsystemType[];
-		if (complete) {
+		this.driver.controllerLog.logNode(node.id, {
+			message: "Querying signaling capabilities...",
+			direction: "outbound",
+		});
+		const resp = await api.getSignalingCapabilities();
+		if (resp) {
 			this.driver.controllerLog.logNode(node.id, {
-				message: "querying signaling capabilities...",
-				direction: "outbound",
+				message: `Received supported subsystem types: ${resp
+					.map((t) => `\n· ${getEnumMemberName(SubsystemType, t)}`)
+					.join("")}`,
+				direction: "inbound",
 			});
-			const resp = await api.getSignalingCapabilities();
-			supportedSubsystems = resp ?? [];
-			if (resp) {
-				this.driver.controllerLog.logNode(node.id, {
-					message: `received supported subsystem types: ${resp
-						.map(
-							(t) => `\n· ${getEnumMemberName(SubsystemType, t)}`,
-						)
-						.join("")}`,
-					direction: "inbound",
-				});
-			}
-		} else {
-			supportedSubsystems =
-				node.getValue<SubsystemType[]>(
-					getSupportedSubsystemTypesValueId(this.endpointIndex),
-				) ?? [];
 		}
+
+		await this.refreshValues();
+
+		// Remember that the interview is complete
+		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
+		const endpoint = this.getEndpoint()!;
+		const api = endpoint.commandClasses["Barrier Operator"].withOptions({
+			priority: MessagePriority.NodeQuery,
+		});
+
+		const supportedSubsystems =
+			this.getValueDB().getValue<SubsystemType[]>(
+				getSupportedSubsystemTypesValueId(this.endpointIndex),
+			) ?? [];
 
 		for (const subsystemType of supportedSubsystems) {
 			this.driver.controllerLog.logNode(node.id, {
-				message: `querying event signaling state for subsystem ${getEnumMemberName(
+				message: `Querying event signaling state for subsystem ${getEnumMemberName(
 					SubsystemType,
 					subsystemType,
 				)}...`,
@@ -357,7 +363,7 @@ export class BarrierOperatorCC extends CommandClass {
 			const state = await api.getEventSignaling(subsystemType);
 			if (state != undefined) {
 				this.driver.controllerLog.logNode(node.id, {
-					message: `subsystem ${getEnumMemberName(
+					message: `Subsystem ${getEnumMemberName(
 						SubsystemType,
 						subsystemType,
 					)} has state ${getEnumMemberName(SubsystemState, state)}`,
@@ -371,9 +377,6 @@ export class BarrierOperatorCC extends CommandClass {
 			direction: "outbound",
 		});
 		await api.get();
-
-		// Remember that the interview is complete
-		this.interviewComplete = true;
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/BasicCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BasicCC.ts
@@ -156,7 +156,7 @@ export class BasicCCAPI extends CCAPI {
 export class BasicCC extends CommandClass {
 	declare ccCommand: BasicCommand;
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses.Basic.withOptions({

--- a/packages/zwave-js/src/lib/commandclass/BatteryCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BatteryCC.ts
@@ -150,19 +150,27 @@ export class BatteryCC extends CommandClass {
 	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
+
+		this.driver.controllerLog.logNode(node.id, {
+			endpoint: this.endpointIndex,
+			message: `Interviewing ${this.ccName}...`,
+			direction: "none",
+		});
+
+		// Query the Battery status
+		await this.refreshValues();
+
+		// Remember that the interview is complete
+		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
+		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses.Battery.withOptions({
 			priority: MessagePriority.NodeQuery,
 		});
 
-		this.driver.controllerLog.logNode(node.id, {
-			endpoint: this.endpointIndex,
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
-			direction: "none",
-		});
-
-		// always query the status
 		this.driver.controllerLog.logNode(node.id, {
 			endpoint: this.endpointIndex,
 			message: "querying battery status...",
@@ -217,9 +225,6 @@ temperature:   ${batteryHealth.temperature} °C`;
 				});
 			}
 		}
-
-		// Remember that the interview is complete
-		this.interviewComplete = true;
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/BatteryCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BatteryCC.ts
@@ -147,7 +147,7 @@ export class BatteryCCAPI extends PhysicalCCAPI {
 export class BatteryCC extends CommandClass {
 	declare ccCommand: BatteryCommand;
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses.Battery.withOptions({

--- a/packages/zwave-js/src/lib/commandclass/BatteryCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BatteryCC.ts
@@ -149,7 +149,6 @@ export class BatteryCC extends CommandClass {
 
 	public async interview(): Promise<void> {
 		const node = this.getNode()!;
-		const endpoint = this.getEndpoint()!;
 
 		this.driver.controllerLog.logNode(node.id, {
 			endpoint: this.endpointIndex,

--- a/packages/zwave-js/src/lib/commandclass/BinarySensorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySensorCC.ts
@@ -163,7 +163,7 @@ export class BinarySensorCCAPI extends PhysicalCCAPI {
 export class BinarySensorCC extends CommandClass {
 	declare ccCommand: BinarySensorCommand;
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses["Binary Sensor"].withOptions({

--- a/packages/zwave-js/src/lib/commandclass/BinarySensorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySensorCC.ts
@@ -172,21 +172,18 @@ export class BinarySensorCC extends CommandClass {
 
 		this.driver.controllerLog.logNode(node.id, {
 			endpoint: this.endpointIndex,
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
+			message: `Interviewing ${this.ccName}...`,
 			direction: "none",
 		});
 
 		// Find out which sensor types this sensor supports
-		let supportedSensorTypes: readonly BinarySensorType[] | undefined;
-		if (complete && this.version >= 2) {
+		if (this.version >= 2) {
 			this.driver.controllerLog.logNode(node.id, {
 				endpoint: this.endpointIndex,
 				message: "querying supported sensor types...",
 				direction: "outbound",
 			});
-			supportedSensorTypes = await api.getSupportedSensorTypes();
+			const supportedSensorTypes = await api.getSupportedSensorTypes();
 			if (supportedSensorTypes) {
 				const logMessage = `received supported sensor types: ${supportedSensorTypes
 					.map((type) => getEnumMemberName(BinarySensorType, type))
@@ -206,13 +203,22 @@ export class BinarySensorCC extends CommandClass {
 				});
 				return;
 			}
-		} else {
-			supportedSensorTypes = this.getValueDB().getValue(
-				getSupportedSensorTypesValueId(this.endpointIndex),
-			);
 		}
 
-		// Always query (all of) the sensor's current value(s)
+		await this.refreshValues();
+
+		// Remember that the interview is complete
+		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
+		const endpoint = this.getEndpoint()!;
+		const api = endpoint.commandClasses["Binary Sensor"].withOptions({
+			priority: MessagePriority.NodeQuery,
+		});
+
+		// Query (all of) the sensor's current value(s)
 		if (this.version === 1) {
 			this.driver.controllerLog.logNode(node.id, {
 				endpoint: this.endpointIndex,
@@ -227,7 +233,12 @@ export class BinarySensorCC extends CommandClass {
 					direction: "inbound",
 				});
 			}
-		} else if (supportedSensorTypes) {
+		} else {
+			const supportedSensorTypes: readonly BinarySensorType[] =
+				this.getValueDB().getValue(
+					getSupportedSensorTypesValueId(this.endpointIndex),
+				) ?? [];
+
 			for (const type of supportedSensorTypes) {
 				const sensorName = getEnumMemberName(BinarySensorType, type);
 				this.driver.controllerLog.logNode(node.id, {
@@ -245,9 +256,6 @@ export class BinarySensorCC extends CommandClass {
 				}
 			}
 		}
-
-		// Remember that the interview is complete
-		this.interviewComplete = true;
 	}
 
 	public setMappedBasicValue(value: number): boolean {

--- a/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
@@ -160,20 +160,27 @@ export class BinarySwitchCC extends CommandClass {
 
 	public async interview(): Promise<void> {
 		const node = this.getNode()!;
+
+		this.driver.controllerLog.logNode(node.id, {
+			endpoint: this.endpointIndex,
+			message: `Interviewing ${this.ccName}...`,
+			direction: "none",
+		});
+
+		await this.refreshValues();
+
+		// Remember that the interview is complete
+		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses["Binary Switch"].withOptions({
 			priority: MessagePriority.NodeQuery,
 		});
 
-		this.driver.controllerLog.logNode(node.id, {
-			endpoint: this.endpointIndex,
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
-			direction: "none",
-		});
-
-		// always query the current state
+		// Query the current state
 		this.driver.controllerLog.logNode(node.id, {
 			endpoint: this.endpointIndex,
 			message: "querying Binary Switch state...",
@@ -195,9 +202,6 @@ remaining duration: ${resp.duration?.toString() ?? "undefined"}`;
 				direction: "inbound",
 			});
 		}
-
-		// Remember that the interview is complete
-		this.interviewComplete = true;
 	}
 
 	public setMappedBasicValue(value: number): boolean {

--- a/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
@@ -158,7 +158,7 @@ export class BinarySwitchCCAPI extends CCAPI {
 export class BinarySwitchCC extends CommandClass {
 	declare ccCommand: BinarySwitchCommand;
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses["Binary Switch"].withOptions({

--- a/packages/zwave-js/src/lib/commandclass/CentralSceneCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/CentralSceneCC.ts
@@ -190,7 +190,7 @@ export class CentralSceneCC extends CommandClass {
 		return true;
 	}
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses["Central Scene"].withOptions({

--- a/packages/zwave-js/src/lib/commandclass/ClockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ClockCC.ts
@@ -99,16 +99,24 @@ export class ClockCC extends CommandClass {
 
 	public async interview(): Promise<void> {
 		const node = this.getNode()!;
+
+		this.driver.controllerLog.logNode(node.id, {
+			endpoint: this.endpointIndex,
+			message: `Interviewing ${this.ccName}...`,
+			direction: "none",
+		});
+
+		await this.refreshValues();
+
+		// Remember that the interview is complete
+		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses.Clock.withOptions({
 			priority: MessagePriority.NodeQuery,
-		});
-
-		this.driver.controllerLog.logNode(node.id, {
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
-			direction: "none",
 		});
 
 		this.driver.controllerLog.logNode(node.id, {
@@ -129,9 +137,6 @@ export class ClockCC extends CommandClass {
 				direction: "inbound",
 			});
 		}
-
-		// Remember that the interview is complete
-		this.interviewComplete = true;
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/ClockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ClockCC.ts
@@ -97,7 +97,7 @@ export class ClockCCAPI extends CCAPI {
 export class ClockCC extends CommandClass {
 	declare ccCommand: ClockCommand;
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses.Clock.withOptions({

--- a/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
@@ -443,7 +443,7 @@ export class ColorSwitchCC extends CommandClass {
 		this.registerValue(getSupportsHexColorValueID(0).property, true);
 	}
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses["Color Switch"].withOptions({

--- a/packages/zwave-js/src/lib/commandclass/CommandClass.ts
+++ b/packages/zwave-js/src/lib/commandclass/CommandClass.ts
@@ -378,14 +378,18 @@ export class CommandClass {
 		return stripUndefined({ ...ret, ...props });
 	}
 
-	// This needs to be overwritten per command class. In the default implementation, don't do anything
 	/**
 	 * Performs the interview procedure for this CC according to SDS14223
-	 * @param complete Whether a complete interview should be performed or only the necessary steps on startup
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	public async interview(complete: boolean = true): Promise<void> {
-		// Empty on purpose
+	public async interview(): Promise<void> {
+		// This needs to be overwritten per command class. In the default implementation, don't do anything
+	}
+
+	/**
+	 * Refreshes all dynamic values of this CC
+	 */
+	public async refreshValues(): Promise<void> {
+		// This needs to be overwritten per command class. In the default implementation, don't do anything
 	}
 
 	/** Determines which CC interviews must be performed before this CC can be interviewed */

--- a/packages/zwave-js/src/lib/commandclass/CommandClass.ts
+++ b/packages/zwave-js/src/lib/commandclass/CommandClass.ts
@@ -176,6 +176,9 @@ export class CommandClass {
 	/** This CC's identifier */
 	public ccId: CommandClasses;
 	public ccCommand?: number;
+	public get ccName(): string {
+		return getCCName(this.ccId);
+	}
 
 	/** The ID of the target node(s) */
 	public nodeId!: number | MulticastDestination;

--- a/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
@@ -483,7 +483,7 @@ export class ConfigurationCC extends CommandClass {
 		this.registerValue("isParamInformationFromConfig" as any, true);
 	}
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 
 		const config = node.deviceConfig?.paramInformation;

--- a/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
@@ -485,6 +485,16 @@ export class ConfigurationCC extends CommandClass {
 
 	public async interview(): Promise<void> {
 		const node = this.getNode()!;
+		const endpoint = this.getEndpoint()!;
+		const api = endpoint.commandClasses.Configuration.withOptions({
+			priority: MessagePriority.NodeQuery,
+		});
+
+		this.driver.controllerLog.logNode(node.id, {
+			endpoint: this.endpointIndex,
+			message: `Interviewing ${this.ccName}...`,
+			direction: "none",
+		});
 
 		const config = node.deviceConfig?.paramInformation;
 		if (config) {
@@ -496,15 +506,112 @@ export class ConfigurationCC extends CommandClass {
 			this.deserializeParamInformationFromConfig(config);
 		}
 
+		if (this.version >= 3) {
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message: "finding first configuration parameter...",
+				direction: "outbound",
+			});
+			const param0props = await api.getProperties(0);
+			let param: number;
+			if (param0props) {
+				param = param0props.nextParameter;
+				if (param === 0) {
+					this.driver.controllerLog.logNode(node.id, {
+						endpoint: this.endpointIndex,
+						message: `didn't report any config params, trying #1 just to be sure...`,
+						direction: "inbound",
+					});
+					param = 1;
+				}
+			} else {
+				this.driver.controllerLog.logNode(node.id, {
+					endpoint: this.endpointIndex,
+					message:
+						"Finding first configuration parameter timed out, skipping interview...",
+					level: "warn",
+				});
+				return;
+			}
+
+			while (param > 0) {
+				this.driver.controllerLog.logNode(node.id, {
+					endpoint: this.endpointIndex,
+					message: `querying parameter #${param} information...`,
+					direction: "outbound",
+				});
+
+				// Query properties and the next param
+				const props = await api.getProperties(param);
+				if (!props) {
+					this.driver.controllerLog.logNode(node.id, {
+						endpoint: this.endpointIndex,
+						message: `Querying parameter #${param} information timed out, skipping interview...`,
+						level: "warn",
+					});
+					return;
+				}
+				const { nextParameter, ...properties } = props;
+
+				let logMessage: string;
+				if (properties.valueSize === 0) {
+					logMessage = `Parameter #${param} is unsupported. Next parameter: ${nextParameter}`;
+				} else {
+					// Query name and info only if the parameter is supported
+					const name = (await api.getName(param)) ?? "(unknown)";
+					// Skip the info query for bugged devices
+					if (
+						!node.deviceConfig?.compat?.skipConfigurationInfoQuery
+					) {
+						await api.getInfo(param);
+					}
+
+					logMessage = `received information for parameter #${param}:
+parameter name:      ${name}
+value format:        ${getEnumMemberName(ValueFormat, properties.valueFormat)}
+value size:          ${properties.valueSize} bytes
+min value:           ${properties.minValue?.toString() ?? "undefined"}
+max value:           ${properties.maxValue?.toString() ?? "undefined"}
+default value:       ${properties.defaultValue?.toString() ?? "undefined"}
+is read-only:        ${!!properties.isReadonly}
+is advanced (UI):    ${!!properties.isAdvanced}
+has bulk support:    ${!properties.noBulkSupport}
+alters capabilities: ${!!properties.altersCapabilities}`;
+				}
+				this.driver.controllerLog.logNode(node.id, {
+					endpoint: this.endpointIndex,
+					message: logMessage,
+					direction: "inbound",
+				});
+
+				// Some devices report their parameter 1 instead of 0 as the next one
+				// when reaching the end. To avoid infinite loops, stop scanning
+				// once the next parameter is lower than the current one
+				if (nextParameter > param) {
+					param = nextParameter;
+				} else {
+					break;
+				}
+			}
+		}
+
+		await this.refreshValues();
+
+		// Remember that the interview is complete
+		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses.Configuration.withOptions({
 			priority: MessagePriority.NodeQuery,
 		});
 
 		if (this.version < 3) {
+			// V1/V2: Query all values defined in the config file
 			const paramInfo = node.deviceConfig?.paramInformation;
 			if (paramInfo?.size) {
-				// Query all values
 				// Because partial params share the same parameter number,
 				// we need to remember which ones we have already queried.
 				const alreadyQueried = new Set<number>();
@@ -546,107 +653,7 @@ export class ConfigurationCC extends CommandClass {
 				});
 			}
 		} else {
-			// Version >= 3
-			this.driver.controllerLog.logNode(node.id, {
-				endpoint: this.endpointIndex,
-				message: `${this.constructor.name}: doing a ${
-					complete ? "complete" : "partial"
-				} interview...`,
-				direction: "none",
-			});
-
-			if (complete) {
-				// Only scan all parameters during complete interviews
-				this.driver.controllerLog.logNode(node.id, {
-					endpoint: this.endpointIndex,
-					message: "finding first configuration parameter...",
-					direction: "outbound",
-				});
-				const param0props = await api.getProperties(0);
-				let param: number;
-				if (param0props) {
-					param = param0props.nextParameter;
-					if (param === 0) {
-						this.driver.controllerLog.logNode(node.id, {
-							endpoint: this.endpointIndex,
-							message: `didn't report any config params, trying #1 just to be sure...`,
-							direction: "inbound",
-						});
-						param = 1;
-					}
-				} else {
-					this.driver.controllerLog.logNode(node.id, {
-						endpoint: this.endpointIndex,
-						message:
-							"Finding first configuration parameter timed out, skipping interview...",
-						level: "warn",
-					});
-					return;
-				}
-
-				while (param > 0) {
-					this.driver.controllerLog.logNode(node.id, {
-						endpoint: this.endpointIndex,
-						message: `querying parameter #${param} information...`,
-						direction: "outbound",
-					});
-
-					// Query properties and the next param
-					const props = await api.getProperties(param);
-					if (!props) {
-						this.driver.controllerLog.logNode(node.id, {
-							endpoint: this.endpointIndex,
-							message: `Querying parameter #${param} information timed out, skipping interview...`,
-							level: "warn",
-						});
-						return;
-					}
-					const { nextParameter, ...properties } = props;
-
-					let logMessage: string;
-					if (properties.valueSize === 0) {
-						logMessage = `Parameter #${param} is unsupported. Next parameter: ${nextParameter}`;
-					} else {
-						// Query name and info only if the parameter is supported
-						const name = (await api.getName(param)) ?? "(unknown)";
-						// Skip the info query for bugged devices
-						if (
-							!node.deviceConfig?.compat
-								?.skipConfigurationInfoQuery
-						) {
-							await api.getInfo(param);
-						}
-
-						logMessage = `received information for parameter #${param}:
-parameter name:      ${name}
-value format:        ${getEnumMemberName(ValueFormat, properties.valueFormat)}
-value size:          ${properties.valueSize} bytes
-min value:           ${properties.minValue?.toString() ?? "undefined"}
-max value:           ${properties.maxValue?.toString() ?? "undefined"}
-default value:       ${properties.defaultValue?.toString() ?? "undefined"}
-is read-only:        ${!!properties.isReadonly}
-is advanced (UI):    ${!!properties.isAdvanced}
-has bulk support:    ${!properties.noBulkSupport}
-alters capabilities: ${!!properties.altersCapabilities}`;
-					}
-					this.driver.controllerLog.logNode(node.id, {
-						endpoint: this.endpointIndex,
-						message: logMessage,
-						direction: "inbound",
-					});
-
-					// Some devices report their parameter 1 instead of 0 as the next one
-					// when reaching the end. To avoid infinite loops, stop scanning
-					// once the next parameter is lower than the current one
-					if (nextParameter > param) {
-						param = nextParameter;
-					} else {
-						break;
-					}
-				}
-			}
-
-			// Query the values of supported parameters during every interview
+			// V3+: Query the values of discovered parameters
 			const parameters = distinct(
 				this.getDefinedValueIDs()
 					.map((v) => v.property)
@@ -661,9 +668,6 @@ alters capabilities: ${!!properties.altersCapabilities}`;
 				await api.get(param);
 			}
 		}
-
-		// Remember that the interview is complete
-		this.interviewComplete = true;
 	}
 
 	/**

--- a/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
@@ -352,9 +352,7 @@ export class DoorLockCC extends CommandClass {
 
 		this.driver.controllerLog.logNode(node.id, {
 			endpoint: this.endpointIndex,
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
+			message: `Interviewing ${this.ccName}...`,
 			direction: "none",
 		});
 
@@ -362,7 +360,7 @@ export class DoorLockCC extends CommandClass {
 		// In this case, do now mark this CC as interviewed completely
 		let hadCriticalTimeout = false;
 
-		if (complete && this.version >= 4) {
+		if (this.version >= 4) {
 			this.driver.controllerLog.logNode(node.id, {
 				endpoint: this.endpointIndex,
 				message: "requesting lock capabilities...",
@@ -377,7 +375,7 @@ supported operation types: ${resp.supportedOperationTypes
 supported door lock modes: ${resp.supportedDoorLockModes
 					.map((t) => getEnumMemberName(DoorLockMode, t))
 					.map((str) => `\n· ${str}`)
-					.join(", ")}
+					.join("")}
 supported outside handles: ${resp.supportedOutsideHandles
 					.map(String)
 					.join(", ")}
@@ -415,6 +413,19 @@ supports block to block:   ${resp.blockToBlockSupported}`;
 				hadCriticalTimeout = true;
 			}
 		}
+
+		await this.refreshValues();
+
+		// Remember that the interview is complete
+		if (!hadCriticalTimeout) this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
+		const endpoint = this.getEndpoint()!;
+		const api = endpoint.commandClasses["Door Lock"].withOptions({
+			priority: MessagePriority.NodeQuery,
+		});
 
 		this.driver.controllerLog.logNode(node.id, {
 			endpoint: this.endpointIndex,
@@ -483,9 +494,6 @@ latch status:       ${status.latchStatus}`;
 				direction: "inbound",
 			});
 		}
-
-		// Remember that the interview is complete
-		if (!hadCriticalTimeout) this.interviewComplete = true;
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
@@ -343,7 +343,7 @@ export class DoorLockCCAPI extends PhysicalCCAPI {
 export class DoorLockCC extends CommandClass {
 	declare ccCommand: DoorLockCommand;
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses["Door Lock"].withOptions({

--- a/packages/zwave-js/src/lib/commandclass/IndicatorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/IndicatorCC.ts
@@ -369,10 +369,64 @@ export class IndicatorCC extends CommandClass {
 
 		this.driver.controllerLog.logNode(node.id, {
 			endpoint: this.endpointIndex,
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
+			message: `Interviewing ${this.ccName}...`,
 			direction: "none",
+		});
+
+		if (this.version > 1) {
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message: "scanning supported indicator IDs...",
+				direction: "outbound",
+			});
+			// Query ID 0 to get the first supported ID
+			let curId = 0x00;
+			const supportedIndicatorIds: number[] = [];
+			do {
+				const supportedResponse = await api.getSupported(curId);
+				if (!supportedResponse) {
+					this.driver.controllerLog.logNode(node.id, {
+						endpoint: this.endpointIndex,
+						message:
+							"Time out while scanning supported indicator IDs, skipping interview...",
+						level: "warn",
+					});
+					return;
+				}
+
+				supportedIndicatorIds.push(
+					supportedResponse.indicatorId ?? curId,
+				);
+				curId = supportedResponse.nextIndicatorId;
+			} while (curId !== 0x00);
+
+			// The IDs are not stored by the report CCs so store them here once we have all of them
+			this.getValueDB().setValue(
+				getSupportedIndicatorIDsValueID(this.endpointIndex),
+				supportedIndicatorIds,
+			);
+			const logMessage = `supported indicator IDs: ${supportedIndicatorIds.join(
+				", ",
+			)}`;
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message: logMessage,
+				direction: "inbound",
+			});
+		}
+
+		// Query current values
+		await this.refreshValues();
+
+		// Remember that the interview is complete
+		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
+		const endpoint = this.getEndpoint()!;
+		const api = endpoint.commandClasses.Indicator.withOptions({
+			priority: MessagePriority.NodeQuery,
 		});
 
 		if (this.version === 1) {
@@ -383,54 +437,10 @@ export class IndicatorCC extends CommandClass {
 			});
 			await api.get();
 		} else {
-			let supportedIndicatorIds: number[];
-			if (complete) {
-				this.driver.controllerLog.logNode(node.id, {
-					endpoint: this.endpointIndex,
-					message: "scanning supported indicator IDs...",
-					direction: "outbound",
-				});
-				// Query ID 0 to get the first supported ID
-				let curId = 0x00;
-				supportedIndicatorIds = [];
-				do {
-					const supportedResponse = await api.getSupported(curId);
-					if (!supportedResponse) {
-						this.driver.controllerLog.logNode(node.id, {
-							endpoint: this.endpointIndex,
-							message:
-								"Time out while scanning supported indicator IDs, skipping interview...",
-							level: "warn",
-						});
-						return;
-					}
-
-					supportedIndicatorIds.push(
-						supportedResponse.indicatorId ?? curId,
-					);
-					curId = supportedResponse.nextIndicatorId;
-				} while (curId !== 0x00);
-
-				// The IDs are not stored by the report CCs so store them here once we have all of them
-				this.getValueDB().setValue(
+			const supportedIndicatorIds: number[] =
+				this.getValueDB().getValue(
 					getSupportedIndicatorIDsValueID(this.endpointIndex),
-					supportedIndicatorIds,
-				);
-				const logMessage = `supported indicator IDs: ${supportedIndicatorIds.join(
-					", ",
-				)}`;
-				this.driver.controllerLog.logNode(node.id, {
-					endpoint: this.endpointIndex,
-					message: logMessage,
-					direction: "inbound",
-				});
-			} else {
-				supportedIndicatorIds =
-					this.getValueDB().getValue(
-						getSupportedIndicatorIDsValueID(this.endpointIndex),
-					) ?? [];
-			}
-
+				) ?? [];
 			for (const indicatorId of supportedIndicatorIds) {
 				this.driver.controllerLog.logNode(node.id, {
 					endpoint: this.endpointIndex,
@@ -442,9 +452,6 @@ export class IndicatorCC extends CommandClass {
 				await api.get(indicatorId);
 			}
 		}
-
-		// Remember that the interview is complete
-		this.interviewComplete = true;
 	}
 
 	public translatePropertyKey(

--- a/packages/zwave-js/src/lib/commandclass/IndicatorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/IndicatorCC.ts
@@ -360,7 +360,7 @@ export class IndicatorCC extends CommandClass {
 		);
 	}
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses.Indicator.withOptions({

--- a/packages/zwave-js/src/lib/commandclass/LanguageCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/LanguageCC.ts
@@ -79,7 +79,7 @@ export class LanguageCCAPI extends CCAPI {
 export class LanguageCC extends CommandClass {
 	declare ccCommand: LanguageCommand;
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses.Language.withOptions({

--- a/packages/zwave-js/src/lib/commandclass/LanguageCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/LanguageCC.ts
@@ -81,16 +81,24 @@ export class LanguageCC extends CommandClass {
 
 	public async interview(): Promise<void> {
 		const node = this.getNode()!;
+
+		this.driver.controllerLog.logNode(node.id, {
+			endpoint: this.endpointIndex,
+			message: `Interviewing ${this.ccName}...`,
+			direction: "none",
+		});
+
+		await this.refreshValues();
+
+		// Remember that the interview is complete
+		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses.Language.withOptions({
 			priority: MessagePriority.NodeQuery,
-		});
-
-		this.driver.controllerLog.logNode(node.id, {
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
-			direction: "none",
 		});
 
 		this.driver.controllerLog.logNode(node.id, {
@@ -108,9 +116,6 @@ export class LanguageCC extends CommandClass {
 				direction: "inbound",
 			});
 		}
-
-		// Remember that the interview is complete
-		this.interviewComplete = true;
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/LockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/LockCC.ts
@@ -117,16 +117,24 @@ export class LockCC extends CommandClass {
 
 	public async interview(): Promise<void> {
 		const node = this.getNode()!;
+
+		this.driver.controllerLog.logNode(node.id, {
+			endpoint: this.endpointIndex,
+			message: `Interviewing ${this.ccName}...`,
+			direction: "none",
+		});
+
+		await this.refreshValues();
+
+		// Remember that the interview is complete
+		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses.Lock.withOptions({
 			priority: MessagePriority.NodeQuery,
-		});
-
-		this.driver.controllerLog.logNode(node.id, {
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
-			direction: "none",
 		});
 
 		this.driver.controllerLog.logNode(node.id, {
@@ -139,9 +147,6 @@ export class LockCC extends CommandClass {
 			message: logMessage,
 			direction: "inbound",
 		});
-
-		// Remember that the interview is complete
-		this.interviewComplete = true;
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/LockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/LockCC.ts
@@ -115,7 +115,7 @@ export class LockCCAPI extends PhysicalCCAPI {
 export class LockCC extends CommandClass {
 	declare ccCommand: LockCommand;
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses.Lock.withOptions({

--- a/packages/zwave-js/src/lib/commandclass/ManufacturerProprietaryCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ManufacturerProprietaryCC.ts
@@ -228,7 +228,7 @@ export class ManufacturerProprietaryCC extends CommandClass {
 			await new FibaroVenetianBlindCC(this.driver, {
 				nodeId: this.nodeId,
 				endpoint: this.endpointIndex,
-			}).interview(complete);
+			}).interview();
 		} else {
 			this.driver.controllerLog.logNode(node.id, {
 				message: `${this.constructor.name}: skipping interview because none of the implemented proprietary CCs are supported...`,
@@ -238,6 +238,33 @@ export class ManufacturerProprietaryCC extends CommandClass {
 
 		// Remember that the interview is complete
 		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		this.assertManufacturerIdIsSet();
+
+		const node = this.getNode()!;
+		// TODO: Can this be refactored?
+		const proprietaryConfig = node.deviceConfig?.proprietary;
+		if (
+			this.manufacturerId === 0x010f /* Fibaro */ &&
+			proprietaryConfig &&
+			isArray(proprietaryConfig.fibaroCCs) &&
+			proprietaryConfig.fibaroCCs.includes(0x26 /* Venetian Blinds */)
+		) {
+			// eslint-disable-next-line @typescript-eslint/no-var-requires
+			const FibaroVenetianBlindCC = (require("./manufacturerProprietary/Fibaro") as typeof import("./manufacturerProprietary/Fibaro"))
+				.FibaroVenetianBlindCC;
+			await new FibaroVenetianBlindCC(this.driver, {
+				nodeId: this.nodeId,
+				endpoint: this.endpointIndex,
+			}).refreshValues();
+		} else {
+			this.driver.controllerLog.logNode(node.id, {
+				message: `${this.constructor.name}: skipping interview because none of the implemented proprietary CCs are supported...`,
+				direction: "none",
+			});
+		}
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/ManufacturerProprietaryCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ManufacturerProprietaryCC.ts
@@ -210,7 +210,7 @@ export class ManufacturerProprietaryCC extends CommandClass {
 		return super.serialize();
 	}
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		this.assertManufacturerIdIsSet();
 
 		const node = this.getNode()!;

--- a/packages/zwave-js/src/lib/commandclass/ManufacturerSpecificCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ManufacturerSpecificCC.ts
@@ -151,7 +151,7 @@ export class ManufacturerSpecificCC extends CommandClass {
 		return [];
 	}
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses[

--- a/packages/zwave-js/src/lib/commandclass/ManufacturerSpecificCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ManufacturerSpecificCC.ts
@@ -158,42 +158,32 @@ export class ManufacturerSpecificCC extends CommandClass {
 			"Manufacturer Specific"
 		].withOptions({ priority: MessagePriority.NodeQuery });
 
-		this.driver.controllerLog.logNode(node.id, {
-			endpoint: this.endpointIndex,
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
-			direction: "none",
-		});
+		if (!node.isControllerNode()) {
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message: `Interviewing ${this.ccName}...`,
+				direction: "none",
+			});
 
-		// manufacturer information is static
-		if (complete) {
-			if (node.isControllerNode()) {
-				this.driver.controllerLog.logNode(
-					node.id,
-					"not querying manufacturer information from the controller...",
-				);
-			} else {
-				this.driver.controllerLog.logNode(node.id, {
-					endpoint: this.endpointIndex,
-					message: "querying manufacturer information...",
-					direction: "outbound",
-				});
-				const mfResp = await api.get();
-				if (mfResp) {
-					const logMessage = `received response for manufacturer information:
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message: "querying manufacturer information...",
+				direction: "outbound",
+			});
+			const mfResp = await api.get();
+			if (mfResp) {
+				const logMessage = `received response for manufacturer information:
   manufacturer: ${
 		this.driver.configManager.lookupManufacturer(mfResp.manufacturerId) ||
 		"unknown"
   } (${num2hex(mfResp.manufacturerId)})
   product type: ${num2hex(mfResp.productType)}
   product id:   ${num2hex(mfResp.productId)}`;
-					this.driver.controllerLog.logNode(node.id, {
-						endpoint: this.endpointIndex,
-						message: logMessage,
-						direction: "inbound",
-					});
-				}
+				this.driver.controllerLog.logNode(node.id, {
+					endpoint: this.endpointIndex,
+					message: logMessage,
+					direction: "inbound",
+				});
 			}
 		}
 

--- a/packages/zwave-js/src/lib/commandclass/MeterCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MeterCC.ts
@@ -349,82 +349,86 @@ export class MeterCC extends CommandClass {
 
 		this.driver.controllerLog.logNode(node.id, {
 			endpoint: this.endpointIndex,
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
+			message: `Interviewing ${this.ccName}...`,
 			direction: "none",
 		});
 
 		if (this.version >= 2) {
-			let type: number;
-			let supportsReset: boolean | undefined;
-			let supportedScales: readonly number[] | undefined;
-			let supportedRateTypes: readonly RateType[] | undefined;
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message: "querying meter support...",
+				direction: "outbound",
+			});
 
-			const storedType = node.getValue<number>(
-				getTypeValueId(this.endpointIndex),
-			);
-
-			if (complete || storedType == undefined) {
+			const suppResp = await api.getSupported();
+			if (suppResp) {
+				const logMessage = `received meter support:
+type:                 ${getMeterTypeName(
+					this.driver.configManager,
+					suppResp.type,
+				)}
+supported scales:     ${suppResp.supportedScales
+					.map(
+						(s) =>
+							this.driver.configManager.lookupMeterScale(
+								suppResp.type,
+								s,
+							).label,
+					)
+					.map((label) => `\n· ${label}`)
+					.join("")}
+supported rate types: ${suppResp.supportedRateTypes
+					.map((rt) => getEnumMemberName(RateType, rt))
+					.map((label) => `\n· ${label}`)
+					.join("")}
+supports reset:       ${suppResp.supportsReset}`;
 				this.driver.controllerLog.logNode(node.id, {
 					endpoint: this.endpointIndex,
-					message: "querying meter support...",
-					direction: "outbound",
+					message: logMessage,
+					direction: "inbound",
 				});
-
-				const suppResp = await api.getSupported();
-				if (suppResp) {
-					type = suppResp.type;
-					supportsReset = suppResp.supportsReset;
-					supportedScales = suppResp.supportedScales;
-					supportedRateTypes = suppResp.supportedRateTypes;
-
-					const logMessage = `received meter support:
-type:                 ${getMeterTypeName(this.driver.configManager, type)}
-supported scales:     ${supportedScales
-						.map(
-							(s) =>
-								this.driver.configManager.lookupMeterScale(
-									type,
-									s,
-								).label,
-						)
-						.map((label) => `\n· ${label}`)
-						.join("")}
-supported rate types: ${supportedRateTypes
-						.map((rt) => getEnumMemberName(RateType, rt))
-						.map((label) => `\n· ${label}`)
-						.join("")}
-supports reset:       ${supportsReset}`;
-					this.driver.controllerLog.logNode(node.id, {
-						endpoint: this.endpointIndex,
-						message: logMessage,
-						direction: "inbound",
-					});
-				} else {
-					this.driver.controllerLog.logNode(node.id, {
-						endpoint: this.endpointIndex,
-						message:
-							"Querying meter support timed out, skipping interview...",
-						level: "warn",
-					});
-					return;
-				}
 			} else {
-				type = storedType;
-				// supportsReset =
-				// 	node.getValue(
-				// 		getSupportsResetValueId(this.endpointIndex),
-				// 	) ?? false;
-				supportedScales =
-					node.getValue(
-						getSupportedScalesValueId(this.endpointIndex),
-					) ?? [];
-				supportedRateTypes =
-					node.getValue(
-						getSupportedRateTypesValueId(this.endpointIndex),
-					) ?? [];
+				this.driver.controllerLog.logNode(node.id, {
+					endpoint: this.endpointIndex,
+					message:
+						"Querying meter support timed out, skipping interview...",
+					level: "warn",
+				});
+				return;
 			}
+		}
+
+		// Query current meter values
+		await this.refreshValues();
+
+		// Remember that the interview is complete
+		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
+		const endpoint = this.getEndpoint()!;
+		const api = endpoint.commandClasses.Meter.withOptions({
+			priority: MessagePriority.NodeQuery,
+		});
+
+		if (this.version === 1) {
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message: `querying default meter value...`,
+				direction: "outbound",
+			});
+			await api.get();
+		} else {
+			const type: number =
+				node.getValue(getTypeValueId(this.endpointIndex)) ?? 0;
+			const supportedScales: readonly number[] =
+				node.getValue(getSupportedScalesValueId(this.endpointIndex)) ??
+				[];
+			const supportedRateTypes: readonly RateType[] =
+				node.getValue(
+					getSupportedRateTypesValueId(this.endpointIndex),
+				) ?? [];
 
 			const rateTypes = supportedRateTypes.length
 				? supportedRateTypes
@@ -454,17 +458,7 @@ supports reset:       ${supportsReset}`;
 					await api.get({ scale, rateType });
 				}
 			}
-		} else {
-			this.driver.controllerLog.logNode(node.id, {
-				endpoint: this.endpointIndex,
-				message: `querying default meter value...`,
-				direction: "outbound",
-			});
-			await api.get();
 		}
-
-		// Remember that the interview is complete
-		this.interviewComplete = true;
 	}
 
 	public translatePropertyKey(

--- a/packages/zwave-js/src/lib/commandclass/MeterCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MeterCC.ts
@@ -340,7 +340,7 @@ export class MeterCCAPI extends PhysicalCCAPI {
 export class MeterCC extends CommandClass {
 	declare ccCommand: MeterCommand;
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses.Meter.withOptions({

--- a/packages/zwave-js/src/lib/commandclass/MultiChannelAssociationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultiChannelAssociationCC.ts
@@ -398,7 +398,7 @@ export class MultiChannelAssociationCC extends CommandClass {
 		return ret;
 	}
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const mcAPI = endpoint.commandClasses["Multi Channel Association"];

--- a/packages/zwave-js/src/lib/commandclass/MultiChannelCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultiChannelCC.ts
@@ -288,7 +288,7 @@ export class MultiChannelCC extends CommandClass {
 		});
 	}
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		// Special interview procedure for legacy nodes
 		if (this.version === 1) return this.interviewV1(complete);
 

--- a/packages/zwave-js/src/lib/commandclass/MultiChannelCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultiChannelCC.ts
@@ -289,10 +289,16 @@ export class MultiChannelCC extends CommandClass {
 	}
 
 	public async interview(): Promise<void> {
-		// Special interview procedure for legacy nodes
-		if (this.version === 1) return this.interviewV1(complete);
-
 		const node = this.getNode()!;
+		this.driver.controllerLog.logNode(node.id, {
+			endpoint: this.endpointIndex,
+			message: `Interviewing ${this.ccName}...`,
+			direction: "none",
+		});
+
+		// Special interview procedure for legacy nodes
+		if (this.version === 1) return this.interviewV1();
+
 		const endpoint = node.getEndpoint(this.endpointIndex)!;
 		const api = endpoint.commandClasses["Multi Channel"].withOptions({
 			priority: MessagePriority.NodeQuery,
@@ -451,65 +457,59 @@ supported CCs:`;
 		this.interviewComplete = true;
 	}
 
-	private async interviewV1(complete: boolean = true): Promise<void> {
-		// Only do the interview once
-		if (complete) {
-			const node = this.getNode()!;
-			const api = node.getEndpoint(this.endpointIndex)!.commandClasses[
-				"Multi Channel"
-			];
+	private async interviewV1(): Promise<void> {
+		const node = this.getNode()!;
+		const api = node.getEndpoint(this.endpointIndex)!.commandClasses[
+			"Multi Channel"
+		];
 
-			// V1 works the opposite way - we scan all CCs and remember how many
-			// endpoints they have
-			const supportedCCs = [...node.implementedCommandClasses.keys()]
-				// Don't query CCs the node only controls
-				.filter((cc) => node.supportsCC(cc))
-				// Don't query CCs that want to skip the endpoint interview
-				.filter(
-					(cc) => !node.createCCInstance(cc)?.skipEndpointInterview(),
-				);
-			const endpointCounts = new Map<CommandClasses, number>();
-			for (const ccId of supportedCCs) {
+		// V1 works the opposite way - we scan all CCs and remember how many
+		// endpoints they have
+		const supportedCCs = [...node.implementedCommandClasses.keys()]
+			// Don't query CCs the node only controls
+			.filter((cc) => node.supportsCC(cc))
+			// Don't query CCs that want to skip the endpoint interview
+			.filter(
+				(cc) => !node.createCCInstance(cc)?.skipEndpointInterview(),
+			);
+		const endpointCounts = new Map<CommandClasses, number>();
+		for (const ccId of supportedCCs) {
+			this.driver.controllerLog.logNode(node.id, {
+				message: `Querying endpoint count for CommandClass ${getCCName(
+					ccId,
+				)}...`,
+				direction: "outbound",
+			});
+			const endpointCount = await api.getEndpointCountV1(ccId);
+			if (endpointCount != undefined) {
+				endpointCounts.set(ccId, endpointCount);
+
 				this.driver.controllerLog.logNode(node.id, {
-					message: `Querying endpoint count for CommandClass ${getCCName(
+					message: `CommandClass ${getCCName(
 						ccId,
-					)}...`,
-					direction: "outbound",
+					)} has ${endpointCount} endpoints`,
+					direction: "inbound",
 				});
-				const endpointCount = await api.getEndpointCountV1(ccId);
-				if (endpointCount != undefined) {
-					endpointCounts.set(ccId, endpointCount);
-
-					this.driver.controllerLog.logNode(node.id, {
-						message: `CommandClass ${getCCName(
-							ccId,
-						)} has ${endpointCount} endpoints`,
-						direction: "inbound",
-					});
-				}
 			}
+		}
 
-			// Store the collected information
-			// We have only individual and no dynamic and no aggregated endpoints
-			const numEndpoints = Math.max(...endpointCounts.values());
-			node.valueDB.setValue(getCountIsDynamicValueId(), false);
-			node.valueDB.setValue(getAggregatedCountValueId(), 0);
-			node.valueDB.setValue(getIndividualCountValueId(), numEndpoints);
-			// Since we queried all CCs separately, we can assume that all
-			// endpoints have different capabilities
-			node.valueDB.setValue(getIdenticalCapabilitiesValueId(), false);
+		// Store the collected information
+		// We have only individual and no dynamic and no aggregated endpoints
+		const numEndpoints = Math.max(...endpointCounts.values());
+		node.valueDB.setValue(getCountIsDynamicValueId(), false);
+		node.valueDB.setValue(getAggregatedCountValueId(), 0);
+		node.valueDB.setValue(getIndividualCountValueId(), numEndpoints);
+		// Since we queried all CCs separately, we can assume that all
+		// endpoints have different capabilities
+		node.valueDB.setValue(getIdenticalCapabilitiesValueId(), false);
 
-			for (let endpoint = 1; endpoint <= numEndpoints; endpoint++) {
-				// Check which CCs exist on this endpoint
-				const endpointCCs = [...endpointCounts.entries()]
-					.filter(([, ccEndpoints]) => ccEndpoints <= endpoint)
-					.map(([ccId]) => ccId);
-				// And store it per endpoint
-				node.valueDB.setValue(
-					getEndpointCCsValueId(endpoint),
-					endpointCCs,
-				);
-			}
+		for (let endpoint = 1; endpoint <= numEndpoints; endpoint++) {
+			// Check which CCs exist on this endpoint
+			const endpointCCs = [...endpointCounts.entries()]
+				.filter(([, ccEndpoints]) => ccEndpoints <= endpoint)
+				.map(([ccId]) => ccId);
+			// And store it per endpoint
+			node.valueDB.setValue(getEndpointCCsValueId(endpoint), endpointCCs);
 		}
 
 		// Remember that the interview is complete

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSensorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSensorCC.ts
@@ -214,15 +214,98 @@ export class MultilevelSensorCC extends CommandClass {
 
 		this.driver.controllerLog.logNode(node.id, {
 			endpoint: this.endpointIndex,
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
+			message: `Interviewing ${this.ccName}...`,
 			direction: "none",
+		});
+
+		if (this.version > 5) {
+			// Query the supported sensor types
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message: "retrieving supported sensor types...",
+				direction: "outbound",
+			});
+			const sensorTypes = await api.getSupportedSensorTypes();
+			if (sensorTypes) {
+				const logMessage =
+					"received supported sensor types:\n" +
+					sensorTypes
+						.map((t) =>
+							this.driver.configManager.getSensorTypeName(t),
+						)
+						.map((name) => `· ${name}`)
+						.join("\n");
+				this.driver.controllerLog.logNode(node.id, {
+					endpoint: this.endpointIndex,
+					message: logMessage,
+					direction: "inbound",
+				});
+			} else {
+				this.driver.controllerLog.logNode(node.id, {
+					endpoint: this.endpointIndex,
+					message:
+						"Querying supported sensor types timed out, skipping interview...",
+					level: "warn",
+				});
+				return;
+			}
+
+			// As well as the supported scales for each sensor
+
+			for (const type of sensorTypes) {
+				this.driver.controllerLog.logNode(node.id, {
+					endpoint: this.endpointIndex,
+					message: `querying supported scales for ${this.driver.configManager.getSensorTypeName(
+						type,
+					)} sensor`,
+					direction: "outbound",
+				});
+				const sensorScales = await api.getSupportedScales(type);
+				if (sensorScales) {
+					const logMessage =
+						"received supported scales:\n" +
+						sensorScales
+							.map(
+								(s) =>
+									this.driver.configManager.lookupSensorScale(
+										type,
+										s,
+									).label,
+							)
+							.map((name) => `· ${name}`)
+							.join("\n");
+					this.driver.controllerLog.logNode(node.id, {
+						endpoint: this.endpointIndex,
+						message: logMessage,
+						direction: "inbound",
+					});
+				} else {
+					this.driver.controllerLog.logNode(node.id, {
+						endpoint: this.endpointIndex,
+						message:
+							"Querying supported scales timed out, skipping interview...",
+						level: "warn",
+					});
+					return;
+				}
+			}
+		}
+
+		await this.refreshValues();
+
+		// Remember that the interview is complete
+		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
+		const endpoint = this.getEndpoint()!;
+		const api = endpoint.commandClasses["Multilevel Sensor"].withOptions({
+			priority: MessagePriority.NodeQuery,
 		});
 
 		if (this.version <= 4) {
 			// Sensors up to V4 only support a single value
-			// This needs to be requested every time
 			this.driver.controllerLog.logNode(node.id, {
 				endpoint: this.endpointIndex,
 				message: "querying current sensor reading...",
@@ -244,99 +327,23 @@ value:       ${mlsResponse.value} ${sensorScale.unit || ""}`;
 				});
 			}
 		} else {
-			// V5+
-
-			// If we haven't yet, query the supported sensor types
-			let sensorTypes: readonly number[] | undefined;
-			if (complete) {
-				this.driver.controllerLog.logNode(node.id, {
+			// Query all sensor values
+			const sensorTypes: readonly number[] =
+				this.getValueDB().getValue({
+					commandClass: this.ccId,
+					property: "supportedSensorTypes",
 					endpoint: this.endpointIndex,
-					message: "retrieving supported sensor types...",
-					direction: "outbound",
-				});
-				sensorTypes = await api.getSupportedSensorTypes();
-				if (sensorTypes) {
-					const logMessage =
-						"received supported sensor types:\n" +
-						sensorTypes
-							.map((t) =>
-								this.driver.configManager.getSensorTypeName(t),
-							)
-							.map((name) => `· ${name}`)
-							.join("\n");
-					this.driver.controllerLog.logNode(node.id, {
-						endpoint: this.endpointIndex,
-						message: logMessage,
-						direction: "inbound",
-					});
-				} else {
-					this.driver.controllerLog.logNode(node.id, {
-						endpoint: this.endpointIndex,
-						message:
-							"Querying supported sensor types timed out, skipping interview...",
-						level: "warn",
-					});
-					return;
-				}
-			} else {
-				sensorTypes =
-					this.getValueDB().getValue({
-						commandClass: this.ccId,
-						property: "supportedSensorTypes",
-						endpoint: this.endpointIndex,
-					}) || [];
-			}
+				}) || [];
 
 			for (const type of sensorTypes) {
-				// If we haven't yet, query the supported scales for each sensor
-				let sensorScales: readonly number[] | undefined;
-				if (complete) {
-					this.driver.controllerLog.logNode(node.id, {
+				const sensorScales: readonly number[] =
+					this.getValueDB().getValue({
+						commandClass: this.ccId,
 						endpoint: this.endpointIndex,
-						message: `querying supported scales for ${this.driver.configManager.getSensorTypeName(
-							type,
-						)} sensor`,
-						direction: "outbound",
-					});
-					sensorScales = await api.getSupportedScales(type);
-					if (sensorScales) {
-						const logMessage =
-							"received supported scales:\n" +
-							sensorScales
-								.map(
-									(s) =>
-										this.driver.configManager.lookupSensorScale(
-											type,
-											s,
-										).label,
-								)
-								.map((name) => `· ${name}`)
-								.join("\n");
-						this.driver.controllerLog.logNode(node.id, {
-							endpoint: this.endpointIndex,
-							message: logMessage,
-							direction: "inbound",
-						});
-					} else {
-						this.driver.controllerLog.logNode(node.id, {
-							endpoint: this.endpointIndex,
-							message:
-								"Querying supported scales timed out, skipping interview...",
-							level: "warn",
-						});
-						return;
-					}
-				} else {
-					sensorScales =
-						this.getValueDB().getValue({
-							commandClass: this.ccId,
-							endpoint: this.endpointIndex,
-							property: "supportedScales",
-							propertyKey: type,
-						}) || [];
-				}
+						property: "supportedScales",
+						propertyKey: type,
+					}) || [];
 
-				// Always query the current sensor reading
 				this.driver.controllerLog.logNode(node.id, {
 					endpoint: this.endpointIndex,
 					message: `querying ${this.driver.configManager.getSensorTypeName(
@@ -362,9 +369,6 @@ value:       ${mlsResponse.value} ${sensorScale.unit || ""}`;
 				}
 			}
 		}
-
-		// Remember that the interview is complete
-		this.interviewComplete = true;
 	}
 
 	public translatePropertyKey(

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSensorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSensorCC.ts
@@ -205,7 +205,7 @@ export class MultilevelSensorCCAPI extends PhysicalCCAPI {
 export class MultilevelSensorCC extends CommandClass {
 	declare ccCommand: MultilevelSensorCommand;
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses["Multilevel Sensor"].withOptions({

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -401,7 +401,7 @@ export class MultilevelSwitchCC extends CommandClass {
 		);
 	}
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses["Multilevel Switch"].withOptions({

--- a/packages/zwave-js/src/lib/commandclass/NodeNamingCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/NodeNamingCC.ts
@@ -178,7 +178,7 @@ export class NodeNamingAndLocationCC extends CommandClass {
 		return true;
 	}
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses[

--- a/packages/zwave-js/src/lib/commandclass/NodeNamingCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/NodeNamingCC.ts
@@ -180,6 +180,21 @@ export class NodeNamingAndLocationCC extends CommandClass {
 
 	public async interview(): Promise<void> {
 		const node = this.getNode()!;
+
+		this.driver.controllerLog.logNode(node.id, {
+			endpoint: this.endpointIndex,
+			message: `Interviewing ${this.ccName}...`,
+			direction: "none",
+		});
+
+		await this.refreshValues();
+
+		// Remember that the interview is complete
+		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses[
 			"Node Naming and Location"
@@ -188,34 +203,28 @@ export class NodeNamingAndLocationCC extends CommandClass {
 		});
 
 		this.driver.controllerLog.logNode(node.id, {
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
-			direction: "none",
-		});
-
-		this.driver.controllerLog.logNode(node.id, {
 			message: "retrieving node name...",
 			direction: "outbound",
 		});
 		const name = await api.getName();
-		this.driver.controllerLog.logNode(node.id, {
-			message: `is named "${name}"`,
-			direction: "inbound",
-		});
+		if (name != undefined) {
+			this.driver.controllerLog.logNode(node.id, {
+				message: `is named "${name}"`,
+				direction: "inbound",
+			});
+		}
 
 		this.driver.controllerLog.logNode(node.id, {
 			message: "retrieving node location...",
 			direction: "outbound",
 		});
 		const location = await api.getLocation();
-		this.driver.controllerLog.logNode(node.id, {
-			message: `received location: ${location}`,
-			direction: "inbound",
-		});
-
-		// Remember that the interview is complete
-		this.interviewComplete = true;
+		if (location != undefined) {
+			this.driver.controllerLog.logNode(node.id, {
+				message: `received location: ${location}`,
+				direction: "inbound",
+			});
+		}
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/NotificationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/NotificationCC.ts
@@ -382,7 +382,7 @@ export class NotificationCC extends CommandClass {
 		return "pull";
 	}
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses.Notification.withOptions({

--- a/packages/zwave-js/src/lib/commandclass/NotificationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/NotificationCC.ts
@@ -382,6 +382,19 @@ export class NotificationCC extends CommandClass {
 		return "pull";
 	}
 
+	private lookupNotificationNames(
+		notificationTypes: readonly number[],
+	): string[] {
+		return notificationTypes
+			.map((n) => {
+				const ret = this.driver.configManager.lookupNotification(n);
+				return [n, ret] as const;
+			})
+			.map(([type, ntfcn]) =>
+				ntfcn ? ntfcn.name : `UNKNOWN (${num2hex(type)})`,
+			);
+	}
+
 	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
@@ -392,112 +405,70 @@ export class NotificationCC extends CommandClass {
 
 		this.driver.controllerLog.logNode(node.id, {
 			endpoint: this.endpointIndex,
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
+			message: `Interviewing ${this.ccName}...`,
 			direction: "none",
 		});
 
 		let supportsV1Alarm = false;
 		if (this.version >= 2) {
-			let supportedNotificationTypes: readonly number[];
-			let supportedNotificationNames: string[];
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message: "querying supported notification types...",
+				direction: "outbound",
+			});
+
+			const suppResponse = await api.getSupported();
+			if (!suppResponse) {
+				this.driver.controllerLog.logNode(node.id, {
+					endpoint: this.endpointIndex,
+					message:
+						"Querying supported notification types timed out, skipping interview...",
+					level: "warn",
+				});
+				return;
+			}
+			supportsV1Alarm = suppResponse.supportsV1Alarm;
+			const supportedNotificationTypes =
+				suppResponse.supportedNotificationTypes;
+			const supportedNotificationNames = this.lookupNotificationNames(
+				supportedNotificationTypes,
+			);
 			const supportedNotificationEvents = new Map<
 				number,
 				readonly number[]
 			>();
 
-			const lookupNotificationNames: () => string[] = () => {
-				return supportedNotificationTypes
-					.map((n) => {
-						const ret = this.driver.configManager.lookupNotification(
-							n,
-						);
-						return [n, ret] as const;
-					})
-					.map(([type, ntfcn]) =>
-						ntfcn ? ntfcn.name : `UNKNOWN (${num2hex(type)})`,
-					);
-			};
+			const logMessage = `received supported notification types:${supportedNotificationNames
+				.map((name) => `\n· ${name}`)
+				.join("")}`;
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message: logMessage,
+				direction: "inbound",
+			});
 
-			if (complete) {
-				this.driver.controllerLog.logNode(node.id, {
-					endpoint: this.endpointIndex,
-					message: "querying supported notification types...",
-					direction: "outbound",
-				});
+			if (this.version >= 3) {
+				// Query each notification for its supported events
+				for (let i = 0; i < supportedNotificationTypes.length; i++) {
+					const type = supportedNotificationTypes[i];
+					const name = supportedNotificationNames[i];
 
-				const suppResponse = await api.getSupported();
-				if (!suppResponse) {
 					this.driver.controllerLog.logNode(node.id, {
 						endpoint: this.endpointIndex,
-						message:
-							"Querying supported notification types timed out, skipping interview...",
-						level: "warn",
+						message: `querying supported notification events for ${name}...`,
+						direction: "outbound",
 					});
-					return;
-				}
-				supportsV1Alarm = suppResponse.supportsV1Alarm;
-				supportedNotificationTypes =
-					suppResponse.supportedNotificationTypes;
-				supportedNotificationNames = lookupNotificationNames();
-
-				const logMessage = `received supported notification types:${supportedNotificationNames
-					.map((name) => `\n· ${name}`)
-					.join("")}`;
-				this.driver.controllerLog.logNode(node.id, {
-					endpoint: this.endpointIndex,
-					message: logMessage,
-					direction: "inbound",
-				});
-
-				if (this.version >= 3) {
-					// Query each notification for its supported events
-					for (
-						let i = 0;
-						i < supportedNotificationTypes.length;
-						i++
-					) {
-						const type = supportedNotificationTypes[i];
-						const name = supportedNotificationNames[i];
-
+					const supportedEvents = await api.getSupportedEvents(type);
+					if (supportedEvents) {
+						supportedNotificationEvents.set(type, supportedEvents);
 						this.driver.controllerLog.logNode(node.id, {
 							endpoint: this.endpointIndex,
-							message: `querying supported notification events for ${name}...`,
-							direction: "outbound",
+							message: `received supported notification events for ${name}: ${supportedEvents
+								.map(String)
+								.join(", ")}`,
+							direction: "inbound",
 						});
-						const supportedEvents = await api.getSupportedEvents(
-							type,
-						);
-						if (supportedEvents) {
-							supportedNotificationEvents.set(
-								type,
-								supportedEvents,
-							);
-							this.driver.controllerLog.logNode(node.id, {
-								endpoint: this.endpointIndex,
-								message: `received supported notification events for ${name}: ${supportedEvents
-									.map(String)
-									.join(", ")}`,
-								direction: "inbound",
-							});
-						}
 					}
-				}
-			} else {
-				// Load supported notification types and events from cache
-				supportedNotificationTypes =
-					valueDB.getValue<readonly number[]>(
-						getSupportedNotificationTypesValueId(),
-					) ?? [];
-				supportedNotificationNames = lookupNotificationNames();
-				for (const type of supportedNotificationTypes) {
-					supportedNotificationEvents.set(
-						type,
-						valueDB.getValue<readonly number[]>(
-							getSupportedNotificationEventsValueId(type),
-						) ?? [],
-					);
 				}
 			}
 
@@ -517,24 +488,7 @@ export class NotificationCC extends CommandClass {
 			}
 
 			if (notificationMode === "pull") {
-				for (let i = 0; i < supportedNotificationTypes.length; i++) {
-					const type = supportedNotificationTypes[i];
-					const name = supportedNotificationNames[i];
-
-					// Always query each notification for its current status
-					this.driver.controllerLog.logNode(node.id, {
-						endpoint: this.endpointIndex,
-						message: `querying notification status for ${name}...`,
-						direction: "outbound",
-					});
-					const response = await api.getInternal({
-						notificationType: type,
-					});
-					// NotificationReports don't store their values themselves,
-					// because the behaviour is too complex and spans the lifetime
-					// of several reports. Thus we handle it in the Node instance
-					if (response) await node.handleCommand(response);
-				}
+				await this.refreshValues();
 			} /* if (notificationMode === "push") */ else {
 				for (let i = 0; i < supportedNotificationTypes.length; i++) {
 					const type = supportedNotificationTypes[i];
@@ -543,15 +497,13 @@ export class NotificationCC extends CommandClass {
 						type,
 					);
 
-					if (complete) {
-						// Enable reports for each notification type
-						this.driver.controllerLog.logNode(node.id, {
-							endpoint: this.endpointIndex,
-							message: `enabling notifications for ${name}...`,
-							direction: "outbound",
-						});
-						await api.set(type, true);
-					}
+					// Enable reports for each notification type
+					this.driver.controllerLog.logNode(node.id, {
+						endpoint: this.endpointIndex,
+						message: `enabling notifications for ${name}...`,
+						direction: "outbound",
+					});
+					await api.set(type, true);
 
 					// Set the value to idle if possible and there is no value yet
 					if (notificationConfig) {
@@ -606,6 +558,46 @@ export class NotificationCC extends CommandClass {
 
 		// Remember that the interview is complete
 		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		// Refreshing values only works on pull nodes
+		if (this.notificationMode === "pull") {
+			const node = this.getNode()!;
+			const endpoint = this.getEndpoint()!;
+			const api = endpoint.commandClasses.Notification.withOptions({
+				priority: MessagePriority.NodeQuery,
+			});
+			const valueDB = this.getValueDB();
+
+			// Load supported notification types and events from cache
+			const supportedNotificationTypes =
+				valueDB.getValue<readonly number[]>(
+					getSupportedNotificationTypesValueId(),
+				) ?? [];
+			const supportedNotificationNames = this.lookupNotificationNames(
+				supportedNotificationTypes,
+			);
+
+			for (let i = 0; i < supportedNotificationTypes.length; i++) {
+				const type = supportedNotificationTypes[i];
+				const name = supportedNotificationNames[i];
+
+				// Always query each notification for its current status
+				this.driver.controllerLog.logNode(node.id, {
+					endpoint: this.endpointIndex,
+					message: `querying notification status for ${name}...`,
+					direction: "outbound",
+				});
+				const response = await api.getInternal({
+					notificationType: type,
+				});
+				// NotificationReports don't store their values themselves,
+				// because the behaviour is too complex and spans the lifetime
+				// of several reports. Thus we handle it in the Node instance
+				if (response) await node.handleCommand(response);
+			}
+		}
 	}
 
 	/** Whether the node implements push or pull notifications */

--- a/packages/zwave-js/src/lib/commandclass/ProtectionCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ProtectionCC.ts
@@ -342,7 +342,7 @@ export class ProtectionCCAPI extends CCAPI {
 export class ProtectionCC extends CommandClass {
 	declare ccCommand: ProtectionCommand;
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses.Protection.withOptions({

--- a/packages/zwave-js/src/lib/commandclass/ProtectionCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ProtectionCC.ts
@@ -350,20 +350,17 @@ export class ProtectionCC extends CommandClass {
 		});
 
 		this.driver.controllerLog.logNode(node.id, {
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
+			endpoint: this.endpointIndex,
+			message: `Interviewing ${this.ccName}...`,
 			direction: "none",
 		});
-
-		const valueDB = this.getValueDB();
 
 		// We need to do some queries after a potential timeout
 		// In this case, do now mark this CC as interviewed completely
 		let hadCriticalTimeout = false;
 
 		// First find out what the device supports
-		if (complete && this.version >= 2) {
+		if (this.version >= 2) {
 			this.driver.controllerLog.logNode(node.id, {
 				message: "querying protection capabilities...",
 				direction: "outbound",
@@ -391,6 +388,20 @@ RF protection states:    ${resp.supportedRFStates
 				hadCriticalTimeout = true;
 			}
 		}
+
+		await this.refreshValues();
+
+		// Remember that the interview is complete
+		if (!hadCriticalTimeout) this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
+		const endpoint = this.getEndpoint()!;
+		const api = endpoint.commandClasses.Protection.withOptions({
+			priority: MessagePriority.NodeQuery,
+		});
+		const valueDB = this.getValueDB();
 
 		const supportsExclusiveControl = !!valueDB.getValue<boolean>(
 			getSupportsExclusiveControlValueID(this.endpointIndex),
@@ -450,9 +461,6 @@ rf     ${getEnumMemberName(RFProtectionState, protectionResp.rf)}`;
 				});
 			}
 		}
-
-		// Remember that the interview is complete
-		if (!hadCriticalTimeout) this.interviewComplete = true;
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
@@ -301,7 +301,7 @@ export class SecurityCC extends CommandClass {
 		};
 	};
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses.Security.withOptions({

--- a/packages/zwave-js/src/lib/commandclass/SoundSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SoundSwitchCC.ts
@@ -294,7 +294,7 @@ export class SoundSwitchCCAPI extends CCAPI {
 export class SoundSwitchCC extends CommandClass {
 	declare ccCommand: SoundSwitchCommand;
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses["Sound Switch"].withOptions({

--- a/packages/zwave-js/src/lib/commandclass/SoundSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SoundSwitchCC.ts
@@ -302,9 +302,8 @@ export class SoundSwitchCC extends CommandClass {
 		});
 
 		this.driver.controllerLog.logNode(node.id, {
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
+			endpoint: this.endpointIndex,
+			message: `Interviewing ${this.ccName}...`,
 			direction: "none",
 		});
 
@@ -323,58 +322,55 @@ default volume: ${config.defaultVolume}`;
 			});
 		}
 
-		if (complete) {
+		this.driver.controllerLog.logNode(node.id, {
+			message: "requesting tone count...",
+			direction: "outbound",
+		});
+		const toneCount = await api.getToneCount();
+		if (toneCount != undefined) {
+			const logMessage = `supports ${toneCount} tones`;
 			this.driver.controllerLog.logNode(node.id, {
-				message: "requesting tone count...",
+				message: logMessage,
+				direction: "inbound",
+			});
+		} else {
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message: "Querying tone count timed out, skipping interview...",
+				level: "warn",
+			});
+			return;
+		}
+
+		const metadataStates: Record<number, string> = {
+			0: "off",
+		};
+		for (let toneId = 1; toneId <= toneCount; toneId++) {
+			this.driver.controllerLog.logNode(node.id, {
+				message: `requesting info for tone #${toneId}`,
 				direction: "outbound",
 			});
-			const toneCount = await api.getToneCount();
-			if (toneCount != undefined) {
-				const logMessage = `supports ${toneCount} tones`;
-				this.driver.controllerLog.logNode(node.id, {
-					message: logMessage,
-					direction: "inbound",
-				});
-			} else {
-				this.driver.controllerLog.logNode(node.id, {
-					endpoint: this.endpointIndex,
-					message:
-						"Querying tone count timed out, skipping interview...",
-					level: "warn",
-				});
-				return;
-			}
-
-			const metadataStates: Record<number, string> = {
-				0: "off",
-			};
-			for (let toneId = 1; toneId <= toneCount; toneId++) {
-				this.driver.controllerLog.logNode(node.id, {
-					message: `requesting info for tone #${toneId}`,
-					direction: "outbound",
-				});
-				const info = await api.getToneInfo(toneId);
-				if (!info) continue;
-				const logMessage = `received info for tone #${toneId}:
+			const info = await api.getToneInfo(toneId);
+			if (!info) continue;
+			const logMessage = `received info for tone #${toneId}:
 name:     ${info.name}
 duration: ${info.duration} seconds`;
-				this.driver.controllerLog.logNode(node.id, {
-					message: logMessage,
-					direction: "inbound",
-				});
-				metadataStates[toneId] = `${info.name} (${info.duration} sec)`;
-			}
-			metadataStates[0xff] = "default";
-
-			// Store tone count and info as a single metadata
-			node.valueDB.setMetadata(getToneIdValueId(this.endpointIndex), {
-				...ValueMetadata.Number,
-				min: 0,
-				max: toneCount,
-				states: metadataStates,
-				label: "Play Tone",
+			this.driver.controllerLog.logNode(node.id, {
+				message: logMessage,
+				direction: "inbound",
 			});
+			metadataStates[toneId] = `${info.name} (${info.duration} sec)`;
 		}
+		metadataStates[0xff] = "default";
+
+		// Store tone count and info as a single metadata
+		node.valueDB.setMetadata(getToneIdValueId(this.endpointIndex), {
+			...ValueMetadata.Number,
+			min: 0,
+			max: toneCount,
+			states: metadataStates,
+			label: "Play Tone",
+		});
 
 		// Remember that the interview is complete
 		this.interviewComplete = true;

--- a/packages/zwave-js/src/lib/commandclass/ThermostatFanModeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatFanModeCC.ts
@@ -217,7 +217,7 @@ export class ThermostatFanModeCCAPI extends CCAPI {
 export class ThermostatFanModeCC extends CommandClass {
 	declare ccCommand: ThermostatFanModeCommand;
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses["Thermostat Fan Mode"].withOptions({

--- a/packages/zwave-js/src/lib/commandclass/ThermostatFanStateCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatFanStateCC.ts
@@ -96,6 +96,21 @@ export class ThermostatFanStateCC extends CommandClass {
 
 	public async interview(): Promise<void> {
 		const node = this.getNode()!;
+
+		this.driver.controllerLog.logNode(node.id, {
+			endpoint: this.endpointIndex,
+			message: `Interviewing ${this.ccName}...`,
+			direction: "none",
+		});
+
+		await this.refreshValues();
+
+		// Remember that the interview is complete
+		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses["Thermostat Fan State"].withOptions(
 			{
@@ -103,15 +118,7 @@ export class ThermostatFanStateCC extends CommandClass {
 			},
 		);
 
-		this.driver.controllerLog.logNode(node.id, {
-			endpoint: this.endpointIndex,
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
-			direction: "none",
-		});
-
-		// Always query the actual status
+		// Query the current status
 		this.driver.controllerLog.logNode(node.id, {
 			endpoint: this.endpointIndex,
 			message: "querying current thermostat fan state...",
@@ -127,9 +134,6 @@ export class ThermostatFanStateCC extends CommandClass {
 				direction: "inbound",
 			});
 		}
-
-		// Remember that the interview is complete
-		this.interviewComplete = true;
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/ThermostatFanStateCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatFanStateCC.ts
@@ -94,7 +94,7 @@ export class ThermostatFanStateCCAPI extends CCAPI {
 export class ThermostatFanStateCC extends CommandClass {
 	declare ccCommand: ThermostatFanStateCommand;
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses["Thermostat Fan State"].withOptions(

--- a/packages/zwave-js/src/lib/commandclass/ThermostatModeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatModeCC.ts
@@ -187,7 +187,7 @@ export class ThermostatModeCCAPI extends CCAPI {
 export class ThermostatModeCC extends CommandClass {
 	declare ccCommand: ThermostatModeCommand;
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses["Thermostat Mode"].withOptions({

--- a/packages/zwave-js/src/lib/commandclass/ThermostatModeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatModeCC.ts
@@ -196,45 +196,51 @@ export class ThermostatModeCC extends CommandClass {
 
 		this.driver.controllerLog.logNode(node.id, {
 			endpoint: this.endpointIndex,
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
+			message: `Interviewing ${this.ccName}...`,
 			direction: "none",
 		});
 
-		if (complete) {
-			// First query the possible modes to set the metadata
+		// First query the possible modes to set the metadata
+		this.driver.controllerLog.logNode(node.id, {
+			endpoint: this.endpointIndex,
+			message: "querying supported thermostat modes...",
+			direction: "outbound",
+		});
+
+		const supportedModes = await api.getSupportedModes();
+		if (supportedModes) {
+			const logMessage = `received supported thermostat modes:${supportedModes
+				.map((mode) => `\n· ${getEnumMemberName(ThermostatMode, mode)}`)
+				.join("")}`;
 			this.driver.controllerLog.logNode(node.id, {
 				endpoint: this.endpointIndex,
-				message: "querying supported thermostat modes...",
-				direction: "outbound",
+				message: logMessage,
+				direction: "inbound",
 			});
-
-			const supportedModes = await api.getSupportedModes();
-			if (supportedModes) {
-				const logMessage = `received supported thermostat modes:${supportedModes
-					.map(
-						(mode) =>
-							`\n· ${getEnumMemberName(ThermostatMode, mode)}`,
-					)
-					.join("")}`;
-				this.driver.controllerLog.logNode(node.id, {
-					endpoint: this.endpointIndex,
-					message: logMessage,
-					direction: "inbound",
-				});
-			} else {
-				this.driver.controllerLog.logNode(node.id, {
-					endpoint: this.endpointIndex,
-					message:
-						"Querying supported thermostat modes timed out, skipping interview...",
-					level: "warn",
-				});
-				return;
-			}
+		} else {
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message:
+					"Querying supported thermostat modes timed out, skipping interview...",
+				level: "warn",
+			});
+			return;
 		}
 
-		// Always query the actual status
+		await this.refreshValues();
+
+		// Remember that the interview is complete
+		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
+		const endpoint = this.getEndpoint()!;
+		const api = endpoint.commandClasses["Thermostat Mode"].withOptions({
+			priority: MessagePriority.NodeQuery,
+		});
+
+		// Query the current status
 		this.driver.controllerLog.logNode(node.id, {
 			endpoint: this.endpointIndex,
 			message: "querying current thermostat mode...",
@@ -250,9 +256,6 @@ export class ThermostatModeCC extends CommandClass {
 				direction: "inbound",
 			});
 		}
-
-		// Remember that the interview is complete
-		this.interviewComplete = true;
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/ThermostatOperatingStateCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatOperatingStateCC.ts
@@ -103,7 +103,7 @@ export class ThermostatOperatingStateCCAPI extends PhysicalCCAPI {
 export class ThermostatOperatingStateCC extends CommandClass {
 	declare ccCommand: ThermostatOperatingStateCommand;
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses[

--- a/packages/zwave-js/src/lib/commandclass/ThermostatOperatingStateCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatOperatingStateCC.ts
@@ -105,20 +105,29 @@ export class ThermostatOperatingStateCC extends CommandClass {
 
 	public async interview(): Promise<void> {
 		const node = this.getNode()!;
-		const endpoint = this.getEndpoint()!;
-		const api = endpoint.commandClasses[
-			"Thermostat Operating State"
-		].withOptions({ priority: MessagePriority.NodeQuery });
 
 		this.driver.controllerLog.logNode(node.id, {
 			endpoint: this.endpointIndex,
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
+			message: `Interviewing ${this.ccName}...`,
 			direction: "none",
 		});
 
-		// Always query the current state
+		await this.refreshValues();
+
+		// Remember that the interview is complete
+		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
+		const endpoint = this.getEndpoint()!;
+		const api = endpoint.commandClasses[
+			"Thermostat Operating State"
+		].withOptions({
+			priority: MessagePriority.NodeQuery,
+		});
+
+		// Query the current state
 		this.driver.controllerLog.logNode(node.id, {
 			endpoint: this.endpointIndex,
 			message: "querying thermostat operating state...",
@@ -136,9 +145,6 @@ export class ThermostatOperatingStateCC extends CommandClass {
 				direction: "inbound",
 			});
 		}
-
-		// Remember that the interview is complete
-		this.interviewComplete = true;
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/ThermostatSetbackCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatSetbackCC.ts
@@ -123,20 +123,27 @@ export class ThermostatSetbackCC extends CommandClass {
 
 	public async interview(): Promise<void> {
 		const node = this.getNode()!;
+
+		this.driver.controllerLog.logNode(node.id, {
+			endpoint: this.endpointIndex,
+			message: `Interviewing ${this.ccName}...`,
+			direction: "none",
+		});
+
+		await this.refreshValues();
+
+		// Remember that the interview is complete
+		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses["Thermostat Setback"].withOptions({
 			priority: MessagePriority.NodeQuery,
 		});
 
-		this.driver.controllerLog.logNode(node.id, {
-			endpoint: this.endpointIndex,
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
-			direction: "none",
-		});
-
-		// Always query the thermostat state
+		// Query the thermostat state
 		this.driver.controllerLog.logNode(node.id, {
 			endpoint: this.endpointIndex,
 			message: "querying the current thermostat state...",
@@ -153,9 +160,6 @@ setback state: ${setbackResp.setbackState}`;
 				direction: "inbound",
 			});
 		}
-
-		// Remember that the interview is complete
-		this.interviewComplete = true;
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/ThermostatSetbackCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatSetbackCC.ts
@@ -121,7 +121,7 @@ export class ThermostatSetbackCCAPI extends CCAPI {
 export class ThermostatSetbackCC extends CommandClass {
 	declare ccCommand: ThermostatSetbackCommand;
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses["Thermostat Setback"].withOptions({

--- a/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
@@ -333,7 +333,7 @@ export class ThermostatSetpointCC extends CommandClass {
 		}
 	}
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses["Thermostat Setpoint"].withOptions({

--- a/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
@@ -342,9 +342,7 @@ export class ThermostatSetpointCC extends CommandClass {
 
 		this.driver.controllerLog.logNode(node.id, {
 			endpoint: this.endpointIndex,
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
+			message: `Interviewing ${this.ccName}...`,
 			direction: "none",
 		});
 
@@ -358,33 +356,24 @@ export class ThermostatSetpointCC extends CommandClass {
 				this.endpointIndex,
 			);
 
-			// If we haven't yet, query the supported setpoint types
-			if (complete) {
+			// Query the supported setpoint types
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message: "retrieving supported setpoint types...",
+				direction: "outbound",
+			});
+			const resp = await api.getSupportedSetpointTypes();
+			if (!resp) {
 				this.driver.controllerLog.logNode(node.id, {
 					endpoint: this.endpointIndex,
-					message: "retrieving supported setpoint types...",
-					direction: "outbound",
+					message:
+						"Querying supported setpoint types timed out, skipping interview...",
+					level: "warn",
 				});
-				const resp = await api.getSupportedSetpointTypes();
-				if (!resp) {
-					this.driver.controllerLog.logNode(node.id, {
-						endpoint: this.endpointIndex,
-						message:
-							"Querying supported setpoint types timed out, skipping interview...",
-						level: "warn",
-					});
-					return;
-				}
-				setpointTypes = [...resp];
-				interpretation = undefined; // we don't know yet which interpretation the device uses
-			} else {
-				setpointTypes =
-					this.getValueDB().getValue(supportedSetpointTypesValueId) ??
-					[];
-				interpretation = this.getValueDB().getValue(
-					getSetpointTypesInterpretationValueID(this.endpointIndex),
-				);
+				return;
 			}
+			setpointTypes = [...resp];
+			interpretation = undefined; // we don't know yet which interpretation the device uses
 
 			// If necessary, test which interpretation the device follows
 
@@ -398,27 +387,20 @@ export class ThermostatSetpointCC extends CommandClass {
 				interpretationChanged = true;
 			}
 
-			if (!interpretation) {
-				if ([3, 4, 5, 6].some((type) => setpointTypes.includes(type))) {
-					this.driver.controllerLog.logNode(node.id, {
-						endpoint: this.endpointIndex,
-						message:
-							"uses Thermostat Setpoint bitmap interpretation A",
-						direction: "none",
-					});
-					switchToInterpretationA();
-				} else {
-					this.driver.controllerLog.logNode(node.id, {
-						endpoint: this.endpointIndex,
-						message:
-							"Thermostat Setpoint bitmap interpretation is unknown, assuming B for now",
-						direction: "none",
-					});
-				}
-			} else if (interpretation === "A") {
-				setpointTypes = setpointTypes.map(
-					(i) => thermostatSetpointTypeMap[i],
-				);
+			if ([3, 4, 5, 6].some((type) => setpointTypes.includes(type))) {
+				this.driver.controllerLog.logNode(node.id, {
+					endpoint: this.endpointIndex,
+					message: "uses Thermostat Setpoint bitmap interpretation A",
+					direction: "none",
+				});
+				switchToInterpretationA();
+			} else {
+				this.driver.controllerLog.logNode(node.id, {
+					endpoint: this.endpointIndex,
+					message:
+						"Thermostat Setpoint bitmap interpretation is unknown, assuming B for now",
+					direction: "none",
+				});
 			}
 
 			// Now scan all endpoints. Each type we received a value for gets marked as supported
@@ -446,6 +428,7 @@ export class ThermostatSetpointCC extends CommandClass {
 					logMessage = `received current value of setpoint ${setpointName}: ${
 						setpoint.value
 					} ${setpoint.scale.unit ?? ""}`;
+					// wotan-disable-next-line
 				} else if (!interpretation) {
 					// The setpoint type is not supported, switch to interpretation A
 					this.driver.controllerLog.logNode(node.id, {
@@ -477,13 +460,12 @@ export class ThermostatSetpointCC extends CommandClass {
 				interpretationChanged = true;
 			}
 
-			// After a complete interview, we need to remember which setpoint types are supported
-			if (complete) {
-				this.getValueDB().setValue(
-					supportedSetpointTypesValueId,
-					supportedSetpointTypes,
-				);
-			}
+			// Remember which setpoint types are actually supported, so we don't
+			// need to do this guesswork again
+			this.getValueDB().setValue(
+				supportedSetpointTypesValueId,
+				supportedSetpointTypes,
+			);
 
 			// Also save the bitmap interpretation if we know it now
 			if (interpretationChanged) {
@@ -495,46 +477,37 @@ export class ThermostatSetpointCC extends CommandClass {
 		} else {
 			// Versions >= 3 adhere to bitmap interpretation A, so we can rely on getSupportedSetpointTypes
 
-			// If we haven't yet, query the supported setpoint types
+			// Query the supported setpoint types
 			let setpointTypes: ThermostatSetpointType[] = [];
-			if (complete) {
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message: "retrieving supported setpoint types...",
+				direction: "outbound",
+			});
+			const resp = await api.getSupportedSetpointTypes();
+			if (resp) {
+				setpointTypes = [...resp];
+				const logMessage =
+					"received supported setpoint types:\n" +
+					setpointTypes
+						.map((type) =>
+							getEnumMemberName(ThermostatSetpointType, type),
+						)
+						.map((name) => `· ${name}`)
+						.join("\n");
 				this.driver.controllerLog.logNode(node.id, {
 					endpoint: this.endpointIndex,
-					message: "retrieving supported setpoint types...",
-					direction: "outbound",
+					message: logMessage,
+					direction: "inbound",
 				});
-				const resp = await api.getSupportedSetpointTypes();
-				if (resp) {
-					setpointTypes = [...resp];
-					const logMessage =
-						"received supported setpoint types:\n" +
-						setpointTypes
-							.map((type) =>
-								getEnumMemberName(ThermostatSetpointType, type),
-							)
-							.map((name) => `· ${name}`)
-							.join("\n");
-					this.driver.controllerLog.logNode(node.id, {
-						endpoint: this.endpointIndex,
-						message: logMessage,
-						direction: "inbound",
-					});
-				} else {
-					this.driver.controllerLog.logNode(node.id, {
-						endpoint: this.endpointIndex,
-						message:
-							"Querying supported setpoint types timed out, skipping interview...",
-						level: "warn",
-					});
-					return;
-				}
 			} else {
-				setpointTypes =
-					this.getValueDB().getValue({
-						commandClass: this.ccId,
-						property: "supportedSetpointTypes",
-						endpoint: this.endpointIndex,
-					}) ?? [];
+				this.driver.controllerLog.logNode(node.id, {
+					endpoint: this.endpointIndex,
+					message:
+						"Querying supported setpoint types timed out, skipping interview...",
+					level: "warn",
+				});
+				return;
 			}
 
 			for (const type of setpointTypes) {
@@ -542,44 +515,25 @@ export class ThermostatSetpointCC extends CommandClass {
 					ThermostatSetpointType,
 					type,
 				);
-				// If we haven't yet, find out the capabilities of this setpoint
-				if (complete) {
-					this.driver.controllerLog.logNode(node.id, {
-						endpoint: this.endpointIndex,
-						message: `retrieving capabilities for setpoint ${setpointName}...`,
-						direction: "outbound",
-					});
-					const setpointCaps = await api.getCapabilities(type);
-					if (setpointCaps) {
-						const minValueUnit = getSetpointUnit(
-							this.driver.configManager,
-							setpointCaps.minValueScale,
-						);
-						const maxValueUnit = getSetpointUnit(
-							this.driver.configManager,
-							setpointCaps.maxValueScale,
-						);
-						const logMessage = `received capabilities for setpoint ${setpointName}:
-minimum value: ${setpointCaps.minValue} ${minValueUnit}
-maximum value: ${setpointCaps.maxValue} ${maxValueUnit}`;
-						this.driver.controllerLog.logNode(node.id, {
-							endpoint: this.endpointIndex,
-							message: logMessage,
-							direction: "inbound",
-						});
-					}
-				}
-				// Every time, query the current value
+				// Find out the capabilities of this setpoint
 				this.driver.controllerLog.logNode(node.id, {
 					endpoint: this.endpointIndex,
-					message: `querying current value of setpoint ${setpointName}...`,
+					message: `retrieving capabilities for setpoint ${setpointName}...`,
 					direction: "outbound",
 				});
-				const setpoint = await api.get(type);
-				if (setpoint) {
-					const logMessage = `received current value of setpoint ${setpointName}: ${
-						setpoint.value
-					} ${setpoint.scale.unit ?? ""}`;
+				const setpointCaps = await api.getCapabilities(type);
+				if (setpointCaps) {
+					const minValueUnit = getSetpointUnit(
+						this.driver.configManager,
+						setpointCaps.minValueScale,
+					);
+					const maxValueUnit = getSetpointUnit(
+						this.driver.configManager,
+						setpointCaps.maxValueScale,
+					);
+					const logMessage = `received capabilities for setpoint ${setpointName}:
+minimum value: ${setpointCaps.minValue} ${minValueUnit}
+maximum value: ${setpointCaps.maxValue} ${maxValueUnit}`;
 					this.driver.controllerLog.logNode(node.id, {
 						endpoint: this.endpointIndex,
 						message: logMessage,
@@ -587,10 +541,51 @@ maximum value: ${setpointCaps.maxValue} ${maxValueUnit}`;
 					});
 				}
 			}
+
+			// Query the current value for all setpoint types
+			await this.refreshValues();
 		}
 
 		// Remember that the interview is complete
 		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
+		const endpoint = this.getEndpoint()!;
+		const api = endpoint.commandClasses["Thermostat Setpoint"].withOptions({
+			priority: MessagePriority.NodeQuery,
+		});
+
+		const setpointTypes: ThermostatSetpointType[] =
+			this.getValueDB().getValue(
+				getSupportedSetpointTypesValueID(this.endpointIndex),
+			) ?? [];
+
+		// Query each setpoint's current value
+		for (const type of setpointTypes) {
+			const setpointName = getEnumMemberName(
+				ThermostatSetpointType,
+				type,
+			);
+			// Every time, query the current value
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message: `querying current value of setpoint ${setpointName}...`,
+				direction: "outbound",
+			});
+			const setpoint = await api.get(type);
+			if (setpoint) {
+				const logMessage = `received current value of setpoint ${setpointName}: ${
+					setpoint.value
+				} ${setpoint.scale.unit ?? ""}`;
+				this.driver.controllerLog.logNode(node.id, {
+					endpoint: this.endpointIndex,
+					message: logMessage,
+					direction: "inbound",
+				});
+			}
+		}
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/TimeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/TimeCC.ts
@@ -140,13 +140,11 @@ export class TimeCC extends CommandClass {
 
 		this.driver.controllerLog.logNode(node.id, {
 			endpoint: this.endpointIndex,
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
+			message: `Interviewing ${this.ccName}...`,
 			direction: "none",
 		});
 
-		// Always keep the slave's time in sync
+		// Synchronize the slave's time
 		if (api.version >= 2) {
 			this.driver.controllerLog.logNode(node.id, {
 				endpoint: this.endpointIndex,

--- a/packages/zwave-js/src/lib/commandclass/TimeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/TimeCC.ts
@@ -131,7 +131,7 @@ export class TimeCCAPI extends CCAPI {
 export class TimeCC extends CommandClass {
 	declare ccCommand: TimeCommand;
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses.Time.withOptions({

--- a/packages/zwave-js/src/lib/commandclass/TimeParametersCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/TimeParametersCC.ts
@@ -174,7 +174,7 @@ export class TimeParametersCCAPI extends CCAPI {
 export class TimeParametersCC extends CommandClass {
 	declare ccCommand: TimeParametersCommand;
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses["Time Parameters"].withOptions({

--- a/packages/zwave-js/src/lib/commandclass/TimeParametersCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/TimeParametersCC.ts
@@ -183,13 +183,11 @@ export class TimeParametersCC extends CommandClass {
 
 		this.driver.controllerLog.logNode(node.id, {
 			endpoint: this.endpointIndex,
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
+			message: `Interviewing ${this.ccName}...`,
 			direction: "none",
 		});
 
-		// Always keep the node's time in sync
+		// Synchronize the node's time
 		this.driver.controllerLog.logNode(node.id, {
 			endpoint: this.endpointIndex,
 			message: "setting current time...",

--- a/packages/zwave-js/src/lib/commandclass/UserCodeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/UserCodeCC.ts
@@ -710,65 +710,76 @@ export class UserCodeCC extends CommandClass {
 		});
 
 		this.driver.controllerLog.logNode(node.id, {
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
+			endpoint: this.endpointIndex,
+			message: `Interviewing ${this.ccName}...`,
 			direction: "none",
 		});
 
-		// Query capabilities first because they determine the next steps
-		let supportsMasterCode = false;
-		let supportsUserCodeChecksum = false;
-		let supportedKeypadModes: readonly KeypadMode[] = [];
-		let supportedUsers: number | undefined;
-		if (complete) {
-			if (this.version >= 2) {
-				this.driver.controllerLog.logNode(node.id, {
-					message: "querying capabilities...",
-					direction: "outbound",
-				});
-				const caps = await api.getCapabilities();
-				if (caps) {
-					supportsMasterCode = caps.supportsMasterCode;
-					supportsUserCodeChecksum = caps.supportsUserCodeChecksum;
-					supportedKeypadModes = caps.supportedKeypadModes;
-				}
-			}
-
+		// Query capabilities first to determine what needs to be done when refreshing
+		if (this.version >= 2) {
 			this.driver.controllerLog.logNode(node.id, {
-				message: "querying number of user codes...",
+				message: "querying capabilities...",
 				direction: "outbound",
 			});
-			supportedUsers = await api.getUsersCount();
-			if (supportedUsers == undefined) {
+			const caps = await api.getCapabilities();
+			if (!caps) {
 				this.driver.controllerLog.logNode(node.id, {
 					endpoint: this.endpointIndex,
 					message:
-						"Querying number of user codes timed out, skipping interview...",
+						"User Code capabilities query timed out, skipping interview...",
 					level: "warn",
 				});
 				return;
 			}
-		} else {
-			supportsMasterCode =
-				node.getValue<boolean>(
-					getSupportsMasterCodeValueID(this.endpointIndex),
-				) ?? false;
-			supportsUserCodeChecksum =
-				node.getValue<boolean>(
-					getSupportsUserCodeChecksumValueID(this.endpointIndex),
-				) ?? false;
-			supportedKeypadModes =
-				node.getValue<readonly KeypadMode[]>(
-					getSupportedKeypadModesValueID(this.endpointIndex),
-				) ?? [];
-			supportedUsers =
-				node.getValue<number>(
-					getSupportedUsersValueID(this.endpointIndex),
-				) ?? 0;
 		}
 
-		// Now check for changed values and codes
+		this.driver.controllerLog.logNode(node.id, {
+			message: "querying number of user codes...",
+			direction: "outbound",
+		});
+		const supportedUsers = await api.getUsersCount();
+		if (supportedUsers == undefined) {
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message:
+					"Querying number of user codes timed out, skipping interview...",
+				level: "warn",
+			});
+			return;
+		}
+
+		// Synchronize user codes and settings
+		await this.refreshValues();
+
+		// Remember that the interview is complete
+		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
+		const endpoint = this.getEndpoint()!;
+		const api = endpoint.commandClasses["User Code"].withOptions({
+			priority: MessagePriority.NodeQuery,
+		});
+
+		const supportsMasterCode =
+			node.getValue<boolean>(
+				getSupportsMasterCodeValueID(this.endpointIndex),
+			) ?? false;
+		const supportsUserCodeChecksum =
+			node.getValue<boolean>(
+				getSupportsUserCodeChecksumValueID(this.endpointIndex),
+			) ?? false;
+		const supportedKeypadModes =
+			node.getValue<readonly KeypadMode[]>(
+				getSupportedKeypadModesValueID(this.endpointIndex),
+			) ?? [];
+		const supportedUsers =
+			node.getValue<number>(
+				getSupportedUsersValueID(this.endpointIndex),
+			) ?? 0;
+
+		// Check for changed values and codes
 		if (this.version >= 2) {
 			if (supportsMasterCode) {
 				this.driver.controllerLog.logNode(node.id, {
@@ -830,9 +841,6 @@ export class UserCodeCC extends CommandClass {
 				await api.get(userId);
 			}
 		}
-
-		// Remember that the interview is complete
-		this.interviewComplete = true;
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/UserCodeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/UserCodeCC.ts
@@ -702,7 +702,7 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 export class UserCodeCC extends CommandClass {
 	declare ccCommand: UserCodeCommand;
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses["User Code"].withOptions({

--- a/packages/zwave-js/src/lib/commandclass/VersionCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/VersionCC.ts
@@ -202,7 +202,7 @@ export class VersionCC extends CommandClass {
 		return true;
 	}
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses.Version.withOptions({

--- a/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
@@ -203,9 +203,7 @@ export class WakeUpCC extends CommandClass {
 
 		this.driver.controllerLog.logNode(node.id, {
 			endpoint: this.endpointIndex,
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
+			message: `Interviewing ${this.ccName}...`,
 			direction: "none",
 		});
 
@@ -225,30 +223,27 @@ export class WakeUpCC extends CommandClass {
 			);
 		} else {
 			// Retrieve the allowed wake up intervals if possible
-			if (complete) {
-				// This information does not change
-				if (this.version >= 2) {
-					this.driver.controllerLog.logNode(node.id, {
-						endpoint: this.endpointIndex,
-						message:
-							"retrieving wakeup capabilities from the device...",
-						direction: "outbound",
-					});
-					const wakeupCaps = await api.getIntervalCapabilities();
-					if (wakeupCaps) {
-						const logMessage = `received wakeup capabilities:
+			if (this.version >= 2) {
+				this.driver.controllerLog.logNode(node.id, {
+					endpoint: this.endpointIndex,
+					message:
+						"retrieving wakeup capabilities from the device...",
+					direction: "outbound",
+				});
+				const wakeupCaps = await api.getIntervalCapabilities();
+				if (wakeupCaps) {
+					const logMessage = `received wakeup capabilities:
 default wakeup interval: ${wakeupCaps.defaultWakeUpInterval} seconds
 minimum wakeup interval: ${wakeupCaps.minWakeUpInterval} seconds
 maximum wakeup interval: ${wakeupCaps.maxWakeUpInterval} seconds
 wakeup interval steps:   ${wakeupCaps.wakeUpIntervalSteps} seconds`;
-						this.driver.controllerLog.logNode(node.id, {
-							endpoint: this.endpointIndex,
-							message: logMessage,
-							direction: "inbound",
-						});
-					} else {
-						hadCriticalTimeout = true;
-					}
+					this.driver.controllerLog.logNode(node.id, {
+						endpoint: this.endpointIndex,
+						message: logMessage,
+						direction: "inbound",
+					});
+				} else {
+					hadCriticalTimeout = true;
 				}
 			}
 

--- a/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
@@ -194,7 +194,7 @@ export class WakeUpCC extends CommandClass {
 		}
 	}
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses["Wake Up"].withOptions({

--- a/packages/zwave-js/src/lib/commandclass/ZWavePlusCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ZWavePlusCC.ts
@@ -124,7 +124,7 @@ export class ZWavePlusCCAPI extends PhysicalCCAPI {
 export class ZWavePlusCC extends CommandClass {
 	declare ccCommand: ZWavePlusCommand;
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		const endpoint = this.getEndpoint()!;
 		const api = endpoint.commandClasses["Z-Wave Plus Info"].withOptions({

--- a/packages/zwave-js/src/lib/commandclass/ZWavePlusCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ZWavePlusCC.ts
@@ -133,33 +133,29 @@ export class ZWavePlusCC extends CommandClass {
 
 		this.driver.controllerLog.logNode(node.id, {
 			endpoint: this.endpointIndex,
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
+			message: `Interviewing ${this.ccName}...`,
 			direction: "none",
 		});
 
-		if (complete) {
-			this.driver.controllerLog.logNode(node.id, {
-				endpoint: this.endpointIndex,
-				message: "querying Z-Wave+ information...",
-				direction: "outbound",
-			});
+		this.driver.controllerLog.logNode(node.id, {
+			endpoint: this.endpointIndex,
+			message: "querying Z-Wave+ information...",
+			direction: "outbound",
+		});
 
-			const zwavePlusResponse = await api.get();
-			if (zwavePlusResponse) {
-				const logMessage = `received response for Z-Wave+ information:
+		const zwavePlusResponse = await api.get();
+		if (zwavePlusResponse) {
+			const logMessage = `received response for Z-Wave+ information:
 Z-Wave+ version: ${zwavePlusResponse.zwavePlusVersion}
 role type:       ${ZWavePlusRoleType[zwavePlusResponse.roleType]}
 node type:       ${ZWavePlusNodeType[zwavePlusResponse.nodeType]}
 installer icon:  ${num2hex(zwavePlusResponse.installerIcon)}
 user icon:       ${num2hex(zwavePlusResponse.userIcon)}`;
-				this.driver.controllerLog.logNode(node.id, {
-					endpoint: this.endpointIndex,
-					message: logMessage,
-					direction: "inbound",
-				});
-			}
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message: logMessage,
+				direction: "inbound",
+			});
 		}
 
 		// Remember that the interview is complete

--- a/packages/zwave-js/src/lib/commandclass/manufacturerProprietary/Fibaro.ts
+++ b/packages/zwave-js/src/lib/commandclass/manufacturerProprietary/Fibaro.ts
@@ -128,11 +128,19 @@ export class FibaroVenetianBlindCC extends FibaroCC {
 		const node = this.getNode()!;
 
 		this.driver.controllerLog.logNode(node.id, {
-			message: `${this.constructor.name}: doing a ${
-				complete ? "complete" : "partial"
-			} interview...`,
+			endpoint: this.endpointIndex,
+			message: `Interviewing ${this.ccName}...`,
 			direction: "none",
 		});
+
+		await this.refreshValues();
+
+		// Remember that the interview is complete
+		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
 
 		this.driver.controllerLog.logNode(node.id, {
 			message: "Requesting venetian blind position and tilt...",
@@ -153,9 +161,6 @@ tilt:     ${resp.tilt}`;
 				direction: "inbound",
 			});
 		}
-
-		// Remember that the interview is complete
-		this.interviewComplete = true;
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/manufacturerProprietary/Fibaro.ts
+++ b/packages/zwave-js/src/lib/commandclass/manufacturerProprietary/Fibaro.ts
@@ -124,7 +124,7 @@ export class FibaroVenetianBlindCC extends FibaroCC {
 		}
 	}
 
-	public async interview(complete: boolean = true): Promise<void> {
+	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 
 		this.driver.controllerLog.logNode(node.id, {

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1074,6 +1074,9 @@ export class Driver extends EventEmitter {
 		this._nodesReady.add(node.id);
 		this.controllerLog.logNode(node.id, "The node is ready to be used");
 
+		// Regularly query listening nodes for updated values
+		node.scheduleManualValueRefreshes();
+
 		this.checkAllNodesReady();
 	}
 

--- a/packages/zwave-js/src/lib/node/Node.test.ts
+++ b/packages/zwave-js/src/lib/node/Node.test.ts
@@ -978,12 +978,12 @@ describe("lib/node/Node", () => {
 			node.destroy();
 		});
 
-		it("nodes with a completed interview don't get their stage reset when resuming from cache", () => {
+		it("a changed interview stage is reflected in the cache", () => {
 			const node = new ZWaveNode(1, fakeDriver);
 			// @ts-ignore We need write access to the map
 			fakeDriver.controller.nodes.set(1, node);
 			node.deserialize(serializedTestNode);
-			node.interviewStage = InterviewStage.RestartFromCache;
+			node.interviewStage = InterviewStage.Complete;
 			expect(node.serialize().interviewStage).toEqual(
 				InterviewStage[InterviewStage.Complete],
 			);

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1622,10 +1622,10 @@ protocol version:      ${this._protocolVersion}`;
 	}
 
 	/**
-	 * Refreshes all non-static values of a single CC from this node.
+	 * Refreshes all non-static values of a single CC from this node (all endpoints).
 	 * WARNING: It is not recommended to await this method!
 	 */
-	private async refreshCCValues(cc: CommandClasses): Promise<void> {
+	public async refreshCCValues(cc: CommandClasses): Promise<void> {
 		for (const endpoint of this.getAllEndpoints()) {
 			const instance = endpoint.createCCInstanceUnsafe(cc);
 			if (instance) {
@@ -1645,7 +1645,7 @@ protocol version:      ${this._protocolVersion}`;
 	}
 
 	/**
-	 * Refreshes all non-static values from this node.
+	 * Refreshes all non-static values from this node's actuator and sensor CCs.
 	 * WARNING: It is not recommended to await this method!
 	 */
 	public async refreshValues(): Promise<void> {

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1322,8 +1322,11 @@ protocol version:      ${this._protocolVersion}`;
 				return "continue";
 			}
 
+			// Skip this step if the CC was already interviewed
+			if (instance.interviewComplete) return "continue";
+
 			try {
-				await instance.interview(!instance.interviewComplete);
+				await instance.interview();
 			} catch (e: unknown) {
 				if (
 					e instanceof ZWaveError &&
@@ -1626,9 +1629,8 @@ protocol version:      ${this._protocolVersion}`;
 		for (const endpoint of this.getAllEndpoints()) {
 			const instance = endpoint.createCCInstanceUnsafe(cc);
 			if (instance) {
-				// Don't do a complete interview, only dynamic values
 				try {
-					await instance.interview(false);
+					await instance.refreshValues();
 				} catch (e) {
 					this.driver.controllerLog.logNode(
 						this.id,
@@ -1656,9 +1658,8 @@ protocol version:      ${this._protocolVersion}`;
 				) {
 					continue;
 				}
-				// Don't do a complete interview, only dynamic values
 				try {
-					await cc.interview(false);
+					await cc.refreshValues();
 				} catch (e) {
 					this.driver.controllerLog.logNode(
 						this.id,

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1047,9 +1047,6 @@ export class ZWaveNode extends Endpoint {
 		await this.setInterviewStage(InterviewStage.Complete);
 		this.readyMachine.send("INTERVIEW_DONE");
 
-		// Regularly query listening nodes for updated values
-		this.scheduleManualValueRefreshesForListeningNodes();
-
 		// Tell listeners that the interview is completed
 		// The driver will then send this node to sleep
 		this.emit("interview completed", this);
@@ -1561,11 +1558,12 @@ protocol version:      ${this._protocolVersion}`;
 	}
 
 	/**
+	 * @internal
 	 * Schedules the regular refreshes of some CC values
 	 */
-	private scheduleManualValueRefreshesForListeningNodes(): void {
+	public scheduleManualValueRefreshes(): void {
 		// Only schedule this for listening nodes. Sleeping nodes are queried on wakeup
-		if (this.supportsCC(CommandClasses["Wake Up"])) return;
+		if (!this.canSleep) return;
 		// Only schedule this if we don't expect any unsolicited updates
 		if (!this.requiresManualValueRefresh()) return;
 

--- a/packages/zwave-js/src/lib/node/NodeReadyMachine.test.ts
+++ b/packages/zwave-js/src/lib/node/NodeReadyMachine.test.ts
@@ -29,10 +29,10 @@ describe("lib/driver/NodeReadyMachine", () => {
 			expect(service.state.value).toBe("notReady");
 		});
 
-		it("when the interview is restarted from cache, the node should be ready as soon as it is known NOT to be dead", () => {
+		it("when the driver is restarted from cache, the node should be ready as soon as it is known NOT to be dead", () => {
 			const testMachine = createNodeReadyMachine();
 			service = interpret(testMachine).start();
-			service.send("RESTART_INTERVIEW_FROM_CACHE");
+			service.send("RESTART_FROM_CACHE");
 			expect(service.state.value).toBe("readyIfNotDead");
 			// service.send("MAYBE_DEAD");
 			// expect(service.state.value).toBe("readyIfNotDead");
@@ -40,11 +40,11 @@ describe("lib/driver/NodeReadyMachine", () => {
 			expect(service.state.value).toBe("ready");
 		});
 
-		it("when the interview is restarted from cache and the node is known to be not dead, it should be ready immediately", () => {
+		it("when the driver is restarted from cache and the node is known to be not dead, it should be ready immediately", () => {
 			const testMachine = createNodeReadyMachine();
 			service = interpret(testMachine).start();
 			service.send("NOT_DEAD");
-			service.send("RESTART_INTERVIEW_FROM_CACHE");
+			service.send("RESTART_FROM_CACHE");
 			expect(service.state.value).toBe("ready");
 		});
 

--- a/packages/zwave-js/src/lib/node/NodeReadyMachine.ts
+++ b/packages/zwave-js/src/lib/node/NodeReadyMachine.ts
@@ -17,7 +17,7 @@ export interface NodeReadyContext {
 export type NodeReadyEvent =
 	| { type: "NOT_DEAD" }
 	| { type: "MAYBE_DEAD" }
-	| { type: "RESTART_INTERVIEW_FROM_CACHE" }
+	| { type: "RESTART_FROM_CACHE" }
 	| { type: "INTERVIEW_DONE" };
 
 export type NodeReadyMachine = StateMachine<
@@ -58,9 +58,7 @@ export function createNodeReadyMachine(
 				notReady: {
 					entry: assign({ isMaybeDead: true }) as any,
 					on: {
-						RESTART_INTERVIEW_FROM_CACHE: [
-							{ target: "readyIfNotDead" },
-						],
+						RESTART_FROM_CACHE: [{ target: "readyIfNotDead" }],
 					},
 				},
 				readyIfNotDead: {

--- a/packages/zwave-js/src/lib/node/Types.ts
+++ b/packages/zwave-js/src/lib/node/Types.ts
@@ -113,16 +113,6 @@ export enum InterviewStage {
 	/** The node has been queried for supported and controlled command classes */
 	NodeInfo,
 
-	// ===== the stuff above should never change =====
-
-	/**
-	 * This marks the beginning of re-interviews on application startup.
-	 * RestartFromCache and later stages will be serialized as "Complete" in the cache
-	 */
-	RestartFromCache,
-
-	// ===== the stuff below changes frequently, so it has to be redone on every start =====
-
 	/**
 	 * Information for all command classes has been queried.
 	 * This includes static information that is requested once as well as dynamic


### PR DESCRIPTION
It is time to part with old habits. With this PR (when done) we no longer query all node values on restart and instead leave it up to the user to query them on demand. Because this might require changes in applications, I'm gonna mark this as breaking (although it is a good break).

As a result, traffic and startup times should be reduced dramatically once all nodes have been interviewed. 

fixes: #1587
fixes: #1884
fixes: #1909
resolves the discussion in https://github.com/zwave-js/node-zwave-js/discussions/1432
