### PR TITLE
feat: support managing associations on endpoints

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -109,20 +109,20 @@ By default, the node will be included securely (with encryption) if a network ke
 
 ### Managing associations
 
-The following methods can be used to manage associations between nodes. This only works AFTER the interview process!
+The following methods can be used to manage associations between nodes and/or endpoints. This only works AFTER the interview process!
 
 ```ts
-getAssociationGroups(nodeId: number): ReadonlyMap<number, AssociationGroup>;
-getAssociations(nodeId: number): ReadonlyMap<number, readonly Association[]>;
-isAssociationAllowed(nodeId: number, group: number, association: Association): boolean;
-addAssociations(nodeId: number, group: number, associations: Association[]): Promise<void>;
-removeAssociations(nodeId: number, group: number, associations: Association[]): Promise<void>;
+getAssociationGroups(nodeId: number, endpointIndex?: number): ReadonlyMap<number, AssociationGroup>;
+getAssociations(nodeId: number, endpointIndex: number): ReadonlyMap<number, readonly AssociationAddress[]>;
+isAssociationAllowed(source: AssociationAddress, group: number, destination: AssociationAddress): boolean;
+addAssociations(source: AssociationAddress, group: number, destinations: AssociationAddress[]): Promise<void>;
+removeAssociations(source: AssociationAddress, group: number, destinations: AssociationAddress[]): Promise<void>;
 removeNodeFromAllAssociations(nodeId: number): Promise<void>;
 ```
 
--   `getAssociationGroups` returns all association groups for a given node.
--   `getAssociations` returns all defined associations of a given node.
--   `addAssociations` can be used to add one or more associations to a node's group. You should check if each association is allowed using `isAssociationAllowed` before doing so.
+-   `getAssociationGroups` returns all association groups for a given node or endpoint.
+-   `getAssociations` returns all defined associations of a given node or endpoint.
+-   `addAssociations` can be used to add one or more associations to a node's or endpoint's group. You should check if each association is allowed using `isAssociationAllowed` before doing so.
 -   To remove a previously added association, use `removeAssociations`
 -   A node can be removed from all other nodes' associations using `removeNodeFromAllAssociations`
 
@@ -149,14 +149,14 @@ interface AssociationGroup {
 }
 ```
 
-#### `Association` interface
+#### `AssociationAddress` interface
 
-This defines the target of a node's association:
+This defines the source and target node/endpoint of an association:
 
-<!-- #import Association from "zwave-js" -->
+<!-- #import AssociationAddress from "zwave-js" -->
 
 ```ts
