### PR TITLE
feat(cc): add Entry Control command class

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/API.ts
+++ b/packages/zwave-js/src/lib/commandclass/API.ts
@@ -304,6 +304,7 @@ export interface CCAPIs {
 	"Color Switch": import("./ColorSwitchCC").ColorSwitchCCAPI;
 	Configuration: import("./ConfigurationCC").ConfigurationCCAPI;
 	"Door Lock": import("./DoorLockCC").DoorLockCCAPI;
+	"Entry Control": import("./EntryControlCC").EntryControlCCAPI;
 	"Firmware Update Meta Data": import("./FirmwareUpdateMetaDataCC").FirmwareUpdateMetaDataCCAPI;
 	Indicator: import("./IndicatorCC").IndicatorCCAPI;
 	Language: import("./LanguageCC").LanguageCCAPI;

--- a/packages/zwave-js/src/lib/commandclass/EntryControlCC.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/EntryControlCC.test.ts
@@ -2,16 +2,16 @@ import { CommandClasses } from "@zwave-js/core";
 import type { Driver } from "../driver/Driver";
 import { createEmptyMockDriver } from "../test/mocks";
 import {
-  EntryControlCommand,
-  EntryControlDataTypes,
-  EntryControlEventTypes,
-  EntryControlCCConfigurationGet,
-  EntryControlCCConfigurationSet,
-  EntryControlCCConfigurationReport,
-  EntryControlCCEventSupportedGet,
-  EntryControlCCEventSupportedReport,
-  EntryControlCCKeySupportedGet,
-  EntryControlCCKeySupportedReport,
+	EntryControlCCConfigurationGet,
+	EntryControlCCConfigurationReport,
+	EntryControlCCConfigurationSet,
+	EntryControlCCEventSupportedGet,
+	EntryControlCCEventSupportedReport,
+	EntryControlCCKeySupportedGet,
+	EntryControlCCKeySupportedReport,
+	EntryControlCommand,
+	EntryControlDataTypes,
+	EntryControlEventTypes,
 } from "./EntryControlCC";
 
 const fakeDriver = (createEmptyMockDriver() as unknown) as Driver;
@@ -27,119 +27,123 @@ function buildCCBuffer(payload: Buffer): Buffer {
 
 describe("lib/commandclass/EntryControlCC => ", () => {
 	it("the ConfigurationGet command should serialize correctly", () => {
-		const cc = new EntryControlCCConfigurationGet(fakeDriver, { nodeId: 1 });
+		const cc = new EntryControlCCConfigurationGet(fakeDriver, {
+			nodeId: 1,
+		});
 		const expected = buildCCBuffer(
 			Buffer.from([
 				EntryControlCommand.ConfigurationGet, // CC Command
 			]),
-    );
+		);
 		expect(cc.serialize()).toEqual(expected);
-  });
+	});
 
 	it("the ConfigurationSet command should serialize correctly", () => {
 		const cc = new EntryControlCCConfigurationSet(fakeDriver, {
-      nodeId: 1,
-      keyCacheSize: 1,
-      keyCacheTimeout: 2,
-    });
+			nodeId: 1,
+			keyCacheSize: 1,
+			keyCacheTimeout: 2,
+		});
 		const expected = buildCCBuffer(
 			Buffer.from([
-        EntryControlCommand.ConfigurationSet, // CC Command
-        0x1,
-        0x2,
+				EntryControlCommand.ConfigurationSet, // CC Command
+				0x1,
+				0x2,
 			]),
-    );
+		);
 		expect(cc.serialize()).toEqual(expected);
-  });
+	});
 
-  it("the ConfigurationReport command should be deserialize correctly", () => {
-    const data = buildCCBuffer(
+	it("the ConfigurationReport command should be deserialize correctly", () => {
+		const data = buildCCBuffer(
 			Buffer.from([
-        EntryControlCommand.ConfigurationReport, // CC Command
-        0x1,
-        0x2,
+				EntryControlCommand.ConfigurationReport, // CC Command
+				0x1,
+				0x2,
 			]),
-    );
+		);
 
 		const cc = new EntryControlCCConfigurationReport(fakeDriver, {
-      nodeId: 1,
-      data
-    });
+			nodeId: 1,
+			data,
+		});
 
-    expect(cc.keyCachedSize).toEqual(1);
-    expect(cc.keyCachedTimeout).toEqual(2);
-  });
+		expect(cc.keyCachedSize).toEqual(1);
+		expect(cc.keyCachedTimeout).toEqual(2);
+	});
 
-  it("the EventSupportedGet command should serialize correctly", () => {
-		const cc = new EntryControlCCEventSupportedGet(fakeDriver, { nodeId: 1 });
+	it("the EventSupportedGet command should serialize correctly", () => {
+		const cc = new EntryControlCCEventSupportedGet(fakeDriver, {
+			nodeId: 1,
+		});
 		const expected = buildCCBuffer(
 			Buffer.from([
 				EntryControlCommand.EventSupportedGet, // CC Command
 			]),
-    );
+		);
 		expect(cc.serialize()).toEqual(expected);
-  });
+	});
 
