### PR TITLE
feat: add new node events to monitor interview progress

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -166,6 +166,12 @@ Resets all information about this node and forces a fresh interview.
 
 > [!WARNING] Take care NOT to call this method when the node is already being interviewed. Otherwise the node information may become inconsistent.
 
+In `zwave-js-server`, calling this command will trigger a `not ready` event for the node. The node is passed as the single argument to the callback:
+
+```ts
+(node: ZWaveNode) => void
+```
+
 ### `interviewCC`
 
 ```ts
@@ -692,16 +698,6 @@ There are two situations when this event is emitted:
 
 > [!NOTE]
 > This event does not imply that the node is currently awake or will respond to requests.
-
-### `"not ready"`
-
-This is emitted when a node that was previously ready is no longer ready.
-
-The node is passed as the single argument to the callback:
-
-```ts
-(node: ZWaveNode) => void
-```
 
 ### `"value added"` / `"value updated"` / `"value removed"`
 

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -164,13 +164,7 @@ refreshInfo(): Promise<void>
 
 Resets all information about this node and forces a fresh interview.
 
-> [!WARNING] Take care NOT to call this method when the node is already being interviewed. Otherwise the node information may become inconsistent.
-
-In `zwave-js-server`, calling this command will trigger a `not ready` event for the node. The node is passed as the single argument to the callback:
-
-```ts
-(node: ZWaveNode) => void
-```
+> [!WARNING] After calling this method, the node will no longer be `ready`. Keep this in mind if you rely on the `ready` state in your application.
 
 ### `interviewCC`
 

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -634,7 +634,7 @@ The initial interview or reinterview process for this node has started. The node
 A state of the interview process for this node was completed. Only the name of the stage is provided and should not be relied on as stage names are subject to change:
 
 ```ts
-(node: ZWaveNode, completedStageName: string) => void
+(node: ZWaveNode, stageName: string) => void
 ```
 
 ### `"interview completed"`

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -621,9 +621,25 @@ A non-sleeping node has stopped responding or just started responding again. The
 (node: ZWaveNode) => void
 ```
 
+### `"interview started"`
+
+The initial interview or reinterview process for this node has started. The node is passed as the single argument to the callback:
+
+```ts
+(node: ZWaveNode) => void
+```
+
+### `"interview stage completed"`
+
+A state of the interview process for this node was completed. Only the name of the stage is provided and should not be relied on as stage names are subject to change:
+
+```ts
+(node: ZWaveNode, completedStageName: string) => void
+```
+
 ### `"interview completed"`
 
-The initial interview process for this node was completed. The node is passed as the single argument to the callback:
+The initial interview or reinterview process for this node was completed. The node is passed as the single argument to the callback:
 
 ```ts
 (node: ZWaveNode) => void
@@ -676,6 +692,16 @@ There are two situations when this event is emitted:
 
 > [!NOTE]
 > This event does not imply that the node is currently awake or will respond to requests.
+
+### `"not ready"`
+
+This is emitted when a node that was previously ready is no longer ready.
+
+The node is passed as the single argument to the callback:
+
+```ts
+(node: ZWaveNode) => void
+```
 
 ### `"value added"` / `"value updated"` / `"value removed"`
 

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -422,11 +422,7 @@ export class ZWaveNode extends Endpoint {
 		if (ready === this._ready) return;
 
 		this._ready = ready;
-		if (ready) {
-			this.emit("ready", this);
-		} else {
-			this.emit("not ready", this);
-		}
+		if (ready) this.emit("ready", this);
 	}
 
 	/**

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -422,7 +422,11 @@ export class ZWaveNode extends Endpoint {
 		if (ready === this._ready) return;
 
 		this._ready = ready;
-		if (ready) this.emit("ready", this);
+		if (ready) {
+			this.emit("ready", this);
+		} else {
+			this.emit("not ready", this);
+		}
 	}
 
 	/**
@@ -1020,6 +1024,7 @@ export class ZWaveNode extends Endpoint {
 				this.id,
 				`new node, doing a full interview...`,
 			);
+			this.emit("interview started", this);
 			await this.queryProtocolInfo();
 		}
 
@@ -1071,6 +1076,11 @@ export class ZWaveNode extends Endpoint {
 		completedStage: InterviewStage,
 	): Promise<void> {
 		this.interviewStage = completedStage;
+		this.emit(
+			"interview stage completed",
+			this,
+			getEnumMemberName(InterviewStage, completedStage),
+		);
 		// Also save to the cache after certain stages
 		switch (completedStage) {
 			case InterviewStage.ProtocolInfo:

--- a/packages/zwave-js/src/lib/node/Types.ts
+++ b/packages/zwave-js/src/lib/node/Types.ts
@@ -102,6 +102,12 @@ export interface ZWaveNodeEventCallbacks extends ZWaveNodeValueEventCallbacks {
 	alive: ZWaveNodeStatusChangeCallback;
 	"interview completed": (node: ZWaveNode) => void;
 	ready: (node: ZWaveNode) => void;
+	"not ready": (node: ZWaveNode) => void;
+	"interview stage completed": (
+		node: ZWaveNode,
+		completedStageName: string,
+	) => void;
+	"interview started": (node: ZWaveNode) => void;
 }
 
 export type ZWaveNodeEvents = Extract<keyof ZWaveNodeEventCallbacks, string>;

--- a/packages/zwave-js/src/lib/node/Types.ts
+++ b/packages/zwave-js/src/lib/node/Types.ts
@@ -102,7 +102,6 @@ export interface ZWaveNodeEventCallbacks extends ZWaveNodeValueEventCallbacks {
 	alive: ZWaveNodeStatusChangeCallback;
 	"interview completed": (node: ZWaveNode) => void;
 	ready: (node: ZWaveNode) => void;
-	"not ready": (node: ZWaveNode) => void;
 	"interview stage completed": (node: ZWaveNode, stageName: string) => void;
 	"interview started": (node: ZWaveNode) => void;
 }

--- a/packages/zwave-js/src/lib/node/Types.ts
+++ b/packages/zwave-js/src/lib/node/Types.ts
@@ -103,10 +103,7 @@ export interface ZWaveNodeEventCallbacks extends ZWaveNodeValueEventCallbacks {
 	"interview completed": (node: ZWaveNode) => void;
 	ready: (node: ZWaveNode) => void;
 	"not ready": (node: ZWaveNode) => void;
-	"interview stage completed": (
-		node: ZWaveNode,
-		completedStageName: string,
-	) => void;
+	"interview stage completed": (node: ZWaveNode, stageName: string) => void;
 	"interview started": (node: ZWaveNode) => void;
 }
 


### PR DESCRIPTION
As discussed in Discord, I added three new events:
- `interview started`
- `interview stage completed`
- ~~`not ready`~~

This will allow us to update the ready status in `zwave-js-server-python` as needed, and also will allow us to display information to the user about the last completed stage of interview during a re-interview or during startup