### PR TITLE
feat: implement SendData[Multicast]_Bridge and prefer it if supported

### DIFF
--- a/packages/zwave-js/src/lib/controller/SendDataShared.ts
+++ b/packages/zwave-js/src/lib/controller/SendDataShared.ts
@@ -1,0 +1,40 @@
+import {
+	SendDataBridgeRequest,
+	SendDataMulticastBridgeRequest,
+} from "./SendDataBridgeMessages";
+import { SendDataMulticastRequest, SendDataRequest } from "./SendDataMessages";
+
+export type SendDataMessage =
+	| SendDataRequest
+	| SendDataMulticastRequest
+	| SendDataBridgeRequest
+	| SendDataMulticastBridgeRequest;
+
+export function isSendData(msg: unknown): msg is SendDataMessage {
+	if (!msg) return false;
+	return (
+		msg instanceof SendDataRequest ||
+		msg instanceof SendDataMulticastRequest ||
+		msg instanceof SendDataBridgeRequest ||
+		msg instanceof SendDataMulticastBridgeRequest
+	);
+}
+
+export function isSendDataSinglecast(
+	msg: unknown,
+): msg is SendDataRequest | SendDataBridgeRequest {
+	if (!msg) return false;
+	return (
+		msg instanceof SendDataRequest || msg instanceof SendDataBridgeRequest
+	);
+}
+
+export function isSendDataMulticast(
+	msg: unknown,
+): msg is SendDataMulticastRequest | SendDataMulticastBridgeRequest {
+	if (!msg) return false;
+	return (
+		msg instanceof SendDataMulticastRequest ||
+		msg instanceof SendDataMulticastBridgeRequest
+	);
+}

--- a/packages/zwave-js/src/lib/driver/CommandQueueMachine.ts
+++ b/packages/zwave-js/src/lib/driver/CommandQueueMachine.ts
@@ -8,10 +8,7 @@ import {
 	StateMachine,
 } from "xstate";
 import { raise, sendParent } from "xstate/lib/actions";
-import {
-	SendDataMulticastRequest,
-	SendDataRequest,
-} from "../controller/SendDataMessages";
+import { isSendData } from "../controller/SendDataShared";
 import type { Message } from "../message/Message";
 import {
 	createSerialAPICommandMachine,
@@ -250,18 +247,11 @@ export function createCommandQueueMachine(
 				executeSuccessful: (_, evt: any) =>
 					evt.data?.type === "success",
 				queueNotEmpty: (ctx) => ctx.queue.length > 0,
-				currentTransactionIsSendData: (ctx) => {
-					const msg = ctx.currentTransaction?.message;
-					return (
-						msg instanceof SendDataRequest ||
-						msg instanceof SendDataMulticastRequest
-					);
-				},
+				currentTransactionIsSendData: (ctx) =>
+					isSendData(ctx.currentTransaction?.message),
 				isSendDataWithCallbackTimeout: (ctx, evt: any) => {
-					const msg = ctx.currentTransaction?.message;
 					return (
-						(msg instanceof SendDataRequest ||
-							msg instanceof SendDataMulticastRequest) &&
+						isSendData(ctx.currentTransaction?.message) &&
 						evt.data?.type === "failure" &&
 						evt.data?.reason === "callback timeout"
 					);

--- a/packages/zwave-js/src/lib/driver/Driver.test.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.test.ts
@@ -21,11 +21,20 @@ import {
 	SendDataRequest,
 	TransmitOptions,
 } from "../controller/SendDataMessages";
-import { MessageType } from "../message/Constants";
+import { FunctionType, MessageType } from "../message/Constants";
 import { Message, messageTypes } from "../message/Message";
 import { ZWaveNode } from "../node/Node";
 import { createAndStartDriver, PORT_ADDRESS } from "../test/utils";
 import { Driver } from "./Driver";
+
+// Test mock for isFunctionSupported to control which commands are getting used
+function isFunctionSupported(fn: FunctionType): boolean {
+	switch (fn) {
+		case FunctionType.SendData:
+			return true;
+	}
+	return false;
+}
 
 @messageTypes(MessageType.Request, 0xff)
 class TestMessage extends Message {}
@@ -397,6 +406,7 @@ describe("lib/driver/Driver => ", () => {
 					get: () => node2,
 					forEach: () => {},
 				},
+				isFunctionSupported,
 			} as any;
 		});
 
@@ -470,6 +480,7 @@ describe("lib/driver/Driver => ", () => {
 					get: () => node2,
 					forEach: () => {},
 				},
+				isFunctionSupported,
 			} as any;
 		});
 

