### PR TITLE
feat(config): add new variant of param 52 for LZW31-SN v1.54+

### DIFF
--- a/packages/config/config/devices/0x031e/lzw31-sn.json
+++ b/packages/config/config/devices/0x031e/lzw31-sn.json
@@ -723,24 +723,28 @@
 			]
 		},
 		"52": {
-			"$if": "firmwareVersion >= 1.47",
+			"$if": "firmwareVersion >= 1.54",
 			"label": "Smart Bulb Mode",
-			"description": "Optimize power output to be more compatible with smart bulbs. This prevents the dimmer from being able to dim & makes it act like an ON / OFF switch.",
+			"description": "Change the working mode of the dimmer. Choose either on / off only which makes the device work like an on / off switch. Or choose smart bulb mode which optimized the device for interaction with smart bulbs. (firmware 1.54+)",
 			"valueSize": 1,
 			"minValue": 0,
-			"maxValue": 1,
+			"maxValue": 2,
 			"defaultValue": 0,
 			"readOnly": false,
 			"writeOnly": false,
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Disable",
+					"label": "Disabled",
 					"value": 0
 				},
 				{
-					"label": "Enable",
+					"label": "On / Off Only",
 					"value": 1
+				}
+				{
+					"label": "Smart Bulb",
+					"value": 2
 				}
 			]
 		}

--- a/packages/config/config/devices/0x031e/lzw31-sn.json
+++ b/packages/config/config/devices/0x031e/lzw31-sn.json
@@ -742,13 +742,13 @@
 					{
 						"label": "On / Off Only",
 						"value": 1
-					}
+					},
 					{
 						"label": "Smart Bulb",
 						"value": 2
 					}
 				]
-			}
+			},
 			{
 				"$if": "firmwareVersion >= 1.47",
 				"label": "Smart Bulb Mode",

--- a/packages/config/config/devices/0x031e/lzw31-sn.json
+++ b/packages/config/config/devices/0x031e/lzw31-sn.json
@@ -750,7 +750,7 @@
 				]
 			},
 			{
-				"$if": "firmwareVersion >= 1.47",
+				"$if": "firmwareVersion >= 1.47 && firmwareVersion < 1.54",
 				"label": "Smart Bulb Mode",
 				"description": "Optimize power output to be more compatible with smart bulbs. This prevents the dimmer from being able to dim & makes it act like an ON / OFF switch.",
 				"valueSize": 1,

--- a/packages/config/config/devices/0x031e/lzw31-sn.json
+++ b/packages/config/config/devices/0x031e/lzw31-sn.json
@@ -722,31 +722,55 @@
 				}
 			]
 		},
-		"52": {
-			"$if": "firmwareVersion >= 1.54",
-			"label": "Smart Bulb Mode",
-			"description": "Change the working mode of the dimmer. Choose either on / off only which makes the device work like an on / off switch. Or choose smart bulb mode which optimized the device for interaction with smart bulbs. (firmware 1.54+)",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 0,
-			"readOnly": false,
-			"writeOnly": false,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disabled",
-					"value": 0
-				},
-				{
-					"label": "On / Off Only",
-					"value": 1
-				}
-				{
-					"label": "Smart Bulb",
-					"value": 2
-				}
-			]
-		}
+		"52": [
+			{
+				"$if": "firmwareVersion >= 1.54",
+				"label": "Smart Bulb Mode",
+				"description": "Change the working mode of the dimmer. Choose either on / off only which makes the device work like an on / off switch. Or choose smart bulb mode which optimized the device for interaction with smart bulbs. (firmware 1.54+)",
+				"valueSize": 1,
+				"minValue": 0,
+				"maxValue": 2,
+				"defaultValue": 0,
+				"readOnly": false,
+				"writeOnly": false,
+				"allowManualEntry": false,
+				"options": [
+					{
+						"label": "Disabled",
+						"value": 0
+					},
+					{
+						"label": "On / Off Only",
+						"value": 1
+					}
+					{
+						"label": "Smart Bulb",
+						"value": 2
+					}
+				]
+			}
+			{
+				"$if": "firmwareVersion >= 1.47",
+				"label": "Smart Bulb Mode",
+				"description": "Optimize power output to be more compatible with smart bulbs. This prevents the dimmer from being able to dim & makes it act like an ON / OFF switch.",
+				"valueSize": 1,
+				"minValue": 0,
+				"maxValue": 1,
+				"defaultValue": 0,
+				"readOnly": false,
+				"writeOnly": false,
+				"allowManualEntry": false,
+				"options": [
+					{
+						"label": "Disable",
+						"value": 0
+					},
+					{
+						"label": "Enable",
+						"value": 1
+					}
+				]
+			}
+		]
 	}
 }


### PR DESCRIPTION
Inovelli has released beta firmware 1.54 which adds a 3rd option (value 2) for Smart Bulb Mode which keeps power on even if the switch is turned off. Wording matches exactly from SmartThings Device Handler revised documentation:

https://github.com/InovelliUSA/SmartThingsInovelli/blob/master/devicetypes/inovelliusa/inovelli-dimmer-red-series-lzw31-sn.src/inovelli-dimmer-red-series-lzw31-sn.groovy

Related community link:
https://community.inovelli.com/t/firmware-v1-54-beta-lzw31-sn-dimmer-red-series-gen-2/8132.

Note I did not split this out from 1.47+ (which is original options set of 0 or 1) as I don't know syntax on how to split this off for only firmware 1.54+. Option 2 is invalid for current production firmware.