### PR TITLE
fix(config): map Basic Set to Binary Sensor Reports for Fibaro FGK101

### DIFF
--- a/packages/config/config/devices/0x010f/fgk101_0.0-2.3.json
+++ b/packages/config/config/devices/0x010f/fgk101_0.0-2.3.json
@@ -246,5 +246,9 @@
 				}
 			]
 		}
+	},
+	"compat": {
+		// The device is a Binary Sensor, but uses Basic Sets to report its status
+		"enableBasicSetMapping": true
 	}
 }


### PR DESCRIPTION
Fibaro FGK101 with firmware version lower than 2.3 does not report properly state change and uses `BasicCC:Set` to do so.

As per discussed in #2417, enabling compat flag to treat the basic set report as a status change (similar to what has been done on #2386).

After applying the patch, I have got the following in logs, confirmed working on two FGK101-2.1 devices
```
2021-04-22T06:31:25.722Z CNTRLR [Node 024] treating BasicCC::Set as a report
2021-04-22 08:31:25.736 INFO ZWAVE: Node 24: value updated: 48-0-Any false => true
2021-04-22T06:31:29.816Z CNTRLR [Node 024] treating BasicCC::Set as a report
2021-04-22 08:31:29.823 INFO ZWAVE: Node 24: value updated: 48-0-Any true => false
```

fixes: #2417