### PR TITLE
refactor: decouple "notification" event from NotificationCC

### DIFF
--- a/docs/api/CCs/_sidebar.md
+++ b/docs/api/CCs/_sidebar.md
@@ -3,6 +3,7 @@
     -   [Introduction](README.md)
     -   [Quick Start](getting-started/quickstart.md)
     -   [Migrating to v6](getting-started/migrating-to-v6.md)
+    -   [Migrating to v7](getting-started/migrating-to-v7.md)
 
 -   API
 

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -707,14 +707,52 @@ The event argument has the shape of [`TranslatedValueID`](api/valueid.md) with o
 
 ### `"notification"`
 
-The node has sent a notification event using the `Notification` command class. The callback signature is as follows:
+This event serves a similar purpose as the `"value notification"`, but is used for more complex CC-specific notifications.
+The base callback signature has the following shape:
 
 ```ts
-(node: ZWaveNode, notificationLabel: string, parameters?: Buffer | Duration | Record<string, number>) => void;
+type ZWaveNotificationCallback = (
+	node: ZWaveNode,
+	ccId: CommandClasses,
+	args: Record<string, unknown>,
+): void;
 ```
 
 where
 
 -   `node` is the current node instance
--   `notificationLabel` is a string representing the notification type (e.g. `"Home security"`)
--   `parameters` _(optional)_ depends on the type of the notification. It may be a `Duration`, a dictionary or a raw Buffer. Details can be found in the Z-Wave specifications.
+-   `ccId` is the identifier for the CC which raised this event
+-   `args` is a CC-specific argument object
+
+The CCs that use this event bring specialized versions of the callback and arguments.
+
+#### `Notification CC`
+
+<!-- #import ZWaveNotificationCallback_NotificationCC from "zwave-js" -->
+
+```ts
+type ZWaveNotificationCallback_NotificationCC = (
+	node: ZWaveNode,
+	ccId: CommandClasses.Notification,
+	args: ZWaveNotificationCallbackArgs_NotificationCC,
+) => void;
+```
+
+with the argument
+
+<!-- #import ZWaveNotificationCallbackArgs_NotificationCC from "zwave-js" -->
+
+```ts
+interface ZWaveNotificationCallbackArgs_NotificationCC {
+	/** The numeric identifier for the notification type */
+	type: number;
+	/** The human-readable label for the notification type */
+	label: string;
+	/** The numeric identifier for the notification event */
+	event: number;
+	/** The human-readable label for the notification event */
+	eventLabel: string;
+	/** Additional information related to the event */
+	parameters?: NotificationCCReport["eventParameters"];
+}
+```

--- a/docs/getting-started/migrating-to-v7.md
+++ b/docs/getting-started/migrating-to-v7.md
@@ -22,3 +22,11 @@ The old parsing code was based on reverse-engineering, best-effort guesses and l
 -   The `supportsSecurity` property was split off from the `isSecure` property because they have a different meaning.
 -   The mutually exclusive `isRoutingSlave` and `isController` properties were merged into the new `nodeType` property.
 -   The old `nodeType` and `roleType` properties were renamed to `zwavePlusNodeType` and `zwavePlusRoleType` to clarify that they refer to Z-Wave+.
