### PR TITLE
fix: do not remove node from other node's association during replace

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -305,12 +305,20 @@ A node could not be included into or excluded from the network for some reason.
 
 The process to include or exclude a node was stopped successfully. Note that these events are also emitted after a node was included or excluded.
 
-### `"node added"` / `"node removed"`
+### `"node added"`
 
-A node has successfully been added to or removed from the network. The added or removed node is passed to the event handler as the only argument:
+A node has successfully been added to the network. The added node is passed to the event handler as the only argument:
 
 ```ts
 (node: ZWaveNode) => void
+```
+
+### `"node removed"`
+
+A node has successfully been replaced or removed from the network. The `replace` parameter indicates whether the node was replaced with another node.
+
+```ts
+(node: ZWaveNode, replaced: boolean) => void
 ```
 
 ### `"heal network progress"`

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -124,7 +124,7 @@ interface ControllerEventCallbacks {
 	"inclusion stopped": () => void;
 	"exclusion stopped": () => void;
 	"node added": (node: ZWaveNode) => void;
-	"node removed": (node: ZWaveNode) => void;
+	"node removed": (node: ZWaveNode, replaced: boolean) => void;
 	"heal network progress": (
 		progress: ReadonlyMap<number, HealNodeStatus>,
 	) => void;
@@ -1157,7 +1157,7 @@ export class ZWaveController extends EventEmitter {
 				this.emit("inclusion stopped");
 
 				if (this._nodePendingReplace) {
-					this.emit("node removed", this._nodePendingReplace);
+					this.emit("node removed", this._nodePendingReplace, true);
 					this._nodes.delete(this._nodePendingReplace.id);
 
 					// Create a fresh node instance and forget the old one
@@ -1308,7 +1308,11 @@ export class ZWaveController extends EventEmitter {
 					);
 
 					// notify listeners
-					this.emit("node removed", this._nodePendingExclusion);
+					this.emit(
+						"node removed",
+						this._nodePendingExclusion,
+						false,
+					);
 					// and forget the node
 					this._nodes.delete(this._nodePendingExclusion.id);
 					this._nodePendingExclusion = undefined;
@@ -2133,7 +2137,7 @@ ${associatedNodes.join(", ")}`,
 					// If everything went well, the status is RemoveFailedNodeStatus.NodeRemoved
 
 					// Emit the removed event so the driver and applications can react
-					this.emit("node removed", this.nodes.get(nodeId)!);
+					this.emit("node removed", this.nodes.get(nodeId)!, false);
 					// and forget the node
 					this._nodes.delete(nodeId);
 


### PR DESCRIPTION
With this PR we no longer do the cleanup work of removing a node from other node's associations of the removal is part of a **replace failed node** process. Cleaning up interferes with the security bootstrapping and can be unexpected since the node ID will still be part of the network after replacing.

fixes: #2020
(if only it were that easy)