### PR TITLE
fix(config): update LZW30 parameters to match documentation/latest firmware

### DIFF
--- a/packages/config/config/devices/0x031e/lzw30.json
+++ b/packages/config/config/devices/0x031e/lzw30.json
@@ -123,6 +123,10 @@
 				{
 					"label": "Pink",
 					"value": 234
+				},
+				{
+					"label": "White (firmware 1.19+)",
+					"value": 255
 				}
 			]
 		},
@@ -238,16 +242,48 @@
 				}
 			]
 		},
-		"8": {
-			"label": "LED Strip Effect",
-			"description": "Calculated sum of parameters as per overview section",
-			"valueSize": 4,
+		"13": {
+			"label": "Special Load Type",
+			"description": "Can be used in certain 3-way dumb switch setups where the load is confusing the switch as to which state it should be in. (firmware 1.17+).",
+			"valueSize": 1,
 			"minValue": 0,
-			"maxValue": 83823359,
+			"maxValue": 1,
 			"defaultValue": 0,
 			"readOnly": false,
 			"writeOnly": false,
-			"allowManualEntry": true
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Detect Load Type",
+					"value": 0
+				},
+				{
+					"label": "Manually set for special load type",
+					"value": 1
+				}
+			]
+		},
+		"51": {
+			"label": "Instant On",
+			"description": "Enables instant on (ie: disables the 700ms button delay). (firmware 1.19+).",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Enabled (no delay)",
+					"value": 0
+				},
+				{
+					"label": "Disabled (700ms delay)",
+					"value": 1
+				}
+			]
 		}
 	}
 }

--- a/packages/config/config/devices/0x031e/lzw30.json
+++ b/packages/config/config/devices/0x031e/lzw30.json
@@ -125,7 +125,8 @@
 					"value": 234
 				},
 				{
-					"label": "White (firmware 1.19+)",
+					"$if": "firmwareVersion >= 1.19",
+					"label": "White",
 					"value": 255
 				}
 			]
@@ -243,8 +244,9 @@
 			]
 		},
 		"13": {
+			"$if": "firmwareVersion >= 1.17",
 			"label": "Special Load Type",
-			"description": "Can be used in certain 3-way dumb switch setups where the load is confusing the switch as to which state it should be in. (firmware 1.17+).",
+			"description": "Can be used in certain 3-way dumb switch setups where the load is confusing the switch as to which state it should be in.",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
@@ -264,8 +266,9 @@
 			]
 		},
 		"51": {
+			"$if": "firmwareVersion >= 1.19",
 			"label": "Instant On",
-			"description": "Enables instant on (ie: disables the 700ms button delay). (firmware 1.19+).",
+			"description": "Enables instant on (ie: disables the 700ms button delay).",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,

--- a/packages/config/config/devices/0x031e/lzw30.json
+++ b/packages/config/config/devices/0x031e/lzw30.json
@@ -268,7 +268,6 @@
 		"51": {
 			"$if": "firmwareVersion >= 1.19",
 			"label": "Instant On",
-			"description": "Enables instant on (ie: disables the 700ms button delay).",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,


### PR DESCRIPTION
LZW30 does not have parameter 8 (that is for lzw30-sn only). Added parameter 13 added in fw version 1.17. Added parameter 51 added in fw version 1.19. Also added White as an LED option also added in fw 1.19.

For reference: 
https://support.inovelli.com/portal/en/kb/articles/firmware-v1-17-beta-lzw30-switch-black-series-gen-2
https://support.inovelli.com/portal/en/kb/articles/firmware-v1-19-beta-lzw30-switch-black-series-gen-2
