### PR TITLE
fix(config): Update lzw31-sn parameter 16 to match documentation.

### DIFF
--- a/packages/config/config/devices/0x031e/lzw31-sn_0.0-1.45.json
+++ b/packages/config/config/devices/0x031e/lzw31-sn_0.0-1.45.json
@@ -261,7 +261,7 @@
 			"label": "LED Strip Effect",
 			"valueSize": 4,
 			"minValue": 0,
-			"maxValue": 83823359,
+			"maxValue": 100600575,
 			"defaultValue": 0,
 			"readOnly": false,
 			"writeOnly": false,

--- a/packages/config/config/devices/0x031e/lzw31-sn_1.47-1.48.json
+++ b/packages/config/config/devices/0x031e/lzw31-sn_1.47-1.48.json
@@ -261,7 +261,7 @@
 			"label": "LED Strip Effect",
 			"valueSize": 4,
 			"minValue": 0,
-			"maxValue": 83823359,
+			"maxValue": 100600575,
 			"defaultValue": 0,
 			"readOnly": false,
 			"writeOnly": false,

--- a/packages/config/config/devices/0x031e/lzw31-sn_1.49.json
+++ b/packages/config/config/devices/0x031e/lzw31-sn_1.49.json
@@ -261,7 +261,7 @@
 			"label": "LED Strip Effect",
 			"valueSize": 4,
 			"minValue": 0,
-			"maxValue": 83823359,
+			"maxValue": 100600575,
 			"defaultValue": 0,
 			"readOnly": false,
 			"writeOnly": false,


### PR DESCRIPTION
This updates the LED effect parameter per docs and the [OZW](https://github.com/InovelliUSA/OpenZWave/blob/master/config/inovelli/lzw31-sn.xml) file.

@AlCalzone A related question,  my read of #1411 is that single params like this are less helpful than splitting each out like [lzw30-sn](packages/config/config/devices/0x031e/lzw30-sn.json). If that's the case, would it be better for me to update this to match that instead of updating this single parameter?