### PR TITLE
revert: do not map root to ambiguous endpoint, opt-in with compat flag

### DIFF
--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -270,11 +270,6 @@ Version 8 of the `Notification CC` added the requirement that devices must issue
 
 Some legacy devices emit an NIF when a local event occurs (e.g. a button press) to signal that the controller should request a status update. However, some of these devices require a delay before they are ready to respond to this request. `manualValueRefreshDelayMs` specifies that delay, expressed in milliseconds. If unset, there will be no delay.
 
-### `mapRootReportsToEndpoints`
-
-Starting with version 3, the `Multi Channel Association CC` allows setting up Multi Channel Lifeline Associations between devices, allowing devices to report the status of their endpoints. Despite this possibility, some devices only use the root device for reporting.  
-When the flag `mapRootReportsToEndpoints` is set to `true`, `zwave-js` will map these suboptimal reports to an endpoint if the mapping is not ambiguous.
-
 ### `preserveRootApplicationCCValueIDs`
 
 The Z-Wave+ specs mandate that the root endpoint must **mirror** the application functionality of endpoint 1 (and potentially others). For this reason, `zwave-js` hides these superfluous values. However, some legacy devices offer additional functionality through the root endpoint, which should not be hidden. To achive this, set `preserveRootApplicationCCValueIDs` to `true`.

--- a/maintenance/schemas/device-config.json
+++ b/maintenance/schemas/device-config.json
@@ -268,9 +268,6 @@
 					"type": "number",
 					"minimum": 0
 				},
-				"mapRootReportsToEndpoints": {
-					"const": true
-				},
 				"overrideFloatEncoding": {
 					"type": "object",
 					"properties": {

--- a/packages/config/src/CompatConfig.ts
+++ b/packages/config/src/CompatConfig.ts
@@ -104,19 +104,6 @@ error in compat option forceNotificationIdleReset`,
 				definition.forceNotificationIdleReset;
 		}
 
-		if (definition.mapRootReportsToEndpoints != undefined) {
-			if (definition.mapRootReportsToEndpoints !== true) {
-				throwInvalidConfig(
-					"devices",
-					`config/devices/${filename}:
-error in compat option mapRootReportsToEndpoints`,
-				);
-			}
-
-			this.mapRootReportsToEndpoints =
-				definition.mapRootReportsToEndpoints;
-		}
-
 		if (definition.preserveRootApplicationCCValueIDs != undefined) {
 			if (definition.preserveRootApplicationCCValueIDs !== true) {
 				throwInvalidConfig(
@@ -381,7 +368,6 @@ compat option alarmMapping must be an array where all items are objects!`,
 	public readonly enableBasicSetMapping?: boolean;
 	public readonly forceNotificationIdleReset?: boolean;
 	public readonly manualValueRefreshDelayMs?: number;
-	public readonly mapRootReportsToEndpoints?: boolean;
 	public readonly overrideFloatEncoding?: {
 		size?: number;
 		precision?: number;

--- a/packages/zwave-js/src/lib/node/Node.test.ts
+++ b/packages/zwave-js/src/lib/node/Node.test.ts
@@ -1512,11 +1512,11 @@ describe("lib/node/Node", () => {
 
 		beforeEach(() => fakeDriver.sendMessage.mockClear());
 
-		it("should map commands from the root endpoint to a supporting endpoint if compat flag mapRootReportsToEndpoints is set", async () => {
+		it("should map commands from the root endpoint to endpoint 1 if MultiChannelAssociationCC is V1/V2", async () => {
 			const node = makeNode([
 				[
 					CommandClasses["Multi Channel Association"],
-					{ isSupported: true },
+					{ isSupported: true, version: 2 },
 				],
 			]);
 			// We have two endpoints
@@ -1539,11 +1539,6 @@ describe("lib/node/Node", () => {
 			node.getEndpoint(1)?.addCC(CommandClasses["Binary Switch"], {
 				isSupported: true,
 			});
-			node["_deviceConfig"] = {
-				compat: {
-					mapRootReportsToEndpoints: true,
-				},
-			} as any;
 
 			// Handle a command for the root endpoint
 			const command = new BinarySwitchCCReport(


### PR DESCRIPTION
This reverts PR #2160 - it caused more harm than good.
The better solution is #2286 