--- a/packages/zwave-js/src/lib/driver/SendThreadMachine.ts
+++ b/packages/zwave-js/src/lib/driver/SendThreadMachine.ts
@@ -18,9 +18,14 @@ import { messageIsPing } from "../commandclass/NoOperationCC";
 import { ApplicationCommandRequest } from "../controller/ApplicationCommandRequest";
 import { BridgeApplicationCommandRequest } from "../controller/BridgeApplicationCommandRequest";
 import {
+	SendDataBridgeRequest,
+	SendDataMulticastBridgeRequest,
+} from "../controller/SendDataBridgeMessages";
+import {
 	SendDataMulticastRequest,
 	SendDataRequest,
 } from "../controller/SendDataMessages";
+import { isSendData } from "../controller/SendDataShared";
 import { MessagePriority } from "../message/Constants";
 import type { Message } from "../message/Message";
 import { InterviewStage, NodeStatus } from "../node/Types";
@@ -213,13 +218,8 @@ const incrementSendDataAttempts: AssignAction<SendThreadContext, any> = assign({
 
 const forwardToCommandQueue = forwardTo<any, any>((ctx) => ctx.commandQueue);
 
-const currentTransactionIsSendData = (ctx: SendThreadContext) => {
-	const msg = ctx.currentTransaction?.message;
-	return (
-		msg instanceof SendDataRequest ||
-		msg instanceof SendDataMulticastRequest
-	);
-};
+const currentTransactionIsSendData = (ctx: SendThreadContext) =>
+	isSendData(ctx.currentTransaction?.message);
 
 const forwardNodeUpdate = pure<SendThreadContext, any>((ctx, evt) => {
 	return raise({
@@ -302,10 +302,13 @@ const guards: MachineOptions<SendThreadContext, SendThreadEvent>["guards"] = {
 	},
 	requiresNoHandshake: (ctx) => {
 		const msg = ctx.currentTransaction?.message;
-		if (!(msg instanceof SendDataRequest)) {
-			return true;
+		if (
+			msg instanceof SendDataRequest ||
+			msg instanceof SendDataBridgeRequest
+		) {
+			return !(msg.command as CommandClass).requiresPreTransmitHandshake();
 		}
-		return !(msg.command as CommandClass).requiresPreTransmitHandshake();
+		return true;
 	},
 	isForActiveTransaction: (ctx, evt: any, meta) => {
 		return (
@@ -318,13 +321,21 @@ const guards: MachineOptions<SendThreadContext, SendThreadEvent>["guards"] = {
 				evt.transaction === ctx.currentTransaction)
 		);
 	},
-	expectsNodeUpdate: (ctx) =>
-		ctx.currentTransaction?.message instanceof SendDataRequest &&
-		(ctx.currentTransaction
-			.message as SendDataRequest).command.expectsCCResponse(),
+	expectsNodeUpdate: (ctx) => {
+		const msg = ctx.currentTransaction?.message;
+		if (
+			msg instanceof SendDataRequest ||
+			msg instanceof SendDataBridgeRequest
+		) {
+			return (msg.command as CommandClass).expectsCCResponse();
+		}
+		return false;
+	},
 	isExpectedUpdate: (ctx, evt, meta) => {
 		if (!meta.state.matches("sending.waitForUpdate")) return false;
-		const sentMsg = ctx.currentTransaction!.message as SendDataRequest;
+		const sentMsg = ctx.currentTransaction!.message as
+			| SendDataRequest
+			| SendDataBridgeRequest;
 		const receivedMsg = (evt as any).message;
 		return (
 			(receivedMsg instanceof ApplicationCommandRequest ||
@@ -335,17 +346,18 @@ const guards: MachineOptions<SendThreadContext, SendThreadEvent>["guards"] = {
 	currentTransactionIsSendData,
 	mayRetry: (ctx, evt: any) => {
 		const msg = ctx.currentTransaction!.message;
-		if (msg instanceof SendDataMulticastRequest) {
+		if (!isSendData(msg)) return false;
+		if (
+			msg instanceof SendDataMulticastRequest ||
+			msg instanceof SendDataMulticastBridgeRequest
+		) {
 			// Don't try to resend multicast messages if they were already transmitted.
 			// One or more nodes might have already reacted
 			if (evt.reason === "callback NOK") {
 				return false;
 			}
 		}
-		return (
-			(msg as SendDataRequest | SendDataMulticastRequest)
-				.maxSendAttempts > ctx.sendDataAttempts
-		);
+		return msg.maxSendAttempts > ctx.sendDataAttempts;
 	},
 
 	/** Whether the message is an outgoing pre-transmit handshake */
@@ -357,18 +369,27 @@ const guards: MachineOptions<SendThreadContext, SendThreadEvent>["guards"] = {
 		const transaction = (evt as any).transaction as Transaction;
 		if (transaction.priority !== MessagePriority.PreTransmitHandshake)
 			return false;
-		if (!(transaction.message instanceof SendDataRequest)) return false;
-		// require the handshake to be for the same node
-		return (
-			transaction.message.command.nodeId ===
-			(ctx.currentTransaction!.message as SendDataRequest).command.nodeId
-		);
+		if (
+			transaction.message instanceof SendDataRequest ||
+			transaction.message instanceof SendDataBridgeRequest
+		) {
+			// require the handshake to be for the same node
+			return (
+				transaction.message.command.nodeId ===
+				(ctx.currentTransaction!.message as
+					| SendDataRequest
+					| SendDataBridgeRequest).command.nodeId
+			);
+		}
+		return false;
 	},
 	isExpectedHandshakeResponse: (ctx, evt, meta) => {
 		if (!ctx.handshakeTransaction) return false;
 		if (!meta.state.matches("sending.handshake.waitForHandshakeResponse"))
 			return false;
-		const sentMsg = ctx.handshakeTransaction.message as SendDataRequest;
+		const sentMsg = ctx.handshakeTransaction.message as
+			| SendDataRequest
+			| SendDataBridgeRequest;
 		const receivedMsg = (evt as any).message;
 		if (!isCommandClassContainer(receivedMsg)) return false;
 		return (
@@ -384,12 +405,19 @@ const guards: MachineOptions<SendThreadContext, SendThreadEvent>["guards"] = {
 		// Then ensure that the event transaction is also SendData
 		const transaction = (evt as any).transaction as Transaction;
 		if (transaction.priority !== MessagePriority.Handshake) return false;
-		if (!(transaction.message instanceof SendDataRequest)) return false;
-		// require the handshake to be for the same node
-		return (
-			transaction.message.command.nodeId ===
-			(ctx.currentTransaction!.message as SendDataRequest).command.nodeId
-		);
+		if (
+			transaction.message instanceof SendDataRequest ||
+			transaction.message instanceof SendDataBridgeRequest
+		) {
+			// require the handshake to be for the same node
+			return (
+				transaction.message.command.nodeId ===
+				(ctx.currentTransaction!.message as
+					| SendDataRequest
+					| SendDataBridgeRequest).command.nodeId
+			);
+		}
+		return false;
 	},
 	shouldNotKeepCurrentTransaction: (ctx, evt) => {
 		const reducer = (evt as any).reducer;
@@ -1013,8 +1041,9 @@ export function createSendThreadMachine(
 				preTransmitHandshake: async (ctx) => {
 					// Execute the pre transmit handshake and swallow all errors
 					try {
-						await (ctx.currentTransaction!
-							.message as SendDataRequest).command.preTransmitHandshake();
+						await (ctx.currentTransaction!.message as
+							| SendDataRequest
+							| SendDataBridgeRequest).command.preTransmitHandshake();
 					} catch (e) {}
 				},
 				notifyRetry: (ctx) => {
@@ -1023,8 +1052,9 @@ export function createSendThreadMachine(
 						undefined,
 						ctx.currentTransaction!.message,
 						ctx.sendDataAttempts,
-						(ctx.currentTransaction!.message as SendDataRequest)
-							.maxSendAttempts,
+						(ctx.currentTransaction!.message as
+							| SendDataRequest
+							| SendDataBridgeRequest).maxSendAttempts,
 						500,
 					);
 					return Promise.resolve();

--- a/packages/zwave-js/src/lib/message/Constants.ts
+++ b/packages/zwave-js/src/lib/message/Constants.ts
@@ -180,6 +180,8 @@ export enum FunctionType {
 	FUNC_ID_ZW_IS_VIRTUAL_NODE = 0xa6, // Virtual node test
 
 	BridgeApplicationCommand = 0xa8, // A message from another node using the Bridge API
+	SendDataBridge = 0xa9, // Send data (Bridge API)
+	SendDataMulticastBridge = 0xab, // Send data using multicast (Bridge API)
 
 	UNKNOWN_FUNC_UNKNOWN_0xB4 = 0xb4, // ??
 

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -8,6 +8,7 @@ import {
 	CommandClassInfo,
 	CRC16_CCITT,
 	getCCName,
+	isTransmissionError,
 	isZWaveError,
 	MAX_NODES,
 	Maybe,
@@ -997,13 +998,7 @@ export class ZWaveNode extends Endpoint {
 				await method();
 				return true;
 			} catch (e: unknown) {
-				if (
-					isZWaveError(e) &&
-					(e.code === ZWaveErrorCodes.Controller_NodeTimeout ||
-						e.code === ZWaveErrorCodes.Controller_ResponseNOK ||
-						e.code === ZWaveErrorCodes.Controller_CallbackNOK ||
-						e.code === ZWaveErrorCodes.Controller_MessageDropped)
-				) {
+				if (isTransmissionError(e)) {
 					return false;
 				}
 				throw e;
@@ -1317,13 +1312,7 @@ protocol version:      ${this._protocolVersion}`;
 			try {
 				await instance.interview();
 			} catch (e: unknown) {
-				if (
-					isZWaveError(e) &&
-					(e.code === ZWaveErrorCodes.Controller_MessageDropped ||
-						e.code === ZWaveErrorCodes.Controller_CallbackNOK ||
-						e.code === ZWaveErrorCodes.Controller_ResponseNOK ||
-						e.code === ZWaveErrorCodes.Controller_NodeTimeout)
-				) {
+				if (isTransmissionError(e)) {
 					// We had a CAN or timeout during the interview
 					// or the node is presumed dead. Abort the process
 					return false;

--- a/packages/zwave-js/src/lib/node/VirtualEndpoint.test.ts
+++ b/packages/zwave-js/src/lib/node/VirtualEndpoint.test.ts
@@ -8,8 +8,19 @@ import type { BinarySensorCCAPI } from "../commandclass/BinarySensorCC";
 import { BinarySwitchCCAPI } from "../commandclass/BinarySwitchCC";
 import { ZWaveController } from "../controller/Controller";
 import type { Driver } from "../driver/Driver";
+import { FunctionType } from "../message/Constants";
 import { createAndStartDriver } from "../test/utils";
 import { ZWaveNode } from "./Node";
+
+// Test mock for isFunctionSupported to control which commands are getting used
+function isFunctionSupported(fn: FunctionType): boolean {
+	switch (fn) {
+		case FunctionType.SendDataBridge:
+		case FunctionType.SendDataMulticastBridge:
+			return false;
+	}
+	return true;
+}
 
 describe("lib/node/VirtualEndpoint", () => {
 	let driver: Driver;
@@ -22,7 +33,7 @@ describe("lib/node/VirtualEndpoint", () => {
 			debugger;
 		}
 		driver["_controller"] = new ZWaveController(driver);
-		driver["_controller"].isFunctionSupported = () => true;
+		driver["_controller"].isFunctionSupported = isFunctionSupported;
 	});
 
 	function makePhysicalNode(nodeId: number): ZWaveNode {

--- a/packages/zwave-js/src/lib/test/assertCC.ts
+++ b/packages/zwave-js/src/lib/test/assertCC.ts
@@ -1,5 +1,6 @@
 import { entries } from "alcalzone-shared/objects";
 import type { CommandClass, Constructable } from "../commandclass/CommandClass";
+import { SendDataBridgeRequest } from "../controller/SendDataBridgeMessages";
 import { SendDataRequest } from "../controller/SendDataMessages";
 
 /** Performs assertions on a sendMessage call argument that's supposed to be a CC */
@@ -13,8 +14,12 @@ export function assertCC<
 		ccValues?: Record<string, any>;
 	},
 ): void {
-	const request: SendDataRequest = callArg;
-	expect(request).toBeInstanceOf(SendDataRequest);
+	const request: SendDataRequest | SendDataBridgeRequest = callArg;
+	try {
+		expect(request).toBeInstanceOf(SendDataRequest);
+	} catch {
+		expect(request).toBeInstanceOf(SendDataBridgeRequest);
+	}
 	if (options.nodeId) expect(request.getNodeId()).toBe(options.nodeId);
 
 	const command = request.command;

--- a/packages/zwave-js/src/lib/test/driver/fixtures.ts
+++ b/packages/zwave-js/src/lib/test/driver/fixtures.ts
@@ -1,0 +1,11 @@
+import { FunctionType } from "../../message/Constants";
+
+// Test mock for isFunctionSupported to control which commands are getting used
+export function isFunctionSupported_NoBridge(fn: FunctionType): boolean {
+	switch (fn) {
+		case FunctionType.SendDataBridge:
+		case FunctionType.SendDataMulticastBridge:
+			return false;
+	}
+	return true;
+}

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepBlockNonceReport.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepBlockNonceReport.test.ts
@@ -5,6 +5,7 @@ import type { Driver } from "../../driver/Driver";
 import { ZWaveNode } from "../../node/Node";
 import { NodeStatus } from "../../node/Types";
 import { createAndStartDriver } from "../utils";
+import { isFunctionSupported_NoBridge } from "./fixtures";
 
 describe("regression tests", () => {
 	let driver: Driver;
@@ -27,7 +28,7 @@ describe("regression tests", () => {
 
 		driver["_controller"] = {
 			ownNodeId: 1,
-			isFunctionSupported: () => true,
+			isFunctionSupported: isFunctionSupported_NoBridge,
 			nodes: new Map(),
 		} as any;
 	});

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepMessageOrder.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepMessageOrder.test.ts
@@ -4,6 +4,7 @@ import type { Driver } from "../../driver/Driver";
 import { ZWaveNode } from "../../node/Node";
 import { NodeStatus } from "../../node/Types";
 import { createAndStartDriver } from "../utils";
+import { isFunctionSupported_NoBridge } from "./fixtures";
 
 describe("regression tests", () => {
 	let driver: Driver;
@@ -15,7 +16,7 @@ describe("regression tests", () => {
 
 		driver["_controller"] = {
 			ownNodeId: 1,
-			isFunctionSupported: () => true,
+			isFunctionSupported: isFunctionSupported_NoBridge,
 			nodes: new Map(),
 		} as any;
 	});

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepNoReject.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepNoReject.test.ts
@@ -7,6 +7,7 @@ import { MessagePriority } from "../../message/Constants";
 import { ZWaveNode } from "../../node/Node";
 import { NodeStatus } from "../../node/Types";
 import { createAndStartDriver } from "../utils";
+import { isFunctionSupported_NoBridge } from "./fixtures";
 
 describe("regression tests", () => {
 	let driver: Driver;
@@ -18,7 +19,7 @@ describe("regression tests", () => {
 
 		driver["_controller"] = {
 			ownNodeId: 1,
-			isFunctionSupported: () => true,
+			isFunctionSupported: isFunctionSupported_NoBridge,
 			nodes: new Map(),
 		} as any;
 	});

--- a/packages/zwave-js/src/lib/test/driver/receiveApplicationCommandHandlerBridge.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/receiveApplicationCommandHandlerBridge.test.ts
@@ -4,6 +4,7 @@ import { wait } from "alcalzone-shared/async";
 import type { Driver } from "../../driver/Driver";
 import { ZWaveNode } from "../../node/Node";
 import { createAndStartDriver } from "../utils";
+import { isFunctionSupported_NoBridge } from "./fixtures";
 
 describe("regression tests", () => {
 	let driver: Driver;
@@ -23,7 +24,7 @@ describe("regression tests", () => {
 
 		driver["_controller"] = {
 			ownNodeId: 1,
-			isFunctionSupported: () => true,
+			isFunctionSupported: isFunctionSupported_NoBridge,
 			nodes: new Map(),
 		} as any;
 	});

--- a/packages/zwave-js/src/lib/test/driver/secureAndSupervisionEncap.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/secureAndSupervisionEncap.test.ts
@@ -3,6 +3,7 @@ import { MockSerialPort } from "@zwave-js/serial";
 import type { Driver } from "../../driver/Driver";
 import { ZWaveNode } from "../../node/Node";
 import { createAndStartDriver } from "../utils";
+import { isFunctionSupported_NoBridge } from "./fixtures";
 
 describe("regression tests", () => {
 	let driver: Driver;
@@ -22,7 +23,7 @@ describe("regression tests", () => {
 
 		driver["_controller"] = {
 			ownNodeId: 1,
-			isFunctionSupported: () => true,
+			isFunctionSupported: isFunctionSupported_NoBridge,
 			nodes: new Map(),
 		} as any;
 	});

--- a/packages/zwave-js/src/lib/test/driver/sendDataCallbackMessageOrder.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/sendDataCallbackMessageOrder.test.ts
@@ -15,6 +15,7 @@ import type { Driver } from "../../driver/Driver";
 import { ZWaveNode } from "../../node/Node";
 import { NodeStatus } from "../../node/Types";
 import { createAndStartDriver } from "../utils";
+import { isFunctionSupported_NoBridge } from "./fixtures";
 
 describe("regression tests", () => {
 	let driver: Driver;
@@ -32,6 +33,9 @@ describe("regression tests", () => {
 			ownNodeId: 1,
 			nonceTimeout: driver.options.timeouts.nonce,
 		});
+		driver[
+			"_controller"
+		]!.isFunctionSupported = isFunctionSupported_NoBridge;
 
 		// We need to create a fake driver instance for Node 17 to support receiving encrypted messages
 		({ driver: driver17 } = await createAndStartDriver({
@@ -39,7 +43,7 @@ describe("regression tests", () => {
 		}));
 		driver17["_controller"] = {
 			ownNodeId: 17,
-			isFunctionSupported: () => true,
+			isFunctionSupported: isFunctionSupported_NoBridge,
 			nodes: new Map(),
 		} as any;
 

--- a/packages/zwave-js/src/lib/test/driver/successfulPingChangeNodeStatus.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/successfulPingChangeNodeStatus.test.ts
@@ -2,9 +2,20 @@ import { MessageHeaders, MockSerialPort } from "@zwave-js/serial";
 import { getEnumMemberName } from "@zwave-js/shared";
 import { wait } from "alcalzone-shared/async";
 import type { Driver } from "../../driver/Driver";
+import { FunctionType } from "../../message/Constants";
 import { ZWaveNode } from "../../node/Node";
 import { NodeStatus } from "../../node/Types";
 import { createAndStartDriver } from "../utils";
+
+// Test mock for isFunctionSupported to control which commands are getting used
+function isFunctionSupported(fn: FunctionType): boolean {
+	switch (fn) {
+		case FunctionType.SendDataBridge:
+		case FunctionType.SendDataMulticastBridge:
+			return false;
+	}
+	return true;
+}
 
 describe("When a ping succeeds, the node should be marked awake/alive", () => {
 	let driver: Driver;
@@ -16,7 +27,7 @@ describe("When a ping succeeds, the node should be marked awake/alive", () => {
 
 		driver["_controller"] = {
 			ownNodeId: 1,
-			isFunctionSupported: () => true,
+			isFunctionSupported,
 			nodes: new Map(),
 		} as any;
 	});

--- a/test/run.ts
+++ b/test/run.ts
@@ -18,6 +18,10 @@ const driver = new Driver("COM5", {
 })
 	.on("error", console.error)
 	.once("driver ready", async () => {
+		driver.on("all nodes ready", async () => {
+			const mc = driver.controller.getMulticastGroup([13, 13]);
+			await mc.commandClasses["Binary Switch"].set(false);
+		});
 		// const cc = new CommandClass(driver, {
 		// 	nodeId: 24,
 		// 	ccId: 0x5d,


### PR DESCRIPTION
Until now, we only had the most basic support for the Bridge API (the command handler). As it turns out, the 700-series stick report support for both SendData and SendDataMulticast, but the latter isn't actually supported.

With this PR, we now prefer the Bridge API variants of these commands when they are supported.

fixes: https://github.com/zwave-js/node-zwave-js/issues/2190