### PR TITLE
fix(config): add enableBasicSetMapping for device ZD2102

### DIFF
--- a/packages/config/config/devices/0x0109/zd2102.json
+++ b/packages/config/config/devices/0x0109/zd2102.json
@@ -32,5 +32,8 @@
 			"maxNodes": 5,
 			"isLifeline": true
 		}
+	},
+	"compat": {
+		"enableBasicSetMapping": true
 	}
 }

--- a/packages/config/config/devices/0x0109/zd2102.json
+++ b/packages/config/config/devices/0x0109/zd2102.json
@@ -34,6 +34,7 @@
 		}
 	},
 	"compat": {
+		// The device is a Binary Sensor, but uses Basic Sets to report its status
 		"enableBasicSetMapping": true
 	}
 }


### PR DESCRIPTION
Without enableBasicSetMapping set, it doesn't treat BasicCC::Set as a event but a report