### PR TITLE
feat: add driver method to return whether statistics are enabled

### DIFF
--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -56,6 +56,14 @@ disableStatistics(): void
 
 Disable sending usage statistics.
 
+### `areStatisticsEnabled`
+
+```ts
+areStatisticsEnabled(): boolean
+```
+
+Returns whether usage statistics are enabled.
+
 ### `getSupportedCCVersionForEndpoint`
 
 ```ts

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1303,6 +1303,11 @@ export class Driver extends EventEmitter {
 		}
 	}
 
+	/** Returns whether or not usage statistics are enabled. */
+	public areStatisticsEnabled(): boolean {
+		return this._statisticsEnabled;
+	}
+
 	/** @internal */
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async getUUID(): Promise<string> {


### PR DESCRIPTION
This would be useful for both `zwavejs2mqtt` and `zwave-js-server`