### PR TITLE
fix(config): do not throw when index generation fails in production

### DIFF
--- a/packages/config/src/Devices.ts
+++ b/packages/config/src/Devices.ts
@@ -157,12 +157,19 @@ export async function loadDeviceIndexInternal(
 					})),
 				);
 			} catch (e: unknown) {
-				throw new ZWaveError(
-					`Error parsing config file ${relativePath}: ${
-						(e as Error).message
-					}`,
-					ZWaveErrorCodes.Config_Invalid,
-				);
+				const message = `Error parsing config file ${relativePath}: ${
+					(e as Error).message
+				}`;
+				// Crash hard during tests, just print an error when in production systems.
+				// A user could have changed a config file
+				if (process.env.NODE_ENV === "test" || !!process.env.CI) {
+					throw new ZWaveError(
+						message,
+						ZWaveErrorCodes.Config_Invalid,
+					);
+				} else {
+					logger?.print(message, "error");
+				}
 			}
 		}
 


### PR DESCRIPTION
With this PR, we skip single files during index generation outside of testing if there are parsing errors. Previously the index would be discarded entirely, causing all devices to be un-identified.

fixes: #1825