### PR TITLE
fix: add compat flag to zen25

### DIFF
--- a/packages/config/config/devices/0x027a/zen25.json
+++ b/packages/config/config/devices/0x027a/zen25.json
@@ -291,5 +291,8 @@
 				}
 			]
 		}
+	},
+	"compat": {
+		"preserveRootApplicationCCValueIDs": true
 	}
 }


### PR DESCRIPTION
zen25 has a similar issue as described in https://github.com/zwave-js/node-zwave-js/pull/2126. Applied compatibility flag and tested. Feedback from zwave device now works properly.