### PR TITLE
fix(config): add enableBasicSetMapping compat flag to SM103

### DIFF
--- a/packages/config/config/devices/0x0060/sm103.json
+++ b/packages/config/config/devices/0x0060/sm103.json
@@ -51,5 +51,9 @@
 			"writeOnly": false,
 			"allowManualEntry": true
 		}
+	},
+	"compat": {
+		// The device is a Binary Sensor, but uses Basic Sets to report its status
+		"enableBasicSetMapping": true	
 	}
 }

--- a/packages/config/config/devices/0x0060/sm103.json
+++ b/packages/config/config/devices/0x0060/sm103.json
@@ -54,6 +54,6 @@
 	},
 	"compat": {
 		// The device is a Binary Sensor, but uses Basic Sets to report its status
-		"enableBasicSetMapping": true	
+		"enableBasicSetMapping": true
 	}
 }


### PR DESCRIPTION
Change basicsetmapping to true to enable binary sensor to report open/closed status as in https://github.com/zwave-js/node-zwave-js/issues/2420