### PR TITLE
fix: do not immediately mark newly included nodes as asleep

### DIFF
--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -1068,6 +1068,10 @@ export class ZWaveController extends EventEmitter {
 					this._nodes.set(newNode.id, newNode);
 					this._nodePendingInclusion = undefined;
 
+					// We're communicating with the device, so assume it is alive
+					// If it is actually a sleeping device, it will be marked as such later
+					newNode.markAsAlive();
+
 					// Assign return route to make sure the node's responses reach us
 					try {
 						this.driver.controllerLog.logNode(newNode.id, {
@@ -1172,6 +1176,10 @@ export class ZWaveController extends EventEmitter {
 					);
 					this._nodePendingReplace = undefined;
 					this._nodes.set(newNode.id, newNode);
+
+					// We're communicating with the device, so assume it is alive
+					// If it is actually a sleeping device, it will be marked as such later
+					newNode.markAsAlive();
 
 					// Assign return route to make sure the node's responses reach us
 					try {

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1138,7 +1138,15 @@ version:               ${this.version}`;
 		});
 
 		// Assume that sleeping nodes start asleep
-		if (this.canSleep) this.markAsAsleep();
+		if (this.canSleep) {
+			if (this.status === NodeStatus.Alive) {
+				// unless it was just inluded and is currently communicating with us
+				// In that case we need to switch from alive/dead to awake/asleep
+				this.markAsAwake();
+			} else {
+				this.markAsAsleep();
+			}
+		}
 
 		await this.setInterviewStage(InterviewStage.ProtocolInfo);
 	}

--- a/packages/zwave-js/src/lib/node/NodeStatusMachine.test.ts
+++ b/packages/zwave-js/src/lib/node/NodeStatusMachine.test.ts
@@ -106,6 +106,13 @@ describe("lib/driver/NodeStatusMachine", () => {
 			{
 				start: "alive",
 				event: "AWAKE",
+				canSleep: true,
+				target: "awake",
+			},
+			{
+				start: "alive",
+				event: "AWAKE",
+				canSleep: false,
 				target: "alive",
 			},
 			{

--- a/packages/zwave-js/src/lib/node/NodeStatusMachine.ts
+++ b/packages/zwave-js/src/lib/node/NodeStatusMachine.ts
@@ -93,6 +93,10 @@ export function createNodeStatusMachine(node: ZWaveNode): NodeStatusMachine {
 							target: "asleep",
 							cond: "canSleep",
 						},
+						AWAKE: {
+							target: "awake",
+							cond: "canSleep",
+						},
 					},
 				},
 				asleep: {


### PR DESCRIPTION
With this PR, we now mark newly included nodes as alive until we know if they can sleep or not.

Fixes: #1923