### PR TITLE
feat(conf): Add assoc. groups to Namron 2 kanaler bryter

### DIFF
--- a/packages/config/config/devices/0x0438/2_kanaler_bryter.json
+++ b/packages/config/config/devices/0x0438/2_kanaler_bryter.json
@@ -15,6 +15,21 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "Launch 1",
+			"maxNodes": 5
+		},
+		"3": {
+			"label": "Launch 2",
+			"maxNodes": 5
+		}
+	},
 	"paramInformation": {
 		"1": {
 			"label": "Factory Reset",


### PR DESCRIPTION
Added the missing association groups for this device.

2. https://www.elektroimportoren.no/docs/lib/4512720-Brukerveiledning-5.pdf
See page 2 for groups.