-interface Association {
+interface AssociationAddress {
 	nodeId: number;
 	endpoint?: number;
 }

--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -113,15 +113,24 @@ The following methods can be used to manage associations between nodes and/or en
 
 ```ts
 getAssociationGroups(nodeId: number, endpointIndex?: number): ReadonlyMap<number, AssociationGroup>;
-getAssociations(nodeId: number, endpointIndex: number): ReadonlyMap<number, readonly AssociationAddress[]>;
+
+getAssociations(nodeId: number, endpointIndex?: number): ReadonlyMap<number, readonly AssociationAddress[]>;
+getAllAssociations(nodeId: number): ReadonlyObjectKeyMap<
+	AssociationAddress,
+	ReadonlyMap<number, readonly AssociationAddress[]>
+>;
+
 isAssociationAllowed(source: AssociationAddress, group: number, destination: AssociationAddress): boolean;
+
 addAssociations(source: AssociationAddress, group: number, destinations: AssociationAddress[]): Promise<void>;
+
 removeAssociations(source: AssociationAddress, group: number, destinations: AssociationAddress[]): Promise<void>;
 removeNodeFromAllAssociations(nodeId: number): Promise<void>;
 ```
 
 -   `getAssociationGroups` returns all association groups for a given node or endpoint.
--   `getAssociations` returns all defined associations of a given node or endpoint.
+-   `getAssociations` returns all defined associations of a given node **or** endpoint. If no endpoint is given, the associations for the root endpoint (`0`) are returned.
+-   `getAllAssociations` returns all defined associations of a given **node and all its endpoints**. The returned `Map` uses the source node+endpoint as keys and its values are `Maps` of association group IDs to target node+endpoint.
 -   `addAssociations` can be used to add one or more associations to a node's or endpoint's group. You should check if each association is allowed using `isAssociationAllowed` before doing so.
 -   To remove a previously added association, use `removeAssociations`
 -   A node can be removed from all other nodes' associations using `removeNodeFromAllAssociations`

--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -112,9 +112,9 @@ By default, the node will be included securely (with encryption) if a network ke
 The following methods can be used to manage associations between nodes and/or endpoints. This only works AFTER the interview process!
 
 ```ts
-getAssociationGroups(nodeId: number, endpointIndex?: number): ReadonlyMap<number, AssociationGroup>;
+getAssociationGroups(source: AssociationAddress): ReadonlyMap<number, AssociationGroup>;
 
-getAssociations(nodeId: number, endpointIndex?: number): ReadonlyMap<number, readonly AssociationAddress[]>;
+getAssociations(source: AssociationAddress): ReadonlyMap<number, readonly AssociationAddress[]>;
 getAllAssociations(nodeId: number): ReadonlyObjectKeyMap<
 	AssociationAddress,
 	ReadonlyMap<number, readonly AssociationAddress[]>

--- a/packages/zwave-js/src/lib/commandclass/AssociationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/AssociationCC.ts
@@ -26,7 +26,7 @@ import {
 	gotDeserializationOptions,
 	implementedVersion,
 } from "./CommandClass";
-import type { Association } from "./MultiChannelAssociationCC";
+import type { AssociationAddress } from "./MultiChannelAssociationCC";
 
 /** Returns the ValueID used to store the maximum number of nodes of an association group */
 export function getMaxNodesValueId(
@@ -295,9 +295,9 @@ export class AssociationCC extends CommandClass {
 	 */
 	public getAllDestinationsCached(): ReadonlyMap<
 		number,
-		readonly Association[]
+		readonly AssociationAddress[]
 	> {
-		const ret = new Map<number, Association[]>();
+		const ret = new Map<number, AssociationAddress[]>();
 		const groupCount = this.getGroupCountCached();
 		const valueDB = this.getValueDB();
 		for (let i = 1; i <= groupCount; i++) {

--- a/packages/zwave-js/src/lib/commandclass/AssociationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/AssociationCC.ts
@@ -10,6 +10,7 @@ import {
 import { distinct } from "alcalzone-shared/arrays";
 import type { Driver } from "../driver/Driver";
 import { MessagePriority } from "../message/Constants";
+import type { Endpoint } from "../node/Endpoint";
 import type { ZWaveNode } from "../node/Node";
 import { PhysicalCCAPI } from "./API";
 import {
@@ -28,46 +29,60 @@ import {
 import type { Association } from "./MultiChannelAssociationCC";
 
 /** Returns the ValueID used to store the maximum number of nodes of an association group */
-export function getMaxNodesValueId(groupId: number): ValueID {
+export function getMaxNodesValueId(
+	endpointIndex: number,
+	groupId: number,
+): ValueID {
 	return {
 		commandClass: CommandClasses.Association,
+		endpoint: endpointIndex,
 		property: "maxNodes",
 		propertyKey: groupId,
 	};
 }
 
 /** Returns the ValueID used to store the node IDs of an association group */
-export function getNodeIdsValueId(groupId: number): ValueID {
+export function getNodeIdsValueId(
+	endpointIndex: number,
+	groupId: number,
+): ValueID {
 	return {
 		commandClass: CommandClasses.Association,
+		endpoint: endpointIndex,
 		property: "nodeIds",
 		propertyKey: groupId,
 	};
 }
 
 /** Returns the ValueID used to store the group count of an association group */
-export function getGroupCountValueId(): ValueID {
+export function getGroupCountValueId(endpointIndex?: number): ValueID {
 	return {
 		commandClass: CommandClasses.Association,
+		endpoint: endpointIndex,
 		property: "groupCount",
 	};
 }
 
 /** Returns the ValueID used to store whether a node has a lifeline association */
-export function getHasLifelineValueId(): ValueID {
+export function getHasLifelineValueId(endpointIndex?: number): ValueID {
 	return {
 		commandClass: CommandClasses.Association,
+		endpoint: endpointIndex,
 		property: "hasLifeline",
 	};
 }
 
-export function getLifelineGroupIds(node: ZWaveNode): number[] {
+export function getLifelineGroupIds(endpoint: Endpoint): number[] {
+	// For now only support this for the root endpoint - i.e. node
+	if (endpoint.index > 0) return [];
+	const node = endpoint as ZWaveNode;
+
 	// Some nodes define multiple lifeline groups, so we need to assign us to
 	// all of them
 	const lifelineGroups: number[] = [];
 
 	// If the target node supports Z-Wave+ info that means the lifeline MUST be group #1
-	if (node.supportsCC(CommandClasses["Z-Wave Plus Info"])) {
+	if (endpoint.supportsCC(CommandClasses["Z-Wave Plus Info"])) {
 		lifelineGroups.push(1);
 	}
 
@@ -222,7 +237,9 @@ export class AssociationCCAPI extends PhysicalCCAPI {
 			// We have to remove the node manually from all groups
 			const node = this.endpoint.getNodeUnsafe()!;
 			const groupCount =
-				node.valueDB.getValue<number>(getGroupCountValueId()) ?? 0;
+				node.valueDB.getValue<number>(
+					getGroupCountValueId(this.endpoint.index),
+				) ?? 0;
 			for (let groupId = 1; groupId <= groupCount; groupId++) {
 				await this.removeNodeIds({ nodeIds, groupId });
 			}
@@ -237,7 +254,7 @@ export class AssociationCC extends CommandClass {
 
 	public constructor(driver: Driver, options: CommandClassOptions) {
 		super(driver, options);
-		this.registerValue(getHasLifelineValueId().property, true);
+		this.registerValue(getHasLifelineValueId(0).property, true);
 	}
 
 	public determineRequiredCCInterviews(): readonly CommandClasses[] {
@@ -248,17 +265,16 @@ export class AssociationCC extends CommandClass {
 		];
 	}
 
-	public skipEndpointInterview(): boolean {
-		// The associations are managed on the root device
-		return true;
-	}
-
 	/**
-	 * Returns the number of association groups reported by the node.
+	 * Returns the number of association groups reported by the node/endpoint.
 	 * This only works AFTER the interview process
 	 */
 	public getGroupCountCached(): number {
-		return this.getValueDB().getValue(getGroupCountValueId()) || 0;
+		return (
+			this.getValueDB().getValue(
+				getGroupCountValueId(this.endpointIndex),
+			) || 0
+		);
 	}
 
 	/**
@@ -266,11 +282,15 @@ export class AssociationCC extends CommandClass {
 	 * This only works AFTER the interview process
 	 */
 	public getMaxNodesCached(groupId: number): number {
-		return this.getValueDB().getValue(getMaxNodesValueId(groupId)) || 1;
+		return (
+			this.getValueDB().getValue(
+				getMaxNodesValueId(this.endpointIndex, groupId),
+			) || 1
+		);
 	}
 
 	/**
-	 * Returns all the destinations of all association groups reported by the node.
+	 * Returns all the destinations of all association groups reported by the node/endpoint.
 	 * This only works AFTER the interview process
 	 */
 	public getAllDestinationsCached(): ReadonlyMap<
@@ -283,7 +303,9 @@ export class AssociationCC extends CommandClass {
 		for (let i = 1; i <= groupCount; i++) {
 			// Add all root destinations
 			const nodes =
-				valueDB.getValue<number[]>(getNodeIdsValueId(i)) ?? [];
+				valueDB.getValue<number[]>(
+					getNodeIdsValueId(this.endpointIndex, i),
+				) ?? [];
 
 			ret.set(
 				i,
@@ -351,14 +373,17 @@ export class AssociationCC extends CommandClass {
 		await this.refreshValues();
 
 		// Assign the controller to all lifeline groups (Z-Wave+ and configured)
-		const lifelineGroups = getLifelineGroupIds(node);
+		const lifelineGroups = getLifelineGroupIds(endpoint);
 		const ownNodeId = this.driver.controller.ownNodeId!;
 		const valueDB = this.getValueDB();
 
 		if (lifelineGroups.length) {
 			for (const group of lifelineGroups) {
 				// Check if we are already in the lifeline group
-				const lifelineValueId = getNodeIdsValueId(group);
+				const lifelineValueId = getNodeIdsValueId(
+					this.endpointIndex,
+					group,
+				);
 				const lifelineNodeIds: number[] =
 					valueDB.getValue(lifelineValueId) ?? [];
 				if (!lifelineNodeIds.includes(ownNodeId)) {
@@ -376,7 +401,7 @@ export class AssociationCC extends CommandClass {
 			}
 
 			// Remember that we have a lifeline association
-			valueDB.setValue(getHasLifelineValueId(), true);
+			valueDB.setValue(getHasLifelineValueId(this.endpointIndex), true);
 		} else {
 			this.driver.controllerLog.logNode(node.id, {
 				endpoint: this.endpointIndex,
@@ -386,7 +411,7 @@ export class AssociationCC extends CommandClass {
 				level: "warn",
 			});
 			// Remember that we have NO lifeline association
-			valueDB.setValue(getHasLifelineValueId(), false);
+			valueDB.setValue(getHasLifelineValueId(this.endpointIndex), false);
 		}
 
 		// Remember that the interview is complete
@@ -613,11 +638,11 @@ export class AssociationCCReport extends AssociationCC {
 
 		// Persist values
 		this.getValueDB().setValue(
-			getMaxNodesValueId(this._groupId),
+			getMaxNodesValueId(this.endpointIndex, this._groupId),
 			this._maxNodes,
 		);
 		this.getValueDB().setValue(
-			getNodeIdsValueId(this._groupId),
+			getNodeIdsValueId(this.endpointIndex, this._groupId),
 			this._nodeIds,
 		);
 	}

--- a/packages/zwave-js/src/lib/commandclass/AssociationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/AssociationCC.ts
@@ -372,46 +372,55 @@ export class AssociationCC extends CommandClass {
 		// Query each association group for its members
 		await this.refreshValues();
 
-		// Assign the controller to all lifeline groups (Z-Wave+ and configured)
-		const lifelineGroups = getLifelineGroupIds(endpoint);
-		const ownNodeId = this.driver.controller.ownNodeId!;
-		const valueDB = this.getValueDB();
+		// TODO: Improve how the assignments are handled. For now only auto-assign associations on the root endpoint
+		if (this.endpointIndex === 0) {
+			// Assign the controller to all lifeline groups (Z-Wave+ and configured)
+			const lifelineGroups = getLifelineGroupIds(endpoint);
+			const ownNodeId = this.driver.controller.ownNodeId!;
+			const valueDB = this.getValueDB();
 
-		if (lifelineGroups.length) {
-			for (const group of lifelineGroups) {
-				// Check if we are already in the lifeline group
-				const lifelineValueId = getNodeIdsValueId(
-					this.endpointIndex,
-					group,
-				);
-				const lifelineNodeIds: number[] =
-					valueDB.getValue(lifelineValueId) ?? [];
-				if (!lifelineNodeIds.includes(ownNodeId)) {
-					this.driver.controllerLog.logNode(node.id, {
-						endpoint: this.endpointIndex,
-						message: `Controller missing from lifeline group #${group}, assigning ourselves...`,
-						direction: "outbound",
-					});
-					// Add a new destination
-					await api.addNodeIds(group, ownNodeId);
-					// and refresh it - don't trust that it worked
-					await api.getGroup(group);
-					// TODO: check if it worked
+			if (lifelineGroups.length) {
+				for (const group of lifelineGroups) {
+					// Check if we are already in the lifeline group
+					const lifelineValueId = getNodeIdsValueId(
+						this.endpointIndex,
+						group,
+					);
+					const lifelineNodeIds: number[] =
+						valueDB.getValue(lifelineValueId) ?? [];
+					if (!lifelineNodeIds.includes(ownNodeId)) {
+						this.driver.controllerLog.logNode(node.id, {
+							endpoint: this.endpointIndex,
+							message: `Controller missing from lifeline group #${group}, assigning ourselves...`,
+							direction: "outbound",
+						});
+						// Add a new destination
+						await api.addNodeIds(group, ownNodeId);
+						// and refresh it - don't trust that it worked
+						await api.getGroup(group);
+						// TODO: check if it worked
+					}
 				}
-			}
 
