### PR TITLE
feat: collect telemetry information for identified devices without a config file

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -4,6 +4,7 @@
     -   [Quick Start](getting-started/quickstart.md)
     -   [Migrating to v6](getting-started/migrating-to-v6.md)
     -   [Migrating to v7](getting-started/migrating-to-v7.md)
+    -   [Disclaimer: Telemetry](getting-started/telemetry.md)
 
 -   API
 

--- a/docs/getting-started/telemetry.md
+++ b/docs/getting-started/telemetry.md
@@ -1,0 +1,21 @@
+# Disclaimer: Telemetry
+
+Since you're probably reading this when getting familiar with `zwave-js`, we want to use this opportunity to disclose that `zwave-js` is collecting some data to ensure an optimal experience going forward. The following sections explain which information we collect and why.
+
+> [!NOTE] We do not store any data which can be used to identify users.
+
+## Crash reports
+
+We use [Sentry](https://sentry.io) for automatic crash reporting. We self-host our sentry instance in Germany to ensure that we have control over the data. The transmitted reports include the following data:
+
+-   `zwave-js` version
+-   A fingerprint which is **randomly generated** during the installation. This is used to gauge how many users an issue affects (and to quickly ignore crashes caused by devs who are just messing around).
+-   A Node.js stacktrace including an error message and the function calls which lead to the error.
+
+## Device telemetry
+
+We also use [Sentry](https://sentry.io) to capture basic information about devices that were successfully interviewed but have no config file. These often have suboptimal labels that we can improve on (or no information at all). The reports include the following data:
+
+-   Whether the device supports `Configuration CC V3+` - if yes, the discovered metadata for the config parameters is recorded
+-   Whether the device supports `Association Group Information CC` - if yes, the discovered association group labels are recorded
+-   Whether the device supports `Z-Wave Plus` and if yes, which version of the standard it implements

--- a/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
@@ -728,6 +728,22 @@ alters capabilities: ${!!properties.altersCapabilities}`;
 	}
 
 	/**
+	 * @internal
+	 * Returns the param info that was queried for this node. This returns the information that was returned by the node
+	 * and does not include partial parameters.
+	 */
+	public getQueriedParamInfos(): Record<number, ConfigurationMetadata> {
+		const parameters = distinct(
+			this.getDefinedValueIDs()
+				.map((v) => v.property)
+				.filter((p): p is number => typeof p === "number"),
+		);
+		return composeObject(
+			parameters.map((p) => [p as any, this.getParamInformation(p)]),
+		);
+	}
+
+	/**
 	 * Returns stored config parameter metadata for all partial config params addressed with the given parameter number
 	 */
 	public getPartialParamInfos(

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -21,7 +21,13 @@ import {
 	ZWaveSerialPortBase,
 	ZWaveSocket,
 } from "@zwave-js/serial";
-import { DeepPartial, num2hex, pick, stringify } from "@zwave-js/shared";
+import {
+	DeepPartial,
+	formatId,
+	num2hex,
+	pick,
+	stringify,
+} from "@zwave-js/shared";
 import { wait } from "alcalzone-shared/async";
 import {
 	createDeferredPromise,
@@ -37,10 +43,12 @@ import { URL } from "url";
 import * as util from "util";
 import { interpret } from "xstate";
 import { FirmwareUpdateStatus } from "../commandclass";
+import { AssociationGroupInfoCC } from "../commandclass/AssociationGroupInfoCC";
 import {
 	CommandClass,
 	getImplementedVersion,
 } from "../commandclass/CommandClass";
+import { ConfigurationCC } from "../commandclass/ConfigurationCC";
 import { DeviceResetLocallyCCNotification } from "../commandclass/DeviceResetLocallyCC";
 import {
 	isEncapsulatingCommandClass,
@@ -960,6 +968,68 @@ export class Driver extends EventEmitter {
 						maxAttempts: maxInterviewAttempts,
 					});
 				}
+			} else if (
+				node.manufacturerId != undefined &&
+				node.productType != undefined &&
+				node.productId != undefined &&
+				!node.deviceConfig &&
+				process.env.NODE_ENV !== "test"
+			) {
+				// The interview succeeded, but we don't have a device config for this node.
+				// Report it, so we can add a config file
+
+				let message = `Missing device config: ${formatId(
+					node.manufacturerId,
+				)}:${formatId(node.productType)}:${formatId(node.productId)}`;
+				if (node.firmwareVersion != undefined) {
+					message += `:${node.firmwareVersion}`;
+				}
+				const contexts: Record<string, any> = {
+					supportsConfigCCV3:
+						node.getCCVersion(CommandClasses.Configuration) >= 3,
+					supportsAGI: node.supportsCC(
+						CommandClasses["Association Group Information"],
+					),
+					supportsZWavePlus: node.supportsCC(
+						CommandClasses["Z-Wave Plus Info"],
+					),
+				};
+				try {
+					if (contexts.supportsConfigCCV3) {
+						// Try to collect all info about config params we can get
+						const instance = node.createCCInstanceUnsafe(
+							ConfigurationCC,
+						)!;
+						contexts.parameters = instance.getQueriedParamInfos();
+					}
+					if (contexts.supportsAGI) {
+						// Try to collect all info about association groups we can get
+						const instance = node.createCCInstanceUnsafe(
+							AssociationGroupInfoCC,
+						)!;
+						// wotan-disable-next-line no-restricted-property-access
+						const associationGroupCount = instance[
+							"getAssociationGroupCountCached"
+						]();
+						const names: string[] = [];
+						for (
+							let group = 1;
+							group <= associationGroupCount;
+							group++
+						) {
+							names.push(
+								instance.getGroupNameCached(group) ?? "",
+							);
+						}
+						contexts.associationGroups = names;
+					}
+					if (contexts.supportsZWavePlus) {
+						contexts.zWavePlusVersion = node.zwavePlusVersion;
+					}
+				} catch {
+					// Don't fail on the last meters :)
+				}
+				Sentry.captureMessage(message, { contexts });
 			}
 		} catch (e: unknown) {
 			if (isZWaveError(e)) {

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -119,7 +119,6 @@ import {
 import type { Driver } from "../driver/Driver";
 import { Extended, interpretEx } from "../driver/StateMachineShared";
 import type { Transaction } from "../driver/Transaction";
-import type { Message } from "../message/Message";
 import { DeviceClass } from "./DeviceClass";
 import { Endpoint } from "./Endpoint";
 import {
@@ -1094,27 +1093,6 @@ export class ZWaveNode extends Endpoint {
 				requestedNodeId: this.id,
 			}),
 		);
-		if (
-			process.env.NODE_ENV !== "test" &&
-			!(resp instanceof GetNodeProtocolInfoResponse)
-		) {
-			// eslint-disable-next-line @typescript-eslint/no-var-requires
-			const Sentry: typeof import("@sentry/node") = require("@sentry/node");
-			Sentry.captureMessage(
-				"Response to GetNodeProtocolInfoRequest is not a GetNodeProtocolInfoResponse",
-				{
-					contexts: {
-						message: {
-							name: ((resp as any) as Message).constructor.name,
-							type: ((resp as any) as Message).type,
-							functionType: ((resp as any) as Message)
-								.functionType,
-							...((resp as any) as Message).toLogEntry(),
-						},
-					},
-				},
-			);
-		}
 		this._deviceClass = resp.deviceClass;
 		for (const cc of this._deviceClass.mandatorySupportedCCs) {
 			this.addCC(cc, { isSupported: true });
@@ -1765,28 +1743,6 @@ protocol version:      ${this._protocolVersion}`;
 					removeNonRepeaters: false,
 				}),
 			);
