### PR TITLE
feat(cc): implement Scene Actuator Configuration CC

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/API.ts
+++ b/packages/zwave-js/src/lib/commandclass/API.ts
@@ -315,6 +315,7 @@ export interface CCAPIs {
 	Notification: import("./NotificationCC").NotificationCCAPI;
 	Protection: import("./ProtectionCC").ProtectionCCAPI;
 	"Scene Activation": import("./SceneActivationCC").SceneActivationCCAPI;
+	"Scene Actuator Configuration": import("./SceneActuatorConfigurationCC").SceneActuatorConfigurationCCAPI;
 	"Scene Controller Configuration": import("./SceneControllerConfigurationCC").SceneControllerConfigurationCCAPI;
 	Security: import("./SecurityCC").SecurityCCAPI;
 	"Sound Switch": import("./SoundSwitchCC").SoundSwitchCCAPI;

--- a/packages/zwave-js/src/lib/commandclass/SceneActuatorConfiguration.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneActuatorConfiguration.test.ts
@@ -1,5 +1,6 @@
 import { CommandClasses, Duration } from "@zwave-js/core";
 import type { Driver } from "../driver/Driver";
+import { ZWaveNode } from "../node/Node";
 import { createEmptyMockDriver } from "../test/mocks";
 import {
 	SceneActuatorConfigurationCC,
@@ -8,8 +9,6 @@ import {
 	SceneActuatorConfigurationCCSet,
 	SceneActuatorConfigurationCommand,
 } from "./SceneActuatorConfigurationCC";
-
-const fakeDriver = (createEmptyMockDriver() as unknown) as Driver;
 
 function buildCCBuffer(payload: Buffer): Buffer {
 	return Buffer.concat([
@@ -21,6 +20,23 @@ function buildCCBuffer(payload: Buffer): Buffer {
 }
 
 describe("lib/commandclass/SceneActuatorConfigurationCC => ", () => {
+	let fakeDriver: Driver;
+	let node2: ZWaveNode;
+
+	beforeAll(() => {
+		fakeDriver = (createEmptyMockDriver() as unknown) as Driver;
+
+		node2 = new ZWaveNode(2, fakeDriver as any);
+		(fakeDriver.controller.nodes as any).set(2, node2);
+		node2.addCC(CommandClasses["Scene Actuator Configuration"], {
+			isSupported: true,
+			version: 1,
+		});
+	});
+
+	afterAll(() => {
+		node2.destroy();
+	});
 	it("the Get command should serialize correctly", () => {
 		const cc = new SceneActuatorConfigurationCCGet(fakeDriver, {
 			nodeId: 1,
@@ -83,7 +99,7 @@ describe("lib/commandclass/SceneActuatorConfigurationCC => ", () => {
 			]),
 		);
 		const cc = new SceneActuatorConfigurationCCReport(fakeDriver, {
-			nodeId: 4,
+			nodeId: 2,
 			data: ccData,
 		});
 

--- a/packages/zwave-js/src/lib/commandclass/SceneActuatorConfiguration.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneActuatorConfiguration.test.ts
@@ -1,0 +1,105 @@
+import { CommandClasses, Duration } from "@zwave-js/core";
+import type { Driver } from "../driver/Driver";
+import { createEmptyMockDriver } from "../test/mocks";
+import {
+	SceneActuatorConfigurationCC,
+	SceneActuatorConfigurationCCGet,
+	SceneActuatorConfigurationCCReport,
+	SceneActuatorConfigurationCCSet,
+	SceneActuatorConfigurationCommand,
+} from "./SceneActuatorConfigurationCC";
+
+const fakeDriver = (createEmptyMockDriver() as unknown) as Driver;
+
+function buildCCBuffer(payload: Buffer): Buffer {
+	return Buffer.concat([
+		Buffer.from([
+			CommandClasses["Scene Actuator Configuration"], // CC
+		]),
+		payload,
+	]);
+}
+
+describe("lib/commandclass/SceneActuatorConfigurationCC => ", () => {
+	it("the Get command should serialize correctly", () => {
+		const cc = new SceneActuatorConfigurationCCGet(fakeDriver, {
+			nodeId: 1,
+			sceneId: 1,
+		});
+		const expected = buildCCBuffer(
+			Buffer.from([
+				SceneActuatorConfigurationCommand.Get, // CC Command
+				1,
+			]),
+		);
+		expect(cc.serialize()).toEqual(expected);
+	});
+
+	it("the Set command should serialize correctly with level", () => {
+		const cc = new SceneActuatorConfigurationCCSet(fakeDriver, {
+			nodeId: 2,
+			sceneId: 2,
+			level: 0x50,
+			dimmingDuration: Duration.parseSet(0x05)!,
+		});
+		const expected = buildCCBuffer(
+			Buffer.from([
+				SceneActuatorConfigurationCommand.Set, // CC Command
+				2,
+				0x05, // dimmingDuration
+				0b1000_0000,
+				0x50, // level
+			]),
+		);
+		expect(cc.serialize()).toEqual(expected);
+	});
+
+	it("the Set command should serialize correctly with undefined level", () => {
+		const cc = new SceneActuatorConfigurationCCSet(fakeDriver, {
+			nodeId: 3,
+			sceneId: 2,
+			level: undefined,
+			dimmingDuration: Duration.parseSet(0x05)!,
+		});
+		const expected = buildCCBuffer(
+			Buffer.from([
+				SceneActuatorConfigurationCommand.Set, // CC Command
+				2,
+				0x05, // dimmingDuration
+				0b0000_0000,
+				0xff, // level
+			]),
+		);
+		expect(cc.serialize()).toEqual(expected);
+	});
+
+	it("the Report command (v1) should be deserialized correctly", () => {
+		const ccData = buildCCBuffer(
+			Buffer.from([
+				SceneActuatorConfigurationCommand.Report, // CC Command
+				55, // sceneId
+				0x50, // level
+				0x05, // dimmingDuration
+			]),
+		);
+		const cc = new SceneActuatorConfigurationCCReport(fakeDriver, {
+			nodeId: 4,
+			data: ccData,
+		});
+
+		expect(cc.sceneId).toBe(55);
+		expect(cc.level).toBe(0x50);
+		expect(cc.dimmingDuration).toStrictEqual(Duration.parseReport(0x05)!);
+	});
+
+	it("deserializing an unsupported command should return an unspecified version of SceneActuatorConfigurationCC", () => {
+		const serializedCC = buildCCBuffer(
+			Buffer.from([255]), // not a valid command
+		);
+		const cc: any = new SceneActuatorConfigurationCC(fakeDriver, {
+			nodeId: 5,
+			data: serializedCC,
+		});
+		expect(cc.constructor).toBe(SceneActuatorConfigurationCC);
+	});
+});

--- a/packages/zwave-js/src/lib/commandclass/SceneActuatorConfiguration.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneActuatorConfiguration.test.ts
@@ -39,7 +39,7 @@ describe("lib/commandclass/SceneActuatorConfigurationCC => ", () => {
 	});
 	it("the Get command should serialize correctly", () => {
 		const cc = new SceneActuatorConfigurationCCGet(fakeDriver, {
-			nodeId: 1,
+			nodeId: 2,
 			sceneId: 1,
 		});
 		const expected = buildCCBuffer(
@@ -72,7 +72,7 @@ describe("lib/commandclass/SceneActuatorConfigurationCC => ", () => {
 
 	it("the Set command should serialize correctly with undefined level", () => {
 		const cc = new SceneActuatorConfigurationCCSet(fakeDriver, {
-			nodeId: 3,
+			nodeId: 2,
 			sceneId: 2,
 			//level: undefined,
 			dimmingDuration: Duration.parseSet(0x05)!,
@@ -113,7 +113,7 @@ describe("lib/commandclass/SceneActuatorConfigurationCC => ", () => {
 			Buffer.from([255]), // not a valid command
 		);
 		const cc: any = new SceneActuatorConfigurationCC(fakeDriver, {
-			nodeId: 5,
+			nodeId: 2,
 			data: serializedCC,
 		});
 		expect(cc.constructor).toBe(SceneActuatorConfigurationCC);

--- a/packages/zwave-js/src/lib/commandclass/SceneActuatorConfiguration.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneActuatorConfiguration.test.ts
@@ -39,7 +39,7 @@ describe("lib/commandclass/SceneActuatorConfigurationCC => ", () => {
 		const cc = new SceneActuatorConfigurationCCSet(fakeDriver, {
 			nodeId: 2,
 			sceneId: 2,
-			level: 0x50,
+			level: 0x00,
 			dimmingDuration: Duration.parseSet(0x05)!,
 		});
 		const expected = buildCCBuffer(
@@ -48,7 +48,7 @@ describe("lib/commandclass/SceneActuatorConfigurationCC => ", () => {
 				2,
 				0x05, // dimmingDuration
 				0b1000_0000,
-				0x50, // level
+				0x00, // level
 			]),
 		);
 		expect(cc.serialize()).toEqual(expected);
@@ -58,7 +58,7 @@ describe("lib/commandclass/SceneActuatorConfigurationCC => ", () => {
 		const cc = new SceneActuatorConfigurationCCSet(fakeDriver, {
 			nodeId: 3,
 			sceneId: 2,
-			level: undefined,
+			//level: undefined,
 			dimmingDuration: Duration.parseSet(0x05)!,
 		});
 		const expected = buildCCBuffer(

--- a/packages/zwave-js/src/lib/commandclass/SceneActuatorConfiguration.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneActuatorConfiguration.test.ts
@@ -63,7 +63,7 @@ describe("lib/commandclass/SceneActuatorConfigurationCC => ", () => {
 				SceneActuatorConfigurationCommand.Set, // CC Command
 				2,
 				0x05, // dimmingDuration
-				0b1000_0000,
+				0b1000_0000, // override
 				0x00, // level
 			]),
 		);
@@ -80,9 +80,9 @@ describe("lib/commandclass/SceneActuatorConfigurationCC => ", () => {
 		const expected = buildCCBuffer(
 			Buffer.from([
 				SceneActuatorConfigurationCommand.Set, // CC Command
-				2,
+				2, // nodeId
 				0x05, // dimmingDuration
-				0b0000_0000,
+				0b0000_0000, // override
 				0xff, // level
 			]),
 		);

--- a/packages/zwave-js/src/lib/commandclass/SceneActuatorConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneActuatorConfigurationCC.ts
@@ -230,6 +230,14 @@ export class SceneActuatorConfigurationCCAPI extends CCAPI {
 			SceneActuatorConfigurationCommand.Get,
 		);
 
+		if (sceneId === 0) {
+			// We need to prevent this, since it will cause the Report sceneId
+			// to be different from the requested sceneId, and the client won't
+			// be able to determine the actual sceneId, because it's hidden in
+			// the return value
+			return;
+		}
+
 		const cc = new SceneActuatorConfigurationCCGet(this.driver, {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
@@ -240,13 +248,12 @@ export class SceneActuatorConfigurationCCAPI extends CCAPI {
 			this.commandOptions,
 		);
 
-		// A response to a
-		if (
-			response &&
-			response.level != undefined &&
-			response.dimmingDuration != undefined
-		) {
+		if (!response) return;
+		if (response.sceneId === sceneId) {
 			return pick(response, ["level", "dimmingDuration"]);
+		} else {
+			// I don't think this can happen, if we block sceneId = 0
+			return;
 		}
 	}
 }

--- a/packages/zwave-js/src/lib/commandclass/SceneActuatorConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneActuatorConfigurationCC.ts
@@ -130,7 +130,7 @@ export class SceneActuatorConfigurationCCAPI extends CCAPI {
 				);
 			}
 
-			// We need to set the dimming duration along with the level
+			// We need to set the dimming duration along with the level.
 			// If no duration is set, we default to 0 seconds
 			const node = this.endpoint.getNodeUnsafe()!;
 			const dimmingDuration =
@@ -249,14 +249,12 @@ export class SceneActuatorConfigurationCCAPI extends CCAPI {
 	}
 }
 
+// @noInterview - We don't want to query 255 scenes
+
 @commandClass(CommandClasses["Scene Actuator Configuration"])
 @implementedVersion(1)
 export class SceneActuatorConfigurationCC extends CommandClass {
 	declare ccCommand: SceneActuatorConfigurationCommand;
-
-	// interview is omitted, because our only option would be
-	// to query all 255 possible sceneIds, which is a lot of traffic
-	// for little benefit
 }
 
 interface SceneActuatorConfigurationCCSetOptions extends CCCommandOptions {
@@ -283,7 +281,7 @@ export class SceneActuatorConfigurationCCSet extends SceneActuatorConfigurationC
 		} else {
 			if (options.sceneId < 1 || options.sceneId > 255) {
 				throw new ZWaveError(
-					`scene id ${options.sceneId} out of range [1..255]`,
+					`The scene id ${options.sceneId} must be between 1 and 255!`,
 					ZWaveErrorCodes.Argument_Invalid,
 				);
 			}
@@ -333,6 +331,7 @@ export class SceneActuatorConfigurationCCReport extends SceneActuatorConfigurati
 	public readonly dimmingDuration?: Duration;
 
 	public persistValues(): boolean {
+		// Do not persist values for an inactive scene
 		if (
 			this.sceneId === 0 ||
 			this.level == undefined ||
@@ -340,6 +339,7 @@ export class SceneActuatorConfigurationCCReport extends SceneActuatorConfigurati
 		) {
 			return false;
 		}
+
 		return persistSceneActuatorConfig.call(
 			this,
 			this.sceneId,

--- a/packages/zwave-js/src/lib/commandclass/SceneActuatorConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneActuatorConfigurationCC.ts
@@ -131,49 +131,17 @@ export class SceneActuatorConfigurationCCAPI extends CCAPI {
 			}
 
 			// We need to set the dimming duration along with the level
+			// If no duration is set, we default to 0 seconds
 			const node = this.endpoint.getNodeUnsafe()!;
-			const dimmingDuration = node.getValue<Duration>(
-				getDimmingDurationValueID(this.endpoint.index, propertyKey),
-			);
-			// If dimmingDuration is missing, we must abort
-			if (dimmingDuration == undefined) {
-				throw new ZWaveError(
-					`The "dimmingDuration" property cannot be changed before the level is known!`,
-					ZWaveErrorCodes.Argument_Invalid,
-				);
-			}
+			const dimmingDuration =
+				node.getValue<Duration>(
+					getDimmingDurationValueID(this.endpoint.index, propertyKey),
+				) ?? new Duration(0, "seconds");
 			await this.set(propertyKey, dimmingDuration, value);
-		} else if (property === "dimmingDuration") {
-			if (!(value instanceof Duration)) {
-				throwWrongValueType(
-					this.ccId,
-					property,
-					"Duration",
-					typeof value,
-				);
-			}
-
-			// We need to set the leve along with the dimming duration
-			const node = this.endpoint.getNodeUnsafe()!;
-			const level = node.getValue<number>(
-				getLevelValueID(this.endpoint.index, propertyKey),
-			);
-			// If level is missing, we must abort
-			if (level == undefined) {
-				throw new ZWaveError(
-					`The "level" property cannot be changed before the dimming duration is known!`,
-					ZWaveErrorCodes.Argument_Invalid,
-				);
-			}
-			await this.set(propertyKey, value, level);
 		} else {
-			// setting dimmingDuration value alone not supported,
-			// to be added when setting Duration values is supported
+			// setting dimmingDuration value alone not supported
 			throwUnsupportedProperty(this.ccId, property);
 		}
-
-		// Verify the current value after a delay
-		this.schedulePoll({ property, propertyKey });
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({

--- a/packages/zwave-js/src/lib/commandclass/SceneActuatorConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneActuatorConfigurationCC.ts
@@ -231,11 +231,10 @@ export class SceneActuatorConfigurationCCAPI extends CCAPI {
 		);
 
 		if (sceneId === 0) {
-			// We need to prevent this, since it will cause the Report sceneId
-			// to be different from the requested sceneId, and the client won't
-			// be able to determine the actual sceneId, because it's hidden in
-			// the return value
-			return;
+			throw new ZWaveError(
+				`sceneId 0 is not valid for get. Use getActive() instead.`,
+				ZWaveErrorCodes.Argument_Invalid,
+			);
 		}
 
 		const cc = new SceneActuatorConfigurationCCGet(this.driver, {
@@ -248,12 +247,8 @@ export class SceneActuatorConfigurationCCAPI extends CCAPI {
 			this.commandOptions,
 		);
 
-		if (!response) return;
-		if (response.sceneId === sceneId) {
+		if (response) {
 			return pick(response, ["level", "dimmingDuration"]);
-		} else {
-			// I don't think this can happen, if we block sceneId = 0
-			return;
 		}
 	}
 }
@@ -332,9 +327,9 @@ export class SceneActuatorConfigurationCCReport extends SceneActuatorConfigurati
 			this.dimmingDuration =
 				Duration.parseReport(this.payload[2]) ??
 				new Duration(0, "unknown");
-
-			this.persistValues();
 		}
+
+		this.persistValues();
 	}
 
 	public readonly sceneId: number;

--- a/packages/zwave-js/src/lib/commandclass/SceneActuatorConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneActuatorConfigurationCC.ts
@@ -232,7 +232,7 @@ export class SceneActuatorConfigurationCCAPI extends CCAPI {
 
 		if (sceneId === 0) {
 			throw new ZWaveError(
-				`sceneId 0 is not valid for get. Use getActive() instead.`,
+				`Invalid scene ID 0. To get the currently active scene, use getActive() instead.`,
 				ZWaveErrorCodes.Argument_Invalid,
 			);
 		}

--- a/packages/zwave-js/src/lib/commandclass/SceneActuatorConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneActuatorConfigurationCC.ts
@@ -264,7 +264,7 @@ export class SceneActuatorConfigurationCCSet extends SceneActuatorConfigurationC
 			}
 			this.sceneId = options.sceneId;
 			this.dimmingDuration = options.dimmingDuration;
-			if (options.level) {
+			if (options.level != undefined) {
 				if (options.level < 0 || options.level > 255) {
 					throw new ZWaveError(
 						`level ${options.level} out of range [1..255]`,

--- a/packages/zwave-js/src/lib/commandclass/SceneActuatorConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneActuatorConfigurationCC.ts
@@ -1,12 +1,27 @@
 import {
 	CommandClasses,
 	Duration,
+	Maybe,
 	MessageOrCCLogEntry,
+	validatePayload,
+	ValueID,
+	ValueMetadata,
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
+import { pick } from "@zwave-js/shared";
 import type { Driver } from "../driver/Driver";
-import { CCAPI } from "./API";
+import {
+	CCAPI,
+	PollValueImplementation,
+	POLL_VALUE,
+	SetValueImplementation,
+	SET_VALUE,
+	throwMissingPropertyKey,
+	throwUnsupportedProperty,
+	throwUnsupportedPropertyKey,
+	throwWrongValueType,
+} from "./API";
 import {
 	API,
 	CCCommand,
@@ -26,22 +41,203 @@ export enum SceneActuatorConfigurationCommand {
 	Report = 0x03,
 }
 
+export function getLevelValueID(
+	endpoint: number | undefined,
+	sceneId: number,
+): ValueID {
+	return {
+		commandClass: CommandClasses["Scene Actuator Configuration"],
+		endpoint,
+		property: "level",
+		propertyKey: sceneId,
+	};
+}
+
+export function getDimmingDurationValueID(
+	endpoint: number | undefined,
+	sceneId: number,
+): ValueID {
+	return {
+		commandClass: CommandClasses["Scene Actuator Configuration"],
+		endpoint,
+		property: "dimmingDuration",
+		propertyKey: sceneId,
+	};
+}
+
+function persistSceneActuatorConfig(
+	this: SceneActuatorConfigurationCC,
+	sceneId: number,
+	level: number,
+	dimmingDuration: Duration,
+) {
+	const levelValueId = getLevelValueID(this.endpointIndex, sceneId);
+	const dimmingDurationValueId = getDimmingDurationValueID(
+		this.endpointIndex,
+		sceneId,
+	);
+	const valueDB = this.getValueDB();
+
+	if (!valueDB.hasMetadata(levelValueId)) {
+		valueDB.setMetadata(levelValueId, {
+			...ValueMetadata.UInt8,
+			label: `Level (${sceneId})`,
+		});
+	}
+	if (!valueDB.hasMetadata(dimmingDurationValueId)) {
+		valueDB.setMetadata(dimmingDurationValueId, {
+			...ValueMetadata.Duration,
+			label: `Dimming duration (${sceneId})`,
+		});
+	}
+
+	valueDB.setValue(levelValueId, level);
+	valueDB.setValue(dimmingDurationValueId, dimmingDuration);
+
+	return true;
+}
+
 @API(CommandClasses["Scene Actuator Configuration"])
 export class SceneActuatorConfigurationCCAPI extends CCAPI {
-	// TODO: Implementation
+	public supportsCommand(
+		cmd: SceneActuatorConfigurationCommand,
+	): Maybe<boolean> {
+		switch (cmd) {
+			case SceneActuatorConfigurationCommand.Get:
+				return this.isSinglecast();
+			case SceneActuatorConfigurationCommand.Set:
+			case SceneActuatorConfigurationCommand.Report:
+				return true;
+		}
+		return super.supportsCommand(cmd);
+	}
+
+	protected [SET_VALUE]: SetValueImplementation = async (
+		{ property, propertyKey },
+		value,
+	): Promise<void> => {
+		if (propertyKey == undefined) {
+			throwMissingPropertyKey(this.ccId, property);
+		} else if (typeof propertyKey !== "number") {
+			throwUnsupportedPropertyKey(this.ccId, property, propertyKey);
+		}
+		if (property === "level") {
+			if (typeof value !== "number") {
+				throwWrongValueType(
+					this.ccId,
+					property,
+					"number",
+					typeof value,
+				);
+			}
+
+			// We need to set the dimming duration along with the level
+			const node = this.endpoint.getNodeUnsafe()!;
+			// If duration is missing, we set a default of instant
+			const dimmingDuration =
+				node.getValue<Duration>(
+					getDimmingDurationValueID(this.endpoint.index, propertyKey),
+				) ?? new Duration(0, "seconds");
+			await this.set(propertyKey, dimmingDuration);
+		} else {
+			// setting dimmingDuration value alone not supported,
+			// to be added when setting Duration values is supported
+			throwUnsupportedProperty(this.ccId, property);
+		}
+
+		// Verify the current value after a delay
+		this.schedulePoll({ property, propertyKey });
+	};
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+		propertyKey,
+	}): Promise<unknown> => {
+		switch (property) {
+			case "level":
+			case "dimmingDuration": {
+				if (propertyKey == undefined) {
+					throwMissingPropertyKey(this.ccId, property);
+				} else if (typeof propertyKey !== "number") {
+					throwUnsupportedPropertyKey(
+						this.ccId,
+						property,
+						propertyKey,
+					);
+				}
+				return (await this.get(propertyKey))?.[property];
+			}
+			default:
+				throwUnsupportedProperty(this.ccId, property);
+		}
+	};
+
+	public async set(
+		sceneId: number,
+		dimmingDuration: Duration,
+		level?: number,
+	): Promise<void> {
+		this.assertSupportsCommand(
+			SceneActuatorConfigurationCommand,
+			SceneActuatorConfigurationCommand.Set,
+		);
+
+		const cc = new SceneActuatorConfigurationCCSet(this.driver, {
+			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
+			sceneId,
+			dimmingDuration,
+			level,
+		});
+
+		await this.driver.sendCommand(cc, this.commandOptions);
+	}
+
+	public async get(
+		sceneId: number,
+	): Promise<
+		| {
+				sceneId: number;
+				level: number;
+				dimmingDuration: Duration;
+		  }
+		| undefined
+	> {
+		this.assertSupportsCommand(
+			SceneActuatorConfigurationCommand,
+			SceneActuatorConfigurationCommand.Get,
+		);
+
+		const cc = new SceneActuatorConfigurationCCGet(this.driver, {
+			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
+			sceneId: sceneId,
+		});
+		const response = await this.driver.sendCommand<SceneActuatorConfigurationCCReport>(
+			cc,
+			this.commandOptions,
+		);
+
+		if (response) {
+			return pick(response, ["sceneId", "level", "dimmingDuration"]);
+		}
+	}
 }
 
 @commandClass(CommandClasses["Scene Actuator Configuration"])
 @implementedVersion(1)
 export class SceneActuatorConfigurationCC extends CommandClass {
 	declare ccCommand: SceneActuatorConfigurationCommand;
+
+	// interview is omitted, because our only option would be
+	// to query all 255 possible sceneIds, which is a lot of traffic
+	// for little benefit
 }
 
 interface SceneActuatorConfigurationCCSetOptions extends CCCommandOptions {
 	sceneId: number;
 	dimmingDuration: Duration;
-	override: boolean;
-	level: number;
+	level?: number;
 }
 
 @CCCommand(SceneActuatorConfigurationCommand.Set)
@@ -60,14 +256,41 @@ export class SceneActuatorConfigurationCCSet extends SceneActuatorConfigurationC
 				ZWaveErrorCodes.Deserialization_NotImplemented,
 			);
 		} else {
-			// TODO: Populate properties from options object
-			throw new Error("not implemented");
+			if (options.sceneId < 1 || options.sceneId > 255) {
+				throw new ZWaveError(
+					`scene id ${options.sceneId} out of range [1..255]`,
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
+			this.sceneId = options.sceneId;
+			this.dimmingDuration = options.dimmingDuration;
+			if (options.level) {
+				if (options.level < 0 || options.level > 255) {
+					throw new ZWaveError(
+						`level ${options.level} out of range [1..255]`,
+						ZWaveErrorCodes.Argument_Invalid,
+					);
+				}
+				this.override = true;
+				this.level = options.level;
+			} else {
+				this.override = false;
+				this.level = 0xff; // will be ignored
+			}
 		}
 	}
 
+	public sceneId: number;
+	public dimmingDuration: Duration;
+	public override: boolean;
+	public level: number;
+
 	public serialize(): Buffer {
 		this.payload = Buffer.from([
-			/* TODO: serialize */
+			this.sceneId,
+			this.dimmingDuration.serializeSet(),
+			this.override ? 0b1000_0000 : 0x00,
+			this.level,
 		]);
 		return super.serialize();
 	}
@@ -80,8 +303,44 @@ export class SceneActuatorConfigurationCCReport extends SceneActuatorConfigurati
 		options: CommandClassDeserializationOptions,
 	) {
 		super(driver, options);
-		// TODO: Deserialize
+		validatePayload(this.payload.length >= 3);
+		this.sceneId = this.payload[0];
+		this.level = this.payload[1];
+		this.dimmingDuration =
+			Duration.parseReport(this.payload[2]) ?? new Duration(0, "unknown");
 	}
+
+	public sceneId: number;
+	public level: number;
+	public dimmingDuration: Duration;
+
+	public persistValues(): boolean {
+		persistSceneActuatorConfig.call(
+			this,
+			this.sceneId,
+			this.level,
+			this.dimmingDuration,
+		);
+		return true;
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: {
+				sceneId: this.sceneId,
+				level: this.level,
+				dimmingDuration: this.dimmingDuration.toString(),
+			},
+		};
+	}
+}
+
+function testResponseForSceneActuatorConfigurationGet(
+	sent: SceneActuatorConfigurationCCGet,
+	received: SceneActuatorConfigurationCCReport,
+) {
+	return received.sceneId === sent.sceneId;
 }
 
 interface SceneActuatorConfigurationCCGetOptions extends CCCommandOptions {
@@ -89,7 +348,10 @@ interface SceneActuatorConfigurationCCGetOptions extends CCCommandOptions {
 }
 
 @CCCommand(SceneActuatorConfigurationCommand.Get)
-@expectedCCResponse(SceneActuatorConfigurationCCReport)
+@expectedCCResponse(
+	SceneActuatorConfigurationCCReport,
+	testResponseForSceneActuatorConfigurationGet,
+)
 export class SceneActuatorConfigurationCCGet extends SceneActuatorConfigurationCC {
 	public constructor(
 		driver: Driver,
@@ -105,6 +367,12 @@ export class SceneActuatorConfigurationCCGet extends SceneActuatorConfigurationC
 				ZWaveErrorCodes.Deserialization_NotImplemented,
 			);
 		} else {
+			if (options.sceneId < 1 || options.sceneId > 255) {
+				throw new ZWaveError(
+					`scene id ${options.sceneId} out of range [1..255]`,
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
 			this.sceneId = options.sceneId;
 		}
 	}

--- a/packages/zwave-js/src/lib/commandclass/SceneActuatorConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneActuatorConfigurationCC.ts
@@ -1,0 +1,125 @@
+import {
+	CommandClasses,
+	Duration,
+	MessageOrCCLogEntry,
+	ZWaveError,
+	ZWaveErrorCodes,
+} from "@zwave-js/core";
+import type { Driver } from "../driver/Driver";
+import { CCAPI } from "./API";
+import {
+	API,
+	CCCommand,
+	CCCommandOptions,
+	CommandClass,
+	commandClass,
+	CommandClassDeserializationOptions,
+	expectedCCResponse,
+	gotDeserializationOptions,
+	implementedVersion,
+} from "./CommandClass";
+
+// All the supported commands
+export enum SceneActuatorConfigurationCommand {
+	Set = 0x01,
+	Get = 0x02,
+	Report = 0x03,
+}
+
+@API(CommandClasses["Scene Actuator Configuration"])
+export class SceneActuatorConfigurationCCAPI extends CCAPI {
+	// TODO: Implementation
+}
+
+@commandClass(CommandClasses["Scene Actuator Configuration"])
+@implementedVersion(1)
+export class SceneActuatorConfigurationCC extends CommandClass {
+	declare ccCommand: SceneActuatorConfigurationCommand;
+}
+
+interface SceneActuatorConfigurationCCSetOptions extends CCCommandOptions {
+	sceneId: number;
+	dimmingDuration: Duration;
+	override: boolean;
+	level: number;
+}
+
+@CCCommand(SceneActuatorConfigurationCommand.Set)
+export class SceneActuatorConfigurationCCSet extends SceneActuatorConfigurationCC {
+	public constructor(
+		driver: Driver,
+		options:
+			| CommandClassDeserializationOptions
+			| SceneActuatorConfigurationCCSetOptions,
+	) {
+		super(driver, options);
+		if (gotDeserializationOptions(options)) {
+			// TODO: Deserialize payload
+			throw new ZWaveError(
+				`${this.constructor.name}: deserialization not implemented`,
+				ZWaveErrorCodes.Deserialization_NotImplemented,
+			);
+		} else {
+			// TODO: Populate properties from options object
+			throw new Error("not implemented");
+		}
+	}
+
+	public serialize(): Buffer {
+		this.payload = Buffer.from([
+			/* TODO: serialize */
+		]);
+		return super.serialize();
+	}
+}
+
+@CCCommand(SceneActuatorConfigurationCommand.Report)
+export class SceneActuatorConfigurationCCReport extends SceneActuatorConfigurationCC {
+	public constructor(
+		driver: Driver,
+		options: CommandClassDeserializationOptions,
+	) {
+		super(driver, options);
+		// TODO: Deserialize
+	}
+}
+
+interface SceneActuatorConfigurationCCGetOptions extends CCCommandOptions {
+	sceneId: number;
+}
+
+@CCCommand(SceneActuatorConfigurationCommand.Get)
+@expectedCCResponse(SceneActuatorConfigurationCCReport)
+export class SceneActuatorConfigurationCCGet extends SceneActuatorConfigurationCC {
+	public constructor(
+		driver: Driver,
+		options:
+			| CommandClassDeserializationOptions
+			| SceneActuatorConfigurationCCGetOptions,
+	) {
+		super(driver, options);
+		if (gotDeserializationOptions(options)) {
+			// TODO: Deserialize payload
+			throw new ZWaveError(
+				`${this.constructor.name}: deserialization not implemented`,
+				ZWaveErrorCodes.Deserialization_NotImplemented,
+			);
+		} else {
+			this.sceneId = options.sceneId;
+		}
+	}
+
+	public sceneId: number;
+
+	public serialize(): Buffer {
+		this.payload = Buffer.from([this.sceneId]);
+		return super.serialize();
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: { "scene id": this.sceneId },
+		};
+	}
+}

--- a/packages/zwave-js/src/lib/commandclass/SceneActuatorConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneActuatorConfigurationCC.ts
@@ -308,6 +308,8 @@ export class SceneActuatorConfigurationCCReport extends SceneActuatorConfigurati
 		this.level = this.payload[1];
 		this.dimmingDuration =
 			Duration.parseReport(this.payload[2]) ?? new Duration(0, "unknown");
+
+		this.persistValues();
 	}
 
 	public sceneId: number;

--- a/packages/zwave-js/src/lib/commandclass/SceneActuatorConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneActuatorConfigurationCC.ts
@@ -327,7 +327,7 @@ export class SceneActuatorConfigurationCCReport extends SceneActuatorConfigurati
 		validatePayload(this.payload.length >= 3);
 		this.sceneId = this.payload[0];
 
-		if (this.sceneId != 0) {
+		if (this.sceneId !== 0) {
 			this.level = this.payload[1];
 			this.dimmingDuration =
 				Duration.parseReport(this.payload[2]) ??


### PR DESCRIPTION
This implements the Scene Actuator Configuration CC and a very basic set of tests.

I have NOT implemented an interview, because I don't think it's appropriate.  Supporting devices are required to support 255 scenes, and there is no method I see for determining which scenes are relevant.  The user will know which scenes they are using and can request the current configuration selectively.  Blindly querying all 255 scenes is excessive, I think.

Setting the `level` is optional in the Set command.  The Zwave interface adds a 1 bit `override` buffer field.  I have chosen to make the `level` field optional and setting the `override` bit automatically on a `options.level != undefined` test.  I'm not sure if that's the preferred interface.

I'm still am not certain about the distinction between PhysicalCCAPI and CCAPI.