### PR TITLE
feat: add config for YRD210 with incorrect manufacturerId

### DIFF
--- a/packages/config/config/devices/0x0109/yrd210.json
+++ b/packages/config/config/devices/0x0109/yrd210.json
@@ -56,48 +56,5 @@
 		"8": {
 			"$import": "../0x0129/templates/yale_template.json#operating_mode"
 		}
-	},
-	"compat": {
-		"alarmMapping": [
-			{
-				"$import": "../0x0129/templates/yale_template.json#alarm_map_keypad_limit"
-			},
-			{
-				"$import": "../0x0129/templates/yale_template.json#alarm_map_manual_unlock"
-			},
-			{
-				"$import": "../0x0129/templates/yale_template.json#alarm_map_rf_unlock"
-			},
-			{
-				"$import": "../0x0129/templates/yale_template.json#alarm_map_keypad_unlock"
-			},
-			{
-				"$import": "../0x0129/templates/yale_template.json#alarm_map_manual_lock"
-			},
-			{
-				"$import": "../0x0129/templates/yale_template.json#alarm_map_rf_lock"
-			},
-			{
-				"$import": "../0x0129/templates/yale_template.json#alarm_map_keypad_lock"
-			},
-			{
-				"$import": "../0x0129/templates/yale_template.json#alarm_map_deadbolt_jammed"
-			},
-			{
-				"$import": "../0x0129/templates/yale_template.json#alarm_map_non_access"
-			},
-			{
-				"$import": "../0x0129/templates/yale_template.json#alarm_map_low_battery"
-			},
-			{
-				"$import": "../0x0129/templates/yale_template.json#alarm_map_auto_relock"
-			},
-			{
-				"$import": "../0x0129/templates/yale_template.json#alarm_map_disabled_pin_used"
-			},
-			{
-				"$import": "../0x0129/templates/yale_template.json#alarm_map_user_outside_schedule"
-			}
-		]
 	}
 }

--- a/packages/config/config/devices/0x0109/yrd210.json
+++ b/packages/config/config/devices/0x0109/yrd210.json
@@ -2,7 +2,7 @@
 // Push Button Deadbolt
 {
 	"manufacturer": "Yale",
-	"manufacturerId": "0x0109",
+	"manufacturerId": "0x0109", // Addresses a series of locks that report the incorrect manufacturerId
 	"label": "YRD210",
 	"description": "Push Button Deadbolt",
 	"devices": [

--- a/packages/config/config/devices/0x0109/yrd210.json
+++ b/packages/config/config/devices/0x0109/yrd210.json
@@ -56,5 +56,48 @@
 		"8": {
 			"$import": "../0x0129/templates/yale_template.json#operating_mode"
 		}
+	},
+	"compat": {
+		"alarmMapping": [
+			{
+				"$import": "../0x0129/templates/yale_template.json#alarm_map_keypad_limit"
+			},
+			{
+				"$import": "../0x0129/templates/yale_template.json#alarm_map_manual_unlock"
+			},
+			{
+				"$import": "../0x0129/templates/yale_template.json#alarm_map_rf_unlock"
+			},
+			{
+				"$import": "../0x0129/templates/yale_template.json#alarm_map_keypad_unlock"
+			},
+			{
+				"$import": "../0x0129/templates/yale_template.json#alarm_map_manual_lock"
+			},
+			{
+				"$import": "../0x0129/templates/yale_template.json#alarm_map_rf_lock"
+			},
+			{
+				"$import": "../0x0129/templates/yale_template.json#alarm_map_keypad_lock"
+			},
+			{
+				"$import": "../0x0129/templates/yale_template.json#alarm_map_deadbolt_jammed"
+			},
+			{
+				"$import": "../0x0129/templates/yale_template.json#alarm_map_non_access"
+			},
+			{
+				"$import": "../0x0129/templates/yale_template.json#alarm_map_low_battery"
+			},
+			{
+				"$import": "../0x0129/templates/yale_template.json#alarm_map_auto_relock"
+			},
+			{
+				"$import": "../0x0129/templates/yale_template.json#alarm_map_disabled_pin_used"
+			},
+			{
+				"$import": "../0x0129/templates/yale_template.json#alarm_map_user_outside_schedule"
+			}
+		]
 	}
 }

--- a/packages/config/config/devices/0x0109/yrd210.json
+++ b/packages/config/config/devices/0x0109/yrd210.json
@@ -1,0 +1,60 @@
+// Yale YRD210
+// Push Button Deadbolt
+{
+	"manufacturer": "Yale",
+	"manufacturerId": "0x0109",
+	"label": "YRD210",
+	"description": "Push Button Deadbolt",
+	"devices": [
+		{
+			"productType": "0x0001",
+			"productId": "0x0000"
+		},
+		{
+			"productType": "0x0002",
+			"productId": "0x0000"
+		},
+		{
+			"productType": "0x0003",
+			"productId": "0x0000"
+		},
+		{
+			"productType": "0x0004",
+			"productId": "0x0000"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Alarm Reports",
+			"maxNodes": 4,
+			"isLifeline": true
+		}
+	},
+	"paramInformation": {
+		"1": {
+			"$import": "../0x0129/templates/yale_template.json#volume_inverted"
+		},
+		"2": {
+			"$import": "../0x0129/templates/yale_template.json#auto_relock"
+		},
+		"3": {
+			"$import": "../0x0129/templates/yale_template.json#auto_relock_time_180"
+		},
+		"4": {
+			"$import": "../0x0129/templates/yale_template.json#wrong_code_limit_10"
+		},
+		"5": {
+			"$import": "../0x0129/templates/yale_template.json#language"
+		},
+		"7": {
+			"$import": "../0x0129/templates/yale_template.json#wrong_code_lockout_10_to_127"
+		},
+		"8": {
+			"$import": "../0x0129/templates/yale_template.json#operating_mode"
+		}
+	}
+}


### PR DESCRIPTION
Fixes @Juggler00's issue in #1713. Yale released some locks with an incorrect manufacturerId.