-  it("the EventSupportedReport command should be deserialize correctly", () => {
-    const data = buildCCBuffer(
+	it("the EventSupportedReport command should be deserialize correctly", () => {
+		const data = buildCCBuffer(
 			Buffer.from([
-        EntryControlCommand.EventSupportedReport, // CC Command
-        1,
-        0b00000100,
-        4,
-        0b01101000,
-        0b00000000,
-        0b00000000,
-        0b00000010,
-        0,
-        5,
-        1,
-        10,
+				EntryControlCommand.EventSupportedReport, // CC Command
+				1,
+				0b00000100,
+				4,
+				0b01101000,
+				0b00000000,
+				0b00000000,
+				0b00000010,
+				0,
+				5,
+				1,
+				10,
 			]),
-    );
+		);
 
 		const cc = new EntryControlCCEventSupportedReport(fakeDriver, {
-      nodeId: 1,
-      data
-    });
+			nodeId: 1,
+			data,
+		});
 
-    expect(cc.dataTypeSupported).toEqual([EntryControlDataTypes.Ascii]);
-    expect(cc.eventTypeSupported).toEqual([
-      EntryControlEventTypes.DisarmAll,
-      EntryControlEventTypes.ArmAway,
-      EntryControlEventTypes.ArmHome,
-      EntryControlEventTypes.Cancel,
-    ]);
-    expect(cc.keyCachedSizeMin).toEqual(0);
-    expect(cc.keyCachedSizeMax).toEqual(5);
-    expect(cc.keyCachedTimeoutMin).toEqual(1);
-    expect(cc.keyCachedTimeoutMax).toEqual(10);
-  });
+		expect(cc.dataTypeSupported).toEqual([EntryControlDataTypes.Ascii]);
+		expect(cc.eventTypeSupported).toEqual([
+			EntryControlEventTypes.DisarmAll,
+			EntryControlEventTypes.ArmAway,
+			EntryControlEventTypes.ArmHome,
+			EntryControlEventTypes.Cancel,
+		]);
+		expect(cc.keyCachedSizeMin).toEqual(0);
+		expect(cc.keyCachedSizeMax).toEqual(5);
+		expect(cc.keyCachedTimeoutMin).toEqual(1);
+		expect(cc.keyCachedTimeoutMax).toEqual(10);
+	});
 
-  it("the KeySupportedGet command should serialize correctly", () => {
+	it("the KeySupportedGet command should serialize correctly", () => {
 		const cc = new EntryControlCCKeySupportedGet(fakeDriver, { nodeId: 1 });
 		const expected = buildCCBuffer(
 			Buffer.from([
 				EntryControlCommand.KeySupportedGet, // CC Command
 			]),
-    );
+		);
 		expect(cc.serialize()).toEqual(expected);
-  });
+	});
 
-  it("the KeySupportedReport command should be deserialize correctly", () => {
-    const data = buildCCBuffer(
+	it("the KeySupportedReport command should be deserialize correctly", () => {
+		const data = buildCCBuffer(
 			Buffer.from([
-        EntryControlCommand.KeySupportedReport, // CC Command
-        1,
-        0b01011010,
+				EntryControlCommand.KeySupportedReport, // CC Command
+				1,
+				0b01011010,
 			]),
-    );
+		);
 
 		const cc = new EntryControlCCKeySupportedReport(fakeDriver, {
-      nodeId: 1,
-      data
-    });
+			nodeId: 1,
+			data,
+		});
 
-    expect(cc.keySupported).toEqual([1,3,4,6]);
-  });
+		expect(cc.keySupported).toEqual([1, 3, 4, 6]);
+	});
 });

--- a/packages/zwave-js/src/lib/commandclass/EntryControlCC.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/EntryControlCC.test.ts
@@ -68,8 +68,8 @@ describe("lib/commandclass/EntryControlCC => ", () => {
 			data,
 		});
 
-		expect(cc.keyCachedSize).toEqual(1);
-		expect(cc.keyCachedTimeout).toEqual(2);
+		expect(cc.keyCacheSize).toEqual(1);
+		expect(cc.keyCacheTimeout).toEqual(2);
 	});
 
 	it("the EventSupportedGet command should serialize correctly", () => {
@@ -107,17 +107,17 @@ describe("lib/commandclass/EntryControlCC => ", () => {
 			data,
 		});
 
-		expect(cc.dataTypeSupported).toEqual([EntryControlDataTypes.Ascii]);
-		expect(cc.eventTypeSupported).toEqual([
+		expect(cc.supportedDataTypes).toEqual([EntryControlDataTypes.ASCII]);
+		expect(cc.supportedEventTypes).toEqual([
 			EntryControlEventTypes.DisarmAll,
 			EntryControlEventTypes.ArmAway,
 			EntryControlEventTypes.ArmHome,
 			EntryControlEventTypes.Cancel,
 		]);
-		expect(cc.keyCachedSizeMin).toEqual(0);
-		expect(cc.keyCachedSizeMax).toEqual(5);
-		expect(cc.keyCachedTimeoutMin).toEqual(1);
-		expect(cc.keyCachedTimeoutMax).toEqual(10);
+		expect(cc.minKeyCacheSize).toEqual(0);
+		expect(cc.maxKeyCacheSize).toEqual(5);
+		expect(cc.minKeyCacheTimeout).toEqual(1);
+		expect(cc.maxKeyCacheTimeout).toEqual(10);
 	});
 
 	it("the KeySupportedGet command should serialize correctly", () => {
@@ -144,6 +144,6 @@ describe("lib/commandclass/EntryControlCC => ", () => {
 			data,
 		});
 
-		expect(cc.keySupported).toEqual([1, 3, 4, 6]);
+		expect(cc.supportedKeys).toEqual([1, 3, 4, 6]);
 	});
 });

