### PR TITLE
fix: do not map root to ambiguous endpoint, opt-in with compat flag

### DIFF
--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -256,6 +256,15 @@ By default, received `Basic` commands are mapped to a more appropriate CC. Setti
 
 The specifications mandate strict rules for the data in `Entry Control CC Notifications`, which some devices do not follow, causing the notifications to get dropped. Setting `disableStrictEntryControlDataValidation` to `true` disables these strict checks.
 
+### `manualValueRefreshDelayMs`
+
+Some legacy devices emit an NIF when a local event occurs (e.g. a button press) to signal that the controller should request a status update. However, some of these devices require a delay before they are ready to respond to this request. `manualValueRefreshDelayMs` specifies that delay, expressed in milliseconds. If unset, there will be no delay.
+
+### `mapRootReportsToEndpoints`
+
+Starting with version 3, the `Multi Channel Association CC` allows setting up Multi Channel Lifeline Associations between devices, allowing devices to report the status of their endpoints. Despite this possibility, some devices only use the root device for reporting.  
+When the flag `mapRootReportsToEndpoints` is set to `true`, `zwave-js` will map these suboptimal reports to an endpoint if the mapping is not ambiguous.
+
 ### `preserveRootApplicationCCValueIDs`
 
 The Z-Wave+ specs mandate that the root endpoint must **mirror** the application functionality of endpoint 1 (and potentially others). For this reason, `zwave-js` hides these superfluous values. However, some legacy devices offer additional functionality through the root endpoint, which should not be hidden. To achive this, set `preserveRootApplicationCCValueIDs` to `true`.
@@ -270,7 +279,3 @@ By default, `Basic CC::Set` commands are interpreted as status updates. This fla
 
 > [!NOTE]
 > If this option is `true`, it has precedence over `disableBasicMapping`.
-
-### `manualValueRefreshDelayMs`
-
-Some legacy devices emit an NIF when a local event occurs (e.g. a button press) to signal that the controller should request a status update. However, some of these devices require a delay before they are ready to respond to this request. `manualValueRefreshDelayMs` specifies that delay, expressed in milliseconds. If unset, there will be no delay.

--- a/maintenance/schemas/device-config.json
+++ b/maintenance/schemas/device-config.json
@@ -262,6 +262,9 @@
 					"type": "number",
 					"minimum": 0
 				},
