### PR TITLE
fix(config): correct LZW31-SN dimming and ramp labels

### DIFF
--- a/packages/config/config/devices/0x031e/lzw31-sn.json
+++ b/packages/config/config/devices/0x031e/lzw31-sn.json
@@ -18,7 +18,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"1": {
-			"label": "Dimming Speed",
+			"label": "Dimming Speed (Z-Wave)",
 			"unit": "seconds",
 			"valueSize": 1,
 			"minValue": 0,
@@ -35,7 +35,7 @@
 			]
 		},
 		"2": {
-			"label": "Dimming Speed (Z-Wave)",
+			"label": "Dimming Speed (Manual)",
 			"unit": "seconds",
 			"valueSize": 1,
 			"minValue": 0,
@@ -56,7 +56,7 @@
 			]
 		},
 		"3": {
-			"label": "Ramp Rate",
+			"label": "Ramp Rate (Z-Wave)",
 			"unit": "seconds",
 			"valueSize": 1,
 			"minValue": 0,
@@ -77,7 +77,7 @@
 			]
 		},
 		"4": {
-			"label": "Ramp Rate (Z-Wave)",
+			"label": "Ramp Rate (Manual)",
 			"unit": "seconds",
 			"valueSize": 1,
 			"minValue": 0,


### PR DESCRIPTION
After some hair pulling and digging it turns out that the original documentation for parameter 2 and 4 are mislabeled for the Inovelli LZW31-SN (Red Dimmer).

I was really confused why setting these parameters wasn't changing what I expected until I realized that they were swapped. 1 & 3 are for z-wave control and 2 & 4 are for wall switch control.

After some digging I came across these forums posts. Not sure why the [official docs](https://support.inovelli.com/portal/api/kbArticles/407409000001873397/attachments/1abnfa5822ce11f1e4dfe9a7306effa38a8cf/content?portalId=1ce1db55e4825f16146555b24f0f1753cbf5f7d83ca0a3d8b31013b2a2d69e1f&inline=true) haven't been updated yet.

https://community.inovelli.com/t/lzw31-manual-dimming-not-working/1315/9
https://community.inovelli.com/t/device-page-inovelli-dimmer-red-series-lzw31-sn/2272
https://community.inovelli.com/t/dimming-speed-and-ramp-rate-parameter1-and-parameter3-are-swapped-fixed-in-2020-08-12-driver/3529/14