-			// Remember that we have a lifeline association
-			valueDB.setValue(getHasLifelineValueId(this.endpointIndex), true);
-		} else {
-			this.driver.controllerLog.logNode(node.id, {
-				endpoint: this.endpointIndex,
-				message:
-					"No information about Lifeline associations, cannot assign ourselves!",
-				direction: "outbound",
-				level: "warn",
-			});
-			// Remember that we have NO lifeline association
-			valueDB.setValue(getHasLifelineValueId(this.endpointIndex), false);
+				// Remember that we have a lifeline association
+				valueDB.setValue(
+					getHasLifelineValueId(this.endpointIndex),
+					true,
+				);
+			} else {
+				this.driver.controllerLog.logNode(node.id, {
+					endpoint: this.endpointIndex,
+					message:
+						"No information about Lifeline associations, cannot assign ourselves!",
+					direction: "outbound",
+					level: "warn",
+				});
+				// Remember that we have NO lifeline association
+				valueDB.setValue(
+					getHasLifelineValueId(this.endpointIndex),
+					false,
+				);
+			}
 		}
 
 		// Remember that the interview is complete

--- a/packages/zwave-js/src/lib/commandclass/AssociationGroupInfoCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/AssociationGroupInfoCC.ts
@@ -247,35 +247,42 @@ export interface AssociationGroup {
 }
 
 /** Returns the ValueID used to store the name of an association group */
