### PR TITLE
feat: log whether an embedded or user-provided device config was loaded

### DIFF
--- a/packages/config/src/Devices.ts
+++ b/packages/config/src/Devices.ts
@@ -645,7 +645,15 @@ export class DeviceConfig {
 		public readonly compat?: CompatConfig,
 		/** Contains instructions and other metadata for the device */
 		public readonly metadata?: DeviceMetadata,
-	) {}
+	) {
+		// A config file is treated as am embedded one when it is located under the devices root dir
+		this.isEmbedded = !path
+			.relative(devicesDir, this.filename)
+			.startsWith("..");
+	}
+
+	/** Whether this is an embedded configuration or not */
+	public readonly isEmbedded: boolean;
 }
 
 export class ConditionalAssociationConfig {

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1387,10 +1387,6 @@ protocol version:      ${this._protocolVersion}`;
 			this.productId != undefined
 		) {
 			// Try to load the config file
-			this.driver.controllerLog.logNode(
-				this.id,
-				"trying to load device config",
-			);
 			this._deviceConfig = await this.driver.configManager.lookupDevice(
 				this.manufacturerId,
 				this.productType,
@@ -1400,12 +1396,16 @@ protocol version:      ${this._protocolVersion}`;
 			if (this._deviceConfig) {
 				this.driver.controllerLog.logNode(
 					this.id,
-					"device config loaded",
+					`${
+						this._deviceConfig.isEmbedded
+							? "Embedded"
+							: "User-provided"
+					} device config loaded`,
 				);
 			} else {
 				this.driver.controllerLog.logNode(
 					this.id,
-					"no device config loaded",
+					"No device config found",
 					"warn",
 				);
 			}


### PR DESCRIPTION
Based on #2406 we now log whether a config file was loaded from the embedded config DB or a user-provided file was picked up. This should help us weed out issues that stem from a misconfigured custom device file.