### PR TITLE
docs: add getLogConfig to Driver methods in docs

### DIFF
--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -196,6 +196,14 @@ updateLogConfig(config: DeepPartial<LogConfig>): void
 
 Updates the logging configuration without having to restart the driver.
 
+### `getLogConfig`
+
+```ts
+getLogConfig(): LogConfig
+```
+
+Returns the current logging configuration.
+
 ## Driver properties
 
 ### `cacheDir`


### PR DESCRIPTION
Noticed this was missing from the docs