### PR TITLE
feat: provide API to lookup device definitions with preserved conditions

### DIFF
--- a/docs/api/config-manager.md
+++ b/docs/api/config-manager.md
@@ -263,6 +263,14 @@ Looks up the definition of a given device in the configuration DB. It is not nec
 
 For details on the available properties, refer to the [config file documentation](development/config-files.md).
 
+### `lookupDevicePreserveConditions`
+
+```ts
+lookupDevicePreserveConditions(manufacturerId: number, productType: number, productId: number, firmwareVersion?: string): Promise<ConditionalDeviceConfig | undefined>;
+```
+
+Like `lookupDevice`, but does not evaluate `$if` conditions. The resulting object will contain all settings that are defined regardless if they apply or not.
+
 ### `loadNotifications`
 
 ```ts

--- a/docs/api/config-manager.md
+++ b/docs/api/config-manager.md
@@ -280,7 +280,10 @@ interface ConditionalDeviceConfig {
 	readonly manufacturerId: number;
 	readonly label: string;
 	readonly description: string;
-	readonly devices: readonly { productType: string; productId: string }[];
+	readonly devices: readonly {
+		productType: number;
+		productId: number;
+	}[];
 	readonly firmwareVersion: FirmwareVersionRange;
 	readonly associations?: ReadonlyMap<number, ConditionalAssociationConfig>;
 	readonly paramInformation?: ReadonlyObjectKeyMap<

--- a/docs/api/config-manager.md
+++ b/docs/api/config-manager.md
@@ -269,7 +269,77 @@ For details on the available properties, refer to the [config file documentation
 lookupDevicePreserveConditions(manufacturerId: number, productType: number, productId: number, firmwareVersion?: string): Promise<ConditionalDeviceConfig | undefined>;
 ```
 
-Like `lookupDevice`, but does not evaluate `$if` conditions. The resulting object will contain all settings that are defined regardless if they apply or not.
+Like `lookupDevice`, but does not evaluate `$if` conditions. The resulting object will contain all settings that are defined regardless if they apply or not. For details, refer to the type definitions:
+
+<!-- This was originally imported, but cleaned up manually -->
+
+```ts
+interface ConditionalDeviceConfig {
+	readonly filename: string;
+	readonly manufacturer: string;
+	readonly manufacturerId: number;
+	readonly label: string;
+	readonly description: string;
+	readonly devices: readonly { productType: string; productId: string }[];
+	readonly firmwareVersion: FirmwareVersionRange;
+	readonly associations?: ReadonlyMap<number, ConditionalAssociationConfig>;
+	readonly paramInformation?: ReadonlyObjectKeyMap<
+		{ parameter: number; valueBitMask?: number },
+		ConditionalParamInformation[]
+	>;
+	readonly proprietary?: Record<string, unknown>;
+	readonly compat?: CompatConfig;
+	readonly metadata?: DeviceMetadata;
+}
+```
+
+> [!NOTE] Each entry of `paramInformation` is guaranteed to be an array (one entry per variant/condition), regardless of how it was defined in the config file.
+
+<!-- #import ConditionalAssociationConfig from "@zwave-js/config" -->
+
+```ts
+interface ConditionalAssociationConfig {
+	readonly condition?: string | undefined;
+	readonly groupId: number;
+	readonly label: string;
+	readonly description?: string | undefined;
+	readonly maxNodes: number;
+	readonly isLifeline: boolean;
+	readonly noEndpoint: boolean;
+}
+```
+
+<!-- #import ConditionalParamInformation from "@zwave-js/config" -->
+
+```ts
+interface ConditionalParamInformation {
+	readonly parameterNumber: number;
+	readonly valueBitMask?: number | undefined;
+	readonly label: string;
+	readonly description?: string | undefined;
+	readonly valueSize: number;
+	readonly minValue: number;
+	readonly maxValue: number;
+	readonly unsigned?: boolean | undefined;
+	readonly defaultValue: number;
+	readonly unit?: string | undefined;
+	readonly readOnly: boolean;
+	readonly writeOnly: boolean;
+	readonly allowManualEntry: boolean;
+	readonly options: readonly ConditionalConfigOption[];
+	readonly condition?: string | undefined;
+}
+```
+
+<!-- #import ConditionalConfigOption from "@zwave-js/config" -->
+
+```ts
+interface ConditionalConfigOption {
+	readonly value: number;
+	readonly label: string;
+	readonly condition?: string | undefined;
+}
+```
 
 ### `loadNotifications`
 

