### PR TITLE
fix(config): update Aeotec ZW056 config

### DIFF
--- a/packages/config/config/devices/0x0086/zw056.json
+++ b/packages/config/config/devices/0x0086/zw056.json
@@ -70,12 +70,10 @@
 		"6": {
 			"$import": "../templates/master_template.json#base_0-100_nounit",
 			"label": "Play Ringtone",
-			"options": [
-				{
-					"label": "Stop playing",
-					"value": 0
-				}
-			]
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 100,
+			"defaultValue": 0,
 		},
 		"7": {
 			"label": "Control Items",

--- a/packages/config/config/devices/0x0086/zw056.json
+++ b/packages/config/config/devices/0x0086/zw056.json
@@ -73,7 +73,7 @@
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 100,
-			"defaultValue": 0,
+			"defaultValue": 0
 		},
 		"7": {
 			"label": "Control Items",


### PR DESCRIPTION
To allow playing ringtones on demand.  Allowable range for parameter 6 should be 0-100, not a set of options:

http://manuals-backend.z-wave.info/make.php?lang=en&sku=ZW056-C&cert=ZC10-15110019