### PR TITLE
fix(config): correct min value for Aeotec "Motion Sensor Timeout" options

### DIFF
--- a/packages/config/config/devices/0x0086/templates/aeotec_template.json
+++ b/packages/config/config/devices/0x0086/templates/aeotec_template.json
@@ -1047,7 +1047,7 @@
 		"label": "Motion Sensor Timeout",
 		"valueSize": 2,
 		"unit": "seconds",
-		"minValue": 15300,
+		"minValue": 1,
 		"maxValue": 15300,
 		"defaultValue": 240,
 		"unsigned": true,


### PR DESCRIPTION

Engineering Specifications for Aeon Labs MultiSensor Gen5 ([link](https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/1163/Instructions%20-%20MultiSensor%20Gen5%20MCert1.pdf)) indicates that the min value for parameter `0x03 (3)` should be `1`

```
2. Range: 1~15300.
```