### PR TITLE
fix: expose values for some controlled CCs

### DIFF
--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -604,13 +604,21 @@ export class ZWaveNode extends Endpoint {
 	/** Returns a list of all value names that are defined on all endpoints of this node */
 	public getDefinedValueIDs(): TranslatedValueID[] {
 		let ret: ValueID[] = [];
+		const allowControlled: CommandClasses[] = [
+			CommandClasses["Scene Activation"],
+		];
 		for (const endpoint of this.getAllEndpoints()) {
 			for (const [cc, info] of endpoint.implementedCommandClasses) {
-				// Don't return value IDs which are only controlled
-				if (!info.isSupported) continue;
-				const ccInstance = endpoint.createCCInstanceUnsafe(cc);
-				if (ccInstance) {
-					ret.push(...ccInstance.getDefinedValueIDs());
+				// Only expose value IDs for CCs that are supported
+				// with some exceptions that are controlled
+				if (
+					info.isSupported ||
+					(info.isControlled && allowControlled.includes(cc))
+				) {
+					const ccInstance = endpoint.createCCInstanceUnsafe(cc);
+					if (ccInstance) {
+						ret.push(...ccInstance.getDefinedValueIDs());
+					}
 				}
 			}
 		}

--- a/packages/zwave-js/src/lib/test/cc/sceneActivationValueID.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/sceneActivationValueID.test.ts
@@ -1,0 +1,38 @@
+import { CommandClasses } from "@zwave-js/core";
+import type { ThrowingMap } from "../../controller/Controller";
+import type { Driver } from "../../driver/Driver";
+import { ZWaveNode } from "../../node/Node";
+import { createAndStartDriver } from "../utils";
+
+describe("regression tests", () => {
+	let driver: Driver;
+
+	beforeEach(async () => {
+		({ driver } = await createAndStartDriver());
+
+		driver["_controller"] = {
+			ownNodeId: 1,
+			isFunctionSupported: () => true,
+			nodes: new Map(),
+		} as any;
+	});
+
+	afterEach(async () => {
+		await driver.destroy();
+		driver.removeAllListeners();
+	});
+
+	it("a node that controls the Scene Activation CC should include the scene ID in getDefinedValueIDs()", async () => {
+		const node2 = new ZWaveNode(2, driver);
+		node2.addCC(CommandClasses["Scene Activation"], {
+			isControlled: true,
+		});
+		(driver.controller.nodes as ThrowingMap<number, ZWaveNode>).set(
+			2,
+			node2,
+		);
+
+		const valueIDs = node2.getDefinedValueIDs();
+		expect(valueIDs.some((v) => v.property === "sceneId")).toBeTrue();
+	});
+});


### PR DESCRIPTION
After #1207 we stopped exposing values for CCs that are only controlled. However, it does make sense in some cases, e.g. Scene Activation CC. 

With this PR, we special case this CC so values are exposed anyways.

Fixes: https://github.com/zwave-js/zwavejs2mqtt/issues/471
Closes: #1848