### PR TITLE
fix(node): do not re-interview the controller

### DIFF
--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1049,11 +1049,16 @@ export class ZWaveNode extends Endpoint {
 
 	/**
 	 * Resets all information about this node and forces a fresh interview.
+	 * **Note:** This does nothing for the controller node.
 	 *
-	 * WARNING: Take care NOT to call this method when the node is already being interviewed.
+	 * **WARNING:** Take care NOT to call this method when the node is already being interviewed.
 	 * Otherwise the node information may become inconsistent.
 	 */
 	public async refreshInfo(): Promise<void> {
+		// It does not make sense to re-interview the controller. All important information is queried
+		// directly via the serial API
+		if (this.isControllerNode()) return;
+
 		// preserve the node name and location, since they might not be stored on the node
 		const name = this.name;
 		const location = this.location;


### PR DESCRIPTION
Re-interviewing the controller essentially only deletes its values from the value DB. Therefore we no longer allow doing that.

fixes: #2401