### PR TITLE
fix(config): update Aeotec ZW095

### DIFF
--- a/packages/config/config/devices/0x0086/templates/aeotec_template.json
+++ b/packages/config/config/devices/0x0086/templates/aeotec_template.json
@@ -708,6 +708,11 @@
 		"label": "Automatic Report: Group 1 - Voltage (Clamp 2)",
 		"valueSize": 4
 	},
+	"auto_report_group1_v_clamp3": {
+		"$import": "../../templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 1 - Voltage (Clamp 3)",
+		"valueSize": 4
+	},
 	"auto_report_group1_v_wholehem": {
 		"$import": "../../templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - Voltage (Whole HEM)",
@@ -726,6 +731,11 @@
 	"auto_report_group1_amp_clamp2": {
 		"$import": "../../templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - Current (Clamp 2)",
+		"valueSize": 4
+	},
+	"auto_report_group1_amp_clamp3": {
+		"$import": "../../templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 1 - Current (Clamp 3)",
 		"valueSize": 4
 	},
 	"auto_report_group1_amp_wholehem": {
@@ -828,6 +838,11 @@
 		"label": "Automatic Report: Group 2 - Voltage (Clamp 2)",
 		"valueSize": 4
 	},
+	"auto_report_group2_v_clamp3": {
+		"$import": "../../templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 2 - Voltage (Clamp 3)",
+		"valueSize": 4
+	},
 	"auto_report_group2_v_wholehem": {
 		"$import": "../../templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Voltage (Whole HEM)",
@@ -846,6 +861,11 @@
 	"auto_report_group2_amp_clamp2": {
 		"$import": "../../templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Current (Clamp 2)",
+		"valueSize": 4
+	},
+	"auto_report_group2_amp_clamp3": {
+		"$import": "../../templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 2 - Current (Clamp 3)",
 		"valueSize": 4
 	},
 	"auto_report_group2_amp_wholehem": {
@@ -948,6 +968,11 @@
 		"label": "Automatic Report: Group 3 - Voltage (Clamp 2)",
 		"valueSize": 4
 	},
+	"auto_report_group3_v_clamp3": {
+		"$import": "../../templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 3 - Voltage (Clamp 3)",
+		"valueSize": 4
+	},
 	"auto_report_group3_v_wholehem": {
 		"$import": "../../templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Voltage (Whole HEM)",
@@ -966,6 +991,11 @@
 	"auto_report_group3_amp_clamp2": {
 		"$import": "../../templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Current (Clamp 2)",
+		"valueSize": 4
+	},
+	"auto_report_group3_amp_clamp3": {
+		"$import": "../../templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 3 - Current (Clamp 3)",
 		"valueSize": 4
 	},
 	"auto_report_group3_amp_wholehem": {

--- a/packages/config/config/devices/0x0086/zw095.json
+++ b/packages/config/config/devices/0x0086/zw095.json
@@ -95,76 +95,148 @@
 			"label": "CRC-16 Encapsulation"
 		},
 		"101[0x01]": {
-			"$import": "templates/aeotec_template.json#auto_report_group1_watt_clamp1"
+			"$import": "templates/aeotec_template.json#auto_report_group1_kwh_wholehem"
 		},
 		"101[0x02]": {
-			"$import": "templates/aeotec_template.json#auto_report_group1_watt_clamp2"
+			"$import": "templates/aeotec_template.json#auto_report_group1_watt_wholehem"
+		},
+		"101[0x04]": {
+			"$import": "templates/aeotec_template.json#auto_report_group1_v_wholehem"
 		},
 		"101[0x08]": {
-			"$import": "templates/aeotec_template.json#auto_report_group1_kwh_clamp1"
-		},
-		"101[0x10]": {
-			"$import": "templates/aeotec_template.json#auto_report_group1_kwh_clamp2"
+			"$import": "templates/aeotec_template.json#auto_report_group1_amp_wholehem"
 		},
 		"101[0x0100]": {
-			"$import": "templates/aeotec_template.json#auto_report_group1_v_clamp1"
+			"$import": "templates/aeotec_template.json#auto_report_group1_watt_clamp1"
 		},
 		"101[0x0200]": {
-			"$import": "templates/aeotec_template.json#auto_report_group1_v_clamp2"
+			"$import": "templates/aeotec_template.json#auto_report_group1_watt_clamp2"
+		},
+		"101[0x0400]": {
+			"$import": "templates/aeotec_template.json#auto_report_group1_watt_clamp3"
 		},
 		"101[0x0800]": {
-			"$import": "templates/aeotec_template.json#auto_report_group1_amp_clamp1"
+			"$import": "templates/aeotec_template.json#auto_report_group1_kwh_clamp1"
 		},
 		"101[0x1000]": {
+			"$import": "templates/aeotec_template.json#auto_report_group1_kwh_clamp2"
+		},
+		"101[0x2000]": {
+			"$import": "templates/aeotec_template.json#auto_report_group1_kwh_clamp3"
+		},
+		"101[0x010000]": {
+			"$import": "templates/aeotec_template.json#auto_report_group1_v_clamp1"
+		},
+		"101[0x020000]": {
+			"$import": "templates/aeotec_template.json#auto_report_group1_v_clamp2"
+		},
+		"101[0x040000]": {
+			"$import": "templates/aeotec_template.json#auto_report_group1_v_clamp3"
+		},
+		"101[0x080000]": {
+			"$import": "templates/aeotec_template.json#auto_report_group1_amp_clamp1"
+		},
+		"101[0x0100000]": {
 			"$import": "templates/aeotec_template.json#auto_report_group1_amp_clamp2"
 		},
+		"101[0x0200000]": {
+			"$import": "templates/aeotec_template.json#auto_report_group1_amp_clamp3"
+		},
 		"102[0x01]": {
-			"$import": "templates/aeotec_template.json#auto_report_group2_watt_clamp1"
+			"$import": "templates/aeotec_template.json#auto_report_group2_kwh_wholehem"
 		},
 		"102[0x02]": {
-			"$import": "templates/aeotec_template.json#auto_report_group2_watt_clamp2"
+			"$import": "templates/aeotec_template.json#auto_report_group2_watt_wholehem"
+		},
+		"102[0x04]": {
+			"$import": "templates/aeotec_template.json#auto_report_group2_v_wholehem"
 		},
 		"102[0x08]": {
-			"$import": "templates/aeotec_template.json#auto_report_group2_kwh_clamp1"
-		},
-		"102[0x10]": {
-			"$import": "templates/aeotec_template.json#auto_report_group2_kwh_clamp2"
+			"$import": "templates/aeotec_template.json#auto_report_group2_amp_wholehem"
 		},
 		"102[0x0100]": {
-			"$import": "templates/aeotec_template.json#auto_report_group2_v_clamp1"
+			"$import": "templates/aeotec_template.json#auto_report_group2_watt_clamp1"
 		},
 		"102[0x0200]": {
-			"$import": "templates/aeotec_template.json#auto_report_group2_v_clamp2"
+			"$import": "templates/aeotec_template.json#auto_report_group2_watt_clamp2"
+		},
+		"102[0x0400]": {
+			"$import": "templates/aeotec_template.json#auto_report_group2_watt_clamp3"
 		},
 		"102[0x0800]": {
-			"$import": "templates/aeotec_template.json#auto_report_group2_amp_clamp1"
+			"$import": "templates/aeotec_template.json#auto_report_group2_kwh_clamp1"
 		},
 		"102[0x1000]": {
+			"$import": "templates/aeotec_template.json#auto_report_group2_kwh_clamp2"
+		},
+		"102[0x2000]": {
+			"$import": "templates/aeotec_template.json#auto_report_group2_kwh_clamp3"
+		},
+		"102[0x010000]": {
+			"$import": "templates/aeotec_template.json#auto_report_group2_v_clamp1"
+		},
+		"102[0x020000]": {
+			"$import": "templates/aeotec_template.json#auto_report_group2_v_clamp2"
+		},
+		"102[0x040000]": {
+			"$import": "templates/aeotec_template.json#auto_report_group2_v_clamp3"
+		},
+		"102[0x080000]": {
+			"$import": "templates/aeotec_template.json#auto_report_group2_amp_clamp1"
+		},
+		"102[0x0100000]": {
 			"$import": "templates/aeotec_template.json#auto_report_group2_amp_clamp2"
 		},
+		"102[0x0200000]": {
+			"$import": "templates/aeotec_template.json#auto_report_group2_amp_clamp3"
+		},
 		"103[0x01]": {
-			"$import": "templates/aeotec_template.json#auto_report_group3_watt_clamp1"
+			"$import": "templates/aeotec_template.json#auto_report_group3_kwh_wholehem"
 		},
 		"103[0x02]": {
-			"$import": "templates/aeotec_template.json#auto_report_group3_watt_clamp2"
+			"$import": "templates/aeotec_template.json#auto_report_group3_watt_wholehem"
+		},
+		"103[0x04]": {
+			"$import": "templates/aeotec_template.json#auto_report_group3_v_wholehem"
 		},
 		"103[0x08]": {
-			"$import": "templates/aeotec_template.json#auto_report_group3_kwh_clamp1"
-		},
-		"103[0x10]": {
-			"$import": "templates/aeotec_template.json#auto_report_group3_kwh_clamp2"
+			"$import": "templates/aeotec_template.json#auto_report_group3_amp_wholehem"
 		},
 		"103[0x0100]": {
-			"$import": "templates/aeotec_template.json#auto_report_group3_v_clamp1"
+			"$import": "templates/aeotec_template.json#auto_report_group3_watt_clamp1"
 		},
 		"103[0x0200]": {
-			"$import": "templates/aeotec_template.json#auto_report_group3_v_clamp2"
+			"$import": "templates/aeotec_template.json#auto_report_group3_watt_clamp2"
+		},
+		"103[0x0400]": {
+			"$import": "templates/aeotec_template.json#auto_report_group3_watt_clamp3"
 		},
 		"103[0x0800]": {
-			"$import": "templates/aeotec_template.json#auto_report_group3_amp_clamp1"
+			"$import": "templates/aeotec_template.json#auto_report_group3_kwh_clamp1"
 		},
 		"103[0x1000]": {
+			"$import": "templates/aeotec_template.json#auto_report_group3_kwh_clamp2"
+		},
+		"103[0x2000]": {
+			"$import": "templates/aeotec_template.json#auto_report_group3_kwh_clamp3"
+		},
+		"103[0x010000]": {
+			"$import": "templates/aeotec_template.json#auto_report_group3_v_clamp1"
+		},
+		"103[0x020000]": {
+			"$import": "templates/aeotec_template.json#auto_report_group3_v_clamp2"
+		},
+		"103[0x040000]": {
+			"$import": "templates/aeotec_template.json#auto_report_group3_v_clamp3"
+		},
+		"103[0x080000]": {
+			"$import": "templates/aeotec_template.json#auto_report_group3_amp_clamp1"
+		},
+		"103[0x0100000]": {
 			"$import": "templates/aeotec_template.json#auto_report_group3_amp_clamp2"
+		},
+		"103[0x0200000]": {
+			"$import": "templates/aeotec_template.json#auto_report_group3_amp_clamp3"
 		},
 		"111": {
 			"$import": "templates/aeotec_template.json#auto_report_interval_group1",

--- a/packages/config/config/devices/0x0086/zw095.json
+++ b/packages/config/config/devices/0x0086/zw095.json
@@ -72,6 +72,7 @@
 			"$import": "templates/aeotec_template.json#power_threshold_clamp2"
 		},
 		"7": {
+			"$if": "productType === 0x0002 && productId === 0x005f",
 			"$import": "templates/aeotec_template.json#power_threshold_clamp3"
 		},
 		"8": {
@@ -87,6 +88,7 @@
 			"defaultValue": 10
 		},
 		"11": {
+			"$if": "productType === 0x0002 && productId === 0x005f",
 			"$import": "templates/aeotec_template.json#percent_threshold_clamp3",
 			"defaultValue": 10
 		},
@@ -113,6 +115,7 @@
 			"$import": "templates/aeotec_template.json#auto_report_group1_watt_clamp2"
 		},
 		"101[0x0400]": {
+			"$if": "productType === 0x0002 && productId === 0x005f",
 			"$import": "templates/aeotec_template.json#auto_report_group1_watt_clamp3"
 		},
 		"101[0x0800]": {
@@ -122,6 +125,7 @@
 			"$import": "templates/aeotec_template.json#auto_report_group1_kwh_clamp2"
 		},
 		"101[0x2000]": {
+			"$if": "productType === 0x0002 && productId === 0x005f",
 			"$import": "templates/aeotec_template.json#auto_report_group1_kwh_clamp3"
 		},
 		"101[0x010000]": {
@@ -131,15 +135,17 @@
 			"$import": "templates/aeotec_template.json#auto_report_group1_v_clamp2"
 		},
 		"101[0x040000]": {
+			"$if": "productType === 0x0002 && productId === 0x005f",
 			"$import": "templates/aeotec_template.json#auto_report_group1_v_clamp3"
 		},
 		"101[0x080000]": {
 			"$import": "templates/aeotec_template.json#auto_report_group1_amp_clamp1"
 		},
-		"101[0x0100000]": {
+		"101[0x100000]": {
 			"$import": "templates/aeotec_template.json#auto_report_group1_amp_clamp2"
 		},
-		"101[0x0200000]": {
+		"101[0x200000]": {
+			"$if": "productType === 0x0002 && productId === 0x005f",
 			"$import": "templates/aeotec_template.json#auto_report_group1_amp_clamp3"
 		},
 		"102[0x01]": {
@@ -161,6 +167,7 @@
 			"$import": "templates/aeotec_template.json#auto_report_group2_watt_clamp2"
 		},
 		"102[0x0400]": {
+			"$if": "productType === 0x0002 && productId === 0x005f",
 			"$import": "templates/aeotec_template.json#auto_report_group2_watt_clamp3"
 		},
 		"102[0x0800]": {
@@ -170,6 +177,7 @@
 			"$import": "templates/aeotec_template.json#auto_report_group2_kwh_clamp2"
 		},
 		"102[0x2000]": {
+			"$if": "productType === 0x0002 && productId === 0x005f",
 			"$import": "templates/aeotec_template.json#auto_report_group2_kwh_clamp3"
 		},
 		"102[0x010000]": {
@@ -179,15 +187,17 @@
 			"$import": "templates/aeotec_template.json#auto_report_group2_v_clamp2"
 		},
 		"102[0x040000]": {
+			"$if": "productType === 0x0002 && productId === 0x005f",
 			"$import": "templates/aeotec_template.json#auto_report_group2_v_clamp3"
 		},
 		"102[0x080000]": {
 			"$import": "templates/aeotec_template.json#auto_report_group2_amp_clamp1"
 		},
-		"102[0x0100000]": {
+		"102[0x100000]": {
 			"$import": "templates/aeotec_template.json#auto_report_group2_amp_clamp2"
 		},
-		"102[0x0200000]": {
+		"102[0x200000]": {
+			"$if": "productType === 0x0002 && productId === 0x005f",
 			"$import": "templates/aeotec_template.json#auto_report_group2_amp_clamp3"
 		},
 		"103[0x01]": {
@@ -209,6 +219,7 @@
 			"$import": "templates/aeotec_template.json#auto_report_group3_watt_clamp2"
 		},
 		"103[0x0400]": {
+			"$if": "productType === 0x0002 && productId === 0x005f",
 			"$import": "templates/aeotec_template.json#auto_report_group3_watt_clamp3"
 		},
 		"103[0x0800]": {
@@ -218,6 +229,7 @@
 			"$import": "templates/aeotec_template.json#auto_report_group3_kwh_clamp2"
 		},
 		"103[0x2000]": {
+			"$if": "productType === 0x0002 && productId === 0x005f",
 			"$import": "templates/aeotec_template.json#auto_report_group3_kwh_clamp3"
 		},
 		"103[0x010000]": {
@@ -227,15 +239,17 @@
 			"$import": "templates/aeotec_template.json#auto_report_group3_v_clamp2"
 		},
 		"103[0x040000]": {
+			"$if": "productType === 0x0002 && productId === 0x005f",
 			"$import": "templates/aeotec_template.json#auto_report_group3_v_clamp3"
 		},
 		"103[0x080000]": {
 			"$import": "templates/aeotec_template.json#auto_report_group3_amp_clamp1"
 		},
-		"103[0x0100000]": {
+		"103[0x100000]": {
 			"$import": "templates/aeotec_template.json#auto_report_group3_amp_clamp2"
 		},
-		"103[0x0200000]": {
+		"103[0x200000]": {
+			"$if": "productType === 0x0002 && productId === 0x005f",
 			"$import": "templates/aeotec_template.json#auto_report_group3_amp_clamp3"
 		},
 		"111": {


### PR DESCRIPTION
Tested these changes against my US 2-phase ZW095 for all groups. The updates were based on this doc at Aeotec's site: https://help.aeotec.com/support/solutions/articles/6000191986-hem-gen5-parameter-101-103-and-111-113-use-

I'd like to double check the values (as shown in the "Meter" section in zwavejs2mqtt) not sure where those are yet though. In the meantime, these all appear correct for my hardware.