### PR TITLE
fix(config): add preserveRootApplicationCCValueIDs to ZEN16, 17, 25

### DIFF
--- a/packages/config/config/devices/0x027a/zen16_0.0_1.0.json
+++ b/packages/config/config/devices/0x027a/zen16_0.0_1.0.json
@@ -320,5 +320,9 @@
 				}
 			]
 		}
+	},
+	"compat": {
+		// This device improperly reports the state of R2 (endpoint 2) through the root endpoint in a way that also changes the state of R1 (endpoint 1)
+		"preserveRootApplicationCCValueIDs": true
 	}
 }

--- a/packages/config/config/devices/0x027a/zen16_1.1_1.1.json
+++ b/packages/config/config/devices/0x027a/zen16_1.1_1.1.json
@@ -470,5 +470,9 @@
 				}
 			]
 		}
+	},
+	"compat": {
+		// This device improperly reports the state of R2 (endpoint 2) through the root endpoint in a way that also changes the state of R1 (endpoint 1)
+		"preserveRootApplicationCCValueIDs": true
 	}
 }

--- a/packages/config/config/devices/0x027a/zen16_1.2_1.2.json
+++ b/packages/config/config/devices/0x027a/zen16_1.2_1.2.json
@@ -494,5 +494,9 @@
 				}
 			]
 		}
+	},
+	"compat": {
+		// This device improperly reports the state of R2 (endpoint 2) through the root endpoint in a way that also changes the state of R1 (endpoint 1)
+		"preserveRootApplicationCCValueIDs": true
 	}
 }

--- a/packages/config/config/devices/0x027a/zen16_1.3.json
+++ b/packages/config/config/devices/0x027a/zen16_1.3.json
@@ -594,5 +594,9 @@
 				}
 			]
 		}
+	},
+	"compat": {
+		// This device improperly reports the state of R2 (endpoint 2) through the root endpoint in a way that also changes the state of R1 (endpoint 1)
+		"preserveRootApplicationCCValueIDs": true
 	}
 }

--- a/packages/config/config/devices/0x027a/zen17.json
+++ b/packages/config/config/devices/0x027a/zen17.json
@@ -424,5 +424,9 @@
 				}
 			]
 		}
+	},
+	"compat": {
+		// This device improperly reports the state of R2 (endpoint 2) through the root endpoint in a way that also changes the state of R1 (endpoint 1)
+		"preserveRootApplicationCCValueIDs": true
 	}
 }

--- a/packages/config/config/devices/0x027a/zen25.json
+++ b/packages/config/config/devices/0x027a/zen25.json
@@ -291,5 +291,8 @@
 				}
 			]
 		}
+	},
+	"compat": {
+		"preserveRootApplicationCCValueIDs": true
 	}
 }


### PR DESCRIPTION
After reverting #2160, the Zooz ZEN switches were missing the compat flag workaround we need until #2286 is solved. This PR re-adds them.