### PR TITLE
fix: correctly parse NodeProtocolInfo response, rework node properties

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -344,7 +344,7 @@ enum InterviewStage {
 ### `deviceClass`
 
 ```ts
-readonly deviceClass: DeviceClass
+readonly deviceClass: DeviceClass | undefined;
 ```
 
 This property returns the node's **DeviceClass**, which provides further information about the kind of device this node is.
@@ -402,10 +402,10 @@ readonly zwavePlusVersion: number | undefined
 
 Returns the version of the `Z-Wave+` Command Class this node supports. If the CC is supported, the value only exists **after** the node is ready.
 
-### `nodeType`
+### `zwavePlusNodeType`
 
 ```ts
-readonly nodeType: ZWavePlusNodeType | undefined
+readonly zwavePlusNodeType: ZWavePlusNodeType | undefined
 ```
 
 If the `Z-Wave+` Command Class is supported, this returns the `Z-Wave+` node type this device has, which is one of the following values:
@@ -419,10 +419,10 @@ enum ZWavePlusNodeType {
 }
 ```
 
-### `roleType`
+### `zwavePlusRoleType`
 
 ```ts
-readonly roleType: ZWavePlusRoleType | undefined
+readonly zwavePlusRoleType: ZWavePlusRoleType | undefined
 ```
 
 If the `Z-Wave+` Command Class is supported, this returns the `Z-Wave+` role type this device has, which is one of the following values:
@@ -445,58 +445,95 @@ enum ZWavePlusRoleType {
 ### `isListening`
 
 ```ts
-readonly isListening: boolean
+readonly isListening: boolean | undefined;
 ```
 
-Whether this node is a listening node.
+Whether this node is always listening.
 
 ### `isFrequentListening`
 
 ```ts
-readonly isFrequentListening: boolean
+readonly isFrequentListening: false | "250ms" | "1000ms" | undefined;
 ```
 
-Whether this node is a frequent listening node.
+Indicates the wakeup interval if this node is a FLiRS node. `false` if it isn't.
+
+### `canSleep`
+
+```ts
+readonly canSleep: boolean | undefined;
+```
+
+Whether this node can sleep. If this is the case it must be expected to be asleep most of the time.
 
 ### `isRouting`
 
 ```ts
-readonly isRouting: boolean
+readonly isRouting: boolean | undefined;
 ```
 
-Whether this node is a routing node.
+Whether the node supports routing/forwarding messages. If both this property and `isListening` are true, it can be assumed that the node **will** route messages.
 
-### `maxBaudRate`
+### `supportedDataRates`
 
 ```ts
-readonly maxBaudRate: number
+readonly supportedDataRates: readonly number[] | undefined;
 ```
 
-The baud rate used to communicate with this node. Possible values are `9.6k`, `40k` and `100k`.
+A list of data rates (in bits per second) this node supports. Possible values are `9600`, `40000` and `100000`.
+
+### `maxDataRate`
+
+```ts
+readonly maxDataRate: number
+```
+
+The maximum data rate this nodes supports.
+
+### `supportsSecurity`
+
+```ts
+readonly supportsSecurity: boolean | undefined;
+```
+
+Whether this node supports secure communication (S0 or S2).
+
+> [!WARNING] Nodes often report this incorrectly - do not blindly trust this value.
 
 ### `isSecure`
 
 ```ts
-readonly isSecure: boolean
+readonly isSecure: boolean | "unknown" | undefined;
 ```
 
 Whether this node is communicating securely with the controller.
 
-### `isBeaming`
+### `supportsBeaming`
 
 ```ts
-readonly isBeaming: boolean
+readonly supportsBeaming: boolean | undefined;
 ```
 
-Whether this node is a beaming node.
+Whether this node can issue wakeup beams to FLiRS nodes
 
-### `version`
+### `protocolVersion`
 
 ```ts
-readonly version: number
+readonly protocolVersion: ProtocolVersion | undefined
 ```
 
 The Z-Wave protocol version this node implements.
+
+<!-- #import ProtocolVersion from "zwave-js" -->
+
+```ts
+enum ProtocolVersion {
+	"unknown" = 0,
+	"2.0" = 1,
+	"4.2x / 5.0x" = 2,
+	"4.5x / 6.0x" = 3,
+}
+```
 
 ### `firmwareVersion`
 

--- a/docs/getting-started/migrating-to-v7.md
+++ b/docs/getting-started/migrating-to-v7.md
@@ -1,0 +1,18 @@
+# Migrating to v7
+
+In version 7.x we got rid of some old habits, leading to several breaking changes. Follow this guide if you're migrating to v7:
+
+## Corrected parsing of Node Information Frames (NIF), reworked node properties
+
+The old parsing code was based on reverse-engineering, best-effort guesses and looking at what OpenZWave did. We've reworked/fixed the parsing code to match the specifications and changed node properties to make more sense:
+
+-   `isFrequentListening` was changed to have the type `FLiRS = false | "250ms" | "1000ms"` (previously `boolean`) to indicate the wakeup frequency.
+-   `maxBaudRate` was renamed to `maxDataRate`, the type `Baudrate` was renamed to `DataRate`
+-   The property `supportedDataRates` was added to provide an array of supported data rates
+-   The 100kbps data rate is now detected correctly
+-   The `version` property was renamed to `protocolVersion` and had its type changed from `number` to the enum `ProtocolVersion` (the underlying values are still the same).
+
+*   The `isBeaming` property was renamed to `supportsBeaming` to better show its intent
+*   The `supportsSecurity` property was split off from the `isSecure` property because they have a different meaning.
+*   The mutually exclusive `isRoutingSlave` and `isController` properties were merged into the new `nodeType` property.
+*   The old `nodeType` and `roleType` properties were renamed to `zwavePlusNodeType` and `zwavePlusRoleType` to clarify that they refer to Z-Wave+.

--- a/packages/config/config/deviceClasses.json
+++ b/packages/config/config/deviceClasses.json
@@ -2,6 +2,7 @@
 // legacy Z-Wave standard (SDS10242)
 {
 	"basic": {
+		// The GetNodeProtocolInfo messages rely on these values - double-check there when changing anything
 		"0x01": "Controller",
 		"0x02": "Static Controller",
 		"0x03": "Slave",

--- a/packages/zwave-js/src/Node.ts
+++ b/packages/zwave-js/src/Node.ts
@@ -3,8 +3,12 @@ export { DeviceClass } from "./lib/node/DeviceClass";
 export { Endpoint } from "./lib/node/Endpoint";
 export { ZWaveNode } from "./lib/node/Node";
 export {
+	DataRate,
+	FLiRS,
 	InterviewStage,
 	NodeInterviewFailedEventArgs,
 	NodeStatus,
+	NodeType,
+	ProtocolVersion,
 	ZWaveNodeEvents,
 } from "./lib/node/Types";

--- a/packages/zwave-js/src/lib/controller/GetNodeProtocolInfoMessages.ts
+++ b/packages/zwave-js/src/lib/controller/GetNodeProtocolInfoMessages.ts
@@ -14,31 +14,7 @@ import {
 	priority,
 } from "../message/Message";
 import { DeviceClass } from "../node/DeviceClass";
-
-enum ProtocolFlags {
-	Listening = 0b10_000_000,
-	Routing = 0b01_000_000,
-
-	Baudrate_100k = 0b00_011_000,
-	Baudrate_40k = 0b00_010_000,
-	Baudrate_9k6 = 0b00_001_000,
-	BaudrateMask = 0b00_111_000,
-
-	VersionMask = 0b111,
-}
-
-enum DeviceCapabilityFlags {
-	Security = 1 << 0,
-	Controller = 1 << 1,
-	SpecificDevice = 1 << 2, // ?
-	RoutingSlave = 1 << 3, // ?
-	BeamCapability = 1 << 4,
-	Sensor250ms = 1 << 5,
-	Sensor1000ms = 1 << 6,
-	OptionalFunctionality = 1 << 7,
-}
-
-export type Baudrate = 9600 | 40000 | 100000;
+import { DataRate, FLiRS, NodeType, ProtocolVersion } from "../node/Types";
 
 interface GetNodeProtocolInfoRequestOptions extends MessageBaseOptions {
 	requestedNodeId: number;
@@ -78,44 +54,69 @@ export class GetNodeProtocolInfoResponse extends Message {
 		super(driver, options);
 
 		const protocol = this.payload[0];
-		this.isListening = (protocol & ProtocolFlags.Listening) !== 0;
-		this.isRouting = (protocol & ProtocolFlags.Routing) !== 0;
+		this.isListening = !!(protocol & 0b10_000_000);
+		this.isRouting = !!(protocol & 0b01_000_000);
 
-		// This is an educated guess. OZW only checks for the 40k flag
-		switch (protocol & ProtocolFlags.BaudrateMask) {
-			case ProtocolFlags.Baudrate_100k:
-				this.maxBaudRate = 100000;
-				break;
-			case ProtocolFlags.Baudrate_40k:
-				this.maxBaudRate = 40000;
-				break;
-			case ProtocolFlags.Baudrate_9k6:
-				this.maxBaudRate = 9600;
-				break;
-			default:
-				// We don't know this baudrate yet, encode it as 0
-				this.maxBaudRate = (0 as any) as Baudrate;
+		const supportedDataRates: DataRate[] = [];
+		const maxSpeed = protocol & 0b00_011_000;
+		const speedExtension = this.payload[2] & 0b111;
+		if (maxSpeed & 0b00_010_000) {
+			supportedDataRates.push(40000);
 		}
+		if (maxSpeed & 0b00_001_000) {
+			supportedDataRates.push(9600);
+		}
+		if (speedExtension & 0b001) {
+			supportedDataRates.push(100000);
+		}
+		if (supportedDataRates.length === 0) {
+			supportedDataRates.push(9600);
+		}
+		this.supportedDataRates = supportedDataRates;
 
-		this.version = (protocol & ProtocolFlags.VersionMask) + 1;
+		this.protocolVersion =
+			((ProtocolVersion[protocol & 0b111] as any) as ProtocolVersion) ??
+			ProtocolVersion.unknown;
 
 		const capability = this.payload[1];
-		this.isSecure = !!(capability & DeviceCapabilityFlags.Security);
-		this.isFrequentListening = !!(
-			capability &
-			(DeviceCapabilityFlags.Sensor1000ms |
-				DeviceCapabilityFlags.Sensor250ms)
-		);
-		this.isBeaming = !!(capability & DeviceCapabilityFlags.BeamCapability);
-		this.isRoutingSlave = !!(
-			capability & DeviceCapabilityFlags.RoutingSlave
-		);
-		this.isController = !!(capability & DeviceCapabilityFlags.Controller);
+		this.optionalFunctionality = !!(capability & 0b1000_0000);
+		switch (capability & 0b0110_0000) {
+			case 0b0100_0000:
+				this.isFrequentListening = "1000ms";
+				break;
+			case 0b0010_0000:
+				this.isFrequentListening = "250ms";
+				break;
+			default:
+				this.isFrequentListening = false;
+		}
+		this.supportsBeaming = !!(capability & 0b0001_0000);
+
+		switch (capability & 0b1010) {
+			case 0b1000:
+				this.nodeType = NodeType["Routing End Node"];
+				break;
+			case 0b0010:
+			default:
+				this.nodeType = NodeType.Controller;
+				break;
+		}
+
+		const containsSpecificDeviceClass = !!(capability & 0b100);
+		this.supportsSecurity = !!(capability & 0b1);
 
 		// parse the device class
-		const basic = this.payload[3];
-		const generic = this.payload[4];
-		const specific = this.payload[5];
+		let offset = 3;
+		let basic: number;
+		if (this.nodeType === NodeType.Controller) {
+			basic = this.payload[offset++];
+		} else {
+			basic = this.isRouting ? 0x04 : 0x03;
+		}
+		const generic = this.payload[offset++];
+		const specific = containsSpecificDeviceClass
+			? this.payload[offset++]
+			: 0x00;
 		this.deviceClass = new DeviceClass(
 			this.driver.configManager,
 			basic,
@@ -124,27 +125,21 @@ export class GetNodeProtocolInfoResponse extends Message {
 		);
 	}
 
+	/** Whether this node is always listening or not */
 	public readonly isListening: boolean;
-	public readonly isFrequentListening: boolean;
+	/** Indicates the wakeup interval if this node is a FLiRS node. `false` if it isn't. */
+	public readonly isFrequentListening: FLiRS;
+	/** Whether the node supports routing/forwarding messages. */
 	public readonly isRouting: boolean;
-	public readonly maxBaudRate: Baudrate;
-	public readonly isController: boolean;
-	public readonly isRoutingSlave: boolean;
-	public readonly isSecure: boolean;
-	public readonly version: number;
-	public readonly isBeaming: boolean;
+	public readonly supportedDataRates: readonly DataRate[];
+	public readonly protocolVersion: ProtocolVersion;
+	/** Whether this node supports additional CCs besides the mandatory minimum */
+	public readonly optionalFunctionality: boolean;
+	/** Whether this node is a controller (can calculate routes) or an end node (relies on route info) */
+	public readonly nodeType: NodeType;
+	/** Whether this node supports security (S0 or S2) */
+	public readonly supportsSecurity: boolean;
+	/** Whether this node can issue wakeup beams to FLiRS nodes */
+	public readonly supportsBeaming: boolean;
 	public readonly deviceClass: DeviceClass;
-
-	public toJSON(): JSONObject {
-		return super.toJSONInherited({
-			isListening: this.isListening,
-			isFrequentListening: this.isFrequentListening,
-			isRouting: this.isRouting,
-			maxBaudRate: this.maxBaudRate,
-			isSecure: this.isSecure,
-			version: this.version,
-			isBeaming: this.isBeaming,
-			deviceClass: this.deviceClass,
-		});
-	}
 }

--- a/packages/zwave-js/src/lib/controller/RequestNodeNeighborUpdateMessages.ts
+++ b/packages/zwave-js/src/lib/controller/RequestNodeNeighborUpdateMessages.ts
@@ -20,6 +20,7 @@ import type {
 	MultiStageCallback,
 	SuccessIndicator,
 } from "../message/SuccessIndicator";
+import { NodeType } from "../node/Types";
 
 export enum NodeNeighborUpdateStatus {
 	UpdateStarted = 0x21,
@@ -75,7 +76,7 @@ export class RequestNodeNeighborUpdateRequest extends RequestNodeNeighborUpdateR
 			7600 +
 			numListeningNodes * 217 +
 			numFlirsNodes * 3517 +
-			(node?.isController ? numNodes * 732 : 0)
+			(node?.nodeType === NodeType.Controller ? numNodes * 732 : 0)
 		);
 	}
 

--- a/packages/zwave-js/src/lib/node/Types.ts
+++ b/packages/zwave-js/src/lib/node/Types.ts
@@ -153,3 +153,19 @@ export enum NodeStatus {
 	Dead,
 	Alive,
 }
+
+export enum ProtocolVersion {
+	"unknown" = 0,
+	"2.0" = 1,
+	"4.2x / 5.0x" = 2,
+	"4.5x / 6.0x" = 3,
+}
+
+export type FLiRS = false | "250ms" | "1000ms";
+
+export type DataRate = 9600 | 40000 | 100000;
+
+export enum NodeType {
+	Controller,
+	"Routing End Node",
+}


### PR DESCRIPTION
This PR bases the (very old) parsing code for the NodeProtocolInfo response on the Z-Wave specifications instead of reverse engineering, guessing and looking at what OpenZWave did. As a result, several Node properties were reworked.

fixes: #1340