### PR TITLE
fix: assume sleeping nodes to be asleep restart w/ incomplete interview

### DIFF
--- a/packages/zwave-js/src/lib/node/Node.test.ts
+++ b/packages/zwave-js/src/lib/node/Node.test.ts
@@ -1146,6 +1146,42 @@ describe("lib/node/Node", () => {
 			expect(node.getCCVersion(0x27)).toBe(0);
 			node.destroy();
 		});
+
+		it("deserialize() should set the node status to Asleep if the node can sleep", () => {
+			const input = {
+				...serializedTestNode,
+				isListening: false,
+				isFrequentListening: false,
+			};
+			const node = new ZWaveNode(1, fakeDriver);
+			node.deserialize(input);
+			expect(node.status).toBe(NodeStatus.Asleep);
+			node.destroy();
+		});
+
+		it("deserialize() should set the node status to Unknown if the node is a listening node", () => {
+			const input = {
+				...serializedTestNode,
+				isListening: true,
+				isFrequentListening: false,
+			};
+			const node = new ZWaveNode(1, fakeDriver);
+			node.deserialize(input);
+			expect(node.status).toBe(NodeStatus.Unknown);
+			node.destroy();
+		});
+
+		it("deserialize() should set the node status to Unknown if the node is a frequent listening node", () => {
+			const input = {
+				...serializedTestNode,
+				isListening: false,
+				isFrequentListening: true,
+			};
+			const node = new ZWaveNode(1, fakeDriver);
+			node.deserialize(input);
+			expect(node.status).toBe(NodeStatus.Unknown);
+			node.destroy();
+		});
 	});
 
 	describe("the emitted events", () => {

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1008,12 +1008,9 @@ export class ZWaveNode extends Endpoint {
 			// Mark nodes as potentially ready. The first message will determine if it is
 			this.readyMachine.send("RESTART_INTERVIEW_FROM_CACHE");
 
-			// Assume that sleeping nodes start asleep and ping listening nodes to check their status
-			if (this.canSleep) {
-				this.markAsAsleep();
-			} else if (this.isListening) {
-				await this.ping();
-			}
+			// Ping listening nodes to check their status
+			// Sleeping nodes are assumed to be asleep after a restart from cache
+			if (this.isListening) await this.ping();
 		}
 
 		// At this point the basic interview of new nodes is done. Start here when re-interviewing known nodes
@@ -3043,6 +3040,9 @@ version:               ${this.version}`;
 		tryParse("isSecure", "boolean");
 		tryParse("isBeaming", "boolean");
 		tryParse("version", "number");
+
+		// A node that can sleep should be assumed to be sleeping after resuming from cache
+		if (this.canSleep) this.markAsAsleep();
 
 		if (isArray(obj.neighbors)) {
 			// parse only valid node IDs


### PR DESCRIPTION
This PR improves on #1784 which was missing the situation where sleeping nodes would still be in ProtocolInfo stage after a restart. We now assume sleeping nodes to always be asleep after restarting from cache, independently of the interview stage.

Fixes: #1797