### PR TITLE
fix: correctly determine node status after restarting from cache

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -49,7 +49,7 @@
 				"${workspaceFolder}/test/run.ts"
 			],
 			"env": {
-				"NO_CACHE": "true"
+				// "NO_CACHE": "true"
 				// "LOGLEVEL": "verbose"
 			},
 			"console": "integratedTerminal",

--- a/packages/zwave-js/src/lib/node/Node.test.ts
+++ b/packages/zwave-js/src/lib/node/Node.test.ts
@@ -1168,7 +1168,7 @@ describe("lib/node/Node", () => {
 			node.destroy();
 		});
 
-		it("deserialize() should set the node status to Asleep if the node can sleep", () => {
+		it("deserialize() should set the node status to Unknown if the node can sleep", () => {
 			const input = {
 				...serializedTestNode,
 				isListening: false,
@@ -1176,7 +1176,7 @@ describe("lib/node/Node", () => {
 			};
 			const node = new ZWaveNode(1, fakeDriver);
 			node.deserialize(input);
-			expect(node.status).toBe(NodeStatus.Asleep);
+			expect(node.status).toBe(NodeStatus.Unknown);
 			node.destroy();
 		});
 

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3116,9 +3116,6 @@ protocol version:      ${this._protocolVersion}`;
 			this._supportedDataRates = obj.supportedDataRates;
 		}
 
-		// A node that can sleep should be assumed to be sleeping after resuming from cache
-		if (this.canSleep) this.markAsAsleep();
-
 		if (isArray(obj.neighbors)) {
 			// parse only valid node IDs
 			this._neighbors = obj.neighbors.filter(

--- a/packages/zwave-js/src/lib/node/NodeStatusMachine.test.ts
+++ b/packages/zwave-js/src/lib/node/NodeStatusMachine.test.ts
@@ -28,13 +28,13 @@ describe("lib/driver/NodeStatusMachine", () => {
 			expect(service.state.value).toBe("unknown");
 		});
 
-		it(`The node should start in the asleep state if it can definitely sleep`, () => {
+		it(`The node should start in the unknown state if it can definitely sleep`, () => {
 			const testMachine = createNodeStatusMachine({
 				canSleep: true,
 			} as any);
 
 			service = interpret(testMachine).start();
-			expect(service.state.value).toBe("asleep");
+			expect(service.state.value).toBe("unknown");
 		});
 
 		const transitions: {

--- a/packages/zwave-js/src/lib/node/NodeStatusMachine.ts
+++ b/packages/zwave-js/src/lib/node/NodeStatusMachine.ts
@@ -5,7 +5,6 @@ import { NodeStatus } from "./Types";
 /* eslint-disable @typescript-eslint/ban-types */
 export interface NodeStatusStateSchema {
 	states: {
-		init: {};
 		unknown: {};
 		// non-sleeping nodes are either dead or alive
 		dead: {};
@@ -25,7 +24,7 @@ const statusDict = {
 	awake: NodeStatus.Awake,
 } as const;
 export function nodeStatusMachineStateToNodeStatus(
-	state: Exclude<keyof NodeStatusStateSchema["states"], "init">,
+	state: keyof NodeStatusStateSchema["states"],
 ): NodeStatus {
 	return statusDict[state] ?? NodeStatus.Unknown;
 }
@@ -51,14 +50,8 @@ export function createNodeStatusMachine(node: ZWaveNode): NodeStatusMachine {
 	return Machine<any, NodeStatusStateSchema, NodeStatusEvent>(
 		{
 			id: "nodeStatus",
-			initial: "init",
+			initial: "unknown",
 			states: {
-				init: {
-					always: [
-						{ target: "asleep", cond: "canSleep" },
-						{ target: "unknown" },
-					],
-				},
 				unknown: {
 					on: {
 						DEAD: {

--- a/test/run.ts
+++ b/test/run.ts
@@ -6,10 +6,9 @@ process.on("unhandledRejection", (_r) => {
 	// debugger;
 });
 
-import { MultilevelSensorCCGet } from "../packages/zwave-js/src/lib/commandclass/MultilevelSensorCC";
 import { Driver } from "../packages/zwave-js/src/lib/driver/Driver";
 
-const driver = new Driver("COM4", {
+const driver = new Driver("COM5", {
 	// prettier-ignore
 	networkKey: Buffer.from([
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
@@ -17,18 +16,6 @@ const driver = new Driver("COM4", {
 })
 	.on("error", console.error)
 	.once("driver ready", async () => {
-		await require("alcalzone-shared/async").wait(2000);
-
-		const node = driver.controller.nodes.get(22)!;
-		const resp = await driver.sendCommand(
-			new MultilevelSensorCCGet(driver, {
-				nodeId: node.id,
-				sensorType: 1,
-				scale: 2,
-			}),
-		);
-		console.dir(resp);
-
 		// const cc = new CommandClass(driver, {
 		// 	nodeId: 24,
 		// 	ccId: 0x5d,


### PR DESCRIPTION
There were still a few weirdnesses when it comes to the node status after a cache restart. The main reason was a wrong event ordering which this PR fixes.

supersedes: #2038