### PR TITLE
feat(config): add config params 13 and 51 to Inovelli LZW30-SN

### DIFF
--- a/packages/config/config/devices/0x031e/lzw30-sn.json
+++ b/packages/config/config/devices/0x031e/lzw30-sn.json
@@ -328,6 +328,48 @@
 			"writeOnly": false,
 			"allowManualEntry": true
 		},
+		"13": {
+			"$if": "firmwareVersion >= 1.17",
+			"label": "",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Automatically detect load type",
+					"value": 0
+				},
+				{
+					"label": "Manually set for special load type",
+					"value": 1
+				}
+			]
+		},
+		"51": {
+			"$if": "firmwareVersion >= 1.19",
+			"label": "Instant On",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "No Delay",
+					"value": 0
+				},
+				{
+					"label": "700ms Delay",
+					"value": 1
+				}
+			]
+		},
 		"8[0xff]": {
 			"label": "LED Strip Effect (Color)",
 			"valueSize": 4,

--- a/packages/config/config/devices/0x031e/lzw30-sn.json
+++ b/packages/config/config/devices/0x031e/lzw30-sn.json
@@ -330,7 +330,7 @@
 		},
 		"13": {
 			"$if": "firmwareVersion >= 1.17",
-			"label": "",
+			"label": "Load Type",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,


### PR DESCRIPTION
These configuration changes add missing parameters for the Inovelli Red Series on/off switch (LZW30-SN) referenced in #2002.

PR will be marked as ready when functional testing is complete.