--- a/packages/config/src/ConfigManager.ts
+++ b/packages/config/src/ConfigManager.ts
@@ -13,6 +13,7 @@ import {
 	SpecificDeviceClass,
 } from "./DeviceClasses";
 import {
+	ConditionalDeviceConfig,
 	DeviceConfig,
 	DeviceConfigIndex,
 	FulltextDeviceConfigIndex,
@@ -451,19 +452,19 @@ export class ConfigManager {
 	}
 
 	/**
-	 * Looks up the definition of a given device in the configuration DB
+	 * Looks up the definition of a given device in the configuration DB, but does not evaluate conditional settings.
 	 * @param manufacturerId The manufacturer id of the device
 	 * @param productType The product type of the device
 	 * @param productId The product id of the device
 	 * @param firmwareVersion If known, configuration for a specific firmware version can be loaded.
 	 * If this is `undefined` or not given, the first matching file with a defined firmware range will be returned.
 	 */
-	public async lookupDevice(
+	public async lookupDevicePreserveConditions(
 		manufacturerId: number,
 		productType: number,
 		productId: number,
 		firmwareVersion?: string,
-	): Promise<DeviceConfig | undefined> {
+	): Promise<ConditionalDeviceConfig | undefined> {
 		// Load/regenerate the index if necessary
 		if (!this.index) await this.loadDeviceIndex();
 
@@ -486,15 +487,7 @@ export class ConfigManager {
 			if (!(await pathExists(filePath))) return;
 
 			try {
-				return await DeviceConfig.from(filePath, {
-					// Specify how the device was identified in order to evaluate conditions
-					deviceId: {
-						manufacturerId,
-						productType,
-						productId,
-						firmwareVersion,
-					},
-				});
+				return await ConditionalDeviceConfig.from(filePath);
 			} catch (e) {
 				if (process.env.NODE_ENV !== "test") {
 					this.logger.print(
@@ -504,6 +497,34 @@ export class ConfigManager {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Looks up the definition of a given device in the configuration DB
+	 * @param manufacturerId The manufacturer id of the device
+	 * @param productType The product type of the device
+	 * @param productId The product id of the device
+	 * @param firmwareVersion If known, configuration for a specific firmware version can be loaded.
+	 * If this is `undefined` or not given, the first matching file with a defined firmware range will be returned.
+	 */
+	public async lookupDevice(
+		manufacturerId: number,
+		productType: number,
+		productId: number,
+		firmwareVersion?: string,
+	): Promise<DeviceConfig | undefined> {
+		const ret = await this.lookupDevicePreserveConditions(
+			manufacturerId,
+			productType,
+			productId,
+			firmwareVersion,
+		);
+		return ret?.evaluate({
+			manufacturerId,
+			productType,
+			productId,
+			firmwareVersion,
+		});
 	}
 
 	public async loadNotifications(): Promise<void> {

--- a/packages/config/src/Devices.ts
+++ b/packages/config/src/Devices.ts
@@ -218,7 +218,8 @@ export async function loadDeviceIndexInternal(
 				manufacturerId: formatId(config.manufacturerId.toString(16)),
 				manufacturer: config.manufacturer,
 				label: config.label,
-				...dev,
+				productType: formatId(dev.productType),
+				productId: formatId(dev.productId),
 				firmwareVersion: config.firmwareVersion,
 			})),
 		logger,
@@ -241,7 +242,8 @@ export async function loadFulltextDeviceIndexInternal(
 				manufacturer: config.manufacturer,
 				label: config.label,
 				description: config.description,
-				...dev,
+				productType: formatId(dev.productType),
+				productId: formatId(dev.productId),
 				firmwareVersion: config.firmwareVersion,
 			})),
 		logger,
@@ -331,7 +333,10 @@ devices is malformed (not an object or type/id that is not a 4-digit hex key)`,
 			);
 		}
 		this.devices = (definition.devices as any[]).map(
-			({ productType, productId }) => ({ productType, productId }),
+			({ productType, productId }) => ({
+				productType: parseInt(productType, 16),
+				productId: parseInt(productId, 16),
+			}),
 		);
 
 		if (
@@ -499,8 +504,8 @@ metadata is not an object`,
 	public readonly label!: string;
 	public readonly description!: string;
 	public readonly devices: readonly {
-		productType: string;
-		productId: string;
+		productType: number;
+		productId: number;
 	}[];
 	public readonly firmwareVersion: FirmwareVersionRange;
 	public readonly associations?: ReadonlyMap<
@@ -581,8 +586,8 @@ export class DeviceConfig {
 		public readonly label: string,
 		public readonly description: string,
 		public readonly devices: readonly {
-			productType: string;
-			productId: string;
+			productType: number;
+			productId: number;
 		}[],
 		public readonly firmwareVersion: FirmwareVersionRange,
 		public readonly associations?: ReadonlyMap<number, AssociationConfig>,

--- a/packages/config/src/Devices.ts
+++ b/packages/config/src/Devices.ts
@@ -51,6 +51,11 @@ export interface FulltextDeviceConfigIndexEntry {
 	filename: string;
 }
 
+export type ConditionalParamInfoMap = ReadonlyObjectKeyMap<
+	{ parameter: number; valueBitMask?: number },
+	ConditionalParamInformation[]
+>;
+
 export type ParamInfoMap = ReadonlyObjectKeyMap<
 	{ parameter: number; valueBitMask?: number },
 	ParamInformation
@@ -270,26 +275,24 @@ function conditionApplies(condition: string, context: unknown): boolean {
 	}
 }
 
-export class DeviceConfig {
+/** This class represents a device config entry whose conditional settings have not been evaluated yet */
+export class ConditionalDeviceConfig {
 	public static async from(
 		filename: string,
 		options: {
 			relativeTo?: string;
-			deviceId?: DeviceID;
 		} = {},
-	): Promise<DeviceConfig> {
-		const { relativeTo, deviceId } = options;
+	): Promise<ConditionalDeviceConfig> {
+		const { relativeTo } = options;
 
 		const relativePath = relativeTo
 			? path.relative(relativeTo, filename).replace(/\\/g, "/")
 			: filename;
 		const json = await readJsonWithTemplate(filename);
-		return new DeviceConfig(relativePath, json, deviceId);
+		return new ConditionalDeviceConfig(relativePath, json);
 	}
 
-	public readonly filename: string;
-
-	public constructor(filename: string, definition: any, deviceId?: DeviceID) {
+	public constructor(filename: string, definition: any) {
 		this.filename = filename;
 
 		if (!isHexKeyWith4Digits(definition.manufacturerId)) {
@@ -347,7 +350,10 @@ firmwareVersion is malformed or invalid`,
 		}
 
 		if (definition.associations != undefined) {
-			const associations = new Map<number, AssociationConfig>();
+			const associations = new Map<
+				number,
+				ConditionalAssociationConfig
+			>();
 			if (!isObject(definition.associations)) {
 				throwInvalidConfig(
 					`device`,
@@ -365,19 +371,15 @@ associations is not an object`,
 found non-numeric group id "${key}" in associations`,
 					);
 				}
-				// Check if this entry applies for the actual config
-				if (
-					deviceId &&
-					"$if" in assocDefinition &&
-					!conditionApplies(assocDefinition.$if, deviceId)
-				) {
-					continue;
-				}
 
 				const keyNum = parseInt(key, 10);
 				associations.set(
 					keyNum,
-					new AssociationConfig(filename, keyNum, assocDefinition),
+					new ConditionalAssociationConfig(
+						filename,
+						keyNum,
+						assocDefinition,
+					),
 				);
 			}
 			this.associations = associations;
@@ -386,7 +388,7 @@ found non-numeric group id "${key}" in associations`,
 		if (definition.paramInformation != undefined) {
 			const paramInformation = new ObjectKeyMap<
 				{ parameter: number; valueBitMask?: number },
-				ParamInformation
+				ConditionalParamInformation[]
 			>();
 			if (!isObject(definition.paramInformation)) {
 				throwInvalidConfig(
@@ -437,34 +439,21 @@ paramInformation "${key}" is invalid: When there are multiple definitions, every
 					);
 				}
 
-				for (const def of defns) {
-					// Check if this entry applies for the actual config
-					if (
-						deviceId &&
-						"$if" in def &&
-						!conditionApplies(def.$if, deviceId)
-					) {
-						continue;
-					}
-
-					const keyNum = parseInt(match[1], 10);
-					const bitMask =
-						match[2] != undefined
-							? parseInt(match[2], 16)
-							: undefined;
-					paramInformation.set(
-						{ parameter: keyNum, valueBitMask: bitMask },
-						new ParamInformation(
-							this,
-							keyNum,
-							bitMask,
-							def,
-							deviceId,
-						),
-					);
-					// Only apply the first matching one
-					break;
-				}
+				const keyNum = parseInt(match[1], 10);
+				const bitMask =
+					match[2] != undefined ? parseInt(match[2], 16) : undefined;
+				paramInformation.set(
+					{ parameter: keyNum, valueBitMask: bitMask },
+					defns.map(
+						(def) =>
+							new ConditionalParamInformation(
+								this,
+								keyNum,
+								bitMask,
+								def,
+							),
+					),
+				);
 			}
 			this.paramInformation = paramInformation;
 		}
@@ -503,6 +492,8 @@ metadata is not an object`,
 		}
 	}
 
+	public readonly filename: string;
+
 	public readonly manufacturer!: string;
 	public readonly manufacturerId: number;
 	public readonly label!: string;
@@ -512,8 +503,11 @@ metadata is not an object`,
 		productId: string;
 	}[];
 	public readonly firmwareVersion: FirmwareVersionRange;
-	public readonly associations?: ReadonlyMap<number, AssociationConfig>;
-	public readonly paramInformation?: ParamInfoMap;
+	public readonly associations?: ReadonlyMap<
+		number,
+		ConditionalAssociationConfig
+	>;
+	public readonly paramInformation?: ConditionalParamInfoMap;
 	/**
 	 * Contains manufacturer-specific support information for the
 	 * ManufacturerProprietary CC
@@ -523,15 +517,105 @@ metadata is not an object`,
 	public readonly compat?: CompatConfig;
 	/** Contains instructions and other metadata for the device */
 	public readonly metadata?: DeviceMetadata;
+
+	public evaluate(deviceId?: DeviceID): DeviceConfig {
+		let associations: Map<number, AssociationConfig> | undefined;
+		if (this.associations) {
+			associations = new Map();
+			for (const [group, assoc] of this.associations) {
+				const evaluated = assoc.evaluateCondition(deviceId);
+				if (evaluated) associations.set(group, evaluated);
+			}
+		}
+
+		let paramInformation:
+			| ObjectKeyMap<
+					{ parameter: number; valueBitMask?: number },
+					ParamInformation
+			  >
+			| undefined;
+		if (this.paramInformation) {
+			paramInformation = new ObjectKeyMap();
+			for (const [key, params] of this.paramInformation.entries()) {
+				// Only take the first matching parameter
+				for (const param of params) {
+					const evaluated = param.evaluateCondition(deviceId);
+					if (evaluated) paramInformation.set(key, evaluated);
+				}
+			}
+		}
+
+		return new DeviceConfig(
+			this.filename,
+			this.manufacturer,
+			this.manufacturerId,
+			this.label,
+			this.description,
+			this.devices,
+			this.firmwareVersion,
+			associations,
+			paramInformation,
+			this.proprietary,
+			this.compat,
+			this.metadata,
+		);
+	}
 }
 
-export class AssociationConfig {
+export class DeviceConfig {
+	public static async from(
+		filename: string,
+		options: {
+			relativeTo?: string;
+			deviceId?: DeviceID;
+		} = {},
+	): Promise<DeviceConfig> {
+		const ret = await ConditionalDeviceConfig.from(filename, options);
+		return ret.evaluate(options.deviceId);
+	}
+
+	public constructor(
+		public readonly filename: string,
+		public readonly manufacturer: string,
+		public readonly manufacturerId: number,
+		public readonly label: string,
+		public readonly description: string,
+		public readonly devices: readonly {
+			productType: string;
+			productId: string;
+		}[],
+		public readonly firmwareVersion: FirmwareVersionRange,
+		public readonly associations?: ReadonlyMap<number, AssociationConfig>,
+		public readonly paramInformation?: ParamInfoMap,
+		/**
+		 * Contains manufacturer-specific support information for the
+		 * ManufacturerProprietary CC
+		 */
+		public readonly proprietary?: Record<string, unknown>,
+		/** Contains compatibility options */
+		public readonly compat?: CompatConfig,
+		/** Contains instructions and other metadata for the device */
+		public readonly metadata?: DeviceMetadata,
+	) {}
+}
+
+export class ConditionalAssociationConfig {
 	public constructor(
 		filename: string,
 		groupId: number,
 		definition: JSONObject,
 	) {
 		this.groupId = groupId;
+
+		if (definition.$if != undefined && typeof definition.$if !== "string") {
+			throwInvalidConfig(
+				"devices",
+				`packages/config/config/devices/${filename}:
+Association ${groupId} has a non-string $if condition`,
+			);
+		}
+		this.condition = definition.$if;
+
 		if (typeof definition.label !== "string") {
 			throwInvalidConfig(
 				"devices",
@@ -587,6 +671,8 @@ noEndpoint in association ${groupId} must be either true or left out`,
 		this.noEndpoint = !!definition.noEndpoint;
 	}
 
+	public readonly condition?: string;
+
 	public readonly groupId: number;
 	public readonly label: string;
 	public readonly description?: string;
@@ -598,18 +684,45 @@ noEndpoint in association ${groupId} must be either true or left out`,
 	public readonly isLifeline: boolean;
 	/** Some devices support multi channel associations but require some of its groups to use node id associations */
 	public readonly noEndpoint: boolean;
+
+	public evaluateCondition(
+		deviceId?: DeviceID,
+	): AssociationConfig | undefined {
+		if (
+			deviceId &&
+			this.condition &&
+			!conditionApplies(this.condition, deviceId)
+		) {
+			return;
+		}
+
+		return pick(this, [
+			"groupId",
+			"label",
+			"description",
+			"maxNodes",
+			"isLifeline",
+			"noEndpoint",
+		]);
+	}
 }
 
-export class ParamInformation {
+export type AssociationConfig = Omit<
+	ConditionalAssociationConfig,
+	"condition" | "evaluateCondition"
+>;
+
+export class ConditionalParamInformation {
 	public constructor(
-		parent: DeviceConfig,
+		parent: ConditionalDeviceConfig,
 		parameterNumber: number,
 		valueBitMask: number | undefined,
 		definition: JSONObject,
-		deviceId?: DeviceID,
 	) {
 		this.parameterNumber = parameterNumber;
 		this.valueBitMask = valueBitMask;
+		// No need to validate here, this should be done one level higher
+		this.condition = definition.$if;
 
 		if (typeof definition.label !== "string") {
 			throwInvalidConfig(
@@ -745,21 +858,12 @@ Parameter #${parameterNumber}: allowManualEntry must be a boolean!`,
 Parameter #${parameterNumber}: options is malformed!`,
 			);
 		}
-		const options = [];
-		if (definition.options) {
-			for (const opt of definition.options) {
-				// Check if this entry applies for the actual config
-				if (
-					deviceId &&
-					"$if" in opt &&
-					!conditionApplies(opt.$if, deviceId)
-				) {
-					continue;
-				}
-				options.push(pick(opt, ["label", "value"]));
-			}
-		}
-		this.options = options;
+
+		this.options =
+			definition.options?.map(
+				(opt: any) =>
+					new ConditionalConfigOption(opt.value, opt.label, opt.$if),
+			) ?? [];
 	}
 
 	public readonly parameterNumber: number;
@@ -775,7 +879,67 @@ Parameter #${parameterNumber}: options is malformed!`,
 	public readonly readOnly: boolean;
 	public readonly writeOnly: boolean;
 	public readonly allowManualEntry: boolean;
-	public readonly options: readonly ConfigOption[];
+	public readonly options: readonly ConditionalConfigOption[];
+
+	public readonly condition?: string;
+
+	public evaluateCondition(
+		deviceId?: DeviceID,
+	): ParamInformation | undefined {
+		if (
+			deviceId &&
+			this.condition &&
+			!conditionApplies(this.condition, deviceId)
+		) {
+			return;
+		}
+
+		return {
+			...pick(this, [
+				"parameterNumber",
+				"valueBitMask",
+				"label",
+				"description",
+				"valueSize",
+				"minValue",
+				"maxValue",
+				"unsigned",
+				"defaultValue",
+				"unit",
+				"readOnly",
+				"writeOnly",
+				"allowManualEntry",
+			]),
+			options: this.options
+				.map((o) => o.evaluateCondition(deviceId))
+				.filter((o): o is ConfigOption => !!o),
+		};
+	}
+}
+
+export type ParamInformation = Omit<
+	ConditionalParamInformation,
+	"condition" | "evaluateCondition" | "options"
+> & { options: readonly ConfigOption[] };
+
+export class ConditionalConfigOption {
+	public constructor(
+		public readonly value: number,
+		public readonly label: string,
+		public readonly condition?: string,
+	) {}
+
+	public evaluateCondition(deviceId?: DeviceID): ConfigOption | undefined {
+		if (
+			deviceId &&
+			this.condition &&
+			!conditionApplies(this.condition, deviceId)
+		) {
+			return;
+		}
+
+		return pick(this, ["value", "label"]);
+	}
 }
 
 export interface ConfigOption {


### PR DESCRIPTION
@marcus-j-davies This is what we discussed. You'll want to use `lookupDevicePreserveConditions` to look up the device config.
The returned object can have a `condition` property on association groups, config parameters (which are all arrays with 1 or more definitions) and config parameter options.

Let me know if you can work with that.