### PR TITLE
fix(config): correct alarm mapping for Yale YRD210

### DIFF
--- a/packages/config/config/devices/0x0109/yrd210.json
+++ b/packages/config/config/devices/0x0109/yrd210.json
@@ -56,5 +56,39 @@
 		"8": {
 			"$import": "../0x0129/templates/yale_template.json#operating_mode"
 		}
+	},
+	"compat": {
+		"alarmMapping": [
+			{
+				"$import": "../0x0129/templates/yale_template.json#alarm_map_keypad_limit"
+			},
+			{
+				"$import": "../0x0129/templates/yale_template.json#alarm_map_manual_unlock"
+			},
+			{
+				"$import": "../0x0129/templates/yale_template.json#alarm_map_rf_unlock"
+			},
+			{
+				"$import": "../0x0129/templates/yale_template.json#alarm_map_keypad_unlock"
+			},
+			{
+				"$import": "../0x0129/templates/yale_template.json#alarm_map_manual_lock"
+			},
+			{
+				"$import": "../0x0129/templates/yale_template.json#alarm_map_rf_lock"
+			},
+			{
+				"$import": "../0x0129/templates/yale_template.json#alarm_map_keypad_lock"
+			},
+			{
+				"$import": "../0x0129/templates/yale_template.json#alarm_map_deadbolt_jammed"
+			},
+			{
+				"$import": "../0x0129/templates/yale_template.json#alarm_map_low_battery"
+			},
+			{
+				"$import": "../0x0129/templates/yale_template.json#alarm_map_auto_relock"
+			}
+		]
 	}
 }


### PR DESCRIPTION
Adding alarm mapping to the alternate yale device ID to correct reporting issues. 

fixes: #2281