### PR TITLE
feat: specify a directory to prioritize loading device configs from

### DIFF
--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -459,17 +459,22 @@ interface ZWaveOptions {
 	timeouts: {
 		/** how long to wait for an ACK */
 		ack: number; // >=1, default: 1000 ms
+
 		/** not sure */
 		byte: number; // >=1, default: 150 ms
+
 		/**
 		 * How long to wait for a controller response. Usually this timeout should never elapse,
 		 * so this is merely a safeguard against the driver stalling
 		 */
 		response: number; // [500...5000], default: 1600 ms
+
 		/** How long to wait for a callback from the host for a SendData[Multicast]Request */
 		sendDataCallback: number; // >=10000, default: 65000 ms
+
 		/** How much time a node gets to process a request and send a response */
 		report: number; // [1000...40000], default: 10000 ms
+
 		/** How long generated nonces are valid */
 		nonce: number; // [3000...20000], default: 5000 ms
 	};
@@ -477,10 +482,13 @@ interface ZWaveOptions {
 	attempts: {
 		/** How often the driver should try communication with the controller before giving up */
 		controller: number; // [1...3], default: 3
+
 		/** How often the driver should try sending SendData commands before giving up */
 		sendData: number; // [1...5], default: 3
+
 		/** Whether a command should be retried when a node acknowledges the receipt but no response is received */
 		retryAfterTransmitReport: boolean; // default: false
+
 		/**
 		 * How many attempts should be made for each node interview before giving up
 		 */
@@ -496,6 +504,12 @@ interface ZWaveOptions {
 		driver: FileSystem;
 		/** Allows you to specify a different cache directory */
 		cacheDir: string;
+		/**
+		 * Allows you to specify a directory where device configuration files can be loaded from with higher priority than the included ones.
+		 * This directory does not get indexed and should be used sparingly, e.g. for testing.
+		 */
+		deviceConfigPriorityDir?: string;
+
 		/**
 		 * How frequently the values and metadata should be written to the DB files. This is a compromise between data loss
 		 * in cause of a crash and disk wear:

--- a/packages/zwave-js/src/Driver.ts
+++ b/packages/zwave-js/src/Driver.ts
@@ -1,6 +1,7 @@
 export { Driver } from "./lib/driver/Driver";
-export type { SendMessageOptions, ZWaveOptions } from "./lib/driver/Driver";
+export type { SendMessageOptions } from "./lib/driver/Driver";
 export type { FileSystem } from "./lib/driver/FileSystem";
+export type { ZWaveOptions } from "./lib/driver/ZWaveOptions";
 export {
 	FunctionType,
 	MessagePriority,

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -445,7 +445,11 @@ export class Driver extends EventEmitter {
 		this.cacheDir = this.options.storage.cacheDir;
 
 		// Initialize config manager
-		this.configManager = new ConfigManager(this._logContainer);
+		this.configManager = new ConfigManager({
+			logContainer: this._logContainer,
+			deviceConfigPriorityDir: this.options.storage
+				.deviceConfigPriorityDir,
+		});
 
 		// And initialize but don't start the send thread machine
 		const sendThreadMachine = createSendThreadMachine(

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -114,7 +114,6 @@ import {
 	compileStatistics,
 	sendStatistics,
 } from "../telemetry/statistics";
-import type { FileSystem } from "./FileSystem";
 import {
 	createSendThreadMachine,
 	SendThreadInterpreter,
@@ -123,6 +122,7 @@ import {
 } from "./SendThreadMachine";
 import { throttlePresets } from "./ThrottlePresets";
 import { Transaction } from "./Transaction";
+import type { ZWaveOptions } from "./ZWaveOptions";
 
 // eslint-disable-next-line
 const { version: libVersion } = require("../../../package.json");
@@ -135,95 +135,6 @@ const libNameString = `
 ███████╗ ╚███╔███╔╝ ██║  ██║  ╚████╔╝  ███████╗        ╚█████╔╝ ███████║
 ╚══════╝  ╚══╝╚══╝  ╚═╝  ╚═╝   ╚═══╝   ╚══════╝         ╚════╝  ╚══════╝
 `;
-
-export interface ZWaveOptions {
-	/** Specify timeouts in milliseconds */
-	timeouts: {
-		/** how long to wait for an ACK */
-		ack: number; // >=1, default: 1000 ms
-		/** not sure */
-		byte: number; // >=1, default: 150 ms
-		/**
-		 * How long to wait for a controller response. Usually this timeout should never elapse,
-		 * so this is merely a safeguard against the driver stalling
-		 */
-		response: number; // [500...5000], default: 1600 ms
-		/** How long to wait for a callback from the host for a SendData[Multicast]Request */
-		sendDataCallback: number; // >=10000, default: 65000 ms
-		/** How much time a node gets to process a request and send a response */
-		report: number; // [1000...40000], default: 10000 ms
-		/** How long generated nonces are valid */
-		nonce: number; // [3000...20000], default: 5000 ms
-
-		/**
-		 * @internal
-		 * How long to wait for a poll after setting a value
-		 */
-		refreshValue: number;
-	};
-
-	attempts: {
-		/** How often the driver should try communication with the controller before giving up */
-		controller: number; // [1...3], default: 3
-		/** How often the driver should try sending SendData commands before giving up */
-		sendData: number; // [1...5], default: 3
-		/** Whether a command should be retried when a node acknowledges the receipt but no response is received */
-		retryAfterTransmitReport: boolean; // default: false
-		/**
-		 * How many attempts should be made for each node interview before giving up
-		 */
-		nodeInterview: number; // [1...10], default: 5
-	};
-
-	/**
-	 * Optional log configuration
-	 */
-	logConfig?: LogConfig;
-
-	/**
-	 * @internal
-	 * Set this to true to skip the controller interview. Useful for testing purposes
-	 */
-	skipInterview?: boolean;
-
-	storage: {
-		/** Allows you to replace the default file system driver used to store and read the cache */
-		driver: FileSystem;
-		/** Allows you to specify a different cache directory */
-		cacheDir: string;
-		/**
-		 * How frequently the values and metadata should be written to the DB files. This is a compromise between data loss
-		 * in cause of a crash and disk wear:
-		 *
-		 * * `"fast"` immediately writes every change to disk
-		 * * `"slow"` writes at most every 5 minutes or after 500 changes - whichever happens first
-		 * * `"normal"` is a compromise between the two options
-		 */
-		throttle: "fast" | "normal" | "slow";
-	};
-
-	/** Specify the network key to use for encryption. This must be a Buffer of exactly 16 bytes. */
-	networkKey?: Buffer;
-
-	/**
-	 * Some Command Classes support reporting that a value is unknown.
-	 * When this flag is `false`, unknown values are exposed as `undefined`.
-	 * When it is `true`, unknown values are exposed as the literal string "unknown" (even if the value is normally numeric).
-	 * Default: `false` */
-	preserveUnknownValues?: boolean;
-
-	/**
-	 * Some SET-type commands optimistically update the current value to match the target value
-	 * when the device acknowledges the command.
-	 *
-	 * While this generally makes UIs feel more responsive, it is not necessary for devices which report their status
-	 * on their own and can lead to confusing behavior when dealing with slow devices like blinds.
-	 *
-	 * To disable the optimistic update, set this option to `true`.
-	 * Default: `false`
-	 */
-	disableOptimisticValueUpdate?: boolean;
-}
 
 const defaultOptions: ZWaveOptions = {
 	timeouts: {

--- a/packages/zwave-js/src/lib/driver/SendThreadMachine.ts
+++ b/packages/zwave-js/src/lib/driver/SendThreadMachine.ts
@@ -34,7 +34,6 @@ import {
 	CommandQueueInterpreter,
 	createCommandQueueMachine,
 } from "./CommandQueueMachine";
-import type { ZWaveOptions } from "./Driver";
 import type {
 	SerialAPICommandDoneData,
 	SerialAPICommandMachineParams,
@@ -44,6 +43,7 @@ import {
 	ServiceImplementations,
 } from "./StateMachineShared";
 import type { Transaction } from "./Transaction";
+import type { ZWaveOptions } from "./ZWaveOptions";
 
 /* eslint-disable @typescript-eslint/ban-types */
 export interface SendThreadStateSchema {

--- a/packages/zwave-js/src/lib/driver/SerialAPICommandMachine.ts
+++ b/packages/zwave-js/src/lib/driver/SerialAPICommandMachine.ts
@@ -13,11 +13,11 @@ import {
 	isMultiStageCallback,
 	isSuccessIndicator,
 } from "../message/SuccessIndicator";
-import type { ZWaveOptions } from "./Driver";
 import {
 	respondUnsolicited,
 	ServiceImplementations,
 } from "./StateMachineShared";
+import type { ZWaveOptions } from "./ZWaveOptions";
 
 /* eslint-disable @typescript-eslint/ban-types */
 export interface SerialAPICommandStateSchema {

--- a/packages/zwave-js/src/lib/driver/ThrottlePresets.ts
+++ b/packages/zwave-js/src/lib/driver/ThrottlePresets.ts
@@ -1,5 +1,5 @@
 import type { JsonlDBOptions } from "@alcalzone/jsonl-db";
-import type { ZWaveOptions } from "./Driver";
+import type { ZWaveOptions } from "./ZWaveOptions";
 
 export const throttlePresets: Record<
 	ZWaveOptions["storage"]["throttle"],

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -65,6 +65,12 @@ export interface ZWaveOptions {
 		/** Allows you to specify a different cache directory */
 		cacheDir: string;
 		/**
+		 * Allows you to specify a directory where device configuration files can be loaded from with higher priority than the included ones.
+		 * This directory does not get indexed and should be used sparingly, e.g. for testing.
+		 */
+		deviceConfigPriorityDir?: string;
+
+		/**
 		 * How frequently the values and metadata should be written to the DB files. This is a compromise between data loss
 		 * in cause of a crash and disk wear:
 		 *

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -1,0 +1,99 @@
+import type { LogConfig } from "@zwave-js/core";
+import type { FileSystem } from "./FileSystem";
+
+export interface ZWaveOptions {
+	/** Specify timeouts in milliseconds */
+	timeouts: {
+		/** how long to wait for an ACK */
+		ack: number; // >=1, default: 1000 ms
+
+		/** not sure */
+		byte: number; // >=1, default: 150 ms
+
+		/**
+		 * How long to wait for a controller response. Usually this timeout should never elapse,
+		 * so this is merely a safeguard against the driver stalling
+		 */
+		response: number; // [500...5000], default: 1600 ms
+
+		/** How long to wait for a callback from the host for a SendData[Multicast]Request */
+		sendDataCallback: number; // >=10000, default: 65000 ms
+
+		/** How much time a node gets to process a request and send a response */
+		report: number; // [1000...40000], default: 10000 ms
+
+		/** How long generated nonces are valid */
+		nonce: number; // [3000...20000], default: 5000 ms
+
+		/**
+		 * @internal
+		 * How long to wait for a poll after setting a value
+		 */
+		refreshValue: number;
+	};
+
+	attempts: {
+		/** How often the driver should try communication with the controller before giving up */
+		controller: number; // [1...3], default: 3
+
+		/** How often the driver should try sending SendData commands before giving up */
+		sendData: number; // [1...5], default: 3
+
+		/** Whether a command should be retried when a node acknowledges the receipt but no response is received */
+		retryAfterTransmitReport: boolean; // default: false
+
+		/**
+		 * How many attempts should be made for each node interview before giving up
+		 */
+		nodeInterview: number; // [1...10], default: 5
+	};
+
+	/**
+	 * Optional log configuration
+	 */
+	logConfig?: LogConfig;
+
+	/**
+	 * @internal
+	 * Set this to true to skip the controller interview. Useful for testing purposes
+	 */
+	skipInterview?: boolean;
+
+	storage: {
+		/** Allows you to replace the default file system driver used to store and read the cache */
+		driver: FileSystem;
+		/** Allows you to specify a different cache directory */
+		cacheDir: string;
+		/**
+		 * How frequently the values and metadata should be written to the DB files. This is a compromise between data loss
+		 * in cause of a crash and disk wear:
+		 *
+		 * * `"fast"` immediately writes every change to disk
+		 * * `"slow"` writes at most every 5 minutes or after 500 changes - whichever happens first
+		 * * `"normal"` is a compromise between the two options
+		 */
+		throttle: "fast" | "normal" | "slow";
+	};
+
+	/** Specify the network key to use for encryption. This must be a Buffer of exactly 16 bytes. */
+	networkKey?: Buffer;
+
+	/**
+	 * Some Command Classes support reporting that a value is unknown.
+	 * When this flag is `false`, unknown values are exposed as `undefined`.
+	 * When it is `true`, unknown values are exposed as the literal string "unknown" (even if the value is normally numeric).
+	 * Default: `false` */
+	preserveUnknownValues?: boolean;
+
+	/**
+	 * Some SET-type commands optimistically update the current value to match the target value
+	 * when the device acknowledges the command.
+	 *
+	 * While this generally makes UIs feel more responsive, it is not necessary for devices which report their status
+	 * on their own and can lead to confusing behavior when dealing with slow devices like blinds.
+	 *
+	 * To disable the optimistic update, set this option to `true`.
+	 * Default: `false`
+	 */
+	disableOptimisticValueUpdate?: boolean;
+}

--- a/packages/zwave-js/src/lib/test/utils.ts
+++ b/packages/zwave-js/src/lib/test/utils.ts
@@ -2,7 +2,8 @@
 
 import { MockSerialPort } from "@zwave-js/serial";
 import type { DeepPartial } from "@zwave-js/shared";
-import { Driver, ZWaveOptions } from "../driver/Driver";
+import { Driver } from "../driver/Driver";
+import type { ZWaveOptions } from "../driver/ZWaveOptions";
 
 // load the driver with stubbed out Serialport
 jest.mock("@zwave-js/serial", () => {


### PR DESCRIPTION
This PR adds a new driver option `storage.deviceConfigPriorityDir` which allows specifying a directory where device configuration files can be loaded from with higher priority than the included ones.

This can be used to test and develop device configuration files in a production environment without having to fiddle with the `node_modules` directory structure.

Note that the priority directory gets indexed only in memory, **every time** the driver starts, so care should be taken not to let this directory grow too large. The feature set is the same as for the included configs - including templates and conditional properties.

However, cross-referencing templates from the priority dir to the included configs is not possible - the templates must be copied into the priority dir if they should be used.

fixes: https://github.com/zwave-js/node-zwave-js/issues/1238