-function getGroupNameValueID(groupId: number): ValueID {
+function getGroupNameValueID(endpointIndex: number, groupId: number): ValueID {
 	return {
 		commandClass: CommandClasses["Association Group Information"],
+		endpoint: endpointIndex,
 		property: "name",
 		propertyKey: groupId,
 	};
 }
 
 /** Returns the ValueID used to store info for an association group */
-function getGroupInfoValueID(groupId: number): ValueID {
+function getGroupInfoValueID(endpointIndex: number, groupId: number): ValueID {
 	return {
 		commandClass: CommandClasses["Association Group Information"],
+		endpoint: endpointIndex,
 		property: "info",
 		propertyKey: groupId,
 	};
 }
 
 /** Returns the ValueID used to store info for an association group */
-function getIssuedCommandsValueID(groupId: number): ValueID {
+function getIssuedCommandsValueID(
+	endpointIndex: number,
+	groupId: number,
+): ValueID {
 	return {
 		commandClass: CommandClasses["Association Group Information"],
+		endpoint: endpointIndex,
 		property: "issuedCommands",
 		propertyKey: groupId,
 	};
 }
 
-function getHasDynamicInfoValueID(): ValueID {
+function getHasDynamicInfoValueID(endpointIndex: number): ValueID {
 	return {
 		commandClass: CommandClasses["Association Group Information"],
+		endpoint: endpointIndex,
 		property: "hasDynamicInfo",
 	};
 }
@@ -369,8 +376,8 @@ export class AssociationGroupInfoCC extends CommandClass {
 
 	public constructor(driver: Driver, options: CommandClassOptions) {
 		super(driver, options);
-		this.registerValue(getGroupNameValueID(0).property, true);
-		this.registerValue(getGroupInfoValueID(0).property, true);
+		this.registerValue(getGroupNameValueID(0, 0).property, true);
+		this.registerValue(getGroupInfoValueID(0, 0).property, true);
 	}
 
 	public determineRequiredCCInterviews(): readonly CommandClasses[] {
@@ -384,7 +391,9 @@ export class AssociationGroupInfoCC extends CommandClass {
 
 	/** Returns the name of an association group */
 	public getGroupNameCached(groupId: number): string | undefined {
-		return this.getValueDB().getValue(getGroupNameValueID(groupId));
+		return this.getValueDB().getValue(
+			getGroupNameValueID(this.endpointIndex, groupId),
+		);
 	}
 
 	/** Returns the association profile for an association group */
@@ -393,14 +402,16 @@ export class AssociationGroupInfoCC extends CommandClass {
 	): AssociationGroupInfoProfile | undefined {
 		return this.getValueDB().getValue<{
 			profile: AssociationGroupInfoProfile;
-		}>(getGroupInfoValueID(groupId))?.profile;
+		}>(getGroupInfoValueID(this.endpointIndex, groupId))?.profile;
 	}
 
 	/** Returns the dictionary of all commands issued by the given association group */
 	public getIssuedCommandsCached(
 		groupId: number,
 	): ReadonlyMap<CommandClasses, readonly number[]> | undefined {
-		return this.getValueDB().getValue(getIssuedCommandsValueID(groupId));
+		return this.getValueDB().getValue(
+			getIssuedCommandsValueID(this.endpointIndex, groupId),
+		);
 	}
 
 	public findGroupsForIssuedCommand(
@@ -506,7 +517,7 @@ export class AssociationGroupInfoCC extends CommandClass {
 		// Query the information for each group (this is the only thing that could be dynamic)
 		const associationGroupCount = this.getAssociationGroupCountCached();
 		const hasDynamicInfo = this.getValueDB().getValue(
-			getHasDynamicInfoValueID(),
+			getHasDynamicInfoValueID(this.endpointIndex),
 		);
 
 		for (let groupId = 1; groupId <= associationGroupCount; groupId++) {
@@ -553,7 +564,7 @@ export class AssociationGroupInfoCCNameReport extends AssociationGroupInfoCC {
 	}
 
 	public persistValues(): boolean {
-		const valueId = getGroupNameValueID(this.groupId);
+		const valueId = getGroupNameValueID(this.endpointIndex, this.groupId);
 		this.getValueDB().setValue(valueId, this.name);
 		return true;
 	}
@@ -652,7 +663,7 @@ export class AssociationGroupInfoCCInfoReport extends AssociationGroupInfoCC {
 		if (!super.persistValues()) return false;
 		for (const group of this.groups) {
 			const { groupId, mode, profile, eventCode } = group;
-			const valueId = getGroupInfoValueID(groupId);
+			const valueId = getGroupInfoValueID(this.endpointIndex, groupId);
 			this.getValueDB().setValue(valueId, {
 				mode,
 				profile,

--- a/packages/zwave-js/src/lib/commandclass/AssociationGroupInfoCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/AssociationGroupInfoCC.ts
@@ -382,11 +382,6 @@ export class AssociationGroupInfoCC extends CommandClass {
 		];
 	}
 
-	public skipEndpointInterview(): boolean {
-		// The associations are managed on the root device
-		return true;
-	}
-
 	/** Returns the name of an association group */
 	public getGroupNameCached(groupId: number): string | undefined {
 		return this.getValueDB().getValue(getGroupNameValueID(groupId));

--- a/packages/zwave-js/src/lib/commandclass/CentralSceneCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/CentralSceneCC.ts
@@ -243,7 +243,7 @@ export class CentralSceneCC extends CommandClass {
 						direction: "outbound",
 					});
 					await this.driver.controller.addAssociations(
-						node.id,
+						{ nodeId: node.id },
 						groupId,
 						[{ nodeId: this.driver.controller.ownNodeId! }],
 					);

--- a/packages/zwave-js/src/lib/commandclass/CentralSceneCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/CentralSceneCC.ts
@@ -228,7 +228,7 @@ export class CentralSceneCC extends CommandClass {
 				const groupId = groupsIssueingNotifications[0];
 				const existingAssociations =
 					this.driver.controller
-						.getAssociations(node.id)
+						.getAssociations({ nodeId: node.id })
 						.get(groupId) ?? [];
 
 				if (

--- a/packages/zwave-js/src/lib/commandclass/NotificationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/NotificationCC.ts
@@ -362,7 +362,9 @@ export class NotificationCC extends CommandClass {
 				node.supportsCC(CommandClasses["Association Group Information"])
 			) {
 				const assocGroups = this.driver.controller.getAssociationGroups(
-					node.id,
+					{
+						nodeId: node.id,
+					},
 				);
 				for (const group of assocGroups.values()) {
 					// Check if this group sends Notification Reports

--- a/packages/zwave-js/src/lib/commandclass/index.ts
+++ b/packages/zwave-js/src/lib/commandclass/index.ts
@@ -48,7 +48,10 @@ export type { IndicatorMetadata } from "./IndicatorCC";
 export { DeviceIdType } from "./ManufacturerSpecificCC";
 export { RateType } from "./MeterCC";
 export type { MeterMetadata } from "./MeterCC";
-export type { Association } from "./MultiChannelAssociationCC";
+export type {
+	Association,
+	AssociationAddress,
+} from "./MultiChannelAssociationCC";
 export type {
 	MultilevelSensorCCReportOptions,
 	MultilevelSensorValue,

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -1614,7 +1614,7 @@ export class ZWaveController extends EventEmitter {
 		try {
 			associatedNodes = distinct(
 				flatMap<number, AssociationAddress[]>(
-					[...(this.getAssociations(nodeId).values() as any)],
+					[...(this.getAssociations({ nodeId }).values() as any)],
 					(assocs: AssociationAddress[]) =>
 						assocs.map((a) => a.nodeId),
 				),

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1015,6 +1015,17 @@ export class ZWaveNode extends Endpoint {
 		return this._endpointInstances.get(index)!;
 	}
 
+	public getEndpointOrThrow(index: number): Endpoint {
+		const ret = this.getEndpoint(index);
+		if (!ret) {
+			throw new ZWaveError(
+				`Endpoint ${index} does not exist on Node ${this.id}`,
+				ZWaveErrorCodes.Controller_EndpointNotFound,
+			);
+		}
+		return ret;
+	}
+
 	/** Returns a list of all endpoints of this node, including the root endpoint (index 0) */
 	public getAllEndpoints(): Endpoint[] {
 		const ret: Endpoint[] = [this];


### PR DESCRIPTION
This PR adds support for managing associations and multi channel associations on endpoints. The controller methods used to do so now either accept a separate `endpointIndex` argument or got a separate overload where the association source is now an object with `nodeId` and `endpointIndex`.

### New deprecations
```ts
// Deprecated overload:
isAssociationAllowed(nodeId: number, group: number, destination: AssociationAddress): boolean;
// Use this one instead
isAssociationAllowed(source: AssociationAddress, group: number, destination: AssociationAddress): boolean;

// Deprecated overload:
addAssociations(nodeId: number, group: number, destinations: AssociationAddress[]): Promise<void>;
// Use this one instead
addAssociations(source: AssociationAddress, group: number, destinations: AssociationAddress[]): Promise<void>;

// Deprecated overload:
removeAssociations(nodeId: number, group: number, destinations: AssociationAddress[]): Promise<void>;
// Use this one instead
removeAssociations(source: AssociationAddress, group: number, destinations: AssociationAddress[]): Promise<void>;

// Deprecated overload:
getAssociationGroups(nodeId: number): ReadonlyMap<number, AssociationGroup>;
// Use this one instead
getAssociationGroups(source: AssociationAddress): ReadonlyMap<number, AssociationGroup>;

// Deprecated overload:
getAssociations(nodeId: number): ReadonlyMap<number, readonly AssociationAddress[]>;
// Use this one instead
getAssociations(source: AssociationAddress): ReadonlyMap<number, readonly AssociationAddress[]>;

// Deprecated type
interface Association {
	nodeId: number;
	endpoint?: number;
}
// Use this identical one instead
interface AssociationAddress{
	nodeId: number;
	endpoint?: number;
}
```

fixes: #1861 