--- a/packages/zwave-js/src/lib/commandclass/EntryControlCC.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/EntryControlCC.test.ts
@@ -1,0 +1,145 @@
+import { CommandClasses } from "@zwave-js/core";
+import type { Driver } from "../driver/Driver";
+import { createEmptyMockDriver } from "../test/mocks";
+import {
+  EntryControlCommand,
+  EntryControlDataTypes,
+  EntryControlEventTypes,
+  EntryControlCCConfigurationGet,
+  EntryControlCCConfigurationSet,
+  EntryControlCCConfigurationReport,
+  EntryControlCCEventSupportedGet,
+  EntryControlCCEventSupportedReport,
+  EntryControlCCKeySupportedGet,
+  EntryControlCCKeySupportedReport,
+} from "./EntryControlCC";
+
+const fakeDriver = (createEmptyMockDriver() as unknown) as Driver;
+
+function buildCCBuffer(payload: Buffer): Buffer {
+	return Buffer.concat([
+		Buffer.from([
+			CommandClasses["Entry Control"], // CC
+		]),
+		payload,
+	]);
+}
+
+describe("lib/commandclass/EntryControlCC => ", () => {
+	it("the ConfigurationGet command should serialize correctly", () => {
+		const cc = new EntryControlCCConfigurationGet(fakeDriver, { nodeId: 1 });
+		const expected = buildCCBuffer(
+			Buffer.from([
+				EntryControlCommand.ConfigurationGet, // CC Command
+			]),
+    );
+		expect(cc.serialize()).toEqual(expected);
+  });
+
+	it("the ConfigurationSet command should serialize correctly", () => {
+		const cc = new EntryControlCCConfigurationSet(fakeDriver, {
+      nodeId: 1,
+      keyCacheSize: 1,
+      keyCacheTimeout: 2,
+    });
+		const expected = buildCCBuffer(
+			Buffer.from([
+        EntryControlCommand.ConfigurationSet, // CC Command
+        0x1,
+        0x2,
+			]),
+    );
+		expect(cc.serialize()).toEqual(expected);
+  });
+
+  it("the ConfigurationReport command should be deserialize correctly", () => {
+    const data = buildCCBuffer(
+			Buffer.from([
+        EntryControlCommand.ConfigurationReport, // CC Command
+        0x1,
+        0x2,
+			]),
+    );
+
+		const cc = new EntryControlCCConfigurationReport(fakeDriver, {
+      nodeId: 1,
+      data
+    });
+
+    expect(cc.keyCachedSize).toEqual(1);
+    expect(cc.keyCachedTimeout).toEqual(2);
+  });
+
+  it("the EventSupportedGet command should serialize correctly", () => {
+		const cc = new EntryControlCCEventSupportedGet(fakeDriver, { nodeId: 1 });
+		const expected = buildCCBuffer(
+			Buffer.from([
+				EntryControlCommand.EventSupportedGet, // CC Command
+			]),
+    );
+		expect(cc.serialize()).toEqual(expected);
+  });
+
+  it("the EventSupportedReport command should be deserialize correctly", () => {
+    const data = buildCCBuffer(
+			Buffer.from([
+        EntryControlCommand.EventSupportedReport, // CC Command
+        1,
+        0b00000100,
+        4,
+        0b01101000,
+        0b00000000,
+        0b00000000,
+        0b00000010,
+        0,
+        5,
+        1,
+        10,
+			]),
+    );
+
+		const cc = new EntryControlCCEventSupportedReport(fakeDriver, {
+      nodeId: 1,
+      data
+    });
+
+    expect(cc.dataTypeSupported).toEqual([EntryControlDataTypes.Ascii]);
+    expect(cc.eventTypeSupported).toEqual([
+      EntryControlEventTypes.DisarmAll,
+      EntryControlEventTypes.ArmAway,
+      EntryControlEventTypes.ArmHome,
+      EntryControlEventTypes.Cancel,
+    ]);
+    expect(cc.keyCachedSizeMin).toEqual(0);
+    expect(cc.keyCachedSizeMax).toEqual(5);
+    expect(cc.keyCachedTimeoutMin).toEqual(1);
+    expect(cc.keyCachedTimeoutMax).toEqual(10);
+  });
+
+  it("the KeySupportedGet command should serialize correctly", () => {
+		const cc = new EntryControlCCKeySupportedGet(fakeDriver, { nodeId: 1 });
+		const expected = buildCCBuffer(
+			Buffer.from([
+				EntryControlCommand.KeySupportedGet, // CC Command
+			]),
+    );
+		expect(cc.serialize()).toEqual(expected);
+  });
+
+  it("the KeySupportedReport command should be deserialize correctly", () => {
+    const data = buildCCBuffer(
+			Buffer.from([
+        EntryControlCommand.KeySupportedReport, // CC Command
+        1,
+        0b01011010,
+			]),
+    );
+
+		const cc = new EntryControlCCKeySupportedReport(fakeDriver, {
+      nodeId: 1,
+      data
+    });
+
+    expect(cc.keySupported).toEqual([1,3,4,6]);
+  });
+});

