### PR TITLE
fix: skip endpoint interview in Multi Channel CC

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/MultiChannelCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultiChannelCC.ts
@@ -297,6 +297,11 @@ export class MultiChannelCC extends CommandClass {
 		});
 	}
 
+	public skipEndpointInterview(): boolean {
+		// The endpoints are discovered by querying the root device
+		return true;
+	}
+
 	public async interview(): Promise<void> {
 		const node = this.getNode()!;
 		this.driver.controllerLog.logNode(node.id, {

--- a/packages/zwave-js/src/lib/node/Endpoint.ts
+++ b/packages/zwave-js/src/lib/node/Endpoint.ts
@@ -91,6 +91,9 @@ export class Endpoint {
 	 * @param info The information about the command class. This is merged with existing information.
 	 */
 	public addCC(cc: CommandClasses, info: Partial<CommandClassInfo>): void {
+		// Endpoints cannot support Multi Channel CC
+		if (this.index > 0 && cc === CommandClasses["Multi Channel"]) return;
+
 		let ccInfo = this._implementedCommandClasses.get(cc) ?? {
 			isSupported: false,
 			isControlled: false,


### PR DESCRIPTION
Ironically, interviewing the Multi Channel CC on endpoints is not a good idea. This does not normally happen, but some device classes (specifically Power Strips) mandate the Multi Channel CC to be supported.
This PR skips the Multi Channel CC interview on endpoints and avoids adding it as supported to endpoints.

fixes: https://github.com/zwave-js/node-zwave-js/issues/2334