### PR TITLE
feat: cancel scheduled value polls when a value is updated

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/BasicCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BasicCC.ts
@@ -106,7 +106,10 @@ export class BasicCCAPI extends CCAPI {
 				);
 			}
 
-			// and verify the current value after a delay
+			// and verify the current value after a delay. We query currentValue instead of targetValue to make sure
+			// that unsolicited updates cancel the scheduled poll
+			// wotan-disable-next-line no-useless-predicate
+			if (property === "targetValue") property = "currentValue";
 			this.schedulePoll({ property });
 		}
 	};

--- a/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
@@ -137,6 +137,9 @@ export class BinarySwitchCCAPI extends CCAPI {
 			// Verify the current value after a delay
 			// TODO: #1321
 			const duration = undefined as Duration | undefined;
+			// We query currentValue instead of targetValue to make sure that unsolicited updates cancel the scheduled poll
+			// wotan-disable-next-line no-useless-predicate
+			if (property === "targetValue") property = "currentValue";
 			this.schedulePoll({ property }, duration?.toMilliseconds() ?? 1000);
 		}
 	};

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -334,6 +334,9 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 				) {
 					// TODO: #1321
 					const duration = undefined as Duration | undefined;
+					// We query currentValue instead of targetValue to make sure that unsolicited updates cancel the scheduled poll
+					// wotan-disable-next-line no-useless-predicate
+					if (property === "targetValue") property = "currentValue";
 					this.schedulePoll({ property }, duration?.toMilliseconds());
 				}
 			}

--- a/packages/zwave-js/src/lib/log/Controller.ts
+++ b/packages/zwave-js/src/lib/log/Controller.ts
@@ -22,7 +22,7 @@ const VALUE_LOGLEVEL = "debug";
 
 interface LogNodeOptions {
 	message: string;
-	level?: "warn" | "error";
+	level?: "verbose" | "warn" | "error";
 	direction?: DataDirection;
 	endpoint?: number;
 }
@@ -46,7 +46,7 @@ export class ControllerLogger extends ZWaveLoggerBase {
 	 * Logs a message
 	 * @param msg The message to output
 	 */
-	public print(message: string, level?: "warn" | "error"): void {
+	public print(message: string, level?: "verbose" | "warn" | "error"): void {
 		const actualLevel = level || CONTROLLER_LOGLEVEL;
 		if (!this.container.isLoglevelVisible(actualLevel)) return;
 
@@ -65,7 +65,7 @@ export class ControllerLogger extends ZWaveLoggerBase {
 	public logNode(
 		nodeId: number,
 		message: string,
-		level?: "warn" | "error",
+		level?: "verbose" | "warn" | "error",
 	): void;
 
 	/**
@@ -77,7 +77,7 @@ export class ControllerLogger extends ZWaveLoggerBase {
 	public logNode(
 		nodeId: number,
 		messageOrOptions: string | LogNodeOptions,
-		logLevel?: "warn" | "error",
+		logLevel?: "verbose" | "warn" | "error",
 	): void {
 		if (typeof messageOrOptions === "string") {
 			return this.logNode(nodeId, {

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -827,8 +827,6 @@ export class ZWaveNode extends Endpoint {
 		// Avoid false positives or false negatives due to a mis-formatted value ID
 		valueId = normalizeValueID(valueId);
 
-		if (this.scheduledPolls.has(valueId)) return false;
-
 		// Try to retrieve the corresponding CC API
 		const endpointInstance = this.getEndpoint(valueId.endpoint || 0);
 		if (!endpointInstance) return false;
@@ -840,6 +838,8 @@ export class ZWaveNode extends Endpoint {
 		// Check if the pollValue method is implemented
 		if (!api.pollValue) return false;
 
+		// make sure there is only one timeout instance per poll
+		this.cancelScheduledPoll(valueId);
 		this.scheduledPolls.set(
 			valueId,
 			setTimeout(async () => {

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -268,6 +268,11 @@ export class ZWaveNode extends Endpoint {
 		]) {
 			if (timeout) clearTimeout(timeout);
 		}
+
+		// Clear all scheduled polls that would interfere with the interview
+		for (const valueId of this.scheduledPolls.keys()) {
+			this.cancelScheduledPoll(valueId);
+		}
 	}
 
 	/**
@@ -1076,6 +1081,11 @@ export class ZWaveNode extends Endpoint {
 		// Restart all state machines
 		this.readyMachine.restart();
 		this.statusMachine.restart();
+
+		// Remove queued polls that would interfere with the interview
+		for (const valueId of this.scheduledPolls.keys()) {
+			this.cancelScheduledPoll(valueId);
+		}
 
 		// Restore the previously saved name/location
 		if (name != undefined) this.name = name;


### PR DESCRIPTION
This PR moves the handling for scheduled verification polls into the Node class. This enables us to cancel scheduled polls whenever the value ID the poll was scheduled for gets updated. This means that the delayed verification for a `setValue` call will no longer happen if the value was updated in the meantime by

1. a manual poll or
2. an unsolicited update by the node

fixes: https://github.com/zwave-js/node-zwave-js/issues/1532
fixes: https://github.com/zwave-js/node-zwave-js/issues/1748
fixes: https://github.com/zwave-js/node-zwave-js/issues/2393