### PR TITLE
fix(config): remove invalid params 1 and 2 from Fibaro FGRM222

### DIFF
--- a/packages/config/config/devices/0x010f/fgrm222_0.0-22.22.json
+++ b/packages/config/config/devices/0x010f/fgrm222_0.0-22.22.json
@@ -43,50 +43,6 @@
 		"fibaroCCs": [38 /* 0x26 (Venetian Blinds) */]
 	},
 	"paramInformation": {
-		"1": {
-			"label": "Local protection",
-			"description": "Enables/disables local protection",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 255,
-			"unsigned": true,
-			"readOnly": false,
-			"writeOnly": false,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "No protection.",
-					"value": 0
-				},
-				{
-					"label": "Local protection active",
-					"value": 2
-				}
-			]
-		},
-		"2": {
-			"label": "Radio protection",
-			"description": "Enables/disables RF protection",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 0,
-			"unsigned": true,
-			"readOnly": false,
-			"writeOnly": false,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "No protection.",
-					"value": 0
-				},
-				{
-					"label": "RF Protection active.",
-					"value": 1
-				}
-			]
-		},
 		"3": {
 			"label": "Reports type",
 			"description": "Enable Venetian Blind mode",


### PR DESCRIPTION
Parameters 1 and 2 don't exist, they are inside the Protected CC.