+
+## Reworked `"notification"` event
+
+This event serves a similar purpose as the `"value notification"` event (which was introduced later), but it was historically only used for the `Notification CC`. These events tend to contain more complicated data than the relatively simple `"value notification"` event, which is why it was kept separate.
+
+Since the original implementation, the need for a more versatile CC-specific notification event has arisen. Therefore we decided to rework this event and decouple it from the `Notification CC`. As a result, the event callback now indicates which CC raised the event and its arguments are moved into a single object parameter.
+
+See the [`"notification"` event](../api/node#quotnotificationquot) docs for a detailed description what changed.

--- a/packages/zwave-js/src/lib/commandclass/NotificationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/NotificationCC.ts
@@ -22,6 +22,7 @@ import { JSONObject, num2hex, pick } from "@zwave-js/shared";
 import { isArray } from "alcalzone-shared/typeguards";
 import type { Driver } from "../driver/Driver";
 import { MessagePriority } from "../message/Constants";
+import type { ZWaveNode } from "../node/Node";
 import { PhysicalCCAPI } from "./API";
 import {
 	API,
@@ -57,6 +58,32 @@ export type NotificationMetadata = ValueMetadata & {
 		notificationType: number;
 	};
 };
+
+/**
+ * @publicAPI
+ */
+export interface ZWaveNotificationCallbackArgs_NotificationCC {
+	/** The numeric identifier for the notification type */
+	type: number;
+	/** The human-readable label for the notification type */
+	label: string;
+	/** The numeric identifier for the notification event */
+	event: number;
+	/** The human-readable label for the notification event */
+	eventLabel: string;
+	/** Additional information related to the event */
+	parameters?: NotificationCCReport["eventParameters"];
+}
+
+/**
+ * @publicAPI
+ * The specialized version of ZWaveNotificationCallback for Notification CC
+ */
+export type ZWaveNotificationCallback_NotificationCC = (
+	node: ZWaveNode,
+	ccId: CommandClasses.Notification,
+	args: ZWaveNotificationCallbackArgs_NotificationCC,
+) => void;
 
 /** Returns the ValueID used to store the supported notification types of a node */
 export function getSupportedNotificationTypesValueId(): ValueID {

--- a/packages/zwave-js/src/lib/commandclass/index.ts
+++ b/packages/zwave-js/src/lib/commandclass/index.ts
@@ -52,7 +52,11 @@ export type {
 } from "./MultilevelSensorCC";
 export { LevelChangeDirection, SwitchType } from "./MultilevelSwitchCC";
 export type { MultilevelSwitchLevelChangeMetadata } from "./MultilevelSwitchCC";
-export type { NotificationMetadata } from "./NotificationCC";
+export type {
+	NotificationMetadata,
+	ZWaveNotificationCallbackArgs_NotificationCC,
+	ZWaveNotificationCallback_NotificationCC,
+} from "./NotificationCC";
 export { LocalProtectionState, RFProtectionState } from "./ProtectionCC";
 export { ToneId } from "./SoundSwitchCC";
 export { SupervisionStatus } from "./SupervisionCC";

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -2385,12 +2385,13 @@ protocol version:      ${this._protocolVersion}`;
 				propertyKey = valueConfig.variableName;
 				allowIdleReset = valueConfig.idle;
 			} else {
-				this.emit(
-					"notification",
-					this,
-					valueConfig.label,
-					command.eventParameters,
-				);
+				this.emit("notification", this, CommandClasses.Notification, {
+					type: command.notificationType,
+					event: value,
+					label: notificationConfig.name,
+					eventLabel: valueConfig.label,
+					parameters: command.eventParameters,
+				});
 				return;
 			}
 

--- a/packages/zwave-js/src/lib/node/Types.ts
+++ b/packages/zwave-js/src/lib/node/Types.ts
@@ -7,7 +7,7 @@ import type {
 	ValueUpdatedArgs,
 } from "@zwave-js/core";
 import type { FirmwareUpdateStatus } from "../commandclass";
-import type { NotificationCCReport } from "../commandclass/NotificationCC";
+import type { ZWaveNotificationCallback_NotificationCC } from "../commandclass/NotificationCC";
 import type { ZWaveNode } from "./Node";
 
 export interface TranslatedValueID extends ValueID {
@@ -57,11 +57,6 @@ export type ZWaveNodeMetadataUpdatedCallback = (
 	node: ZWaveNode,
 	args: ZWaveNodeMetadataUpdatedArgs,
 ) => void;
-export type ZWaveNotificationCallback = (
-	node: ZWaveNode,
-	notificationLabel: string,
-	parameters?: NotificationCCReport["eventParameters"],
-) => void;
 export type ZWaveInterviewFailedCallback = (
 	node: ZWaveNode,
 	args: NodeInterviewFailedEventArgs,
@@ -80,6 +75,8 @@ export type ZWaveNodeStatusChangeCallback = (
 	node: ZWaveNode,
 	oldStatus: NodeStatus,
 ) => void;
+
+export type ZWaveNotificationCallback = ZWaveNotificationCallback_NotificationCC;
 
 export interface ZWaveNodeValueEventCallbacks {
 	"value added": ZWaveNodeValueAddedCallback;


### PR DESCRIPTION
With this PR, the `"notification"` event is no longer exclusive to the `Notification CC`, but instead includes the CC that raised it and a CC-specific argument object in its event signature.

fixes: #1869