### PR TITLE
docs: clarify the use of `associations`  in config files

### DIFF
--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -66,7 +66,16 @@ Can be used to add instructions for the user to a device:
 
 ## `associations`
 
-For devices that don't support the Z-Wave+ standard, the associations must be defined. The property looks as follows:
+For devices which do not allow auto-discovering associations, the associations must be defined in the config file.
+
+Before defining `associations` in a config file, please make sure that **at least one** of the following points applies:
+
+-   The device **does not** support `Z-Wave Plus CC` and `Association Group Info CC`
+-   The auto-discovered labels are **bad** (content or formatting wise), like `GROUP_1` instead of something useful like `Multilevel Sensor Reports`
+-   Additional lifelines besides the primary one are **necessary** to get all desired reports
+-   `zwave-js` auto-assigns an endpoint association (node 1, endpoint 0) to the lifeline, but the device needs a node association (node 1, no endpoint) to report properly
+
+The property looks as follows:
 
 ```json
 "associations": {

--- a/docs/config-files/style-guide.md
+++ b/docs/config-files/style-guide.md
@@ -77,6 +77,16 @@ These should generally conform to the name under which the device is sold. If th
 
 Descriptions should be **Title Case**.
 
+## Association Groups
+
+The association group labels should be clear and concise. They should clearly explain what the association group is for, e.g. `Multilevel Sensor Reports`. Avoid generic names like `Group #1`.
+
+The primary reporting group (usually group 1 for Z-Wave Plus) **must** be called `Lifeline`.
+
+Labels should be **Title Case**.
+
+> [!NOTE] Association Groups should only be defined if necessary. Refer to the [property definition](config-files/file-format.md#associations) to figure out when that is the case.
+
 ## Configuration Parameters
 
 ### Labels


### PR DESCRIPTION
Seems that we often get unnecessary association definitions. We should clarify in the docs when to add them and when not.