### PR TITLE
fix: allow healing single nodes

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -51,6 +51,8 @@ A Z-Wave network needs to be reorganized (healed) from time to time. To do so, t
 
 The `healNode` method performs this step for a given node. The returned promise resolves to `true` if the process was completed, or `false` if it was unsuccessful.
 
+> [!ATTENTION] Healing a Z-Wave network causes a lot of traffic and can take very long. Degraded performance **must** be expected while a healing process is active.
+
 ### `beginHealingNetwork`
 
 ```ts


### PR DESCRIPTION
With this PR, we now treat healing a single node similar to healing the entire network. Healing a single node now remembers that a heal process is active, so the method that does the actual work does not just exit.
As a result, it won't be possible to perform a heal on another node or the network until the single-node healing process was completed or aborted.

fixes: #2114 