### PR TITLE
fix(cc): in configuration metadata, parse `states` even when `allowManualEntry` is true

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
@@ -812,7 +812,7 @@ alters capabilities: ${!!properties.altersCapabilities}`;
 				writeable: !info.readOnly,
 				allowManualEntry: info.allowManualEntry,
 				states:
-					!info.allowManualEntry && info.options.length > 0
+					info.options.length > 0
 						? composeObject(
 								info.options.map(({ label, value }) => [
 									value.toString(),


### PR DESCRIPTION
Fixes #1927