### PR TITLE
fix(docs): avoid search collisions

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -45,6 +45,9 @@
 				// coverpage: true,
 				// onlyCover: true,
 
+				// Avoid collisions with other docs on the same domain
+				namespace: "node-zwave-js",
+
 				plugins: [
 					EditOnGithubPlugin.create(
 						"https://github.com/zwave-js/node-zwave-js/blob/master/docs/",


### PR DESCRIPTION
@robertsLando I think this is why search isn't working in your docs. You might want to apply this to your repo too