### PR TITLE
fix(config): add additional ProductID to Fibaro FGS-224

### DIFF
--- a/packages/config/config/devices/0x010f/fgs224.json
+++ b/packages/config/config/devices/0x010f/fgs224.json
@@ -7,6 +7,10 @@
 		{
 			"productType": "0x0204",
 			"productId": "0x1000"
+		},
+		{
+			"productType": "0x0204",
+			"productId": "0x3000"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
added additional ProductID "0x3000" believe this is for the Australian Frequency module