### PR TITLE
fix(config): incorrect assignment of 914/c

### DIFF
--- a/packages/config/config/devices/0x0090/914.json
+++ b/packages/config/config/devices/0x0090/914.json
@@ -14,6 +14,10 @@
 		{
 			"productType": "0x0003",
 			"productId": "0x4006"
+		},
+		{
+			"productType": "0x0003",
+			"productId": "0x0440"
 		}
 	],
 	"firmwareVersion": {

--- a/packages/config/config/devices/0x0090/914c.json
+++ b/packages/config/config/devices/0x0090/914c.json
@@ -9,10 +9,6 @@
 		{
 			"productType": "0x0003",
 			"productId": "0x0446"
-		},
-		{
-			"productType": "0x0003",
-			"productId": "0x0440"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
The Product ID for the Kwikset 914 lock was incorrectly assigned to the 914c (convert) lock.  Fixes https://github.com/zwave-js/node-zwave-js/issues/1789.