### PR TITLE
feat(log): define formats in logger and transports, use ISO dates for non-TTY logging

### DIFF
--- a/packages/core/src/log/shared.ts
+++ b/packages/core/src/log/shared.ts
@@ -175,10 +175,9 @@ export class ZWaveLogContainer extends winston.Container {
 				((config.transports as any) as Transport[] | undefined) ??
 				this.createLogTransports();
 
-			this.loggers.forEach((logger, label) =>
+			this.loggers.forEach((logger) =>
 				logger.configure({
 					transports: this.logConfig.transports,
-					format: this.createLoggerFormat(label),
 				}),
 			);
 		}

--- a/packages/serial/src/Logger.test.ts
+++ b/packages/serial/src/Logger.test.ts
@@ -1,4 +1,7 @@
-import { ZWaveLogContainer } from "@zwave-js/core";
+import {
+	createDefaultTransportFormat,
+	ZWaveLogContainer,
+} from "@zwave-js/core";
 import { assertMessage, SpyTransport } from "@zwave-js/testing";
 import colors from "ansi-colors";
 import { pseudoRandomBytes } from "crypto";
@@ -11,6 +14,7 @@ describe("lib/log/Serial =>", () => {
 	// Replace all defined transports with a spy transport
 	beforeAll(() => {
 		spyTransport = new SpyTransport();
+		spyTransport.format = createDefaultTransportFormat(true, true);
 		serialLogger = new SerialLogger(
 			new ZWaveLogContainer({
 				transports: [spyTransport],

--- a/packages/zwave-js/src/lib/log/Controller.test.ts
+++ b/packages/zwave-js/src/lib/log/Controller.test.ts
@@ -1,4 +1,8 @@
-import { CommandClasses, ZWaveLogContainer } from "@zwave-js/core";
+import {
+	CommandClasses,
+	createDefaultTransportFormat,
+	ZWaveLogContainer,
+} from "@zwave-js/core";
 import { assertLogInfo, assertMessage, SpyTransport } from "@zwave-js/testing";
 import { InterviewStage } from "../node/Types";
 import { ControllerLogger } from "./Controller";
@@ -10,6 +14,7 @@ describe("lib/log/Controller =>", () => {
 	// Replace all defined transports with a spy transport
 	beforeAll(() => {
 		spyTransport = new SpyTransport();
+		spyTransport.format = createDefaultTransportFormat(true, true);
 		controllerLogger = new ControllerLogger(
 			new ZWaveLogContainer({
 				transports: [spyTransport],

--- a/packages/zwave-js/src/lib/log/Driver.test.ts
+++ b/packages/zwave-js/src/lib/log/Driver.test.ts
@@ -1,4 +1,8 @@
-import { getDirectionPrefix, ZWaveLogContainer } from "@zwave-js/core";
+import {
+	createDefaultTransportFormat,
+	getDirectionPrefix,
+	ZWaveLogContainer,
+} from "@zwave-js/core";
 import { assertLogInfo, assertMessage, SpyTransport } from "@zwave-js/testing";
 import { createDeferredPromise } from "alcalzone-shared/deferred-promise";
 import { SortedList } from "alcalzone-shared/sorted-list";
@@ -56,6 +60,7 @@ describe("lib/log/Driver =>", () => {
 	// Replace all defined transports with a spy transport
 	beforeAll(() => {
 		spyTransport = new SpyTransport();
+		spyTransport.format = createDefaultTransportFormat(true, true);
 		driverLogger = new DriverLogger(
 			new ZWaveLogContainer({
 				transports: [spyTransport],


### PR DESCRIPTION
By splitting the format definitions between loggers and transports, writing custom transports will be much easier since they will have all the default information and only need to care about formatting.

closes: #1979 
fixes: #1968 

With this PR, now now also use UTC ISO dates when not logging to a TTY. This means that timestamps in logfiles now look like this:
```
2021-03-02T08:26:36.074Z DRIVER   ███████╗ ██╗    ██╗  █████╗  ██╗   ██╗ ███████╗             ██╗ ███████╗
                                  ╚══███╔╝ ██║    ██║ ██╔══██╗ ██║   ██║ ██╔════╝             ██║ ██╔════╝
                                    ███╔╝  ██║ █╗ ██║ ███████║ ██║   ██║ █████╗   █████╗      ██║ ███████╗
                                   ███╔╝   ██║███╗██║ ██╔══██║ ╚██╗ ██╔╝ ██╔══╝   ╚════╝ ██   ██║ ╚════██║
                                  ███████╗ ╚███╔███╔╝ ██║  ██║  ╚████╔╝  ███████╗        ╚█████╔╝ ███████║
                                  ╚══════╝  ╚══╝╚══╝  ╚═╝  ╚═╝   ╚═══╝   ╚══════╝         ╚════╝  ╚══════╝
2021-03-02T08:26:36.074Z DRIVER   version 6.6.0
2021-03-02T08:26:36.074Z DRIVER   
2021-03-02T08:26:36.074Z DRIVER   starting driver...
2021-03-02T08:26:36.074Z DRIVER   opening serial port COM4
2021-03-02T08:26:36.098Z DRIVER   serial port opened
2021-03-02T08:26:36.098Z SERIAL » [NAK]                                                                   (0x15)
```

instead of 

```
09:28:08.340 DRIVER   ███████╗ ██╗    ██╗  █████╗  ██╗   ██╗ ███████╗             ██╗ ███████╗
                      ╚══███╔╝ ██║    ██║ ██╔══██╗ ██║   ██║ ██╔════╝             ██║ ██╔════╝
                        ███╔╝  ██║ █╗ ██║ ███████║ ██║   ██║ █████╗   █████╗      ██║ ███████╗
                       ███╔╝   ██║███╗██║ ██╔══██║ ╚██╗ ██╔╝ ██╔══╝   ╚════╝ ██   ██║ ╚════██║
                      ███████╗ ╚███╔███╔╝ ██║  ██║  ╚████╔╝  ███████╗        ╚█████╔╝ ███████║
                      ╚══════╝  ╚══╝╚══╝  ╚═╝  ╚═╝   ╚═══╝   ╚══════╝         ╚════╝  ╚══════╝
09:28:08.343 DRIVER   version 6.6.0
09:28:08.343 DRIVER
09:28:08.344 DRIVER   starting driver...
09:28:08.350 DRIVER   opening serial port COM4
09:28:08.365 DRIVER   serial port opened
09:28:08.365 SERIAL » [NAK]                                                                   (0x15)
```

The latter format is still used for TTYs because it is less noisy and easier to digest for the one looking at the TTY.

Edit: rebased onto #1911 to include those changes, so this is breaking now.