### PR TITLE
feat(config): add FGFS-101 v3.4 productId

### DIFF
--- a/packages/config/config/devices/0x010f/fgfs101_3.2-23.0.json
+++ b/packages/config/config/devices/0x010f/fgfs101_3.2-23.0.json
@@ -24,6 +24,10 @@
 		},
 		{
 			"productType": "0x0b01",
+			"productId": "0x2003"
+		},
+		{
+			"productType": "0x0b01",
 			"productId": "0x3002"
 		}
 	],


### PR DESCRIPTION
Added productId for [v3.4](https://products.z-wavealliance.org/products/3466) of FGFS-101 flood sensor.

