### PR TITLE
fix(config): remove erroneous descriptions from Fibaro FBGS222

### DIFF
--- a/packages/config/config/devices/0x010f/fgbs222.json
+++ b/packages/config/config/devices/0x010f/fgbs222.json
@@ -199,7 +199,6 @@
 		},
 		"64": {
 			"label": "Analog inputs - periodical reports",
-			"description": "reporting period of analog inputs value",
 			"unit": "seconds",
 			"valueSize": 2,
 			"minValue": 0,
@@ -235,7 +234,6 @@
 		},
 		"67": {
 			"label": "External sensors threshold",
-			"description": "External sensors - minimal change to report",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 255,


### PR DESCRIPTION
This file needs a lot of cleanup, but for now I've removed the erronous desciptions as they are unnecessary anyway.

Closes #2049