### PR TITLE
fix(cc): length validation in Security S0 Message Encapsulation

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
@@ -496,9 +496,9 @@ export class SecurityCCCommandEncapsulation extends SecurityCC {
 		}
 
 		if (gotDeserializationOptions(options)) {
-			// HALF_NONCE_SIZE bytes iv, 1 byte frame control, 2 bytes CC header, 1 byte nonce id, 8 bytes auth code
+			// HALF_NONCE_SIZE bytes iv, 1 byte frame control, 1 byte CC header, 1 byte nonce id, 8 bytes auth code
 			validatePayload(
-				this.payload.length >= HALF_NONCE_SIZE + 1 + 2 + 1 + 8,
+				this.payload.length >= HALF_NONCE_SIZE + 1 + 1 + 1 + 8,
 			);
 			const iv = this.payload.slice(0, HALF_NONCE_SIZE);
 			const encryptedPayload = this.payload.slice(HALF_NONCE_SIZE, -9);

--- a/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
@@ -496,9 +496,9 @@ export class SecurityCCCommandEncapsulation extends SecurityCC {
 		}
 
 		if (gotDeserializationOptions(options)) {
-			// HALF_NONCE_SIZE bytes iv, 1 byte frame control, 2 bytes CC header, 1 byte nonce id, 8 bytes auth code
+			// HALF_NONCE_SIZE bytes iv, 1 byte frame control, at least 1 CC byte, 1 byte nonce id, 8 bytes auth code
 			validatePayload(
-				this.payload.length >= HALF_NONCE_SIZE + 1 + 2 + 1 + 8,
+				this.payload.length >= HALF_NONCE_SIZE + 1 + 1 + 1 + 8,
 			);
 			const iv = this.payload.slice(0, HALF_NONCE_SIZE);
 			const encryptedPayload = this.payload.slice(HALF_NONCE_SIZE, -9);
@@ -596,6 +596,8 @@ export class SecurityCCCommandEncapsulation extends SecurityCC {
 		this.decryptedCCBytes = Buffer.concat(
 			[...partials, this].map((cc) => cc.decryptedCCBytes!),
 		);
+		// make sure this contains a complete CC command that's worth splitting
+		validatePayload(this.decryptedCCBytes.length >= 2);
 		// and deserialize the CC
 		this.encapsulated = CommandClass.from(this.driver, {
 			data: this.decryptedCCBytes,


### PR DESCRIPTION
- To be honest I don't know if this is the right solution but it seems to work.
- I been trying to add the Ring Alarm Keypad and I noticed that node.firmwareVersion was undefined.
- After some debugging I realize that `await node.commandClasses.Version.get()` didn't work. It just failed every time.
  - Logs https://gist.github.com/WizKid/b5e62faa0a833916e4969830469f986e which shows that we fail to unwrap the message
- After this diff it instead looks like this:
  - https://gist.github.com/WizKid/0ab37503ee8b887e4ee77f48853fb0cf