### PR TITLE
fix(config): update Qubino Smart Plug 16A, parameter 41 does not exist

### DIFF
--- a/packages/config/config/devices/0x0159/smart_plug_16a.json
+++ b/packages/config/config/devices/0x0159/smart_plug_16a.json
@@ -136,13 +136,13 @@
 			"writeOnly": false,
 			"allowManualEntry": true
 		},
-		"41": {
-			"label": "Treshold time for power reporting",
-			"unit": "sec",
+		"42": {
+			"label": "Power reporting in Watts by Time interval",
+			"description": "Set value means time interval when power report is send",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 32535,
-			"defaultValue": 0,
+			"defaultValue": 300,
 			"readOnly": false,
 			"writeOnly": false,
 			"allowManualEntry": true


### PR DESCRIPTION
It removes parameter (config) 41, and adds 42. Trying to retrieve parameter 41 seems to kill all Z-Wave communication to the Qubino Smart Plug (I need to physically unplug and replug to get it alive again).