### PR TITLE
fix(config): don't use endpoint associations for ZW111 Lifeline

### DIFF
--- a/packages/config/config/devices/0x0086/zw111_2.3.json
+++ b/packages/config/config/devices/0x0086/zw111_2.3.json
@@ -36,7 +36,7 @@
 			"label": "Lifeline",
 			"maxNodes": 5,
 			"isLifeline": true,
-			"noEndpoint": true,
+			"noEndpoint": true
 		},
 		"2": {
 			"label": "Forward Received Commands",

--- a/packages/config/config/devices/0x0086/zw111_2.3.json
+++ b/packages/config/config/devices/0x0086/zw111_2.3.json
@@ -31,7 +31,26 @@
 		"min": "2.3",
 		"max": "255.255"
 	},
-	"supportsZWavePlus": true,
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5,
+			"isLifeline": true,
+			"noEndpoint": true,
+		},
+		"2": {
+			"label": "Forward Received Commands",
+			"maxNodes": 5
+		},
+		"3": {
+			"label": "Basic Set for Switch S1",
+			"maxNodes": 5
+		},
+		"4": {
+			"label": "Basic Set for Switch S2",
+			"maxNodes": 5
+		}
+	},
 	"paramInformation": {
 		"3": {
 			"label": "Current Overload Protection",


### PR DESCRIPTION
fixes: #1738