--- a/packages/zwave-js/src/lib/commandclass/EntryControlCC.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/EntryControlCC.test.ts
@@ -10,6 +10,7 @@ import {
 	EntryControlCCEventSupportedReport,
 	EntryControlCCKeySupportedGet,
 	EntryControlCCKeySupportedReport,
+	EntryControlCCNotification,
 	EntryControlCommand,
 	EntryControlDataTypes,
 	EntryControlEventTypes,
@@ -36,6 +37,32 @@ describe("lib/commandclass/EntryControlCC => ", () => {
 			isSupported: true,
 			version: 1,
 		});
+	});
+
+	it("the Notification command should deserialize correctly", () => {
+		const data = buildCCBuffer(
+			Buffer.from([
+				EntryControlCommand.Notification, // CC Command
+				0x1,
+				0x2,
+				0x3,
+				4,
+				49,
+				50,
+				51,
+				52,
+			]),
+		);
+
+		const cc = new EntryControlCCNotification(fakeDriver, {
+			nodeId: 1,
+			data,
+		});
+
+		expect(cc.sequenceNumber).toEqual(1);
+		expect(cc.dataType).toEqual(EntryControlDataTypes.ASCII);
+		expect(cc.eventType).toEqual(EntryControlEventTypes.DisarmAll);
+		expect(cc.eventData).toEqual("1234");
 	});
 
 	it("the ConfigurationGet command should serialize correctly", () => {

--- a/packages/zwave-js/src/lib/commandclass/EntryControlCC.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/EntryControlCC.test.ts
@@ -1,5 +1,6 @@
 import { CommandClasses } from "@zwave-js/core";
 import type { Driver } from "../driver/Driver";
+import { ZWaveNode } from "../node/Node";
 import { createEmptyMockDriver } from "../test/mocks";
 import {
 	EntryControlCCConfigurationGet,
@@ -14,8 +15,6 @@ import {
 	EntryControlEventTypes,
 } from "./EntryControlCC";
 
-const fakeDriver = (createEmptyMockDriver() as unknown) as Driver;
-
 function buildCCBuffer(payload: Buffer): Buffer {
 	return Buffer.concat([
 		Buffer.from([
@@ -26,6 +25,19 @@ function buildCCBuffer(payload: Buffer): Buffer {
 }
 
 describe("lib/commandclass/EntryControlCC => ", () => {
+	let fakeDriver: Driver;
+	let node1: ZWaveNode;
+
+	beforeAll(() => {
+		fakeDriver = (createEmptyMockDriver() as unknown) as Driver;
+		node1 = new ZWaveNode(1, fakeDriver as any);
+		(fakeDriver.controller.nodes as any).set(1, node1);
+		node1.addCC(CommandClasses["Entry Control"], {
+			isSupported: true,
+			version: 1,
+		});
+	});
+
 	it("the ConfigurationGet command should serialize correctly", () => {
 		const cc = new EntryControlCCConfigurationGet(fakeDriver, {
 			nodeId: 1,
@@ -95,10 +107,10 @@ describe("lib/commandclass/EntryControlCC => ", () => {
 				0b00000000,
 				0b00000000,
 				0b00000010,
-				0,
-				5,
 				1,
-				10,
+				20,
+				2,
+				9,
 			]),
 		);
 
@@ -114,10 +126,10 @@ describe("lib/commandclass/EntryControlCC => ", () => {
 			EntryControlEventTypes.ArmHome,
 			EntryControlEventTypes.Cancel,
 		]);
-		expect(cc.minKeyCacheSize).toEqual(0);
-		expect(cc.maxKeyCacheSize).toEqual(5);
-		expect(cc.minKeyCacheTimeout).toEqual(1);
-		expect(cc.maxKeyCacheTimeout).toEqual(10);
+		expect(cc.minKeyCacheSize).toEqual(1);
+		expect(cc.maxKeyCacheSize).toEqual(20);
+		expect(cc.minKeyCacheTimeout).toEqual(2);
+		expect(cc.maxKeyCacheTimeout).toEqual(9);
 	});
 
 	it("the KeySupportedGet command should serialize correctly", () => {

--- a/packages/zwave-js/src/lib/commandclass/EntryControlCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/EntryControlCC.ts
@@ -397,7 +397,7 @@ export class EntryControlCCEventSupportedReport extends EntryControlCC {
 
 		const eventTypeLength = this.payload[1 + dataTypeLength] & 0b0001_1111;
 		validatePayload(this.payload.length >= 6 + dataTypeLength + eventTypeLength);
-		this._eventTypeSupported = parseBitMask(this.payload.slice(1, 2 + dataTypeLength + eventTypeLength), 0);
+		this._eventTypeSupported = parseBitMask(this.payload.slice(2 + dataTypeLength, 2 + dataTypeLength + eventTypeLength), 0);
 
 		const minMaxStart = 2 + dataTypeLength + eventTypeLength;
 		this._keyCachedSizeMin = this.payload[minMaxStart];
@@ -481,8 +481,8 @@ export class EntryControlCCEventSupportedReport extends EntryControlCC {
 		return {
 			...super.toLogEntry(),
 			message: {
-				"supported data types": this.dataTypeSupported.toString(),
-				"supported event types": this.eventTypeSupported.toString(),
+				"supported data types": this.dataTypeSupported.map((dt) => EntryControlDataTypes[dt]).toString(),
+				"supported event types": this.eventTypeSupported.map((et) => EntryControlEventTypes[et]).toString(),
 				"min key cached size": this.keyCachedSizeMin,
 				"max key cached size": this.keyCachedSizeMax,
 				"min key cached timeout": this.keyCachedTimeoutMin,

--- a/packages/zwave-js/src/lib/commandclass/EntryControlCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/EntryControlCC.ts
@@ -1,0 +1,600 @@
+import {
+	API,
+	CCCommand,
+	CCCommandOptions,
+	CommandClass,
+	commandClass,
+	ccValue,
+	ccValueMetadata,
+	expectedCCResponse,
+	implementedVersion,
+	CommandClassDeserializationOptions,
+	gotDeserializationOptions,
+} from "./CommandClass";
+import type {
+	Maybe,
+	MessageOrCCLogEntry,
+	MessageRecord,
+	ValueID,
+} from "@zwave-js/core";
+import {
+	CommandClasses,
+	validatePayload,
+	ZWaveError,
+	ZWaveErrorCodes,
+	ValueMetadata,
+	parseBitMask,
+} from "@zwave-js/core";
+import { pick } from "@zwave-js/shared";
+import {
+	CCAPI,
+	PollValueImplementation,
+	POLL_VALUE,
+	SetValueImplementation,
+	SET_VALUE,
+	throwUnsupportedProperty,
+	throwWrongValueType,
+} from "./API";
+import type { Driver } from "../driver/Driver";
+import { MessagePriority } from "../message/Constants";
+
+// All the supported commands
+export enum EntryControlCommand {
+	Notification = 0x01,
+	KeySupportedGet = 0x02,
+	KeySupportedReport = 0x03,
+	EventSupportedGet = 0x04,
+	EventSupportedReport = 0x05,
+	ConfigurationSet = 0x06,
+	ConfigurationGet = 0x07,
+	ConfigurationReport = 0x08,
+}
+
+export enum EntryControlEventTypes {
+	Caching = 0x00,
+	CachedKeys = 0x01,
+	Enter = 0x02,
+	DisarmAll = 0x03,
+	ArmAll = 0x04,
+	ArmAway = 0x05,
+	ArmHome = 0x06,
+	ExitDelay = 0x07,
+	Arm1 = 0x08,
+	Arm2 = 0x09,
+	Arm3 = 0x0A,
+	Arm4 = 0x0B,
+	Arm5 = 0x0C,
+	Arm6 = 0x0D,
+	Rfid = 0x0E,
+	Bell = 0x0F,
+	Fire = 0x10,
+	Police = 0x11,
+	AlertPanic = 0x12,
+	AlertMedical = 0x13,
+	GateOpen = 0x14,
+	GateClose = 0x15,
+	Lock = 0x16,
+	Unlock = 0x17,
+	Test = 0x18,
+	Cancel = 0x19,
+}
+
+export enum EntryControlDataTypes {
+	NA = 0x00,
+	Raw = 0x01,
+	Ascii = 0x02,
+	Md5 = 0x03,
+}
+
+export function getKeyCachedSizeStateValueID(endpoint: number): ValueID {
+	return {
+		commandClass: CommandClasses["Entry Control"],
+		endpoint,
+		property: "keyCachedSize",
+	};
+}
+
+export function getKeyCachedTimeoutStateValueID(endpoint: number): ValueID {
+	return {
+		commandClass: CommandClasses["Entry Control"],
+		endpoint,
+		property: "keyCachedTimeout",
+	};
+}
+
+@API(CommandClasses["Entry Control"])
+export class EntryControlCCAPI extends CCAPI {
+
+	public supportsCommand(cmd: EntryControlCommand): Maybe<boolean> {
+		switch (cmd) {
+			case EntryControlCommand.KeySupportedGet:
+			case EntryControlCommand.EventSupportedGet:
+			case EntryControlCommand.ConfigurationGet:
+				return this.isSinglecast();
+			case EntryControlCommand.ConfigurationSet:
+				return true;
+		}
+		return super.supportsCommand(cmd);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+	public async getKeySupported() {
+		this.assertSupportsCommand(
+			EntryControlCommand,
+			EntryControlCommand.KeySupportedGet,
+		);
+
+		const cc = new EntryControlCCKeySupportedGet(this.driver, {
+			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
+		});
+		const response = await this.driver.sendCommand<EntryControlCCKeySupportedReport>(
+			cc,
+			this.commandOptions,
+		);
+		if (response) {
+			return pick(response, ["keySupported"]);
+		}
+	}
+
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+	public async getEventSupported() {
+		this.assertSupportsCommand(
+			EntryControlCommand,
+			EntryControlCommand.EventSupportedGet,
+		);
+
+		const cc = new EntryControlCCEventSupportedGet(this.driver, {
+			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
+		});
+		const response = await this.driver.sendCommand<EntryControlCCEventSupportedReport>(
+			cc,
+			this.commandOptions,
+		);
+		if (response) {
+			return pick(response, [
+				"dataTypeSupported",
+				"eventTypeSupported",
+				"keyCachedSizeMin",
+				"keyCachedSizeMax",
+				"keyCachedTimeoutMin",
+				"keyCachedTimeoutMax",
+			]);
+		}
+	}
+
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+	public async getConfiguration() {
+		this.assertSupportsCommand(
+			EntryControlCommand,
+			EntryControlCommand.ConfigurationGet,
+		);
+
+		const cc = new EntryControlCCConfigurationGet(this.driver, {
+			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
+		});
+		const response = await this.driver.sendCommand<EntryControlCCConfigurationReport>(
+			cc,
+			this.commandOptions,
+		);
+		if (response) {
+			return pick(response, ["keyCachedSize", "keyCachedTimeout"]);
+		}
+	}
+
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+	public async setConfiguration(keyCacheSize: number, keyCacheTimeout: number) {
+		this.assertSupportsCommand(
+			EntryControlCommand,
+			EntryControlCommand.ConfigurationGet,
+		);
+
+		const cc = new EntryControlCCConfigurationSet(this.driver, {
+			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
+			keyCacheSize,
+			keyCacheTimeout,
+		});
+		const response = await this.driver.sendCommand<EntryControlCCConfigurationReport>(
+			cc,
+			this.commandOptions,
+		);
+		if (response) {
+			return pick(response, ["keyCachedSize", "keyCachedTimeout"]);
+		}
+	}
+
+	protected [SET_VALUE]: SetValueImplementation = async (
+		{ property },
+		value,
+	): Promise<void> => {
+		if (property !== "keyCachedSize" && property !== "keyCachedTimeout") {
+			throwUnsupportedProperty(this.ccId, property);
+		}
+		if (typeof value !== "number") {
+			throwWrongValueType(this.ccId, property, "number", typeof value);
+		}
+		const valueDB = this.endpoint.getNodeUnsafe()!.valueDB;
+
+		let keyCachedSize = value;
+		let keyCachedTimeout: number = value;
+		if (property === "keyCachedSize") {
+			const oldKeyCachedTimeout = valueDB.getValue<number>(
+				getKeyCachedTimeoutStateValueID(this.endpoint.index),
+			);
+			if (oldKeyCachedTimeout == undefined) {
+				throw new ZWaveError(
+					`The "keyCachedSize" property cannot be changed before the key cached timeout is known!`,
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
+			keyCachedTimeout = oldKeyCachedTimeout;
+		} else {
+			const oldKeyCachedSize = valueDB.getValue<number>(
+				getKeyCachedSizeStateValueID(this.endpoint.index),
+			);
+			if (oldKeyCachedSize == undefined) {
+				throw new ZWaveError(
+					`The "keyCachedTimeout" property cannot be changed before the key cached size is known!`,
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
+			keyCachedSize = oldKeyCachedSize;
+		}
+		await this.setConfiguration(keyCachedSize, keyCachedTimeout);
+	};
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+	}): Promise<unknown> => {
+		switch (property) {
+			case "dataTypeSupported":
+			case "eventTypeSupported":
+			case "keyCachedSizeMin":
+			case "keyCachedSizeMax":
+			case "keyCachedTimeoutMin":
+			case "keyCachedTimeoutMax":
+				return (await this.getEventSupported())?.[property];
+			case "keySupported":
+				return (await this.getKeySupported())?.[property];
+			case "keyCachedSize":
+			case "keyCachedTimeout":
+				return (await this.getConfiguration())?.[property];
+		}
+		throwUnsupportedProperty(this.ccId, property);
+	};
+}
+
+@commandClass(CommandClasses["Entry Control"])
+@implementedVersion(1)
+export class EntryControlCC extends CommandClass {
+	declare ccCommand: EntryControlCommand;
+
+	public async interview(complete: boolean = true): Promise<void> {
+		const node = this.getNode()!;
+		const endpoint = this.getEndpoint()!;
+		const api = endpoint.commandClasses["Entry Control"].withOptions({
+			priority: MessagePriority.NodeQuery,
+		});
+
+		await api.getKeySupported();
+		await api.getEventSupported();
+		await api.getConfiguration();
+
+		// Remember that the interview is complete
+		this.interviewComplete = true;
+	}
+}
+
+@CCCommand(EntryControlCommand.Notification)
+export class EntryControlCCNotication extends EntryControlCC {
+	public constructor(
+		driver: Driver,
+		options: CommandClassDeserializationOptions,
+	) {
+		super(driver, options);
+
+		validatePayload(this.payload.length >= 4);
+		this._sequenceNumber = this.payload[0];
+		this._dataType = this.payload[1] & 0b11;
+		this._eventType = this.payload[2];
+		const eventDataLength = this.payload[3];
+
+		validatePayload(this.payload.length >= 4 + eventDataLength);
+		this._eventData = Buffer.from(this.payload.slice(4, 4 + eventDataLength));
+	}
+
+	private _sequenceNumber: number;
+	public get sequenceNumber(): number {
+		return this._sequenceNumber;
+	}
+
+	private _dataType: EntryControlDataTypes;
+	public get dataType(): EntryControlDataTypes {
+		return this._dataType;
+	}
+
+	private _eventType: EntryControlEventTypes;
+	public get eventType(): EntryControlEventTypes {
+		return this._eventType;
+	}
+
+	private _eventData: Buffer;
+	public get eventData(): Buffer {
+		return this._eventData;
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		const message: MessageRecord = {
+			"sequence number": this.sequenceNumber,
+			"data type": this.dataType,
+			"event type": this.eventType,
+			"event data": this.eventData.toString(),
+		};
+		return {
+			...super.toLogEntry(),
+			message,
+		};
+	}
+}
+
+@CCCommand(EntryControlCommand.KeySupportedReport)
+export class EntryControlCCKeySupportedReport extends EntryControlCC {
+	public constructor(
+		driver: Driver,
+		options: CommandClassDeserializationOptions,
+	) {
+		super(driver, options);
+
+		validatePayload(this.payload.length >= 1);
+		const length = this.payload[0];
+		validatePayload(this.payload.length >= 1 + length);
+		this._keySupported = parseBitMask(this.payload.slice(1, 1 + length), 0);
+		this.persistValues();
+	}
+
+	private _keySupported: number[];
+
+	@ccValue()
+	@ccValueMetadata({
+		...ValueMetadata.ReadOnly,
+		type: "number[]",
+		label: "Supported keys",
+		description:
+			"A list of supported keys",
+	})
+	public get keySupported(): number[] {
+		return this._keySupported;
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: { "supported keys": this.keySupported.toString() },
+		};
+	}
+}
+
+@CCCommand(EntryControlCommand.KeySupportedGet)
+@expectedCCResponse(EntryControlCCKeySupportedReport)
+export class EntryControlCCKeySupportedGet extends EntryControlCC {}
+
+@CCCommand(EntryControlCommand.EventSupportedReport)
+export class EntryControlCCEventSupportedReport extends EntryControlCC {
+	public constructor(
+		driver: Driver,
+		options: CommandClassDeserializationOptions,
+	) {
+		super(driver, options);
+
+		validatePayload(this.payload.length >= 6);
+
+		const dataTypeLength = this.payload[0] & 0b0000_0011;
+		validatePayload(this.payload.length >= 6 + dataTypeLength);
+		this._dataTypeSupported = parseBitMask(this.payload.slice(1, 1 + dataTypeLength), 0);
+
+		const eventTypeLength = this.payload[1 + dataTypeLength] & 0b0001_1111;
+		validatePayload(this.payload.length >= 6 + dataTypeLength + eventTypeLength);
+		this._eventTypeSupported = parseBitMask(this.payload.slice(1, 2 + dataTypeLength + eventTypeLength), 0);
+
+		const minMaxStart = 2 + dataTypeLength + eventTypeLength;
+		this._keyCachedSizeMin = this.payload[minMaxStart];
+		this._keyCachedSizeMax = this.payload[minMaxStart + 1];
+		this._keyCachedTimeoutMin = this.payload[minMaxStart + 2];
+		this._keyCachedTimeoutMax = this.payload[minMaxStart + 3];
+		this.persistValues();
+	}
+
+	private _dataTypeSupported: EntryControlDataTypes[];
+
+	@ccValue()
+	@ccValueMetadata({
+		...ValueMetadata.ReadOnly,
+		type: "number[]",
+		label: "Supported data types",
+		description: "A list of supported data types",
+	})
+	public get dataTypeSupported(): EntryControlDataTypes[] {
+		return this._dataTypeSupported;
+	}
+
+	private _eventTypeSupported: EntryControlEventTypes[];
+
+	@ccValue()
+	@ccValueMetadata({
+		...ValueMetadata.ReadOnly,
+		type: "number[]",
+		label: "Supported event types",
+		description: "A list of supported event types",
+	})
+	public get eventTypeSupported(): EntryControlEventTypes[] {
+		return this._eventTypeSupported;
+	}
+
+	private _keyCachedSizeMin: number;
+
+	@ccValue()
+	@ccValueMetadata({
+		...ValueMetadata.ReadOnlyUInt8,
+		label: "Minimum supported value of key cache size",
+	})
+	public get keyCachedSizeMin(): number {
+		return this._keyCachedSizeMin;
+	}
+
+	private _keyCachedSizeMax: number;
+
+	@ccValue()
+	@ccValueMetadata({
+		...ValueMetadata.ReadOnlyUInt8,
+		label: "Maximum supported value of key cache size",
+	})
+	public get keyCachedSizeMax(): number {
+		return this._keyCachedSizeMax;
+	}
+
+	private _keyCachedTimeoutMin: number;
+
+	@ccValue()
+	@ccValueMetadata({
+		...ValueMetadata.ReadOnlyUInt8,
+		label: "Minimum supported value of key cache timeout",
+	})
+	public get keyCachedTimeoutMin(): number {
+		return this._keyCachedTimeoutMin;
+	}
+
+	private _keyCachedTimeoutMax: number;
+
+	@ccValue()
+	@ccValueMetadata({
+		...ValueMetadata.ReadOnlyUInt8,
+		label: "Maximum supported value of key cache timeout",
+	})
+	public get keyCachedTimeoutMax(): number {
+		return this._keyCachedTimeoutMax;
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: {
+				"supported data types": this.dataTypeSupported.toString(),
+				"supported event types": this.eventTypeSupported.toString(),
+				"min key cached size": this.keyCachedSizeMin,
+				"max key cached size": this.keyCachedSizeMax,
+				"min key cached timeout": this.keyCachedTimeoutMin,
+				"max key cached timeout": this.keyCachedTimeoutMax,
+			},
+		};
+	}
+}
+
+@CCCommand(EntryControlCommand.EventSupportedGet)
+@expectedCCResponse(EntryControlCCEventSupportedReport)
+export class EntryControlCCEventSupportedGet extends EntryControlCC {}
+
+@CCCommand(EntryControlCommand.ConfigurationReport)
+export class EntryControlCCConfigurationReport extends EntryControlCC {
+	public constructor(
+		driver: Driver,
+		options: CommandClassDeserializationOptions,
+	) {
+		super(driver, options);
+
+		validatePayload(this.payload.length >= 2);
+
+		this._keyCachedSize = this.payload[0];
+		this._keyCachedTimeout = this.payload[1];
+		this.persistValues();
+	}
+
+	private _keyCachedSize: number;
+
+	@ccValue()
+	@ccValueMetadata({
+		...ValueMetadata.UInt8,
+		label: "Key cache size",
+		description:
+			"Number of character that must be stored before sending",
+	})
+	public get keyCachedSize(): number {
+		return this._keyCachedSize;
+	}
+
+	private _keyCachedTimeout: number;
+
+	@ccValue()
+	@ccValueMetadata({
+		...ValueMetadata.UInt8,
+		label: "Key cache timeout",
+		description:
+			"Number of seconds that the key cache must wait for additional characters",
+	})
+	public get keyCachedTimeout(): number {
+		return this._keyCachedTimeout;
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: {
+				"key cached size": this.keyCachedSize,
+				"key cached timeout": this.keyCachedTimeout,
+			},
+		};
+	}
+}
+
+@CCCommand(EntryControlCommand.ConfigurationGet)
+@expectedCCResponse(EntryControlCCConfigurationReport)
+export class EntryControlCCConfigurationGet extends EntryControlCC {}
+
+interface EntryControlCCConfigurationSetOptions extends CCCommandOptions {
+	keyCacheSize: number;
+	keyCacheTimeout: number;
+}
+
+@CCCommand(EntryControlCommand.ConfigurationSet)
+@expectedCCResponse(EntryControlCCConfigurationReport)
+export class EntryControlCCConfigurationSet extends EntryControlCC {
+	public constructor(
+		driver: Driver,
+		options: CommandClassDeserializationOptions | EntryControlCCConfigurationSetOptions,
+	) {
+		super(driver, options);
+		if (gotDeserializationOptions(options)) {
+			// TODO: Deserialize payload
+			throw new ZWaveError(
+				`${this.constructor.name}: deserialization not implemented`,
+				ZWaveErrorCodes.Deserialization_NotImplemented,
+			);
+		} else {
+			this.keyCacheSize = options.keyCacheSize;
+			this.keyCacheTimeout = options.keyCacheTimeout;
+		}
+	}
+
+	public keyCacheSize: number;
+	public keyCacheTimeout: number;
+
+	public serialize(): Buffer {
+		this.payload = Buffer.from([
+			this.keyCacheSize,
+			this.keyCacheTimeout,
+		]);
+		return super.serialize();
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: {
+				"key cache size": this.keyCacheSize,
+				"key cache timeout": this.keyCacheTimeout,
+			},
+		};
+	}
+}

--- a/packages/zwave-js/src/lib/commandclass/EntryControlCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/EntryControlCC.ts
@@ -476,16 +476,12 @@ export class EntryControlCCEventSupportedReport extends EntryControlCC {
 	@ccValue({ internal: true })
 	public readonly supportedEventTypes: readonly EntryControlEventTypes[];
 
-	@ccValue({ internal: true })
 	public readonly minKeyCacheSize: number;
 
-	@ccValue({ internal: true })
 	public readonly maxKeyCacheSize: number;
 
-	@ccValue({ internal: true })
 	public readonly minKeyCacheTimeout: number;
 
-	@ccValue({ internal: true })
 	public readonly maxKeyCacheTimeout: number;
 
 	public toLogEntry(): MessageOrCCLogEntry {

--- a/packages/zwave-js/src/lib/node/Node.test.ts
+++ b/packages/zwave-js/src/lib/node/Node.test.ts
@@ -13,6 +13,12 @@ import {
 	BinarySwitchCCReport,
 	BinarySwitchCommand,
 } from "../commandclass/BinarySwitchCC";
+import {
+	EntryControlCCNotification,
+	EntryControlCommand,
+	EntryControlDataTypes,
+	EntryControlEventTypes,
+} from "../commandclass/EntryControlCC";
 import { NoOperationCC } from "../commandclass/NoOperationCC";
 import { WakeUpCC, WakeUpCommand } from "../commandclass/WakeUpCC";
 import {
@@ -1461,6 +1467,52 @@ describe("lib/node/Node", () => {
 			).toBe(true);
 
 			node.destroy();
+		});
+
+		it("event is sent when recieving a EntryControlNotification", async () => {
+			const node = makeNode([
+				[
+					CommandClasses["Entry Control"],
+					{ isSupported: true, version: 1 },
+				],
+			]);
+
+			const onEntryControlNotification = jest.fn();
+
+			node.on("entry control notification", onEntryControlNotification);
+
+			const buf = Buffer.from([
+				CommandClasses["Entry Control"],
+				EntryControlCommand.Notification, // CC Command
+				0x5,
+				0x2,
+				0x3,
+				4,
+				49,
+				50,
+				51,
+				52,
+			]);
+
+			const command = new EntryControlCCNotification(
+				(fakeDriver as unknown) as Driver,
+				{
+					nodeId: node.id,
+					data: buf,
+				},
+			);
+
+			node.handleCommand(command);
+
+			const calls = onEntryControlNotification.mock.calls;
+			expect(calls.length).toBe(1);
+			const call = calls[0];
+
+			expect(call[0].id).toBe(node.id);
+			expect(call[1]).toBe(5);
+			expect(call[2]).toBe(EntryControlDataTypes.ASCII);
+			expect(call[3]).toBe(EntryControlEventTypes.DisarmAll);
+			expect(call[4]).toBe("1234");
 		});
 	});
 });

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -56,6 +56,7 @@ import {
 	DoorLockMode,
 	getCurrentModeValueId as getCurrentLockModeValueId,
 } from "../commandclass/DoorLockCC";
+import { EntryControlCCNotification } from "../commandclass/EntryControlCC";
 import {
 	FirmwareUpdateMetaDataCC,
 	FirmwareUpdateMetaDataCCGet,
@@ -1830,6 +1831,8 @@ version:               ${this.version}`;
 			return this.handleFirmwareUpdateGet(command);
 		} else if (command instanceof FirmwareUpdateMetaDataCCStatusReport) {
 			return this.handleFirmwareUpdateStatusReport(command);
+		} else if (command instanceof EntryControlCCNotification) {
+			return this.handleEntryControlNotification(command);
 		}
 
 		// Ignore all commands that don't need to be handled
@@ -1968,16 +1971,16 @@ version:               ${this.version}`;
 		- A new Key Held Down notification MUST be sent every 200ms until the key is released.
 		- The Sequence Number field MUST be updated at each notification transmission.
 		- If not receiving a new Key Held Down notification within 400ms, a controlling node SHOULD use an adaptive timeout approach as described in 4.17.1:
-		A controller SHOULD apply an adaptive approach based on the reception of the Key Released Notification. 
-		Initially, the controller SHOULD time out if not receiving any Key Held Down Notification refresh after 
-		400ms and consider this to be a Key Up Notification. If, however, the controller subsequently receives a 
-		Key Released Notification, the controller SHOULD consider the sending node to be operating with the Slow 
+		A controller SHOULD apply an adaptive approach based on the reception of the Key Released Notification.
+		Initially, the controller SHOULD time out if not receiving any Key Held Down Notification refresh after
+		400ms and consider this to be a Key Up Notification. If, however, the controller subsequently receives a
+		Key Released Notification, the controller SHOULD consider the sending node to be operating with the Slow
 		Refresh capability enabled.
 
 		If the Slow Refresh field is true:
 		- A new Key Held Down notification MUST be sent every 55 seconds until the key is released.
 		- The Sequence Number field MUST be updated at each notification refresh.
-		- If not receiving a new Key Held Down notification within 60 seconds after the most recent Key Held Down 
+		- If not receiving a new Key Held Down notification within 60 seconds after the most recent Key Held Down
 		notification, a receiving node MUST respond as if it received a Key Release notification.
 		*/
 
@@ -2948,6 +2951,20 @@ version:               ${this.version}`;
 			}
 			throw e;
 		}
+	}
+
+	private handleEntryControlNotification(
+		notif: EntryControlCCNotification,
+	): void {
+		// Notify listeners
+		this.emit(
+			"entry control notification",
+			this,
+			notif.sequenceNumber,
+			notif.dataType,
+			notif.eventType,
+			notif.eventData,
+		);
 	}
 
 	/**

--- a/packages/zwave-js/src/lib/node/Types.ts
+++ b/packages/zwave-js/src/lib/node/Types.ts
@@ -7,6 +7,10 @@ import type {
 	ValueUpdatedArgs,
 } from "@zwave-js/core";
 import type { FirmwareUpdateStatus } from "../commandclass";
+import type {
+	EntryControlDataTypes,
+	EntryControlEventTypes,
+} from "../commandclass/EntryControlCC";
 import type { NotificationCCReport } from "../commandclass/NotificationCC";
 import type { ZWaveNode } from "./Node";
 
@@ -80,6 +84,13 @@ export type ZWaveNodeStatusChangeCallback = (
 	node: ZWaveNode,
 	oldStatus: NodeStatus,
 ) => void;
+export type ZWaveNodeEntryControlNotificationCallback = (
+	node: ZWaveNode,
+	sequenceNumber: number,
+	dataType: EntryControlDataTypes,
+	eventType: EntryControlEventTypes,
+	eventData: Buffer | string,
+) => void;
 
 export interface ZWaveNodeValueEventCallbacks {
 	"value added": ZWaveNodeValueAddedCallback;
@@ -100,6 +111,7 @@ export interface ZWaveNodeEventCallbacks extends ZWaveNodeValueEventCallbacks {
 	alive: ZWaveNodeStatusChangeCallback;
 	"interview completed": (node: ZWaveNode) => void;
 	ready: (node: ZWaveNode) => void;
+	"entry control notification": ZWaveNodeEntryControlNotificationCallback;
 }
 
 export type ZWaveNodeEvents = Extract<keyof ZWaveNodeEventCallbacks, string>;


### PR DESCRIPTION
My attempt to add support for Entry Control command class.

Tested it with my Ring Keypad and everything I tested works.

In this pull request there is still nothing that handle the Notification message but I figured it is better to submit this first and then work on that.