### PR TITLE
fix: typo in log file for Association CC

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/AssociationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/AssociationCC.ts
@@ -388,7 +388,7 @@ currently assigned nodes: ${group.nodeIds.map(String).join(", ")}`;
 				if (!lifelineNodeIds.includes(ownNodeId)) {
 					this.driver.controllerLog.logNode(node.id, {
 						endpoint: this.endpointIndex,
-						message: `Controller missing from lifeline group #${group}, assinging ourselves...`,
+						message: `Controller missing from lifeline group #${group}, assigning ourselves...`,
 						direction: "outbound",
 					});
 					// Add a new destination


### PR DESCRIPTION
Corrects a typo noted in the log file of #2054.