### PR TITLE
feat(controller): manage SUC return routes and controller promotion

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
@@ -20,10 +20,8 @@ import { buffer2hex, num2hex, pick } from "@zwave-js/shared";
 import { randomBytes } from "crypto";
 import type { ZWaveController } from "../controller/Controller";
 import { SendDataBridgeRequest } from "../controller/SendDataBridgeMessages";
-import {
-	SendDataRequest,
-	TransmitOptions,
-} from "../controller/SendDataMessages";
+import { SendDataRequest } from "../controller/SendDataMessages";
+import { TransmitOptions } from "../controller/SendDataShared";
 import type { Driver } from "../driver/Driver";
 import { FunctionType, MessagePriority } from "../message/Constants";
 import { PhysicalCCAPI } from "./API";

--- a/packages/zwave-js/src/lib/commandclass/ZWavePlusCC.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/ZWavePlusCC.test.ts
@@ -1,8 +1,6 @@
 import { CommandClasses } from "@zwave-js/core";
-import {
-	SendDataRequest,
-	TransmitOptions,
-} from "../controller/SendDataMessages";
+import { SendDataRequest } from "../controller/SendDataMessages";
+import { TransmitOptions } from "../controller/SendDataShared";
 import type { Driver } from "../driver/Driver";
 import { ZWaveNode } from "../node/Node";
 import { assertCC } from "../test/assertCC";

--- a/packages/zwave-js/src/lib/controller/AssignReturnRouteMessages.ts
+++ b/packages/zwave-js/src/lib/controller/AssignReturnRouteMessages.ts
@@ -23,7 +23,7 @@ import {
 } from "../message/Message";
 import type { SuccessIndicator } from "../message/SuccessIndicator";
 import type { INodeQuery } from "../node/INodeQuery";
-import { TransmitStatus } from "./SendDataMessages";
+import { TransmitStatus } from "./SendDataShared";
 
 @messageTypes(MessageType.Request, FunctionType.AssignReturnRoute)
 @priority(MessagePriority.NodeQuery)

--- a/packages/zwave-js/src/lib/controller/AssignReturnRouteMessages.ts
+++ b/packages/zwave-js/src/lib/controller/AssignReturnRouteMessages.ts
@@ -26,7 +26,7 @@ import type { INodeQuery } from "../node/INodeQuery";
 import { TransmitStatus } from "./SendDataShared";
 
 @messageTypes(MessageType.Request, FunctionType.AssignReturnRoute)
