### PR TITLE
feat: support configuring the treatment of "unknown", fix Fibaro CC

### DIFF
--- a/docs/api/valueid.md
+++ b/docs/api/valueid.md
@@ -92,6 +92,9 @@ interface ValueMetadataNumeric extends ValueMetadataAny {
 -   `states`: Human-readable names for numeric values, for example `{0: "off", 1: "on"}`.
 -   `unit`: An optional unit for numeric values
 
+> [!WARNING]
+> A value with `type: "number"` can contain the literal string `"unknown"` if the driver option `preserveUnknownValues` is `true`.
+
 #### `boolean`
 
 <!-- #import ValueMetadataBoolean from "zwave-js" with no-jsdoc -->
@@ -104,6 +107,9 @@ interface ValueMetadataBoolean extends ValueMetadataAny {
 ```
 
 -   `default`: The default value
+
+> [!WARNING]
+> A value with `type: "boolean"` can contain the literal string `"unknown"` if the driver option `preserveUnknownValues` is `true`.
 
 #### `string`
 

--- a/packages/core/src/values/Primitive.ts
+++ b/packages/core/src/values/Primitive.ts
@@ -10,8 +10,15 @@ export const unknownNumber = "unknown" as Maybe<number>;
 export const unknownBoolean = "unknown" as Maybe<boolean>;
 
 /** Parses a boolean that is encoded as a single byte and might also be "unknown" */
-export function parseMaybeBoolean(val: number): Maybe<boolean> | undefined {
-	return val === 0xfe ? unknownBoolean : parseBoolean(val);
+export function parseMaybeBoolean(
+	val: number,
+	preserveUnknown: boolean = true,
+): Maybe<boolean> | undefined {
+	return val === 0xfe
+		? preserveUnknown
+			? unknownBoolean
+			: undefined
+		: parseBoolean(val);
 }
 
 /** Parses a boolean that is encoded as a single byte */
@@ -20,8 +27,15 @@ export function parseBoolean(val: number): boolean | undefined {
 }
 
 /** Parses a single-byte number from 0 to 100, which might also be "unknown" */
-export function parseMaybeNumber(val: number): Maybe<number> | undefined {
-	return val === 0xfe ? unknownNumber : parseNumber(val);
+export function parseMaybeNumber(
+	val: number,
+	preserveUnknown: boolean = true,
+): Maybe<number> | undefined {
+	return val === 0xfe
+		? preserveUnknown
+			? unknownNumber
+			: undefined
+		: parseNumber(val);
 }
 
 /** Parses a single-byte number from 0 to 100 */

--- a/packages/zwave-js/src/lib/commandclass/BasicCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BasicCC.ts
@@ -271,59 +271,53 @@ export class BasicCCReport extends BasicCC {
 
 		if (gotDeserializationOptions(options)) {
 			validatePayload(this.payload.length >= 1);
-			this._currentValue = parseMaybeNumber(this.payload[0]);
+			this.currentValue = parseMaybeNumber(
+				this.payload[0],
+				driver.options.preserveUnknownValues,
+			);
 
 			if (this.version >= 2 && this.payload.length >= 3) {
-				this._targetValue = parseNumber(this.payload[1]);
-				this._duration = Duration.parseReport(this.payload[2]);
+				this.targetValue = parseNumber(this.payload[1]);
+				this.duration = Duration.parseReport(this.payload[2]);
 			}
 			// Do not persist values here. We want to control when this is happening,
 			// in case the report is mapped to another CC
 		} else {
-			this._currentValue = options.currentValue;
+			this.currentValue = options.currentValue;
 			if ("targetValue" in options) {
-				this._targetValue = options.targetValue;
-				this._duration = options.duration;
+				this.targetValue = options.targetValue;
+				this.duration = options.duration;
 			}
 		}
 	}
 
-	private _currentValue: Maybe<number> | undefined;
 	@ccValue()
 	@ccValueMetadata({
 		...ValueMetadata.ReadOnlyLevel,
 		label: "Current value",
 	})
-	public get currentValue(): Maybe<number> | undefined {
-		return this._currentValue;
-	}
+	public readonly currentValue: Maybe<number> | undefined;
 
-	private _targetValue: number | undefined;
 	@ccValue({ forceCreation: true })
 	@ccValueMetadata({
 		...ValueMetadata.Level,
 		label: "Target value",
 	})
-	public get targetValue(): number | undefined {
-		return this._targetValue;
-	}
+	public readonly targetValue: number | undefined;
 
-	private _duration: Duration | undefined;
 	@ccValue({ minVersion: 2 })
 	@ccValueMetadata({
 		...ValueMetadata.ReadOnlyDuration,
 		label: "Remaining duration until target value",
 	})
-	public get duration(): Duration | undefined {
-		return this._duration;
-	}
+	public readonly duration: Duration | undefined;
 
 	public serialize(): Buffer {
 		const payload: number[] = [
-			typeof this._currentValue !== "number" ? 0xfe : this._currentValue,
+			typeof this.currentValue !== "number" ? 0xfe : this.currentValue,
 		];
-		if (this.version >= 2 && this._targetValue && this._duration) {
-			payload.push(this._targetValue, this._duration.serializeReport());
+		if (this.version >= 2 && this.targetValue && this.duration) {
+			payload.push(this.targetValue, this.duration.serializeReport());
 		}
 		this.payload = Buffer.from(payload);
 		return super.serialize();

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -564,54 +564,45 @@ export class MultilevelSwitchCCReport extends MultilevelSwitchCC {
 		super(driver, options);
 
 		validatePayload(this.payload.length >= 1);
-		// if the payload contains a reserved value, return the actual value
-		// instead of undefined
-		this._currentValue =
-			parseMaybeNumber(this.payload[0]) || this.payload[0];
+		this.currentValue = parseMaybeNumber(
+			this.payload[0],
+			driver.options.preserveUnknownValues,
+		);
 		if (this.version >= 4 && this.payload.length >= 3) {
-			this._targetValue = parseNumber(this.payload[1]);
-			this._duration = Duration.parseReport(this.payload[2]);
+			this.targetValue = parseNumber(this.payload[1]);
+			this.duration = Duration.parseReport(this.payload[2]);
 		}
 		this.persistValues();
 	}
 
-	private _targetValue: number | undefined;
 	@ccValue({ forceCreation: true })
 	@ccValueMetadata({
 		...ValueMetadata.Level,
 		label: "Target value",
 	})
-	public get targetValue(): number | undefined {
-		return this._targetValue;
-	}
+	public readonly targetValue: number | undefined;
 
-	private _duration: Duration | undefined;
 	@ccValue()
 	@ccValueMetadata({
 		...ValueMetadata.Duration,
 		label: "Transition duration",
 	})
-	public get duration(): Duration | undefined {
-		return this._duration;
-	}
+	public readonly duration: Duration | undefined;
 
-	private _currentValue: Maybe<number>;
 	@ccValue()
 	@ccValueMetadata({
 		...ValueMetadata.ReadOnlyLevel,
 		label: "Current value",
 	})
-	public get currentValue(): Maybe<number> {
-		return this._currentValue;
-	}
+	public readonly currentValue: Maybe<number> | undefined;
 
 	public toLogEntry(): MessageOrCCLogEntry {
 		const message: MessageRecord = {
-			"current value": this._currentValue,
+			"current value": this.currentValue,
 		};
-		if (this._targetValue != undefined && this._duration) {
-			message["target value"] = this._targetValue;
-			message.duration = this._duration.toString();
+		if (this.targetValue != undefined && this.duration) {
+			message["target value"] = this.targetValue;
+			message.duration = this.duration.toString();
 		}
 		return {
 			...super.toLogEntry(),

--- a/packages/zwave-js/src/lib/commandclass/manufacturerProprietary/Fibaro.ts
+++ b/packages/zwave-js/src/lib/commandclass/manufacturerProprietary/Fibaro.ts
@@ -1,7 +1,9 @@
 import {
 	CommandClasses,
+	Maybe,
 	MessageOrCCLogEntry,
 	MessageRecord,
+	parseMaybeNumber,
 	validatePayload,
 	ValueID,
 	ValueMetadata,
@@ -237,7 +239,10 @@ export class FibaroVenetianBlindCCReport extends FibaroVenetianBlindCC {
 		// When the node sends a report, payload[0] === 0b11. This is probably a
 		// bit mask for position and tilt
 		if (!!(this.payload[0] & 0b10)) {
-			this.position = this.payload[1];
+			this.position = parseMaybeNumber(
+				this.payload[1],
+				driver.options.preserveUnknownValues,
+			);
 			const positionValueId = getFibaroVenetianBlindPositionValueId(
 				this.endpointIndex,
 			);
@@ -248,7 +253,10 @@ export class FibaroVenetianBlindCCReport extends FibaroVenetianBlindCC {
 			valueDB.setValue(positionValueId, this.position);
 		}
 		if (!!(this.payload[0] & 0b01)) {
-			this.tilt = this.payload[2];
+			this.tilt = parseMaybeNumber(
+				this.payload[2],
+				driver.options.preserveUnknownValues,
+			);
 			const tiltValueId = getFibaroVenetianBlindTiltValueId(
 				this.endpointIndex,
 			);
@@ -260,8 +268,8 @@ export class FibaroVenetianBlindCCReport extends FibaroVenetianBlindCC {
 		}
 	}
 
-	public readonly position?: number;
-	public readonly tilt?: number;
+	public readonly position?: Maybe<number>;
+	public readonly tilt?: Maybe<number>;
 
 	public toLogEntry(): MessageOrCCLogEntry {
 		const message: MessageRecord = {};

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -177,6 +177,13 @@ export interface ZWaveOptions {
 
 	/** Specify the network key to use for encryption. This must be a Buffer of exactly 16 bytes. */
 	networkKey?: Buffer;
+
+	/**
+	 * Some Command Classes support reporting that a value is unknown.
+	 * When this flag is `false`, unknown values are exposed as `undefined`.
+	 * When it is `true`, unknown values are exposed as the literal string "unknown" (even if the value is normally numeric).
+	 * Default: `false` */
+	preserveUnknownValues?: boolean;
 }
 
 const defaultOptions: ZWaveOptions = {
@@ -195,6 +202,7 @@ const defaultOptions: ZWaveOptions = {
 		retryAfterTransmitReport: false,
 		nodeInterview: 5,
 	},
+	preserveUnknownValues: false,
 	skipInterview: false,
 	storage: {
 		driver: fsExtra,


### PR DESCRIPTION
With this PR, values that could previously have `"unknown"` as the value now expose `undefined` in this case instead, since exposing a string where numbers/booleans are used can be very unexpected. To configure this and gain access to the "unknown" state, the driver option `preserveUnknownValues` (default: `false`) was added.

This PR also fixes the parsing of the Fibaro CC values, which can also report unknown.

fixes: #1845