### PR TITLE
feat: emit an event when node status changes to unknown

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -621,6 +621,14 @@ A non-sleeping node has stopped responding or just started responding again. The
 (node: ZWaveNode) => void
 ```
 
+### `"unknown"`
+
+A message is received from a presumably dead node. The node is passed as the single argument to the callback:
+
+```ts
+(node: ZWaveNode) => void
+```
+
 ### `"interview completed"`
 
 The initial interview process for this node was completed. The node is passed as the single argument to the callback:

--- a/packages/zwave-js/src/lib/node/Node.test.ts
+++ b/packages/zwave-js/src/lib/node/Node.test.ts
@@ -1331,6 +1331,13 @@ describe("lib/node/Node", () => {
 				expectedEvent: "alive",
 			});
 		});
+
+		it("Changing the status to unknown should raise the unknown event", () => {
+			performTest({
+				targetStatus: NodeStatus.Unknown,
+				expectedEvent: "unknown",
+			});
+		});
 	});
 
 	describe("getValue()", () => {

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -367,6 +367,8 @@ export class ZWaveNode extends Endpoint {
 			this.emit("dead", this, oldStatus);
 		} else if (this._status === NodeStatus.Alive) {
 			this.emit("alive", this, oldStatus);
+		} else {
+			this.emit("unknown", this, oldStatus);
 		}
 
 		// To be marked ready, a node must be known to be not dead.

--- a/packages/zwave-js/src/lib/node/Types.ts
+++ b/packages/zwave-js/src/lib/node/Types.ts
@@ -100,6 +100,7 @@ export interface ZWaveNodeEventCallbacks extends ZWaveNodeValueEventCallbacks {
 	sleep: ZWaveNodeStatusChangeCallback;
 	dead: ZWaveNodeStatusChangeCallback;
 	alive: ZWaveNodeStatusChangeCallback;
+	unknown: ZWaveNodeStatusChangeCallback;
 	"interview completed": (node: ZWaveNode) => void;
 	ready: (node: ZWaveNode) => void;
 }


### PR DESCRIPTION
As I had mentioned in Discord (https://discord.com/channels/330944238910963714/800356888827002880/822887257983811647) it appears that a node can go from dead to unknown if a message is received when a node is in a dead state. It is useful to capture this state change as an event so that we can handle this scenario downstream.

I wasn't sure whether we wanted to log something or perform an action when this event is fired like we do for all other status change events, but I can add that in if that's desired