-			if (
-				process.env.NODE_ENV !== "test" &&
-				!(resp instanceof GetRoutingInfoResponse)
-			) {
-				// eslint-disable-next-line @typescript-eslint/no-var-requires
-				const Sentry: typeof import("@sentry/node") = require("@sentry/node");
-				Sentry.captureMessage(
-					"Response to GetRoutingInfoRequest is not a GetRoutingInfoResponse",
-					{
-						contexts: {
-							message: {
-								name: ((resp as any) as Message).constructor
-									.name,
-								type: ((resp as any) as Message).type,
-								functionType: ((resp as any) as Message)
-									.functionType,
-								...((resp as any) as Message).toLogEntry(),
-							},
-						},
-					},
-				);
-			}
 			this._neighbors = resp.nodeIds;
 			this.driver.controllerLog.logNode(this.id, {
 				message: `  node neighbors received: ${this._neighbors.join(

--- a/test/run.ts
+++ b/test/run.ts
@@ -6,6 +6,8 @@ process.on("unhandledRejection", (_r) => {
 	// debugger;
 });
 
+// Uncomment this to test Sentry reporting
+// import "../packages/zwave-js";
 import { Driver } from "../packages/zwave-js/src/lib/driver/Driver";
 
 const driver = new Driver("COM5", {


### PR DESCRIPTION
With this PR, we detect at the end of an interview whether the device could be identified but we don't have a config file for it. In that case, we collect some basic information that helps us create said config file:

- Whether the device supports Configuration CC V3+ - if yes, the detected config parameters are recorded
- Whether the device supports AGI CC - if yes, the association group names are recorded
- Whether the device supports Z-Wave+ and which version of the standard it implements

/cc @blhoward2 