### PR TITLE
feat(config): add compat flag to GE zw3008 to re-enable basic command events to replicate central scene functionality

### DIFF
--- a/packages/config/config/devices/0x0063/26932_26933_zw3008.json
+++ b/packages/config/config/devices/0x0063/26932_26933_zw3008.json
@@ -377,5 +377,8 @@
 				}
 			]
 		}
+	},
+	"compat": {
+		"treatBasicSetAsEvent": true
 	}
 }

--- a/packages/config/config/devices/0x0063/26932_26933_zw3008.json
+++ b/packages/config/config/devices/0x0063/26932_26933_zw3008.json
@@ -378,8 +378,8 @@
 			]
 		}
 	},
-	// Add compat flag to re-enable basic command events to replicate central scene functionality. 
-	// Allows user to detect switch button presses as events when zwave controller is added to Group 2 or 3. 
+	// Add compat flag to re-enable basic command events to replicate central scene functionality.
+	// Allows user to detect switch button presses as events when zwave controller is added to Group 2 or 3.
 	"compat": {
 		"treatBasicSetAsEvent": true
 	}

--- a/packages/config/config/devices/0x0063/26932_26933_zw3008.json
+++ b/packages/config/config/devices/0x0063/26932_26933_zw3008.json
@@ -378,6 +378,8 @@
 			]
 		}
 	},
+	// Add compat flag to re-enable basic command events to replicate central scene functionality. 
+	// Allows user to detect switch button presses as events when zwave controller is added to Group 2 or 3. 
 	"compat": {
 		"treatBasicSetAsEvent": true
 	}


### PR DESCRIPTION
Although the GE zw3008 does not support double taps, it is still useful to trigger an event on a single button push if the user want to manually trigger actions within Home Assistant.