### PR TITLE
fix: add missing exports for Message class

### DIFF
--- a/packages/zwave-js/src/Driver.ts
+++ b/packages/zwave-js/src/Driver.ts
@@ -1,4 +1,14 @@
 export { Driver } from "./lib/driver/Driver";
 export type { SendMessageOptions, ZWaveOptions } from "./lib/driver/Driver";
 export type { FileSystem } from "./lib/driver/FileSystem";
-export { MessagePriority } from "./lib/message/Constants";
+export {
+	FunctionType,
+	MessagePriority,
+	MessageType,
+} from "./lib/message/Constants";
+export { Message } from "./lib/message/Message";
+export type {
+	MessageOptions,
+	ResponsePredicate,
+	ResponseRole,
+} from "./lib/message/Message";

--- a/packages/zwave-js/src/lib/message/Message.ts
+++ b/packages/zwave-js/src/lib/message/Message.ts
@@ -38,7 +38,7 @@ export interface MessageBaseOptions {
 	callbackId?: number;
 }
 
-interface MessageCreationOptions extends MessageBaseOptions {
+export interface MessageCreationOptions extends MessageBaseOptions {
 	type?: MessageType;
 	functionType?: FunctionType;
 	expectedResponse?: FunctionType | typeof Message | ResponsePredicate;


### PR DESCRIPTION
This PR adds the following missing exports to the `zwave-js` and `zwave-js/Driver` entrypoints:
* `FunctionType` enum
* `MessageType` enum
* `Message` class
* `MessageOptions` type
* `ResponsePredicate` type
* `ResponseRole` type

fixes: #2182 