### PR TITLE
fix(config): add additional product ID to Fibaro Roller Shutter 3

### DIFF
--- a/packages/config/config/devices/0x010f/fgr223.json
+++ b/packages/config/config/devices/0x010f/fgr223.json
@@ -8,7 +8,7 @@
 	"devices": [
 		{
 			"productType": "0x0303",
-			"productId": "0x1000"
+			"productId": "0x3000"
 		}
 	],
 	"firmwareVersion": {

--- a/packages/config/config/devices/0x010f/fgr223.json
+++ b/packages/config/config/devices/0x010f/fgr223.json
@@ -8,6 +8,10 @@
 	"devices": [
 		{
 			"productType": "0x0303",
+			"productId": "0x1000"
+		},
+		{
+			"productType": "0x0303",
 			"productId": "0x3000"
 		}
 	],


### PR DESCRIPTION
Product ID is incorrect at "0x1000", needs to be "0x3000" for correct automated identification