### PR TITLE
feat: replace ZWaveError stack to include where the method call originates from

### DIFF
--- a/packages/core/src/error/ZWaveError.ts
+++ b/packages/core/src/error/ZWaveError.ts
@@ -144,6 +144,11 @@ export class ZWaveError extends Error {
 		// We need to set the prototype explicitly
 		Object.setPrototypeOf(this, ZWaveError.prototype);
 		Object.getPrototypeOf(this).name = "ZWaveError";
+
+		// If there's a better stack, use it
+		if (typeof transactionSource === "string") {
+			this.stack = `ZWaveError: ${this.message}\n${transactionSource}`;
+		}
 	}
 }
 

--- a/packages/zwave-js/src/lib/driver/Transaction.test.ts
+++ b/packages/zwave-js/src/lib/driver/Transaction.test.ts
@@ -357,7 +357,6 @@ describe("lib/driver/Transaction => ", () => {
 			undefined as any,
 			undefined as any,
 		);
-		expect(test.stack).toStartWith("Transaction:");
 		expect(test.stack).toInclude("Transaction.test.ts");
 		expect(test.stack).not.toInclude("FOOBAR");
 	});

--- a/packages/zwave-js/src/lib/driver/Transaction.ts
+++ b/packages/zwave-js/src/lib/driver/Transaction.ts
@@ -25,10 +25,7 @@ export class Transaction implements Comparable<Transaction> {
 		// class will try to print the message
 		const tmp = { message: "" };
 		Error.captureStackTrace(tmp, Transaction);
-		this.stack = (tmp as any).stack;
-		if (this.stack.startsWith("Error")) {
-			this.stack = "Transaction" + this.stack.substr(5);
-		}
+		this.stack = (tmp as any).stack.replace(/^Error:?\s*\n/, "");
 	}
 
 	/** The timestamp at which the transaction was created */


### PR DESCRIPTION
This PR changes ZWaveError that are raised in response to application code using zwave-js to include the calling code, not zwave-js's state machine.

**Before:**
```
ZWaveError: Failed to send the message after 3 attempts
    at Object.sendDataErrorToZWaveError (C:\Repositories\node-zwave-js\packages\zwave-js\src\lib\driver\StateMachineShared.ts:62:11)
    at C:\Repositories\node-zwave-js\packages\zwave-js\src\lib\driver\SendThreadMachine.ts:441:4
    at C:\Repositories\node-zwave-js\node_modules\xstate\lib\utils.js:410:33
    at Array.reduce (<anonymous>)
    at Object.updateContext (C:\Repositories\node-zwave-js\node_modules\xstate\lib\utils.js:400:25)
    at Object.resolveActions (C:\Repositories\node-zwave-js\node_modules\xstate\lib\actions.js:409:19)
    at StateNode.resolveTransition (C:\Repositories\node-zwave-js\node_modules\xstate\lib\StateNode.js:787:35)
    at StateNode.transition (C:\Repositories\node-zwave-js\node_modules\xstate\lib\StateNode.js:733:21)
    at StateNode.resolveRaisedTransition (C:\Repositories\node-zwave-js\node_modules\xstate\lib\StateNode.js:738:22)
    at StateNode.resolveTransition (C:\Repositories\node-zwave-js\node_modules\xstate\lib\StateNode.js:873:39)
```

**After:**
```
ZWaveError: Failed to send the message after 3 attempts
    at Driver.sendMessage (C:\Repositories\node-zwave-js\packages\zwave-js\src\lib\driver\Driver.ts:2132:23)
    at Driver.sendCommand (C:\Repositories\node-zwave-js\packages\zwave-js\src\lib\driver\Driver.ts:2237:28)
    at Proxy.set (C:\Repositories\node-zwave-js\packages\zwave-js\src\lib\commandclass\BasicCC.ts:150:21)
    at ZWaveNode.<anonymous> (C:\Repositories\node-zwave-js\test\run.ts:36:37)
```