### PR TITLE
fix(config): minor update for some Inovelli switches and dimmer

### DIFF
--- a/packages/config/config/devices/0x031e/lzw30-sn.json
+++ b/packages/config/config/devices/0x031e/lzw30-sn.json
@@ -1,10 +1,10 @@
 // Inovelli LZW30-SN
-// Red Series On/Off switch
+// Red Series On/Off Switch
 {
 	"manufacturer": "Inovelli",
 	"manufacturerId": "0x031e",
 	"label": "LZW30-SN",
-	"description": "Red Series On/Off switch",
+	"description": "Red Series On/Off Switch",
 	"devices": [
 		{
 			"productType": "0x0002",

--- a/packages/config/config/devices/0x031e/lzw30-sn.json
+++ b/packages/config/config/devices/0x031e/lzw30-sn.json
@@ -126,9 +126,9 @@
 					"value": 234
 				},
 				{
-				"$if": "firmwareVersion >= 1.19",
-				"label": "White",
-				"value": 255
+					"$if": "firmwareVersion >= 1.19",
+					"label": "White",
+					"value": 255
 				}
 			]
 		},

--- a/packages/config/config/devices/0x031e/lzw30-sn.json
+++ b/packages/config/config/devices/0x031e/lzw30-sn.json
@@ -124,6 +124,11 @@
 				{
 					"label": "Pink",
 					"value": 234
+				},
+				{
+				"$if": "firmwareVersion >= 1.19",
+				"label": "White",
+				"value": 255
 				}
 			]
 		},

