### PR TITLE
feat(config): add Zooz ZSE11

### DIFF
--- a/packages/config/config/devices/0x027a/zse11.json
+++ b/packages/config/config/devices/0x027a/zse11.json
@@ -1,0 +1,111 @@
+// Zooz ZSE11
+// Q Sensor
+{
+	"manufacturer": "Zooz",
+	"manufacturerId": "0x027a",
+	"label": "ZSE11",
+	"description": "Q Sensor",
+	"devices": [
+		{
+			"productType": "0x0201",
+			"productId": "0x0006"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"metadata": {
+		"inclusion": "Put your Z-Wave hub into inclusion mode and click the Z-Wave button 3 times as quickly as possible. The LED indicator will start blinking to confirm inclusion mode. The sensor will automatically pair as a repeater if connected to USB power, no special button sequence required.",
+		"exclusion": "Bring the sensor within direct range of your Z-Wave gateway (hub). Put the Z-Wave hub into exclusion mode. Press and release the Z-Wave button 3 times quickly.",
+		"wakeup": "Press and hold the Z-Wave Button for 3 seconds to wake the sensor up manually"
+	},
+	"paramInformation": {
+		"12": {
+			"label": "Motion Sensor Sensitivity",
+			"description": "8 is the highest sensitivity",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 8,
+			"defaultValue": 6,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"13": {
+			"label": "Motion Detection Timeout",
+			"valueSize": 2,
+			"unit": "seconds",
+			"minValue": 10,
+			"maxValue": 3600,
+			"defaultValue": 30,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"19": {
+			"label": "LED Indicator for Motion",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Off",
+					"value": 0
+				},
+				{
+					"label": "Flash LED on Motion",
+					"value": 1
+				}
+			]
+		},
+		"172": {
+			"label": "Minimum Reporting Frequency",
+			"valueSize": 2,
+			"unit": "hours",
+			"minValue": 1,
+			"maxValue": 744,
+			"defaultValue": 4,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"183": {
+			"label": "Temperature Reporting Threshold",
+			"valueSize": 2,
+			"unit": "°F",
+			"minValue": 1,
+			"maxValue": 144,
+			"defaultValue": 1,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"184": {
+			"label": "Humidity Reporting Threshold",
+			"valueSize": 2,
+			"unit": "%",
+			"minValue": 1,
+			"maxValue": 80,
+			"defaultValue": 5,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		},
+		"185": {
+			"label": "Lux Reporting Threshold",
+			"valueSize": 2,
+			"unit": "lux",
+			"minValue": 1,
+			"maxValue": 30000,
+			"defaultValue": 50,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": true
+		}
+	}
+}

--- a/packages/config/config/devices/0x027a/zse11.json
+++ b/packages/config/config/devices/0x027a/zse11.json
@@ -44,7 +44,7 @@
 			"allowManualEntry": true
 		},
 		"19": {
-			"label": "LED Indicator for Motion",
+			"label": "Flash LED on Motion",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
@@ -54,11 +54,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Off",
+					"label": "Disable",
 					"value": 0
 				},
 				{
-					"label": "Flash LED on Motion",
+					"label": "Enable",
 					"value": 1
 				}
 			]


### PR DESCRIPTION
I'm not sure if I did this correctly, but I took a stab at creating an initial config for the newly launched Zooz multi sensor. It isn't in any of the databases just yet, and is in somewhat of a "beta" release. I tested this with a physical ZSE11 device, and the parameters seem to take effect as expected.

If I can improve this PR, I am very welcome to feedback, or if this is something that should be handled in a different way, totally understand. I can work on a template if that is truly preferred, but it seems each Zooz sensor has pretty different configs. This unit would compare with the ZSE40, which has different inclusion/exclusion/wake instructions, different parameters, etc. Same manufacturer, same type of device, but fairly different in the configs.

**Which device is missing?**

Zooz ZSE11 "Q Sensor"

**What are the IDs?**

Manufacturer ID: 0x027a
Product type: 0x0201
Product ID: 0x0006

**Did you check if we really don't have it?**
- [ x ] It is not in the [configuration DB](https://devices.zwave-js.io/)
- [ x ] It was not [merged recently](https://github.com/zwave-js/node-zwave-js/pulls?q=is%3Apr+is%3Aclosed) or has a [pending PR](https://github.com/zwave-js/node-zwave-js/pulls?q=is%3Aopen+is%3Apr)
- [ x ] It is not in the [TODO list](https://github.com/zwave-js/node-zwave-js/issues/1600)

**Do you have a link to the PDF manual?**

Manual: https://cdn.shopify.com/s/files/1/0218/7704/files/zooz-q-sensor-zse11-ver1-manual-online.pdf
Store Page: https://www.thesmartesthouse.com/products/zooz-z-wave-plus-q-sensor-zse11-motion-temp-humidity-light