### PR TITLE
fix(config): correct Linear wd500z

### DIFF
--- a/packages/config/config/devices/0x0014/wd500z.json
+++ b/packages/config/config/devices/0x0014/wd500z.json
@@ -1,7 +1,7 @@
-// Cyberhouse WD500Z
+// Linear WD500Z
 // Dimmer Switch
 {
-	"manufacturer": "Cyberhouse",
+	"manufacturer": "Linear",
 	"manufacturerId": "0x0014",
 	"label": "WD500Z-1",
 	"description": "Dimmer Switch",

--- a/packages/config/config/devices/0x0014/wd500z.json
+++ b/packages/config/config/devices/0x0014/wd500z.json
@@ -55,6 +55,7 @@
 		},
 		"3": {
 			"label": "Night Light",
+			"description": "When enabled, the LED indicator will turn on when the light is turned off",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,

--- a/packages/config/config/devices/0x0014/wd500z.json
+++ b/packages/config/config/devices/0x0014/wd500z.json
@@ -1,10 +1,10 @@
 // Cyberhouse WD500Z
-// Linear -1
+// Dimmer Switch
 {
 	"manufacturer": "Cyberhouse",
 	"manufacturerId": "0x0014",
 	"label": "WD500Z-1",
-	"description": "Linear WD500Z-1",
+	"description": "Dimmer Switch",
 	"devices": [
 		{
 			"productType": "0x4457",

--- a/packages/config/config/devices/0x0014/wd500z.json
+++ b/packages/config/config/devices/0x0014/wd500z.json
@@ -3,8 +3,8 @@
 {
 	"manufacturer": "Cyberhouse",
 	"manufacturerId": "0x0014",
-	"label": "WD500Z",
-	"description": "Linear -1",
+	"label": "WD500Z-1",
+	"description": "Linear WD500Z-1",
 	"devices": [
 		{
 			"productType": "0x4457",

--- a/packages/config/config/devices/0x0014/wd500z.json
+++ b/packages/config/config/devices/0x0014/wd500z.json
@@ -15,5 +15,173 @@
 	"firmwareVersion": {
 		"min": "0.0",
 		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "Double Tap",
+			"maxNodes": 5
+		},
+		"3": {
+			"label": "Triple Tap",
+			"maxNodes": 5
+		}
+	},
+	"paramInformation": {
+		"1": {
+			"label": "Ignore Start Level",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Enable",
+					"value": 0
+				},
+				{
+					"label": "Disable",
+					"value": 1
+				}
+			]
+		},
+		"3": {
+			"label": "Night Light",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		"4": {
+			"label": "Invert Switch",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"readOnly": true,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		"14": {
+			"label": "Shade Control Group 2",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		"15": {
+			"label": "Shade Control Group 3",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		"19": {
+			"label": "LED Indicator",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 2,
+			"defaultValue": 2,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Flicker while transmitting",
+					"value": 1
+				},
+				{
+					"label": "Flicker for 1 second",
+					"value": 2
+				}
+			]
+		},
+		"29": {
+			"label": "Load Sense",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"unsigned": true,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		}
 	}
 }


### PR DESCRIPTION
Corrected to spec for the Linear wd500z.  Could you please confirm zwave js will identify this as different than the nortek?  Only difference is a z-wave alliance ID.  Device IDs are identical.  Only updating as it already existing in zwave JS. https://github.com/zwave-js/node-zwave-js/blob/541ddb486173882b99f908cd437982367e15379a/packages/config/config/devices/0x014f/wd500z-1.json