### PR TITLE
fix(config): add missing Sunricher device configs

### DIFF
--- a/packages/config/config/devices/0x0330/zv9001k12-dim-z4.json
+++ b/packages/config/config/devices/0x0330/zv9001k12-dim-z4.json
@@ -1,13 +1,23 @@
-// ShenZhen Sunricher Technology, Ltd. SR-ZV9001K12-DIM-Z4
-// Z-Wave Dim Remote Control
+// Sunricher ZV9001K12-DIM-Z4
+// 4 Channel Dimmer Remote Control
 {
-	"manufacturer": "ShenZhen Sunricher Technology, Ltd.",
+	"manufacturer": "Sunricher",
 	"manufacturerId": "0x0330",
-	"label": "SR-ZV9001K12-DIM-Z4",
-	"description": "Z-Wave Dim Remote Control",
+	"label": "ZV9001K12-DIM-Z4",
+	"description": "4 Channel Dimmer Remote Control",
 	"devices": [
 		{
 			"productType": "0x0300",
+			"productId": "0xb302",
+			"zwaveAllianceId": 3907
+		},
+		{
+			"productType": "0x0301",
+			"productId": "0xb302",
+			"zwaveAllianceId": 3907
+		},
+		{
+			"productType": "0x0302",
 			"productId": "0xb302",
 			"zwaveAllianceId": 3907
 		}
@@ -16,24 +26,10 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
-	"paramInformation": {
-		"1": {
-			"label": "Factory Reset",
-			"description": "Factory reset",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 21930,
-			"defaultValue": 0,
-			"unsigned": true,
-			"readOnly": false,
-			"writeOnly": false,
-			"allowManualEntry": true
-		}
-	},
 	"metadata": {
 		"inclusion": "Step 1. Make sure the remote control does not belong to any Z-Wave network, short press any button, if LED\nindicator does not turn on, the remote control does not belong to any network, then continue step 2,if LED\nindicator turns on, it means the remote control has already been included to a network, please first set the\nremote control to exclusion mode (refer to the part \"Exclusion\" of this manual),then continue step 2.\nStep 2. Set primary controller/gateway into inclusion mode (Please refer to your primary controllers manual on\nhow to turn your controller into inclusion).\nStep 3. Press and hold down both buttons All On I and All Off O for over 3 seconds, LED indicator turns on, the\nremote control will be set to inclusion mode, and waiting to be included, after 10s LED indicator blinks 6 times\nquickly to indicate successful inclusion. The remote control is a sleepy device, after inclusion it will not enter\ninto sleepy mode immediately, and will continue activation status for 30s and wait data interaction from the\ngateway, the LED indicator will stay solid on, please be patient to wait LED indicator to turn off",
 		"exclusion": "There are two exclusion methods:\nMethod 1: Exclusion from the primary controller/gateway as follows:\n1. Set the primary controller/gateway into exclusion mode (Please refer to your primary controllers manual on\nhow to set your controller into exclusion).\n2. Press and hold down both buttons All On I and All Off O for over 3 seconds, LED indicator turns on, the\nremote control will be set to exclusion mode, and waiting to be excluded, after 7s LED indicator blinks 4 times\nquickly to indicate successful exclusion.\nMethod 2: Factory reset the remote control will force the remote control to be excluded from a network. (please refer to the part “Factory Reset” of this manual)",
 		"reset": "Press and hold down both buttons All On I and All Off O for over 10 seconds, LED indicator turns on and then\nblinks 4 times quickly to indicate successful factory reset.\nNote: Please use this procedure only when the network primary controller is missing or otherwise inoperable",
-		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=product_documents/3907/SR-ZV9001K12-DIM-Z4%20Instruction.pdf"
+		"manual": "https://www.sunricher.com/media/resources/manual/SR-ZV9001K12-DIM-Z4%20V2%20Instruction.pdf"
 	}
 }

--- a/packages/config/config/devices/0x0330/zv9001k12-dim-z5.json
+++ b/packages/config/config/devices/0x0330/zv9001k12-dim-z5.json
@@ -1,0 +1,32 @@
+// Sunricher ZV9001K12-DIM-Z5
+// 5 Channel Dimmer Remote Control
+{
+	"manufacturer": "Sunricher",
+	"manufacturerId": "0x0330",
+	"label": "ZV9001K12-DIM-Z5",
+	"description": "5 Channel Dimmer Remote Control",
+	"devices": [
+		{
+			"productType": "0x0300",
+			"productId": "0xb301"
+		},
+		{
+			"productType": "0x0301",
+			"productId": "0xb301"
+		},
+		{
+			"productType": "0x0302",
+			"productId": "0xb301"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"metadata": {
+		"inclusion": "Step 1. Make sure the remote control does not belong to any Z-Wave network, short press any button, if LED\nindicator does not turn on, the remote control does not belong to any network, then continue step 2,if LED\nindicator turns on, it means the remote control has already been included to a network, please first set the\nremote control to exclusion mode (refer to the part \"Exclusion\" of this manual),then continue step 2.\nStep 2. Set primary controller/gateway into inclusion mode (Please refer to your primary controllers manual on\nhow to turn your controller into inclusion).\nStep 3. Press and hold down both buttons All On I and All Off O for over 3 seconds, LED indicator turns on, the\nremote control will be set to inclusion mode, and waiting to be included, after 10s LED indicator blinks 6 times\nquickly to indicate successful inclusion. The remote control is a sleepy device, after inclusion it will not enter\ninto sleepy mode immediately, and will continue activation status for 30s and wait data interaction from the\ngateway, the LED indicator will stay solid on, please be patient to wait LED indicator to turn off",
+		"exclusion": "There are two exclusion methods:\nMethod 1: Exclusion from the primary controller/gateway as follows:\n1. Set the primary controller/gateway into exclusion mode (Please refer to your primary controllers manual on\nhow to set your controller into exclusion).\n2. Press and hold down both buttons All On I and All Off O for over 3 seconds, LED indicator turns on, the\nremote control will be set to exclusion mode, and waiting to be excluded, after 7s LED indicator blinks 4 times\nquickly to indicate successful exclusion.\nMethod 2: Factory reset the remote control will force the remote control to be excluded from a network. (please refer to the part “Factory Reset” of this manual)",
+		"reset": "Press and hold down both buttons All On I and All Off O for over 10 seconds, LED indicator turns on and then\nblinks 4 times quickly to indicate successful factory reset.\nNote: Please use this procedure only when the network primary controller is missing or otherwise inoperable",
+		"manual": "https://www.sunricher.com/media/resources/manual/SR-ZV9001K12-DIM-Z5%20V2%20Instruction.pdf"
+	}
+}

--- a/packages/config/config/devices/0x0330/zv9001k4-dim-g2.json
+++ b/packages/config/config/devices/0x0330/zv9001k4-dim-g2.json
@@ -1,0 +1,22 @@
+// Sunricher ZV9001K4-DIM-G2
+// 2 group single color wall mounted remote
+{
+	"manufacturer": "Sunricher",
+	"manufacturerId": "0x0330",
+	"label": "ZV9001K4-DIM-G2",
+	"description": "2 group single color wall mounted remote",
+	"devices": [
+		{
+			"productType": "0x0003",
+			"productId": "0xa306",
+			"zwaveAllianceId": 3783
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"metadata": {
+		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=product_documents/3783/SR-ZV9001K4-DIM-G2%20Instruction.pdf"
+	}
+}

--- a/packages/config/config/devices/0x0330/zv9001k4-dim.json
+++ b/packages/config/config/devices/0x0330/zv9001k4-dim.json
@@ -1,0 +1,21 @@
+// Sunricher ZV9001K4-DIM
+// Z-Wave Dim Remote Control
+{
+	"manufacturer": "Sunricher",
+	"manufacturerId": "0x0330",
+	"label": "ZV9001K4-DIM",
+	"description": "Z-Wave Dim Remote Control",
+	"devices": [
+		{
+			"productType": "0x0003",
+			"productId": "0xa310"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"metadata": {
+		"manual": "https://www.sunricher.com/media/resources/manual/SR-ZV9001K4-DIM%20Instruction%20V1.pdf"
+	}
+}


### PR DESCRIPTION
This PR adds the following Sunricher devices:
* `ZV9001K4-DIM` Z-Wave Dim Remote Control
* `ZV9001K4-DIM-G2` 2 group single color wall mounted remote
* `ZV9001K12-DIM-Z5` 5 Channel Dimmer Remote Control

It also updates the existing config file for the `ZV9001K12-DIM-Z4` 4 Channel Dimmer Remote Control, adding some missing information and making it more in line with other Sunricher device configs.