### PR TITLE
fix(config): remove Group 2 Lifeline attribute for Aeotec ZW098

### DIFF
--- a/packages/config/config/devices/0x0086/zw098.json
+++ b/packages/config/config/devices/0x0086/zw098.json
@@ -32,7 +32,7 @@
 		"2": {
 			"label": "Group 2",
 			"maxNodes": 5,
-			"isLifeline": true
+			"isLifeline": false
 		}
 	},
 	"paramInformation": {

--- a/packages/config/config/devices/0x0086/zw098.json
+++ b/packages/config/config/devices/0x0086/zw098.json
@@ -31,8 +31,7 @@
 		},
 		"2": {
 			"label": "Group 2",
-			"maxNodes": 5,
-			"isLifeline": false
+			"maxNodes": 5
 		}
 	},
 	"paramInformation": {


### PR DESCRIPTION
fixes #2128 

Current value is erroneous and causes problem outlined in above issue