-@priority(MessagePriority.NodeQuery)
+@priority(MessagePriority.Normal)
 export class AssignReturnRouteRequestBase extends Message {
 	public constructor(driver: Driver, options: MessageOptions) {
 		if (

--- a/packages/zwave-js/src/lib/controller/AssignSUCReturnRouteMessages.ts
+++ b/packages/zwave-js/src/lib/controller/AssignSUCReturnRouteMessages.ts
@@ -25,34 +25,37 @@ import type { SuccessIndicator } from "../message/SuccessIndicator";
 import type { INodeQuery } from "../node/INodeQuery";
 import { TransmitStatus } from "./SendDataShared";
 
-@messageTypes(MessageType.Request, FunctionType.DeleteReturnRoute)
+@messageTypes(MessageType.Request, FunctionType.AssignSUCReturnRoute)
 @priority(MessagePriority.Normal)
-export class DeleteReturnRouteRequestBase extends Message {
+export class AssignSUCReturnRouteRequestBase extends Message {
 	public constructor(driver: Driver, options: MessageOptions) {
 		if (
 			gotDeserializationOptions(options) &&
-			(new.target as any) !== DeleteReturnRouteRequestTransmitReport
+			(new.target as any) !== AssignSUCReturnRouteRequestTransmitReport
 		) {
-			return new DeleteReturnRouteRequestTransmitReport(driver, options);
+			return new AssignSUCReturnRouteRequestTransmitReport(
+				driver,
+				options,
+			);
 		}
 		super(driver, options);
 	}
 }
 
-export interface DeleteReturnRouteRequestOptions extends MessageBaseOptions {
+export interface AssignSUCReturnRouteRequestOptions extends MessageBaseOptions {
 	nodeId: number;
 }
 
-@expectedResponse(FunctionType.DeleteReturnRoute)
-@expectedCallback(FunctionType.DeleteReturnRoute)
-export class DeleteReturnRouteRequest
-	extends DeleteReturnRouteRequestBase
+@expectedResponse(FunctionType.AssignSUCReturnRoute)
+@expectedCallback(FunctionType.AssignSUCReturnRoute)
+export class AssignSUCReturnRouteRequest
+	extends AssignSUCReturnRouteRequestBase
 	implements INodeQuery {
 	public constructor(
 		driver: Driver,
 		options:
 			| MessageDeserializationOptions
-			| DeleteReturnRouteRequestOptions,
+			| AssignSUCReturnRouteRequestOptions,
 	) {
 		super(driver, options);
 		if (gotDeserializationOptions(options)) {
@@ -74,37 +77,37 @@ export class DeleteReturnRouteRequest
 	}
 }
 
-@messageTypes(MessageType.Response, FunctionType.DeleteReturnRoute)
-export class DeleteReturnRouteResponse
+@messageTypes(MessageType.Response, FunctionType.AssignSUCReturnRoute)
+export class AssignSUCReturnRouteResponse
 	extends Message
 	implements SuccessIndicator {
 	public constructor(driver: Driver, options: MessageDeserializationOptions) {
 		super(driver, options);
-		this.hasStarted = this.payload[0] !== 0;
+		this.wasExecuted = this.payload[0] !== 0;
 	}
 
 	public isOK(): boolean {
-		return this.hasStarted;
+		return this.wasExecuted;
 	}
 
-	public readonly hasStarted: boolean;
+	public readonly wasExecuted: boolean;
 
 	public toJSON(): JSONObject {
 		return super.toJSONInherited({
-			hasStarted: this.hasStarted,
+			wasExecuted: this.wasExecuted,
 		});
 	}
 
 	public toLogEntry(): MessageOrCCLogEntry {
 		return {
 			...super.toLogEntry(),
-			message: { "has started": this.hasStarted },
+			message: { "was executed": this.wasExecuted },
 		};
 	}
 }
 
-export class DeleteReturnRouteRequestTransmitReport
-	extends DeleteReturnRouteRequestBase
+export class AssignSUCReturnRouteRequestTransmitReport
+	extends AssignSUCReturnRouteRequestBase
 	implements SuccessIndicator {
 	public constructor(driver: Driver, options: MessageDeserializationOptions) {
 		super(driver, options);
@@ -113,13 +116,13 @@ export class DeleteReturnRouteRequestTransmitReport
 		this._transmitStatus = this.payload[1];
 	}
 
+	public isOK(): boolean {
+		return this._transmitStatus === TransmitStatus.OK;
+	}
+
 	private _transmitStatus: TransmitStatus;
 	public get transmitStatus(): TransmitStatus {
 		return this._transmitStatus;
-	}
-
-	public isOK(): boolean {
-		return this._transmitStatus === TransmitStatus.OK;
 	}
 
 	public toJSON(): JSONObject {

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -39,6 +39,8 @@ import type {
 } from "../commandclass/MultiChannelAssociationCC";
 import type { Driver, RequestHandler } from "../driver/Driver";
 import { FunctionType } from "../message/Constants";
+import type { Message } from "../message/Message";
+import type { SuccessIndicator } from "../message/SuccessIndicator";
 import { DeviceClass } from "../node/DeviceClass";
 import { ZWaveNode } from "../node/Node";
 import { InterviewStage, NodeStatus } from "../node/Types";
@@ -108,6 +110,7 @@ import {
 	SetSerialApiTimeoutsRequest,
 	SetSerialApiTimeoutsResponse,
 } from "./SetSerialApiTimeoutsMessages";
+import { SetSUCNodeIdRequest } from "./SetSUCNodeIDMessages";
 import { ZWaveLibraryTypes } from "./ZWaveLibraryTypes";
 
 export type HealNodeStatus = "pending" | "done" | "failed" | "skipped";
@@ -1645,6 +1648,25 @@ ${associatedNodes.join(", ")}`,
 		return true;
 	}
 
+	/** Configures the given Node to be SUC/SIS or not */
+	public async configureSUC(
+		nodeId: number,
+		enableSUC: boolean,
+		enableSIS: boolean,
+	): Promise<boolean> {
+		const result = await this.driver.sendMessage<
+			Message & SuccessIndicator
+		>(
+			new SetSUCNodeIdRequest(this.driver, {
+				sucNodeId: nodeId,
+				enableSUC,
+				enableSIS,
+			}),
+		);
+
+		return result.isOK();
+	}
+
 	public async assignReturnRoute(
 		nodeId: number,
 		destinationNodeId: number,
@@ -1656,6 +1678,7 @@ ${associatedNodes.join(", ")}`,
 			}),
 		);
 	}
+
 	/**
 	 * Returns a dictionary of all association groups of this node and their information.
 	 * This only works AFTER the interview process

--- a/packages/zwave-js/src/lib/controller/DeleteReturnRouteMessages.ts
+++ b/packages/zwave-js/src/lib/controller/DeleteReturnRouteMessages.ts
@@ -23,7 +23,7 @@ import {
 } from "../message/Message";
 import type { SuccessIndicator } from "../message/SuccessIndicator";
 import type { INodeQuery } from "../node/INodeQuery";
-import { TransmitStatus } from "./SendDataMessages";
+import { TransmitStatus } from "./SendDataShared";
 
 @messageTypes(MessageType.Request, FunctionType.DeleteReturnRoute)
 @priority(MessagePriority.NodeQuery)

--- a/packages/zwave-js/src/lib/controller/DeleteSUCReturnRouteMessages.ts
+++ b/packages/zwave-js/src/lib/controller/DeleteSUCReturnRouteMessages.ts
@@ -25,34 +25,37 @@ import type { SuccessIndicator } from "../message/SuccessIndicator";
 import type { INodeQuery } from "../node/INodeQuery";
 import { TransmitStatus } from "./SendDataShared";
 
-@messageTypes(MessageType.Request, FunctionType.DeleteReturnRoute)
+@messageTypes(MessageType.Request, FunctionType.DeleteSUCReturnRoute)
 @priority(MessagePriority.Normal)
-export class DeleteReturnRouteRequestBase extends Message {
+export class DeleteSUCReturnRouteRequestBase extends Message {
 	public constructor(driver: Driver, options: MessageOptions) {
 		if (
 			gotDeserializationOptions(options) &&
-			(new.target as any) !== DeleteReturnRouteRequestTransmitReport
+			(new.target as any) !== DeleteSUCReturnRouteRequestTransmitReport
 		) {
-			return new DeleteReturnRouteRequestTransmitReport(driver, options);
+			return new DeleteSUCReturnRouteRequestTransmitReport(
+				driver,
+				options,
+			);
 		}
 		super(driver, options);
 	}
 }
 
-export interface DeleteReturnRouteRequestOptions extends MessageBaseOptions {
+export interface DeleteSUCReturnRouteRequestOptions extends MessageBaseOptions {
 	nodeId: number;
 }
 
-@expectedResponse(FunctionType.DeleteReturnRoute)
-@expectedCallback(FunctionType.DeleteReturnRoute)
-export class DeleteReturnRouteRequest
-	extends DeleteReturnRouteRequestBase
+@expectedResponse(FunctionType.DeleteSUCReturnRoute)
+@expectedCallback(FunctionType.DeleteSUCReturnRoute)
+export class DeleteSUCReturnRouteRequest
+	extends DeleteSUCReturnRouteRequestBase
 	implements INodeQuery {
 	public constructor(
 		driver: Driver,
 		options:
 			| MessageDeserializationOptions
-			| DeleteReturnRouteRequestOptions,
+			| DeleteSUCReturnRouteRequestOptions,
 	) {
 		super(driver, options);
 		if (gotDeserializationOptions(options)) {
@@ -74,37 +77,37 @@ export class DeleteReturnRouteRequest
 	}
 }
 
-@messageTypes(MessageType.Response, FunctionType.DeleteReturnRoute)
-export class DeleteReturnRouteResponse
+@messageTypes(MessageType.Response, FunctionType.DeleteSUCReturnRoute)
+export class DeleteSUCReturnRouteResponse
 	extends Message
 	implements SuccessIndicator {
 	public constructor(driver: Driver, options: MessageDeserializationOptions) {
 		super(driver, options);
-		this.hasStarted = this.payload[0] !== 0;
+		this.wasExecuted = this.payload[0] !== 0;
 	}
 
 	public isOK(): boolean {
-		return this.hasStarted;
+		return this.wasExecuted;
 	}
 
-	public readonly hasStarted: boolean;
+	public readonly wasExecuted: boolean;
 
 	public toJSON(): JSONObject {
 		return super.toJSONInherited({
-			hasStarted: this.hasStarted,
+			wasExecuted: this.wasExecuted,
 		});
 	}
 
 	public toLogEntry(): MessageOrCCLogEntry {
 		return {
 			...super.toLogEntry(),
-			message: { "has started": this.hasStarted },
+			message: { "was executed": this.wasExecuted },
 		};
 	}
 }
 
-export class DeleteReturnRouteRequestTransmitReport
-	extends DeleteReturnRouteRequestBase
+export class DeleteSUCReturnRouteRequestTransmitReport
+	extends DeleteSUCReturnRouteRequestBase
 	implements SuccessIndicator {
 	public constructor(driver: Driver, options: MessageDeserializationOptions) {
 		super(driver, options);

--- a/packages/zwave-js/src/lib/controller/SendDataBridgeMessages.ts
+++ b/packages/zwave-js/src/lib/controller/SendDataBridgeMessages.ts
@@ -30,11 +30,8 @@ import {
 	priority,
 } from "../message/Message";
 import type { SuccessIndicator } from "../message/SuccessIndicator";
-import {
-	MAX_SEND_ATTEMPTS,
-	TransmitOptions,
-	TransmitStatus,
-} from "./SendDataMessages";
+import { MAX_SEND_ATTEMPTS } from "./SendDataMessages";
+import { TransmitOptions, TransmitStatus } from "./SendDataShared";
 
 @messageTypes(MessageType.Request, FunctionType.SendDataBridge)
 @priority(MessagePriority.Normal)

--- a/packages/zwave-js/src/lib/controller/SendDataMessages.ts
+++ b/packages/zwave-js/src/lib/controller/SendDataMessages.ts
@@ -30,27 +30,7 @@ import {
 	priority,
 } from "../message/Message";
 import type { SuccessIndicator } from "../message/SuccessIndicator";
-
-export enum TransmitOptions {
-	NotSet = 0,
-
-	ACK = 1 << 0,
-	LowPower = 1 << 1,
-	AutoRoute = 1 << 2,
-
-	NoRoute = 1 << 4,
-	Explore = 1 << 5,
-
-	DEFAULT = ACK | AutoRoute | Explore,
-}
-
-export enum TransmitStatus {
-	OK = 0x00, // Transmission complete and ACK received
-	NoAck = 0x01, // Transmission complete, no ACK received
-	Fail = 0x02, // Transmission failed
-	NotIdle = 0x03, // Transmission failed, network busy
-	NoRoute = 0x04, // Transmission complete, no return route
-}
+import { TransmitOptions, TransmitStatus } from "./SendDataShared";
 
 export const MAX_SEND_ATTEMPTS = 5;
 

--- a/packages/zwave-js/src/lib/controller/SendDataShared.ts
+++ b/packages/zwave-js/src/lib/controller/SendDataShared.ts
@@ -10,6 +10,27 @@ export type SendDataMessage =
 	| SendDataBridgeRequest
 	| SendDataMulticastBridgeRequest;
 
+export enum TransmitOptions {
+	NotSet = 0,
+
+	ACK = 1 << 0,
+	LowPower = 1 << 1,
+	AutoRoute = 1 << 2,
+
+	NoRoute = 1 << 4,
+	Explore = 1 << 5,
+
+	DEFAULT = ACK | AutoRoute | Explore,
+}
+
+export enum TransmitStatus {
+	OK = 0x00, // Transmission complete and ACK received
+	NoAck = 0x01, // Transmission complete, no ACK received
+	Fail = 0x02, // Transmission failed
+	NotIdle = 0x03, // Transmission failed, network busy
+	NoRoute = 0x04, // Transmission complete, no return route
+}
+
 export function isSendData(msg: unknown): msg is SendDataMessage {
 	if (!msg) return false;
 	return (

--- a/packages/zwave-js/src/lib/controller/SetSUCNodeIDMessages.ts
+++ b/packages/zwave-js/src/lib/controller/SetSUCNodeIDMessages.ts
@@ -1,0 +1,134 @@
+import {
+	MessageOrCCLogEntry,
+	ZWaveError,
+	ZWaveErrorCodes,
+} from "@zwave-js/core";
+import type { Driver } from "../driver/Driver";
+import {
+	FunctionType,
+	MessagePriority,
+	MessageType,
+} from "../message/Constants";
+import {
+	expectedCallback,
+	expectedResponse,
+	gotDeserializationOptions,
+	Message,
+	MessageBaseOptions,
+	MessageDeserializationOptions,
+	MessageOptions,
+	messageTypes,
+	priority,
+} from "../message/Message";
+import type { SuccessIndicator } from "../message/SuccessIndicator";
+import { TransmitOptions, TransmitStatus } from "./SendDataShared";
+
+export interface SetSUCNodeIdRequestOptions extends MessageBaseOptions {
+	sucNodeId?: number;
+	enableSUC: boolean;
+	enableSIS: boolean;
+	transmitOptions?: TransmitOptions;
+}
+
+@messageTypes(MessageType.Request, FunctionType.SetSUCNodeId)
+@priority(MessagePriority.Controller)
+export class SetSUCNodeIdRequestBase extends Message {
+	public constructor(driver: Driver, options: MessageOptions) {
+		if (
+			gotDeserializationOptions(options) &&
+			(new.target as any) !== SetSUCNodeIdRequestStatusReport
+		) {
+			return new SetSUCNodeIdRequestStatusReport(driver, options);
+		}
+		super(driver, options);
+	}
+}
+
+@expectedResponse(FunctionType.SetSUCNodeId)
+@expectedCallback(FunctionType.SetSUCNodeId)
+export class SetSUCNodeIdRequest extends SetSUCNodeIdRequestBase {
+	public constructor(
+		driver: Driver,
+		options: MessageDeserializationOptions | SetSUCNodeIdRequestOptions,
+	) {
+		super(driver, options);
+		if (gotDeserializationOptions(options)) {
+			throw new ZWaveError(
+				`${this.constructor.name}: deserialization not implemented`,
+				ZWaveErrorCodes.Deserialization_NotImplemented,
+			);
+		} else {
+			this.sucNodeId = options.sucNodeId ?? driver.controller.ownNodeId!;
+			this.enableSUC = options.enableSUC;
+			this.enableSIS = options.enableSIS;
+			this.transmitOptions =
+				options.transmitOptions ?? TransmitOptions.DEFAULT;
+		}
+	}
+
+	public sucNodeId: number;
+	public enableSUC: boolean;
+	public enableSIS: boolean;
+	public transmitOptions: TransmitOptions;
+
+	public serialize(): Buffer {
+		this.payload = Buffer.from([
+			this.sucNodeId,
+			this.enableSUC ? 0x01 : 0x00,
+			this.transmitOptions,
+			this.enableSIS ? 0x01 : 0x00,
+			this.callbackId,
+		]);
+
+		return super.serialize();
+	}
+
+	public expectsCallback(): boolean {
+		if (this.sucNodeId === this.driver.controller.ownNodeId) return false;
+		return super.expectsCallback();
+	}
+}
+
+@messageTypes(MessageType.Response, FunctionType.SetSUCNodeId)
+export class SetSUCNodeIdResponse extends Message implements SuccessIndicator {
+	public constructor(driver: Driver, options: MessageDeserializationOptions) {
+		super(driver, options);
+		this._wasExecuted = this.payload[0] !== 0;
+	}
+
+	isOK(): boolean {
+		return this._wasExecuted;
+	}
+
+	private _wasExecuted: boolean;
+	public get wasExecuted(): boolean {
+		return this._wasExecuted;
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: { "was executed": this.wasExecuted },
+		};
+	}
+}
+
+export class SetSUCNodeIdRequestStatusReport
+	extends SetSUCNodeIdRequestBase
+	implements SuccessIndicator {
+	public constructor(driver: Driver, options: MessageDeserializationOptions) {
+		super(driver, options);
+
+		this.callbackId = this.payload[0];
+		this._status = this.payload[1];
+	}
+
+	private _status: TransmitStatus;
+	public get status(): TransmitStatus {
+		return this._status;
+	}
+
+	public isOK(): boolean {
+		return this._status === TransmitStatus.OK;
+	}
+}

--- a/packages/zwave-js/src/lib/driver/Driver.test.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.test.ts
@@ -17,10 +17,8 @@ import { MultiCommandCCCommandEncapsulation } from "../commandclass/MultiCommand
 import { SecurityCCCommandEncapsulation } from "../commandclass/SecurityCC";
 import { WakeUpCCIntervalSet } from "../commandclass/WakeUpCC";
 import { ApplicationCommandRequest } from "../controller/ApplicationCommandRequest";
-import {
-	SendDataRequest,
-	TransmitOptions,
-} from "../controller/SendDataMessages";
+import { SendDataRequest } from "../controller/SendDataMessages";
+import { TransmitOptions } from "../controller/SendDataShared";
 import { FunctionType, MessageType } from "../message/Constants";
 import { Message, messageTypes } from "../message/Message";
 import { ZWaveNode } from "../node/Node";

--- a/packages/zwave-js/src/lib/driver/SendThreadMachine.test.ts
+++ b/packages/zwave-js/src/lib/driver/SendThreadMachine.test.ts
@@ -23,8 +23,8 @@ import {
 import {
 	SendDataRequest,
 	SendDataRequestTransmitReport,
-	TransmitStatus,
 } from "../controller/SendDataMessages";
+import { TransmitStatus } from "../controller/SendDataShared";
 import { MessagePriority } from "../message/Constants";
 import type { Message } from "../message/Message";
 import { createEmptyMockDriver } from "../test/mocks";

--- a/packages/zwave-js/src/lib/driver/StateMachineShared.ts
+++ b/packages/zwave-js/src/lib/driver/StateMachineShared.ts
@@ -26,9 +26,8 @@ import {
 	SendDataMulticastRequestTransmitReport,
 	SendDataRequest,
 	SendDataRequestTransmitReport,
-	TransmitStatus,
 } from "../controller/SendDataMessages";
-import { isSendData } from "../controller/SendDataShared";
+import { isSendData, TransmitStatus } from "../controller/SendDataShared";
 import type { DriverLogger } from "../log/Driver";
 import type { Message } from "../message/Message";
 import type { SendDataErrorData } from "./SendThreadMachine";

--- a/packages/zwave-js/src/lib/message/Constants.ts
+++ b/packages/zwave-js/src/lib/message/Constants.ts
@@ -126,12 +126,11 @@ export enum FunctionType {
 	FUNC_ID_ZW_CREATE_NEW_PRIMARY = 0x4c, // Control the createnewprimary process...start, stop, etc.
 	FUNC_ID_ZW_CONTROLLER_CHANGE = 0x4d, // Control the transferprimary process...start, stop, etc.
 	FUNC_ID_ZW_SET_LEARN_MODE = 0x50, // Put a controller into learn mode for replication/ receipt of configuration info
-	FUNC_ID_ZW_ASSIGN_SUC_RETURN_ROUTE = 0x51, // Assign a return route to the SUC
+	AssignSUCReturnRoute = 0x51, // Assign a return route to the SUC
 	FUNC_ID_ZW_ENABLE_SUC = 0x52, // Make a controller a Static Update Controller
 	FUNC_ID_ZW_REQUEST_NETWORK_UPDATE = 0x53, // Network update for a SUC(?)
-	FUNC_ID_ZW_SET_SUC_NODE_ID = 0x54, // Identify a Static Update Controller node id
-	FUNC_ID_ZW_DELETE_SUC_RETURN_ROUTE = 0x55, // Remove return routes to the SUC
-
+	SetSUCNodeId = 0x54, // Configure a static/bridge controller to be a SUC/SIS node (or not)
+	DeleteSUCReturnRoute = 0x55, // Remove return routes to the SUC
 	GetSUCNodeId = 0x56, // Try to retrieve a Static Update Controller node id (zero if no SUC present)
 
 	UNKNOWN_FUNC_SEND_SUC_ID = 0x57,

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -145,6 +145,14 @@ import type {
 } from "./Types";
 import { InterviewStage, NodeStatus, NodeType, ProtocolVersion } from "./Types";
 
+/** Returns a Value ID that can be used to store node specific data without relating it to a CC */
+function getNodeMetaValueID(property: string): ValueID {
+	return {
+		commandClass: -1,
+		property,
+	};
+}
+
 export interface ZWaveNode {
 	on<TEvent extends ZWaveNodeEvents>(
 		event: TEvent,
@@ -564,6 +572,16 @@ export class ZWaveNode extends Endpoint {
 		} else {
 			this._valueDB.removeValue(getNodeLocationValueId());
 		}
+	}
+
+	/** Whether a SUC return route was configured for this node */
+	public get hasSUCReturnRoute(): boolean {
+		return !!this.valueDB.getValue<boolean>(
+			getNodeMetaValueID("hasSUCReturnRoute"),
+		);
+	}
+	public set hasSUCReturnRoute(value: boolean) {
+		this.valueDB.setValue(getNodeMetaValueID("hasSUCReturnRoute"), value);
 	}
 
 	private _deviceConfig: DeviceConfig | undefined;


### PR DESCRIPTION
This PR implements support for:
- Promoting the controller to SUC/SIS if necessary
- Assigning SUC return routes to nodes as the first thing during an interview
- Assigning SUC return routes to nodes after the interview if we're not sure that they have a SUC return route already

fixes: #2191 