### PR TITLE
fix: use forceNotificationIdleReset compat option for auto-idle opt-in

### DIFF
--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -256,6 +256,10 @@ By default, received `Basic` commands are mapped to a more appropriate CC. Setti
 
 The specifications mandate strict rules for the data in `Entry Control CC Notifications`, which some devices do not follow, causing the notifications to get dropped. Setting `disableStrictEntryControlDataValidation` to `true` disables these strict checks.
 
+### `forceNotificationIdleReset`
+
+Version 8 of the `Notification CC` added the requirement that devices must issue an idle notification after a notification variable is no longer active. Several legacy devices and some misbehaving V8 devices do not return their variables to idle automatically. By setting `forceNotificationIdleReset` to `true`, `zwave-js` auto-idles supporting notification variables after 5 minutes.
+
 ### `manualValueRefreshDelayMs`
 
 Some legacy devices emit an NIF when a local event occurs (e.g. a button press) to signal that the controller should request a status update. However, some of these devices require a delay before they are ready to respond to this request. `manualValueRefreshDelayMs` specifies that delay, expressed in milliseconds. If unset, there will be no delay.

--- a/maintenance/schemas/device-config.json
+++ b/maintenance/schemas/device-config.json
@@ -258,6 +258,9 @@
 				"disableStrictEntryControlDataValidation": {
 					"const": true
 				},
+				"forceNotificationIdleReset": {
+					"const": true
+				},
 				"manualValueRefreshDelayMs": {
 					"type": "number",
 					"minimum": 0

--- a/packages/config/src/CompatConfig.ts
+++ b/packages/config/src/CompatConfig.ts
@@ -79,6 +79,19 @@ error in compat option disableStrictEntryControlDataValidation`,
 				definition.disableStrictEntryControlDataValidation;
 		}
 
+		if (definition.forceNotificationIdleReset != undefined) {
+			if (definition.forceNotificationIdleReset !== true) {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+error in compat option forceNotificationIdleReset`,
+				);
+			}
+
+			this.forceNotificationIdleReset =
+				definition.forceNotificationIdleReset;
+		}
+
 		if (definition.mapRootReportsToEndpoints != undefined) {
 			if (definition.mapRootReportsToEndpoints !== true) {
 				throwInvalidConfig(
@@ -353,6 +366,7 @@ compat option alarmMapping must be an array where all items are objects!`,
 	>;
 	public readonly disableBasicMapping?: boolean;
 	public readonly disableStrictEntryControlDataValidation?: boolean;
+	public readonly forceNotificationIdleReset?: boolean;
 	public readonly manualValueRefreshDelayMs?: number;
 	public readonly mapRootReportsToEndpoints?: boolean;
 	public readonly overrideFloatEncoding?: {

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -2407,14 +2407,13 @@ protocol version:      ${this._protocolVersion}`;
 				propertyKey,
 			};
 			this.valueDB.setValue(valueId, value);
-			// Nodes before V8 don't necessarily reset the notification to idle
-			// Set a fallback timer in case the node does not reset it.
+			// Nodes before V8 (and some misbehaving V8 ones) don't necessarily reset the notification to idle.
+			// The specifications advise to auto-reset the variables, but it has been found that this interferes
+			// with some motion sensors that don't refresh their active notification. Therefore, we set a fallback
+			// timer if the `forceNotificationIdleReset` compat flag is set.
 			if (
 				allowIdleReset &&
-				this.driver.getSafeCCVersionForNode(
-					CommandClasses.Notification,
-					this.id,
-				) <= 7
+				!!this._deviceConfig?.compat?.forceNotificationIdleReset
 			) {
 				this.scheduleNotificationIdleReset(valueId, () =>
 					setStateIdle(value),


### PR DESCRIPTION
With this PR we no longer automatically set a fallback timer of 5 minutes to idle notifications. Instead, we introduce the compat flag `forceNotificationIdleReset` to opt-in to this behavior through configuration files.

fixes: https://github.com/zwave-js/zwavejs2mqtt/issues/990