### PR TITLE
fix: add compat flag to lzw36

### DIFF
--- a/packages/config/config/devices/0x031e/lzw36.json
+++ b/packages/config/config/devices/0x031e/lzw36.json
@@ -1115,7 +1115,7 @@
 				}
 			}
 		},
-		// This device improperly reports the state of R2 (endpoint 2) through the root endpoint in a way that also changes the state of R1 (endpoint 1)
+		// This device improperly reports the state of endpoint 2 through the root endpoint in a way that also changes the state of endpoint 1
 		"preserveRootApplicationCCValueIDs": true
 	}
 }

--- a/packages/config/config/devices/0x031e/lzw36.json
+++ b/packages/config/config/devices/0x031e/lzw36.json
@@ -1114,6 +1114,8 @@
 					"endpoints": "*"
 				}
 			}
-		}
+		},
+		// This device improperly reports the state of R2 (endpoint 2) through the root endpoint in a way that also changes the state of R1 (endpoint 1)
+		"preserveRootApplicationCCValueIDs": true
 	}
 }


### PR DESCRIPTION
Closes #2480. After reverting #2160, this switch was missing the compat flag workaround we need until #2286 is solved. This PR re-adds it.