### PR TITLE
fix: rely on prototype property to identify ZWaveErrors, not instanceOf

### DIFF
--- a/packages/config/src/ConfigManager.ts
+++ b/packages/config/src/ConfigManager.ts
@@ -1,4 +1,9 @@
-import { ZWaveError, ZWaveErrorCodes, ZWaveLogContainer } from "@zwave-js/core";
+import {
+	isZWaveError,
+	ZWaveError,
+	ZWaveErrorCodes,
+	ZWaveLogContainer,
+} from "@zwave-js/core";
 import { num2hex } from "@zwave-js/shared";
 import { pathExists } from "fs-extra";
 import path from "path";
@@ -85,10 +90,7 @@ export class ConfigManager {
 			this.manufacturers = await loadManufacturersInternal();
 		} catch (e: unknown) {
 			// If the config file is missing or invalid, don't try to find it again
-			if (
-				e instanceof ZWaveError &&
-				e.code === ZWaveErrorCodes.Config_Invalid
-			) {
+			if (isZWaveError(e) && e.code === ZWaveErrorCodes.Config_Invalid) {
 				if (process.env.NODE_ENV !== "test") {
 					this.logger.print(
 						`Could not load manufacturers config: ${e.message}`,
@@ -155,10 +157,7 @@ export class ConfigManager {
 			this.indicatorProperties = config.properties;
 		} catch (e: unknown) {
 			// If the config file is missing or invalid, don't try to find it again
-			if (
-				e instanceof ZWaveError &&
-				e.code === ZWaveErrorCodes.Config_Invalid
-			) {
+			if (isZWaveError(e) && e.code === ZWaveErrorCodes.Config_Invalid) {
 				if (process.env.NODE_ENV !== "test") {
 					this.logger.print(
 						`Could not load indicators config: ${e.message}`,
@@ -208,10 +207,7 @@ export class ConfigManager {
 			this.namedScales = await loadNamedScalesInternal();
 		} catch (e: unknown) {
 			// If the config file is missing or invalid, don't try to find it again
-			if (
-				e instanceof ZWaveError &&
-				e.code === ZWaveErrorCodes.Config_Invalid
-			) {
+			if (isZWaveError(e) && e.code === ZWaveErrorCodes.Config_Invalid) {
 				if (process.env.NODE_ENV !== "test") {
 					this.logger.print(
 						`Could not load scales config: ${e.message}`,
@@ -251,10 +247,7 @@ export class ConfigManager {
 			this.sensorTypes = await loadSensorTypesInternal(this);
 		} catch (e: unknown) {
 			// If the config file is missing or invalid, don't try to find it again
-			if (
-				e instanceof ZWaveError &&
-				e.code === ZWaveErrorCodes.Config_Invalid
-			) {
+			if (isZWaveError(e) && e.code === ZWaveErrorCodes.Config_Invalid) {
 				if (process.env.NODE_ENV !== "test") {
 					this.logger.print(
 						`Could not load sensor types config: ${e.message}`,
@@ -300,10 +293,7 @@ export class ConfigManager {
 			this.meters = await loadMetersInternal();
 		} catch (e: unknown) {
 			// If the config file is missing or invalid, don't try to find it again
-			if (
-				e instanceof ZWaveError &&
-				e.code === ZWaveErrorCodes.Config_Invalid
-			) {
+			if (isZWaveError(e) && e.code === ZWaveErrorCodes.Config_Invalid) {
 				if (process.env.NODE_ENV !== "test") {
 					this.logger.print(
 						`Could not meters config: ${e.message}`,
@@ -350,10 +340,7 @@ export class ConfigManager {
 			this.genericDeviceClasses = config.genericDeviceClasses;
 		} catch (e: unknown) {
 			// If the config file is missing or invalid, don't try to find it again
-			if (
-				e instanceof ZWaveError &&
-				e.code === ZWaveErrorCodes.Config_Invalid
-			) {
+			if (isZWaveError(e) && e.code === ZWaveErrorCodes.Config_Invalid) {
 				if (process.env.NODE_ENV !== "test") {
 					this.logger.print(
 						`Could not load scales config: ${e.message}`,
@@ -418,9 +405,8 @@ export class ConfigManager {
 		} catch (e: unknown) {
 			// If the index file is missing or invalid, don't try to find it again
 			if (
-				(!(e instanceof ZWaveError) && e instanceof Error) ||
-				(e instanceof ZWaveError &&
-					e.code === ZWaveErrorCodes.Config_Invalid)
+				(!isZWaveError(e) && e instanceof Error) ||
+				(isZWaveError(e) && e.code === ZWaveErrorCodes.Config_Invalid)
 			) {
 				// Fall back to no index on production systems
 				if (!this.index) this.index = [];
@@ -511,10 +497,7 @@ export class ConfigManager {
 			this.notifications = await loadNotificationsInternal();
 		} catch (e: unknown) {
 			// If the config file is missing or invalid, don't try to find it again
-			if (
-				e instanceof ZWaveError &&
-				e.code === ZWaveErrorCodes.Config_Invalid
-			) {
+			if (isZWaveError(e) && e.code === ZWaveErrorCodes.Config_Invalid) {
 				if (process.env.NODE_ENV !== "test") {
 					this.logger.print(
 						`Could not load notifications config: ${e.message}`,

--- a/packages/config/src/DeviceClasses.ts
+++ b/packages/config/src/DeviceClasses.ts
@@ -1,4 +1,9 @@
-import { CommandClasses, ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
+import {
+	CommandClasses,
+	isZWaveError,
+	ZWaveError,
+	ZWaveErrorCodes,
+} from "@zwave-js/core";
 import { JSONObject, num2hex } from "@zwave-js/shared";
 import { distinct } from "alcalzone-shared/arrays";
 import { entries } from "alcalzone-shared/objects";
@@ -77,7 +82,7 @@ export async function loadDeviceClassesInternal(): Promise<{
 
 		return { basicDeviceClasses, genericDeviceClasses };
 	} catch (e: unknown) {
-		if (e instanceof ZWaveError) {
+		if (isZWaveError(e)) {
 			throw e;
 		} else {
 			throwInvalidConfig("device classes");

--- a/packages/config/src/Indicators.ts
+++ b/packages/config/src/Indicators.ts
@@ -1,5 +1,9 @@
-import type { ValueType } from "@zwave-js/core";
-import { ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
+import {
+	isZWaveError,
+	ValueType,
+	ZWaveError,
+	ZWaveErrorCodes,
+} from "@zwave-js/core";
 import { JSONObject, num2hex } from "@zwave-js/shared";
 import { entries } from "alcalzone-shared/objects";
 import { isObject } from "alcalzone-shared/typeguards";
@@ -70,7 +74,7 @@ export async function loadIndicatorsInternal(): Promise<{
 
 		return { indicators, properties };
 	} catch (e: unknown) {
-		if (e instanceof ZWaveError) {
+		if (isZWaveError(e)) {
 			throw e;
 		} else {
 			throwInvalidConfig("indicators");

--- a/packages/config/src/Manufacturers.ts
+++ b/packages/config/src/Manufacturers.ts
@@ -1,4 +1,4 @@
-import { ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
+import { isZWaveError, ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
 import { formatId, stringify } from "@zwave-js/shared";
 import { entries } from "alcalzone-shared/objects";
 import { isObject } from "alcalzone-shared/typeguards";
@@ -48,7 +48,7 @@ export async function loadManufacturersInternal(): Promise<ManufacturersMap> {
 
 		return manufacturers;
 	} catch (e: unknown) {
-		if (e instanceof ZWaveError) {
+		if (isZWaveError(e)) {
 			throw e;
 		} else {
 			throwInvalidConfig("manufacturers");

--- a/packages/config/src/Meters.ts
+++ b/packages/config/src/Meters.ts
@@ -1,4 +1,4 @@
-import { ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
+import { isZWaveError, ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
 import { JSONObject, num2hex } from "@zwave-js/shared";
 import { entries } from "alcalzone-shared/objects";
 import { isObject } from "alcalzone-shared/typeguards";
@@ -39,7 +39,7 @@ export async function loadMetersInternal(): Promise<MeterMap> {
 		}
 		return meters;
 	} catch (e: unknown) {
-		if (e instanceof ZWaveError) {
+		if (isZWaveError(e)) {
 			throw e;
 		} else {
 			throwInvalidConfig("meters");

--- a/packages/config/src/Notifications.ts
+++ b/packages/config/src/Notifications.ts
@@ -1,4 +1,4 @@
-import { ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
+import { isZWaveError, ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
 import { JSONObject, num2hex } from "@zwave-js/shared";
 import { entries } from "alcalzone-shared/objects";
 import { isArray, isObject } from "alcalzone-shared/typeguards";
@@ -65,7 +65,7 @@ export async function loadNotificationsInternal(): Promise<NotificationMap> {
 		}
 		return notifications;
 	} catch (e: unknown) {
-		if (e instanceof ZWaveError) {
+		if (isZWaveError(e)) {
 			throw e;
 		} else {
 			throwInvalidConfig("notifications");

--- a/packages/config/src/Scales.ts
+++ b/packages/config/src/Scales.ts
@@ -1,4 +1,4 @@
-import { ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
+import { isZWaveError, ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
 import { JSONObject, num2hex } from "@zwave-js/shared";
 import { entries } from "alcalzone-shared/objects";
 import { isObject } from "alcalzone-shared/typeguards";
@@ -56,7 +56,7 @@ export async function loadNamedScalesInternal(): Promise<NamedScalesGroupMap> {
 		}
 		return namedScales;
 	} catch (e: unknown) {
-		if (e instanceof ZWaveError) {
+		if (isZWaveError(e)) {
 			throw e;
 		} else {
 			throwInvalidConfig("named scales");

--- a/packages/config/src/SensorTypes.ts
+++ b/packages/config/src/SensorTypes.ts
@@ -1,4 +1,4 @@
-import { ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
+import { isZWaveError, ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
 import { JSONObject, num2hex } from "@zwave-js/shared";
 import { entries } from "alcalzone-shared/objects";
 import { isObject } from "alcalzone-shared/typeguards";
@@ -50,7 +50,7 @@ export async function loadSensorTypesInternal(
 		}
 		return sensorTypes;
 	} catch (e: unknown) {
-		if (e instanceof ZWaveError) {
+		if (isZWaveError(e)) {
 			throw e;
 		} else {
 			throwInvalidConfig("sensor types");

--- a/packages/core/src/error/ZWaveError.ts
+++ b/packages/core/src/error/ZWaveError.ts
@@ -147,6 +147,10 @@ export class ZWaveError extends Error {
 	}
 }
 
+export function isZWaveError(e: unknown): e is ZWaveError {
+	return e instanceof Error && Object.getPrototypeOf(e).name === "ZWaveError";
+}
+
 export function isTransmissionError(
 	e: unknown,
 ): e is ZWaveError & {
@@ -157,7 +161,7 @@ export function isTransmissionError(
 		| ZWaveErrorCodes.Controller_NodeTimeout;
 } {
 	return (
-		e instanceof ZWaveError &&
+		isZWaveError(e) &&
 		(e.code === ZWaveErrorCodes.Controller_MessageDropped ||
 			e.code === ZWaveErrorCodes.Controller_CallbackNOK ||
 			e.code === ZWaveErrorCodes.Controller_ResponseNOK ||

--- a/packages/core/src/values/ValueDB.ts
+++ b/packages/core/src/values/ValueDB.ts
@@ -1,7 +1,7 @@
 import type { JsonlDB } from "@alcalzone/jsonl-db";
 import { EventEmitter } from "events";
 import type { CommandClasses } from "../capabilities/CommandClasses";
-import { ZWaveError, ZWaveErrorCodes } from "../error/ZWaveError";
+import { isZWaveError, ZWaveError, ZWaveErrorCodes } from "../error/ZWaveError";
 import type { ValueMetadata } from "../values/Metadata";
 
 /** Uniquely identifies to which CC, endpoint and property a value belongs to */
@@ -219,7 +219,7 @@ export class ValueDB extends EventEmitter {
 			dbKey = this.valueIdToDBKey(valueId);
 		} catch (e) {
 			if (
-				e instanceof ZWaveError &&
+				isZWaveError(e) &&
 				e.code === ZWaveErrorCodes.Argument_Invalid &&
 				options.noThrow === true
 			) {
@@ -374,7 +374,7 @@ export class ValueDB extends EventEmitter {
 			dbKey = this.valueIdToDBKey(valueId);
 		} catch (e) {
 			if (
-				e instanceof ZWaveError &&
+				isZWaveError(e) &&
 				e.code === ZWaveErrorCodes.Argument_Invalid &&
 				options.noThrow === true
 			) {

--- a/packages/zwave-js/src/lib/commandclass/CommandClass.ts
+++ b/packages/zwave-js/src/lib/commandclass/CommandClass.ts
@@ -4,6 +4,7 @@ import {
 	CommandClasses,
 	deserializeCacheValue,
 	getCCName,
+	isZWaveError,
 	MessageOrCCLogEntry,
 	MessageRecord,
 	NODE_ID_BROADCAST,
@@ -451,10 +452,7 @@ export class CommandClass {
 			return this.getNode();
 		} catch (e: unknown) {
 			// This was expected
-			if (
-				e instanceof ZWaveError &&
-				e.code === ZWaveErrorCodes.Driver_NotReady
-			) {
+			if (isZWaveError(e) && e.code === ZWaveErrorCodes.Driver_NotReady) {
 				return undefined;
 			}
 			// Something else happened

--- a/packages/zwave-js/src/lib/commandclass/NotificationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/NotificationCC.ts
@@ -7,6 +7,7 @@ import {
 import {
 	CommandClasses,
 	Duration,
+	isZWaveError,
 	Maybe,
 	MessageOrCCLogEntry,
 	MessageRecord,
@@ -943,7 +944,7 @@ export class NotificationCCReport extends NotificationCC {
 					this.eventParameters = json;
 				} catch (e: unknown) {
 					if (
-						e instanceof ZWaveError &&
+						isZWaveError(e) &&
 						e.code ===
 							ZWaveErrorCodes.PacketFormat_InvalidPayload &&
 						Buffer.isBuffer(this.eventParameters)

--- a/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
@@ -6,6 +6,7 @@ import {
 	generateAuthKey,
 	generateEncryptionKey,
 	getCCName,
+	isZWaveError,
 	Maybe,
 	MessageOrCCLogEntry,
 	MessageRecord,
@@ -203,7 +204,7 @@ export class SecurityCCAPI extends PhysicalCCAPI {
 			});
 		} catch (e) {
 			if (
-				e instanceof ZWaveError &&
+				isZWaveError(e) &&
 				(e.code === ZWaveErrorCodes.Controller_ResponseNOK ||
 					e.code === ZWaveErrorCodes.Controller_CallbackNOK ||
 					e.code === ZWaveErrorCodes.Controller_NodeTimeout ||

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -3,6 +3,7 @@ import {
 	CommandClasses,
 	indexDBsByNode,
 	isTransmissionError,
+	isZWaveError,
 	NODE_ID_BROADCAST,
 	ValueDB,
 	ZWaveError,
@@ -818,7 +819,7 @@ export class ZWaveController extends EventEmitter {
 				node.isSecure = true;
 			} catch (e: unknown) {
 				let errorMessage = `Security bootstrapping failed, the node is included insecurely`;
-				if (!(e instanceof ZWaveError)) {
+				if (!isZWaveError(e)) {
 					errorMessage += `: ${e as any}`;
 				} else if (
 					e.code === ZWaveErrorCodes.Controller_MessageExpired

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -6,6 +6,7 @@ import {
 	deserializeCacheValue,
 	Duration,
 	highResTimestamp,
+	isZWaveError,
 	LogConfig,
 	SecurityManager,
 	serializeCacheValue,
@@ -732,7 +733,7 @@ export class Driver extends EventEmitter {
 			} catch (e: unknown) {
 				let message: string;
 				if (
-					e instanceof ZWaveError &&
+					isZWaveError(e) &&
 					e.code === ZWaveErrorCodes.Controller_MessageDropped
 				) {
 					message = `Failed to initialize the driver, no response from the controller. Are you sure this is a Z-Wave controller?`;
@@ -960,7 +961,7 @@ export class Driver extends EventEmitter {
 				}
 			}
 		} catch (e: unknown) {
-			if (e instanceof ZWaveError) {
+			if (isZWaveError(e)) {
 				if (
 					e.code === ZWaveErrorCodes.Driver_NotReady ||
 					e.code === ZWaveErrorCodes.Controller_NodeRemoved
@@ -1477,7 +1478,7 @@ export class Driver extends EventEmitter {
 		e: Error,
 		data: Buffer,
 	): MessageHeaders | undefined {
-		if (e instanceof ZWaveError) {
+		if (isZWaveError(e)) {
 			switch (e.code) {
 				case ZWaveErrorCodes.PacketFormat_Invalid:
 				case ZWaveErrorCodes.PacketFormat_Checksum:
@@ -1641,7 +1642,7 @@ It is probably asleep, moving its messages to the wakeup queue.`,
 					try {
 						command.mergePartialCCs(session);
 					} catch (e: unknown) {
-						if (e instanceof ZWaveError) {
+						if (isZWaveError(e)) {
 							switch (e.code) {
 								case ZWaveErrorCodes.Deserialization_NotImplemented:
 								case ZWaveErrorCodes.CC_NotImplemented:
@@ -1698,7 +1699,7 @@ It is probably asleep, moving its messages to the wakeup queue.`,
 				await this.handleRequest(msg);
 			} catch (e) {
 				if (
-					e instanceof ZWaveError &&
+					isZWaveError(e) &&
 					e.code === ZWaveErrorCodes.Driver_NotReady
 				) {
 					this.driverLog.print(
@@ -2185,7 +2186,7 @@ ${handlers.length} left`,
 			}
 			return ret;
 		} catch (e) {
-			if (e instanceof ZWaveError) {
+			if (isZWaveError(e)) {
 				if (
 					// If a controller command failed (that is not SendData), pass the response/callback through
 					(e.code === ZWaveErrorCodes.Controller_ResponseNOK ||
@@ -2243,7 +2244,7 @@ ${handlers.length} left`,
 		} catch (e: unknown) {
 			// A timeout always has to be expected. In this case return nothing.
 			if (
-				e instanceof ZWaveError &&
+				isZWaveError(e) &&
 				e.code === ZWaveErrorCodes.Controller_NodeTimeout
 			) {
 				if (command.isSinglecast()) {

--- a/packages/zwave-js/src/lib/driver/StateMachineShared.ts
+++ b/packages/zwave-js/src/lib/driver/StateMachineShared.ts
@@ -1,4 +1,4 @@
-import { ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
+import { isZWaveError, ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
 import { getEnumMemberName } from "@zwave-js/shared";
 import {
 	assign,
@@ -158,7 +158,7 @@ export function sendDataErrorToZWaveError(
 
 /** Tests whether the given error is one that was caused by the serial API execution */
 export function isSerialCommandError(error: unknown): boolean {
-	if (!(error instanceof ZWaveError)) return false;
+	if (!isZWaveError(error)) return false;
 	switch (error.code) {
 		case ZWaveErrorCodes.Controller_Timeout:
 		case ZWaveErrorCodes.Controller_ResponseNOK:

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -8,6 +8,7 @@ import {
 	CommandClassInfo,
 	CRC16_CCITT,
 	getCCName,
+	isZWaveError,
 	MAX_NODES,
 	Maybe,
 	MetadataUpdatedArgs,
@@ -723,7 +724,7 @@ export class ZWaveNode extends Endpoint {
 		} catch (e: unknown) {
 			// Define which errors during setValue are expected and won't crash
 			// the driver:
-			if (e instanceof ZWaveError) {
+			if (isZWaveError(e)) {
 				let handled = false;
 				let emitErrorEvent = false;
 				switch (e.code) {
@@ -986,7 +987,7 @@ export class ZWaveNode extends Endpoint {
 				return true;
 			} catch (e: unknown) {
 				if (
-					e instanceof ZWaveError &&
+					isZWaveError(e) &&
 					(e.code === ZWaveErrorCodes.Controller_NodeTimeout ||
 						e.code === ZWaveErrorCodes.Controller_ResponseNOK ||
 						e.code === ZWaveErrorCodes.Controller_CallbackNOK ||
@@ -1297,7 +1298,7 @@ protocol version:      ${this._protocolVersion}`;
 				instance = endpoint.createCCInstance(cc)!;
 			} catch (e: unknown) {
 				if (
-					e instanceof ZWaveError &&
+					isZWaveError(e) &&
 					e.code === ZWaveErrorCodes.CC_NotSupported
 				) {
 					// The CC is no longer supported. This can happen if the node tells us
@@ -1327,7 +1328,7 @@ protocol version:      ${this._protocolVersion}`;
 				await instance.interview();
 			} catch (e: unknown) {
 				if (
-					e instanceof ZWaveError &&
+					isZWaveError(e) &&
 					(e.code === ZWaveErrorCodes.Controller_MessageDropped ||
 						e.code === ZWaveErrorCodes.Controller_CallbackNOK ||
 						e.code === ZWaveErrorCodes.Controller_ResponseNOK ||
@@ -2709,7 +2710,7 @@ protocol version:      ${this._protocolVersion}`;
 			this.keepAwake = false;
 		} catch (e: unknown) {
 			if (
-				e instanceof ZWaveError &&
+				isZWaveError(e) &&
 				e.code === ZWaveErrorCodes.Controller_NodeTimeout
 			) {
 				throw new ZWaveError(
@@ -2931,7 +2932,7 @@ protocol version:      ${this._protocolVersion}`;
 			this.handleFirmwareUpdateStatusReport(report);
 		} catch (e: unknown) {
 			if (
-				e instanceof ZWaveError &&
+				isZWaveError(e) &&
 				e.code === ZWaveErrorCodes.Controller_NodeTimeout
 			) {
 				this.driver.controllerLog.logNode(

--- a/packages/zwave-js/src/lib/node/VirtualNode.ts
+++ b/packages/zwave-js/src/lib/node/VirtualNode.ts
@@ -1,4 +1,9 @@
-import { ValueID, ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
+import {
+	isZWaveError,
+	ValueID,
+	ZWaveError,
+	ZWaveErrorCodes,
+} from "@zwave-js/core";
 import type { CCAPI } from "../commandclass/API";
 import type { Driver } from "../driver/Driver";
 import type { ZWaveNode } from "./Node";
@@ -50,7 +55,7 @@ export class VirtualNode extends VirtualEndpoint {
 		} catch (e: unknown) {
 			// Define which errors during setValue are expected and won't crash
 			// the driver:
-			if (e instanceof ZWaveError) {
+			if (isZWaveError(e)) {
 				let handled = false;
 				let emitErrorEvent = false;
 				switch (e.code) {


### PR DESCRIPTION
Seems the `instanceof` approach can result in quite some weirdness when mixed dependencies are involved.