### PR TITLE
feat: add option to opt-out from optimistic value update

### DIFF
--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -484,6 +484,18 @@ interface ZWaveOptions {
 	 * When it is `true`, unknown values are exposed as the literal string "unknown" (even if the value is normally numeric).
 	 * Default: `false` */
 	preserveUnknownValues?: boolean;
+
+	/**
+	 * Some SET-type commands optimistically update the current value to match the target value
+	 * when the device acknowledges the command.
+	 *
+	 * While this generally makes UIs feel more responsive, it is not necessary for devices which report their status
+	 * on their own and can lead to confusing behavior when dealing with slow devices like blinds.
+	 *
+	 * To disable the optimistic update, set this option to `true`.
+	 * Default: `false`
+	 */
+	disableOptimisticValueUpdate?: boolean;
 }
 ```
 

--- a/packages/zwave-js/src/lib/commandclass/BasicCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BasicCC.ts
@@ -94,7 +94,11 @@ export class BasicCCAPI extends CCAPI {
 		// so UIs have immediate feedback
 		if (this.isSinglecast()) {
 			// Only update currentValue for valid target values
-			if (value >= 0 && value <= 99) {
+			if (
+				!this.driver.options.disableOptimisticValueUpdate &&
+				value >= 0 &&
+				value <= 99
+			) {
 				const valueDB = this.endpoint.getNodeUnsafe()?.valueDB;
 				valueDB?.setValue(
 					getCurrentValueValueId(this.endpoint.index),

--- a/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
@@ -126,11 +126,13 @@ export class BinarySwitchCCAPI extends CCAPI {
 		// If the command did not fail, assume that it succeeded and update the currentValue accordingly
 		// so UIs have immediate feedback
 		if (this.isSinglecast()) {
-			const valueDB = this.endpoint.getNodeUnsafe()?.valueDB;
-			valueDB?.setValue(
-				getCurrentValueValueId(this.endpoint.index),
-				value,
-			);
+			if (!this.driver.options.disableOptimisticValueUpdate) {
+				const valueDB = this.endpoint.getNodeUnsafe()?.valueDB;
+				valueDB?.setValue(
+					getCurrentValueValueId(this.endpoint.index),
+					value,
+				);
+			}
 
 			// Verify the current value after a delay
 			// TODO: #1321

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -314,7 +314,11 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 			// so UIs have immediate feedback
 			if (this.isSinglecast() && completed) {
 				// Only update currentValue for valid target values
-				if (value >= 0 && value <= 99) {
+				if (
+					!this.driver.options.disableOptimisticValueUpdate &&
+					value >= 0 &&
+					value <= 99
+				) {
 					const valueDB = this.endpoint.getNodeUnsafe()?.valueDB;
 					valueDB?.setValue(
 						getCurrentValueValueId(this.endpoint.index),

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -193,6 +193,18 @@ export interface ZWaveOptions {
 	 * When it is `true`, unknown values are exposed as the literal string "unknown" (even if the value is normally numeric).
 	 * Default: `false` */
 	preserveUnknownValues?: boolean;
+
+	/**
+	 * Some SET-type commands optimistically update the current value to match the target value
+	 * when the device acknowledges the command.
+	 *
+	 * While this generally makes UIs feel more responsive, it is not necessary for devices which report their status
+	 * on their own and can lead to confusing behavior when dealing with slow devices like blinds.
+	 *
+	 * To disable the optimistic update, set this option to `true`.
+	 * Default: `false`
+	 */
+	disableOptimisticValueUpdate?: boolean;
 }
 
 const defaultOptions: ZWaveOptions = {
@@ -212,6 +224,7 @@ const defaultOptions: ZWaveOptions = {
 		nodeInterview: 5,
 	},
 	preserveUnknownValues: false,
+	disableOptimisticValueUpdate: false,
 	skipInterview: false,
 	storage: {
 		driver: fsExtra,


### PR DESCRIPTION
This PR adds a new driver option `disableOptimisticValueUpdate` which disables the optimistic update of `currentValue` when the option is set.

fixes: https://github.com/zwave-js/zwavejs2mqtt/issues/958