### PR TITLE
feat(conf): Add missing assoc. groups for 1 kanal bryter

### DIFF
--- a/packages/config/config/devices/0x0438/1_kanal_bryter.json
+++ b/packages/config/config/devices/0x0438/1_kanal_bryter.json
@@ -15,6 +15,17 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "Launch 1",
+			"maxNodes": 5
+		}
+	},
 	"paramInformation": {
 		"1": {
 			"label": "Factory Reset",


### PR DESCRIPTION
Added the missing association groups.

1. https://www.elektroimportoren.no/docs/lib/4512712-Brukerveiledning-5.pdf
