### PR TITLE
feat: add forceRefreshValuesCCReport to support dual relay switch ZL7432

### DIFF
--- a/packages/config/config/devices/0x0109/zl7432.json
+++ b/packages/config/config/devices/0x0109/zl7432.json
@@ -27,5 +27,8 @@
 			"maxNodes": 5,
 			"isLifeline": true
 		}
+	},
+	"compat": {
+		"forceRefreshValuesCCReport": true
 	}
 }

--- a/packages/config/src/CompatConfig.ts
+++ b/packages/config/src/CompatConfig.ts
@@ -91,6 +91,19 @@ error in compat option enableBasicSetMapping`,
 			this.enableBasicSetMapping = definition.enableBasicSetMapping;
 		}
 
+		if (definition.forceRefreshValuesCCReport != undefined) {
+			if (definition.forceRefreshValuesCCReport !== true) {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+error in compat option forceRefreshValuesCCReport`,
+				);
+			}
+
+			this.forceRefreshValuesCCReport =
+				definition.forceRefreshValuesCCReport;
+		}
+
 		if (definition.forceNotificationIdleReset != undefined) {
 			if (definition.forceNotificationIdleReset !== true) {
 				throwInvalidConfig(
@@ -366,6 +379,7 @@ compat option alarmMapping must be an array where all items are objects!`,
 	public readonly disableBasicMapping?: boolean;
 	public readonly disableStrictEntryControlDataValidation?: boolean;
 	public readonly enableBasicSetMapping?: boolean;
+	public readonly forceRefreshValuesCCReport?: boolean;
 	public readonly forceNotificationIdleReset?: boolean;
 	public readonly manualValueRefreshDelayMs?: number;
 	public readonly overrideFloatEncoding?: {

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -47,6 +47,7 @@ import {
 	getCompatEventValueId as getBasicCCCompatEventValueId,
 	getCurrentValueValueId as getBasicCCCurrentValueValueId,
 } from "../commandclass/BasicCC";
+import { BinarySwitchCCReport } from "../commandclass/BinarySwitchCC";
 import {
 	CentralSceneCCNotification,
 	CentralSceneKeys,
@@ -1867,6 +1868,8 @@ protocol version:      ${this._protocolVersion}`;
 			return this.handleFirmwareUpdateStatusReport(command);
 		} else if (command instanceof EntryControlCCNotification) {
 			return this.handleEntryControlNotification(command);
+		} else if (command instanceof BinarySwitchCCReport) {
+			return this.handleBinarySwitchReport(command);
 		}
 
 		// Ignore all commands that don't need to be handled
@@ -3039,6 +3042,16 @@ protocol version:      ${this._protocolVersion}`;
 			CommandClasses["Entry Control"],
 			pick(command, ["eventType", "dataType", "eventData"]),
 		);
+	}
+
+	private handleBinarySwitchReport(_command: BinarySwitchCCReport): void {
+		if (this.deviceConfig?.compat?.forceRefreshValuesCCReport) {
+			this.driver.controllerLog.logNode(
+				this.id,
+				`Refreshing values for all endpoints...`,
+			);
+			void this.refreshValues();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Added the device compat option `forceRefreshValuesCCReport` to force refreshing values of a device when handling BinarySwitchCCReport which lacks of endpoint information.

The issue comes from the dual relay switch ZL7432. When manually press one of the switch, it sends the BinarySwitchCCReport but doesn't include the endpoint id. Therefore, the driver doesn't know which endpoint has value changed.

This fix will force refreshing the value of a device (all endpoints) if it get the BinarySwitchCCReport.