+				"mapRootReportsToEndpoints": {
+					"const": true
+				},
 				"overrideFloatEncoding": {
 					"type": "object",
 					"properties": {

--- a/packages/config/src/CompatConfig.ts
+++ b/packages/config/src/CompatConfig.ts
@@ -79,6 +79,19 @@ error in compat option disableStrictEntryControlDataValidation`,
 				definition.disableStrictEntryControlDataValidation;
 		}
 
+		if (definition.mapRootReportsToEndpoints != undefined) {
+			if (definition.mapRootReportsToEndpoints !== true) {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+error in compat option mapRootReportsToEndpoints`,
+				);
+			}
+
+			this.mapRootReportsToEndpoints =
+				definition.mapRootReportsToEndpoints;
+		}
+
 		if (definition.preserveRootApplicationCCValueIDs != undefined) {
 			if (definition.preserveRootApplicationCCValueIDs !== true) {
 				throwInvalidConfig(
@@ -340,6 +353,8 @@ compat option alarmMapping must be an array where all items are objects!`,
 	>;
 	public readonly disableBasicMapping?: boolean;
 	public readonly disableStrictEntryControlDataValidation?: boolean;
+	public readonly manualValueRefreshDelayMs?: number;
+	public readonly mapRootReportsToEndpoints?: boolean;
 	public readonly overrideFloatEncoding?: {
 		size?: number;
 		precision?: number;
@@ -347,7 +362,6 @@ compat option alarmMapping must be an array where all items are objects!`,
 	public readonly preserveRootApplicationCCValueIDs?: boolean;
 	public readonly skipConfigurationInfoQuery?: boolean;
 	public readonly treatBasicSetAsEvent?: boolean;
-	public readonly manualValueRefreshDelayMs?: number;
 	public readonly queryOnWakeup?: readonly [
 		string,
 		string,

--- a/packages/zwave-js/src/lib/node/Node.test.ts
+++ b/packages/zwave-js/src/lib/node/Node.test.ts
@@ -1507,11 +1507,11 @@ describe("lib/node/Node", () => {
 
 		beforeEach(() => fakeDriver.sendMessage.mockClear());
 
-		it("should map commands from the root endpoint to endpoint 1 if MultiChannelAssociationCC is V1/V2", async () => {
+		it("should map commands from the root endpoint to a supporting endpoint if compat flag mapRootReportsToEndpoints is set", async () => {
 			const node = makeNode([
 				[
 					CommandClasses["Multi Channel Association"],
-					{ isSupported: true, version: 2 },
+					{ isSupported: true },
 				],
 			]);
 			// We have two endpoints
@@ -1534,6 +1534,11 @@ describe("lib/node/Node", () => {
 			node.getEndpoint(1)?.addCC(CommandClasses["Binary Switch"], {
 				isSupported: true,
 			});
+			node["_deviceConfig"] = {
+				compat: {
+					mapRootReportsToEndpoints: true,
+				},
+			} as any;
 
 			// Handle a command for the root endpoint
 			const command = new BinarySwitchCCReport(

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1828,27 +1828,29 @@ protocol version:      ${this._protocolVersion}`;
 		this.cancelManualValueRefresh(command.ccId);
 
 		// If this is a report for the root endpoint and the node supports the CC on another endpoint,
-		// we need to map it to endpoint 1. Either it does not support multi channel associations or
+		// it was probably meant to come from that endpoint. Either it does not support multi channel associations or
 		// it is misbehaving. In any case, we would hide this report if we didn't map it
 		if (
 			command.endpointIndex === 0 &&
 			command.constructor.name.endsWith("Report") &&
 			this.getEndpointCount() >= 1 &&
-			// skip the root to endpoint mapping if the root endpoint values are not meant to mirror endpoint 1
+			// skip the root to endpoint mapping if the root endpoint values are not meant to mirror a different endpoint
 			!this._deviceConfig?.compat?.preserveRootApplicationCCValueIDs
 		) {
-			// Find the first endpoint that supports the received CC - if there is none, we don't map the report
-			for (const endpoint of this.getAllEndpoints()) {
-				if (endpoint.index === 0) continue;
-				if (!endpoint.supportsCC(command.ccId)) continue;
-				// Force the CC to store its values again under the supporting endpoint
+			// Figure out if the mapping from root to another endpoint is unambiguous.
+			// Otherwise, we cannot map without getting it wrong some of the time.
+			const supportingEndpoints = this.getAllEndpoints().filter(
+				(e) => e.index !== 0 && e.supportsCC(command.ccId),
+			);
+			if (supportingEndpoints.length === 1) {
+				const endpoint = supportingEndpoints[0];
+				// Force the CC to store its values again under the only supporting endpoint
 				this.driver.controllerLog.logNode(
 					this.nodeId,
-					`Mapping unsolicited report from root device to first supporting endpoint #${endpoint.index}`,
+					`Mapping unsolicited report from root device to endpoint #${endpoint.index}`,
 				);
 				command.endpointIndex = endpoint.index;
 				command.persistValues();
-				break;
 			}
 		}
 

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1827,15 +1827,14 @@ protocol version:      ${this._protocolVersion}`;
 		// was wrong. Stop querying it regularly for updates
 		this.cancelManualValueRefresh(command.ccId);
 
-		// If this is a report for the root endpoint and the node supports the CC on another endpoint,
-		// it was probably meant to come from that endpoint. Either it does not support multi channel associations or
-		// it is misbehaving. In any case, we would hide this report if we didn't map it
+		// If this is a report for the root endpoint and the node supports the CC on another endpoint, it was probably
+		// meant to come from that endpoint. Either it does not support multi channel associations or it is misbehaving.
+		// We map these to a supporting endpoint if the corresponding compat flag is set
 		if (
 			command.endpointIndex === 0 &&
 			command.constructor.name.endsWith("Report") &&
 			this.getEndpointCount() >= 1 &&
-			// skip the root to endpoint mapping if the root endpoint values are not meant to mirror a different endpoint
-			!this._deviceConfig?.compat?.preserveRootApplicationCCValueIDs
+			this._deviceConfig?.compat?.mapRootReportsToEndpoints
 		) {
 			// Figure out if the mapping from root to another endpoint is unambiguous.
 			// Otherwise, we cannot map without getting it wrong some of the time.


### PR DESCRIPTION
With this PR, we no longer blindly map root endpoint reports to the first supporting endpoint. Unless the mapping is unambiguous, there's a good chance we'd get it wrong otherwise.

Instead, we now check if there's **exactly one** endpoint which supports the received CC. If so, the report gets mapped, otherwise it stays on the root endpoint. We can then go on a case-by-case basis and decide for which devices this report is actually needed and the root values need to be preserved.
Also, the new compat option `mapRootReportsToEndpoints` now determines if we even attempt mapping the report at all.

fixes: https://github.com/zwave-js/node-zwave-js/issues/2155
closes: #2156