### PR TITLE
fix(config): enable Basic Set mapping for FGBS001

### DIFF
--- a/packages/config/config/devices/0x010f/fgbs001.json
+++ b/packages/config/config/devices/0x010f/fgbs001.json
@@ -353,6 +353,7 @@
 		}
 	},
 	"compat": {
+		"enableBasicSetMapping": true,
 		"commandClasses": {
 			"remove": {
 				// Alarm Sensor CC is reported as supported, but we either get no response


### PR DESCRIPTION
Adding enableBasicSetMapping to fix FGBS001. After the latest update it was not working anymore. I tried and applied the suggested fix by frescoast in the URL below, and this fixes the problem.

https://community.home-assistant.io/t/fibaro-universal-binary-sensor-fgbs001-not-working-when-upgrading-z-wave-js-to-0-1-16/296802