### PR TITLE
fix(cc): persist Basic CC values when requested using Basic CC API

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/BasicCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BasicCC.ts
@@ -139,6 +139,11 @@ export class BasicCCAPI extends CCAPI {
 			this.commandOptions,
 		);
 		if (response) {
+			const valueDB = this.endpoint.getNodeUnsafe()?.valueDB;
+			valueDB?.setValue(
+				getCurrentValueValueId(this.endpoint.index),
+				response.currentValue,
+			);
 			return pick(response, ["currentValue", "targetValue", "duration"]);
 		}
 	}
@@ -224,10 +229,6 @@ current value:      ${basicResponse.currentValue}`;
 target value:       ${basicResponse.targetValue}
 remaining duration: ${basicResponse.duration?.toString() ?? "undefined"}`;
 			}
-			this.getValueDB().setValue(
-				getCurrentValueValueId(this.endpointIndex),
-				basicResponse.currentValue,
-			);
 			this.driver.controllerLog.logNode(node.id, {
 				endpoint: this.endpointIndex,
 				message: logMessage,

--- a/packages/zwave-js/src/lib/commandclass/BasicCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BasicCC.ts
@@ -224,6 +224,10 @@ current value:      ${basicResponse.currentValue}`;
 target value:       ${basicResponse.targetValue}
 remaining duration: ${basicResponse.duration?.toString() ?? "undefined"}`;
 			}
+			this.getValueDB().setValue(
+				getCurrentValueValueId(this.endpointIndex),
+				basicResponse.currentValue,
+			);
 			this.driver.controllerLog.logNode(node.id, {
 				endpoint: this.endpointIndex,
 				message: logMessage,


### PR DESCRIPTION
Possibly a bug when doing interview as below:

My device is `WADWAZ-1`. I am pretty sure it supports BasicCC (use Z-Wave PC Controller and has confirmed it). But whatever I interview it, I always get the message `No response to Basic Get command, assuming the node does not support Basic CC...`

Now, I checked the code [Node.js](https://github.com/zwave-js/node-zwave-js/blob/master/packages/zwave-js/src/lib/node/Node.ts) and I found that during the interview, it refreshes the values (without storing the value) and right after that, it checks if there is a value from the `ValueDB`.

Here is the detail: the method at the line 174 [await this.refreshValues()](https://github.com/zwave-js/node-zwave-js/blob/master/packages/zwave-js/src/lib/commandclass/BasicCC.ts#L174) does not store the value into `ValueDB` so at the line 186 [this.getValueDB().getValue](https://github.com/zwave-js/node-zwave-js/blob/master/packages/zwave-js/src/lib/commandclass/BasicCC.ts#L186), it will return `undefined` and think it doesn't support BasicCC.

Below is the fix for `BasicCC.ts`. I haven't check other `CC` if it actually uses the values **_right after_** doing `refreshValues`. Please verify other `CC`.

Because of this issue, many devices have to inject the `enableBasicSetMapping`. Without `enableBasicSetMapping`, because the driver already removes the BasicSet for that device already, the driver just caches the value and does nothing (which means HA doesn't get any state update)

My device `WADWAZ-1` didn't work until 13 days ago until this commit [add enableBasicSetMapping compat flag to wadwaz-1 and wapirz-1](https://github.com/zwave-js/node-zwave-js/commit/ff376539643b33e572d93617827f709168d922f3). But, if the driver had handled interview correctly, we didn't need to set `enableBasicSetMapping` for wadwaz-1 and wapirz-1
