### PR TITLE
fix(config): map `alarmLevel` to `userId` for Yale locks

### DIFF
--- a/packages/config/config/devices/0x0129/templates/yale_template.json
+++ b/packages/config/config/devices/0x0129/templates/yale_template.json
@@ -368,7 +368,10 @@
 		},
 		"to": {
 			"notificationType": 6, // Access Control
-			"notificationEvent": 6 // Keypad unlock operation
+			"notificationEvent": 6, // Keypad unlock operation
+			"eventParameters": {
+				"userId": "alarmLevel"
+			}
 		}
 	},
 	"alarm_map_manual_lock": {
@@ -396,7 +399,10 @@
 		},
 		"to": {
 			"notificationType": 6, // Access Control
-			"notificationEvent": 5 // Keypad lock operation
+			"notificationEvent": 5, // Keypad lock operation
+			"eventParameters": {
+				"userId": "alarmLevel"
+			}
 		}
 	},
 	"alarm_map_deadbolt_jammed": {


### PR DESCRIPTION
Closes #2206