### PR TITLE
Update aeotec_template.json

### DIFF
--- a/packages/config/config/devices/0x0086/templates/aeotec_template.json
+++ b/packages/config/config/devices/0x0086/templates/aeotec_template.json
@@ -1085,7 +1085,7 @@
 			},
 			{
 				"label": "Night light mode",
-				"value": 1
+				"value": 2
 			}
 		]
 	},


### PR DESCRIPTION
led_indicator_three_options had 0, 1, and 1 as options.  Suggested change is to change the last to 2.  Assuming this is why I am only seeing 2 options for this config item in Home Assistant Zwave JS.  Not a programmer, so hopefully this is helpful