### PR TITLE
fix: don't reschedule interview attempt when user initiated re-interview

### DIFF
--- a/packages/core/src/error/ZWaveError.ts
+++ b/packages/core/src/error/ZWaveError.ts
@@ -33,6 +33,9 @@ export enum ZWaveErrorCodes {
 	Controller_InclusionFailed,
 	Controller_ExclusionFailed,
 
+	/** The interview for this node was restarted by the user */
+	Controller_InterviewRestarted,
+
 	/** The node with the given node ID was not found */
 	Controller_NodeNotFound,
 	/** The endpoint with the given index was not found on the node */

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -899,7 +899,10 @@ export class Driver extends EventEmitter {
 
 		// Drop all pending messages that come from a previous interview attempt
 		this.rejectTransactions(
-			(t) => t.tag === "interview" && t.message.getNodeId() === node.id,
+			(t) =>
+				t.message.getNodeId() === node.id &&
+				(t.priority === MessagePriority.NodeQuery ||
+					t.tag === "interview"),
 			"The interview was restarted",
 			ZWaveErrorCodes.Controller_InterviewRestarted,
 		);

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -899,11 +899,9 @@ export class Driver extends EventEmitter {
 
 		// Drop all pending messages that come from a previous interview attempt
 		this.rejectTransactions(
-			(t) =>
-				t.priority === MessagePriority.NodeQuery &&
-				t.message.getNodeId() === node.id,
+			(t) => t.tag === "interview" && t.message.getNodeId() === node.id,
 			"The interview was restarted",
-			ZWaveErrorCodes.Controller_MessageDropped,
+			ZWaveErrorCodes.Controller_InterviewRestarted,
 		);
 
 		const maxInterviewAttempts = this.options.attempts.nodeInterview;
@@ -967,6 +965,11 @@ export class Driver extends EventEmitter {
 					e.code === ZWaveErrorCodes.Controller_NodeRemoved
 				) {
 					// This only happens when a node is removed during the interview - we don't log this
+					return;
+				} else if (
+					e.code === ZWaveErrorCodes.Controller_InterviewRestarted
+				) {
+					// The interview was restarted by a user - we don't log this
 					return;
 				}
 				this.controllerLog.logNode(
@@ -2124,6 +2127,10 @@ ${handlers.length} left`,
 			options.priority !== MessagePriority.Handshake &&
 			options.priority !== MessagePriority.PreTransmitHandshake
 		) {
+			if (options.priority === MessagePriority.NodeQuery) {
+				// Remember that this transaction was part of an interview
+				options.tag = "interview";
+			}
 			options.priority = MessagePriority.WakeUp;
 		}
 
@@ -2413,13 +2420,21 @@ ${handlers.length} left`,
 			type: "requeue",
 			priority: MessagePriority.WakeUp,
 		};
+		const requeueAndTagAsInterview: TransactionReducerResult = {
+			...requeue,
+			tag: "interview",
+		};
 
 		const reducer: TransactionReducer = (transaction, _source) => {
 			const msg = transaction.message;
 			if (msg.getNodeId() !== nodeId) return { type: "keep" };
 			// Drop all messages that are not allowed in the wakeup queue
 			// For all other messages, change the priority to wakeup
-			return this.mayMoveToWakeupQueue(transaction) ? requeue : reject;
+			return this.mayMoveToWakeupQueue(transaction)
+				? transaction.priority === MessagePriority.NodeQuery
+					? requeueAndTagAsInterview
+					: requeue
+				: reject;
 		};
 
 		// Apply the reducer to the send thread

--- a/packages/zwave-js/src/lib/driver/SendThreadMachine.ts
+++ b/packages/zwave-js/src/lib/driver/SendThreadMachine.ts
@@ -156,10 +156,11 @@ export type TransactionReducerResult =
 			message?: Message;
 	  }
 	| {
-			// Changes the priority of the transaction if a new one is given,
+			// Changes the priority (and tag) of the transaction if a new one is given,
 			// and moves the current transaction back to the queue
 			type: "requeue";
 			priority?: MessagePriority;
+			tag?: any;
 	  };
 
 export type TransactionReducer = (
@@ -588,6 +589,9 @@ export function createSendThreadMachine(
 					case "requeue":
 						if (reducerResult.priority != undefined) {
 							transaction.priority = reducerResult.priority;
+						}
+						if (reducerResult.tag != undefined) {
+							transaction.tag = reducerResult.tag;
 						}
 						requeue.push(transaction);
 						break;


### PR DESCRIPTION
With this PR, we now correctly identify all messages that are queued as part of an interview process. Previously, this was done by checking the message priority, which failed when a message was moved to the wakeup queue. These messages are now tagged, so they an be detected and rejected when a user requests a re-interview.

fixes: #1652