--- a/packages/config/config/devices/0x031e/lzw30.json
+++ b/packages/config/config/devices/0x031e/lzw30.json
@@ -73,7 +73,7 @@
 			"allowManualEntry": true
 		},
 		"4": {
-			"label": "Association Behaviour",
+			"label": "Association Behavior",
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 15,

--- a/packages/config/config/devices/0x031e/lzw30.json
+++ b/packages/config/config/devices/0x031e/lzw30.json
@@ -1,10 +1,10 @@
 // Inovelli LZW30
-// Black Series On/Off switch
+// Black Series On/Off Switch
 {
 	"manufacturer": "Inovelli",
 	"manufacturerId": "0x031e",
 	"label": "LZW30",
-	"description": "Black Series On/Off switch",
+	"description": "Black Series On/Off Switch",
 	"devices": [
 		{
 			"productType": "0x0004",

--- a/packages/config/config/devices/0x031e/lzw30.json
+++ b/packages/config/config/devices/0x031e/lzw30.json
@@ -1,10 +1,10 @@
 // Inovelli LZW30
-// Base model On-Off switch
+// Black Series On/Off switch
 {
 	"manufacturer": "Inovelli",
 	"manufacturerId": "0x031e",
 	"label": "LZW30",
-	"description": "Base model On-Off switch",
+	"description": "Black Series On/Off switch",
 	"devices": [
 		{
 			"productType": "0x0004",

--- a/packages/config/config/devices/0x031e/lzw30.json
+++ b/packages/config/config/devices/0x031e/lzw30.json
@@ -84,6 +84,7 @@
 		},
 		"5": {
 			"label": "LED Indicator Color",
+			"description": "Uses a scaled hue value (realHue / 360 * 255).",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 255,

--- a/packages/config/config/devices/0x031e/lzw30.json
+++ b/packages/config/config/devices/0x031e/lzw30.json
@@ -90,7 +90,7 @@
 			"defaultValue": 170,
 			"readOnly": false,
 			"writeOnly": false,
-			"allowManualEntry": false,
+			"allowManualEntry": true,
 			"options": [
 				{
 					"label": "Red",

--- a/packages/config/config/devices/0x031e/lzw31-bsd_0.0-1.45.json
+++ b/packages/config/config/devices/0x031e/lzw31-bsd_0.0-1.45.json
@@ -228,6 +228,7 @@
 		},
 		"13": {
 			"label": "LED Indicator Color",
+			"description": "Uses a scaled hue value (realHue / 360 * 255).",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 255,

--- a/packages/config/config/devices/0x031e/lzw31-bsd_0.0-1.45.json
+++ b/packages/config/config/devices/0x031e/lzw31-bsd_0.0-1.45.json
@@ -235,7 +235,46 @@
 			"unsigned": true,
 			"readOnly": false,
 			"writeOnly": false,
-			"allowManualEntry": true
+			"allowManualEntry": true,
+			"options": [
+				{
+					"label": "Red",
+					"value": 0
+				},
+				{
+					"label": "Orange",
+					"value": 21
+				},
+				{
+					"label": "Yellow",
+					"value": 42
+				},
+				{
+					"label": "Green",
+					"value": 85
+				},
+				{
+					"label": "Cyan",
+					"value": 127
+				},
+				{
+					"label": "Blue",
+					"value": 170
+				},
+				{
+					"label": "Violet",
+					"value": 212
+				},
+				{
+					"label": "Pink",
+					"value": 234
+				},
+				{
+					"$if": "firmwareVersion >= 1.45",
+					"label": "White",
+					"value": 255
+				}
+			]
 		},
 		"14": {
 			"label": "LED Indicator Intensity",

--- a/packages/config/config/devices/0x031e/lzw31-bsd_1.47-1.48.json
+++ b/packages/config/config/devices/0x031e/lzw31-bsd_1.47-1.48.json
@@ -228,6 +228,7 @@
 		},
 		"13": {
 			"label": "LED Indicator Color",
+			"description": "Uses a scaled hue value (realHue / 360 * 255).",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 255,

--- a/packages/config/config/devices/0x031e/lzw31-bsd_1.47-1.48.json
+++ b/packages/config/config/devices/0x031e/lzw31-bsd_1.47-1.48.json
@@ -235,7 +235,46 @@
 			"unsigned": true,
 			"readOnly": false,
 			"writeOnly": false,
-			"allowManualEntry": true
+			"allowManualEntry": true,
+			"options": [
+				{
+					"label": "Red",
+					"value": 0
+				},
+				{
+					"label": "Orange",
+					"value": 21
+				},
+				{
+					"label": "Yellow",
+					"value": 42
+				},
+				{
+					"label": "Green",
+					"value": 85
+				},
+				{
+					"label": "Cyan",
+					"value": 127
+				},
+				{
+					"label": "Blue",
+					"value": 170
+				},
+				{
+					"label": "Violet",
+					"value": 212
+				},
+				{
+					"label": "Pink",
+					"value": 234
+				},
+				{
+					"$if": "firmwareVersion >= 1.45",
+					"label": "White",
+					"value": 255
+				}
+			]
 		},
 		"14": {
 			"label": "LED Indicator Intensity",

--- a/packages/config/config/devices/0x031e/lzw31-bsd_1.49.json
+++ b/packages/config/config/devices/0x031e/lzw31-bsd_1.49.json
@@ -228,6 +228,7 @@
 		},
 		"13": {
 			"label": "LED Indicator Color",
+			"description": "Uses a scaled hue value (realHue / 360 * 255).",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 255,

--- a/packages/config/config/devices/0x031e/lzw31-bsd_1.49.json
+++ b/packages/config/config/devices/0x031e/lzw31-bsd_1.49.json
@@ -235,7 +235,46 @@
 			"unsigned": true,
 			"readOnly": false,
 			"writeOnly": false,
-			"allowManualEntry": true
+			"allowManualEntry": true,
+			"options": [
+				{
+					"label": "Red",
+					"value": 0
+				},
+				{
+					"label": "Orange",
+					"value": 21
+				},
+				{
+					"label": "Yellow",
+					"value": 42
+				},
+				{
+					"label": "Green",
+					"value": 85
+				},
+				{
+					"label": "Cyan",
+					"value": 127
+				},
+				{
+					"label": "Blue",
+					"value": 170
+				},
+				{
+					"label": "Violet",
+					"value": 212
+				},
+				{
+					"label": "Pink",
+					"value": 234
+				},
+				{
+					"$if": "firmwareVersion >= 1.45",
+					"label": "White",
+					"value": 255
+				}
+			]
 		},
 		"14": {
 			"label": "LED Indicator Intensity",


### PR DESCRIPTION
I updated the `LED Indicator Color` parameter to be more consistent for the Inovelli switches and dimmers
- allow manual entry and add parameter description for the `lzw30`
- add "White" option for the `lzw30-sn`
- add color options and add parameter description for the `lzw31`

I also updated the device description for the `lzw30` and `lzw30-sn` switches to Title Case, and fixed minor typo