### PR TITLE
fix(cc): use alternate firmware ID when updating target > 0

### DIFF
--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -2578,7 +2578,7 @@ version:               ${this.version}`;
 		// TODO: Should manufacturer id and firmware id be provided externally?
 		const status = await api.requestUpdate({
 			manufacturerId: meta.manufacturerId,
-			firmwareId: meta.firmwareId,
+			firmwareId: (target == 0 ? meta.firmwareId : meta.additionalFirmwareIDs[target - 1]),
 			firmwareTarget: target,
 			fragmentSize: this._firmwareUpdateStatus.fragmentSize,
 			checksum: CRC16_CCITT(data),

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -2578,7 +2578,10 @@ version:               ${this.version}`;
 		// TODO: Should manufacturer id and firmware id be provided externally?
 		const status = await api.requestUpdate({
 			manufacturerId: meta.manufacturerId,
-			firmwareId: (target == 0 ? meta.firmwareId : meta.additionalFirmwareIDs[target - 1]),
+			firmwareId:
+				target == 0
+					? meta.firmwareId
+					: meta.additionalFirmwareIDs[target - 1],
 			firmwareTarget: target,
 			fragmentSize: this._firmwareUpdateStatus.fragmentSize,
 			checksum: CRC16_CCITT(data),


### PR DESCRIPTION
Set firmware id by target

Partially addresses: [(#1761)](https://github.com/zwave-js/node-zwave-js/issues/1761).