### PR TITLE
feat: implement get/setPowerlevel, get/setRFRegion, auto-enable TX status reports

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -202,6 +202,48 @@ Creates a virtual node that can be used to send commands to multiple supporting 
 > -   Broadcasting or multicasting commands is not possible using `Security S0`.
 > -   Secure multicast requires `Security S2`, which is not yet supported by `zwave-js` and requires devices that support it.
 
+### Configure RF region
+
+```ts
+setRFRegion(region: RFRegion): Promise<boolean>
+getRFRegion(): Promise<RFRegion>
+```
+
+Configure or read the RF region at the Z-Wave API Module. The possible regions are:
+
+```ts
+export enum RFRegion {
+	"Europe" = 0x00,
+	"USA" = 0x01,
+	"Australia/New Zealand" = 0x02,
+	"Hong Kong" = 0x03,
+	"India" = 0x05,
+	"Israel" = 0x06,
+	"Russia" = 0x07,
+	"China" = 0x08,
+	"USA (Long Range)" = 0x09,
+	"Japan" = 0x20,
+	"Korea" = 0x21,
+	"Unknown" = 0xfe,
+	"Default (EU)" = 0xff,
+}
+```
+
+> [!ATTENTION] Not all controllers support configuring the RF region. These methods will throw if they are not supported
+
+### Configure TX powerlevel
+
+```ts
+setPowerlevel(powerlevel: number, measured0dBm: number): Promise<boolean>;
+getPowerlevel(): Promise<{powerlevel: number, measured0dBm: number}>;
+```
+
+Configure or read the TX powerlevel setting of the Z-Wave API. `powerlevel` is the normal powerlevel, `measured0dBm` the measured output power at 0 dBm. Both are in dBm and must be between -12.8 and +12.7.
+
+> [!ATTENTION] Not all controllers support configuring the TX powerlevel. These methods will throw if they are not supported.
+
+> [!WARNING] Increasing the powerlevel (i.e. "shouting louder") does not improve reception of the controller and may even be **against the law**. Use at your own risk!
+
 ## Controller properties
 
 ### `nodes`

--- a/packages/zwave-js/src/Controller.ts
+++ b/packages/zwave-js/src/Controller.ts
@@ -4,3 +4,4 @@ export type {
 	ZWaveController,
 } from "./lib/controller/Controller";
 export type { ZWaveLibraryTypes } from "./lib/controller/ZWaveLibraryTypes";
+export { RFRegion } from "./lib/serialapi/misc/SerialAPISetupMessages";

--- a/packages/zwave-js/src/lib/message/Constants.ts
+++ b/packages/zwave-js/src/lib/message/Constants.ts
@@ -60,7 +60,7 @@ export enum FunctionType {
 	UNKNOWN_FUNC_UNKNOWN_0x09 = 0x09, // ??
 	UNKNOWN_FUNC_UNKNOWN_0x0a = 0x0a, // ??
 
-	UNKNOWN_FUNC_SerialAPISetup = 0x0b,
+	SerialAPISetup = 0x0b, // Configure the Serial API
 
 	UNKNOWN_FUNC_RF_RECEIVE_MODE = 0x10, // Power down the RF section of the stick
 	UNKNOWN_FUNC_SET_SLEEP_MODE = 0x11, // Set the CPU into sleep mode

--- a/packages/zwave-js/src/lib/serialapi/misc/SerialAPISetupMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/misc/SerialAPISetupMessages.ts
@@ -1,0 +1,183 @@
+import {
+	MessageOrCCLogEntry,
+	parseBitMask,
+	validatePayload,
+	ZWaveError,
+	ZWaveErrorCodes,
+} from "@zwave-js/core";
+import type { Driver } from "../../driver/Driver";
+import {
+	FunctionType,
+	MessagePriority,
+	MessageType,
+} from "../../message/Constants";
+import {
+	expectedResponse,
+	gotDeserializationOptions,
+	Message,
+	MessageBaseOptions,
+	MessageDeserializationOptions,
+	MessageOptions,
+	messageTypes,
+	priority,
+} from "../../message/Message";
+import type { SuccessIndicator } from "../../message/SuccessIndicator";
+
+export enum SerialAPISetupCommand {
+	GetSupportedCommands = 0x01,
+	SetTxStatusReport = 0x02,
+	SetPowerlevel = 0x04,
+	GetPowerlevel = 0x08,
+	GetMaximumPayloadSize = 0x10,
+	GetLRMaximumPayloadSize = 0x11,
+	GetRFRegion = 0x20,
+	SetRFRegion = 0x40,
+	SetNodeIDBase = 0x80,
+}
+
+@messageTypes(MessageType.Request, FunctionType.SerialAPISetup)
+@priority(MessagePriority.Controller)
+@expectedResponse(FunctionType.SerialAPISetup)
+export class SerialAPISetupRequest extends Message {
+	// This must be set in subclasses
+	public command!: SerialAPISetupCommand;
+
+	public serialize(): Buffer {
+		this.payload = Buffer.concat([
+			Buffer.from([this.command]),
+			this.payload,
+		]);
+
+		return super.serialize();
+	}
+}
+
+@messageTypes(MessageType.Response, FunctionType.SerialAPISetup)
+export class SerialAPISetupResponse extends Message {
+	public constructor(driver: Driver, options: MessageDeserializationOptions) {
+		super(driver, options);
+		this.command = options.data[0];
+
+		let CommandConstructor: typeof SerialAPISetupResponse | undefined;
+		switch (this.command) {
+			case SerialAPISetupCommand.SetTxStatusReport:
+				CommandConstructor = SerialAPISetup_SetTXStatusReportResponse;
+				break;
+		}
+
+		if (CommandConstructor && (new.target as any) !== CommandConstructor) {
+			return new CommandConstructor(driver, options);
+		}
+	}
+
+	public readonly command!: SerialAPISetupCommand;
+}
+
+// =============================================================================
+
+export class SerialAPISetup_GetSupportedCommandsRequest extends SerialAPISetupRequest {
+	public constructor(driver: Driver, options?: MessageOptions) {
+		super(driver, options);
+		this.command = SerialAPISetupCommand.GetSupportedCommands;
+	}
+}
+
+export class SerialAPISetup_GetSupportedCommandsResponse extends SerialAPISetupResponse {
+	public constructor(driver: Driver, options: MessageDeserializationOptions) {
+		super(driver, options);
+		validatePayload(this.payload.length >= 1);
+
+		if (this.payload.length > 1) {
+			// This module supports the extended bitmask to report the supported serial API setup commands
+			// Parse it as a bitmask
+			this.supportedCommands = parseBitMask(
+				this.payload.slice(1),
+				SerialAPISetupCommand.GetSupportedCommands,
+			);
+		} else {
+			// This module only uses the single byte power-of-2 bitmask. Decode it manually
+			this.supportedCommands = [];
+			for (const cmd of [
+				SerialAPISetupCommand.GetSupportedCommands,
+				SerialAPISetupCommand.SetTxStatusReport,
+				SerialAPISetupCommand.SetPowerlevel,
+				SerialAPISetupCommand.GetPowerlevel,
+				SerialAPISetupCommand.GetMaximumPayloadSize,
+				SerialAPISetupCommand.GetRFRegion,
+				SerialAPISetupCommand.SetRFRegion,
+				SerialAPISetupCommand.SetNodeIDBase,
+			] as const) {
+				if (!!(this.payload[0] & cmd)) this.supportedCommands.push(cmd);
+			}
+		}
+	}
+
+	public readonly supportedCommands: SerialAPISetupCommand[];
+}
+
+// =============================================================================
+
+export interface SerialAPISetup_SetTXStatusReportOptions
+	extends MessageBaseOptions {
+	enabled: boolean;
+}
+
+export class SerialAPISetup_SetTXStatusReportRequest extends SerialAPISetupRequest {
+	public constructor(
+		driver: Driver,
+		options:
+			| MessageDeserializationOptions
+			| SerialAPISetup_SetTXStatusReportOptions,
+	) {
+		super(driver, options);
+		this.command = SerialAPISetupCommand.SetTxStatusReport;
+
+		if (gotDeserializationOptions(options)) {
+			throw new ZWaveError(
+				`${this.constructor.name}: deserialization not implemented`,
+				ZWaveErrorCodes.Deserialization_NotImplemented,
+			);
+		} else {
+			this.enabled = options.enabled;
+		}
+	}
+
+	public enabled: boolean;
+
+	public serialize(): Buffer {
+		this.payload = Buffer.from([this.enabled ? 0xff : 0x00]);
+
+		return super.serialize();
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: {
+				enabled: this.enabled,
+			},
+		};
+	}
+}
+
+export class SerialAPISetup_SetTXStatusReportResponse
+	extends SerialAPISetupResponse
+	implements SuccessIndicator {
+	public constructor(driver: Driver, options: MessageDeserializationOptions) {
+		super(driver, options);
+		this.success = this.payload[0] !== 0;
+	}
+
+	isOK(): boolean {
+		return this.success;
+	}
+
+	public readonly success: boolean;
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: { success: this.success },
+		};
+	}
+}

--- a/packages/zwave-js/src/lib/serialapi/misc/SerialAPISetupMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/misc/SerialAPISetupMessages.ts
@@ -1,10 +1,12 @@
 import {
 	MessageOrCCLogEntry,
+	MessageRecord,
 	parseBitMask,
 	validatePayload,
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
+import { getEnumMemberName } from "@zwave-js/shared";
 import type { Driver } from "../../driver/Driver";
 import {
 	FunctionType,
@@ -35,6 +37,22 @@ export enum SerialAPISetupCommand {
 	SetNodeIDBase = 0x80,
 }
 
+export enum RFRegion {
+	"Europe" = 0x00,
+	"USA" = 0x01,
+	"Australia/New Zealand" = 0x02,
+	"Hong Kong" = 0x03,
+	"India" = 0x05,
+	"Israel" = 0x06,
+	"Russia" = 0x07,
+	"China" = 0x08,
+	"USA (Long Range)" = 0x09,
+	"Japan" = 0x20,
+	"Korea" = 0x21,
+	"Unknown" = 0xfe,
+	"Default (EU)" = 0xff,
+}
+
 @messageTypes(MessageType.Request, FunctionType.SerialAPISetup)
 @priority(MessagePriority.Controller)
 @expectedResponse(FunctionType.SerialAPISetup)
@@ -50,18 +68,47 @@ export class SerialAPISetupRequest extends Message {
 
 		return super.serialize();
 	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		const message: MessageRecord = {
+			command: getEnumMemberName(SerialAPISetupCommand, this.command),
+		};
+		if (this.payload.length > 0) {
+			message.payload = `0x${this.payload.toString("hex")}`;
+		}
+		return {
+			...super.toLogEntry(),
+			message,
+		};
+	}
 }
 
 @messageTypes(MessageType.Response, FunctionType.SerialAPISetup)
 export class SerialAPISetupResponse extends Message {
 	public constructor(driver: Driver, options: MessageDeserializationOptions) {
 		super(driver, options);
-		this.command = options.data[0];
+		this.command = this.payload[0];
+		this.payload = this.payload.slice(1);
 
 		let CommandConstructor: typeof SerialAPISetupResponse | undefined;
 		switch (this.command) {
 			case SerialAPISetupCommand.SetTxStatusReport:
 				CommandConstructor = SerialAPISetup_SetTXStatusReportResponse;
+				break;
+			case SerialAPISetupCommand.GetSupportedCommands:
+				CommandConstructor = SerialAPISetup_GetSupportedCommandsResponse;
+				break;
+			case SerialAPISetupCommand.SetRFRegion:
+				CommandConstructor = SerialAPISetup_SetRFRegionResponse;
+				break;
+			case SerialAPISetupCommand.GetRFRegion:
+				CommandConstructor = SerialAPISetup_GetRFRegionResponse;
+				break;
+			case SerialAPISetupCommand.SetPowerlevel:
+				CommandConstructor = SerialAPISetup_SetPowerlevelResponse;
+				break;
+			case SerialAPISetupCommand.GetPowerlevel:
+				CommandConstructor = SerialAPISetup_GetPowerlevelResponse;
 				break;
 		}
 
@@ -71,6 +118,19 @@ export class SerialAPISetupResponse extends Message {
 	}
 
 	public readonly command!: SerialAPISetupCommand;
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		const message: MessageRecord = {
+			command: getEnumMemberName(SerialAPISetupCommand, this.command),
+		};
+		if (this.payload.length > 0) {
+			message.payload = `0x${this.payload.toString("hex")}`;
+		}
+		return {
+			...super.toLogEntry(),
+			message,
+		};
+	}
 }
 
 // =============================================================================
@@ -109,6 +169,17 @@ export class SerialAPISetup_GetSupportedCommandsResponse extends SerialAPISetupR
 			] as const) {
 				if (!!(this.payload[0] & cmd)) this.supportedCommands.push(cmd);
 			}
+		}
+		// Apparently GetSupportedCommands is not always included in the bitmask, although we
+		// just received a response to the command
+		if (
+			!this.supportedCommands.includes(
+				SerialAPISetupCommand.GetSupportedCommands,
+			)
+		) {
+			this.supportedCommands.unshift(
+				SerialAPISetupCommand.GetSupportedCommands,
+			);
 		}
 	}
 
@@ -151,12 +222,11 @@ export class SerialAPISetup_SetTXStatusReportRequest extends SerialAPISetupReque
 	}
 
 	public toLogEntry(): MessageOrCCLogEntry {
-		return {
-			...super.toLogEntry(),
-			message: {
-				enabled: this.enabled,
-			},
-		};
+		const ret = { ...super.toLogEntry() };
+		const message = ret.message!;
+		message.enabled = this.enabled;
+		delete message.payload;
+		return ret;
 	}
 }
 
@@ -175,9 +245,226 @@ export class SerialAPISetup_SetTXStatusReportResponse
 	public readonly success: boolean;
 
 	public toLogEntry(): MessageOrCCLogEntry {
-		return {
-			...super.toLogEntry(),
-			message: { success: this.success },
+		const ret = { ...super.toLogEntry() };
+		const message = ret.message!;
+		message.success = this.success;
+		delete message.payload;
+		return ret;
+	}
+}
+
+// =============================================================================
+
+export class SerialAPISetup_GetRFRegionRequest extends SerialAPISetupRequest {
+	public constructor(driver: Driver, options?: MessageOptions) {
+		super(driver, options);
+		this.command = SerialAPISetupCommand.GetRFRegion;
+	}
+}
+
+export class SerialAPISetup_GetRFRegionResponse extends SerialAPISetupResponse {
+	public constructor(driver: Driver, options: MessageDeserializationOptions) {
+		super(driver, options);
+		this.region = this.payload[0];
+	}
+
+	public readonly region: RFRegion;
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		const ret = { ...super.toLogEntry() };
+		const message = ret.message!;
+		message.region = getEnumMemberName(RFRegion, this.region);
+		delete message.payload;
+		return ret;
+	}
+}
+
+// =============================================================================
+
+export interface SerialAPISetup_SetRFRegionOptions extends MessageBaseOptions {
+	region: RFRegion;
+}
+
+export class SerialAPISetup_SetRFRegionRequest extends SerialAPISetupRequest {
+	public constructor(
+		driver: Driver,
+		options:
+			| MessageDeserializationOptions
+			| SerialAPISetup_SetRFRegionOptions,
+	) {
+		super(driver, options);
+		this.command = SerialAPISetupCommand.SetRFRegion;
+
+		if (gotDeserializationOptions(options)) {
+			throw new ZWaveError(
+				`${this.constructor.name}: deserialization not implemented`,
+				ZWaveErrorCodes.Deserialization_NotImplemented,
+			);
+		} else {
+			this.region = options.region;
+		}
+	}
+
+	public region: RFRegion;
+
+	public serialize(): Buffer {
+		this.payload = Buffer.from([this.region]);
+		return super.serialize();
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		const ret = { ...super.toLogEntry() };
+		const message = ret.message!;
+		message.region = getEnumMemberName(RFRegion, this.region);
+		delete message.payload;
+		return ret;
+	}
+}
+
+export class SerialAPISetup_SetRFRegionResponse
+	extends SerialAPISetupResponse
+	implements SuccessIndicator {
+	public constructor(driver: Driver, options: MessageDeserializationOptions) {
+		super(driver, options);
+		this.success = this.payload[0] !== 0;
+	}
+
+	isOK(): boolean {
+		return this.success;
+	}
+
+	public readonly success: boolean;
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		const ret = { ...super.toLogEntry() };
+		const message = ret.message!;
+		message.success = this.success;
+		delete message.payload;
+		return ret;
+	}
+}
+
+// =============================================================================
+
+export class SerialAPISetup_GetPowerlevelRequest extends SerialAPISetupRequest {
+	public constructor(driver: Driver, options?: MessageOptions) {
+		super(driver, options);
+		this.command = SerialAPISetupCommand.GetPowerlevel;
+	}
+}
+
+export class SerialAPISetup_GetPowerlevelResponse extends SerialAPISetupResponse {
+	public constructor(driver: Driver, options: MessageDeserializationOptions) {
+		super(driver, options);
+		validatePayload(this.payload.length >= 2);
+		// The values are in 0.1 dBm
+		this.powerlevel = this.payload[0] / 10;
+		this.measured0dBm = this.payload[1] / 10;
+	}
+
+	/** The configured normal powerlevel in dBm */
+	public readonly powerlevel: number;
+	/** The measured output power in dBm for a normal output powerlevel of 0 */
+	public readonly measured0dBm: number;
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		const ret = { ...super.toLogEntry() };
+		const message: MessageRecord = {
+			...ret.message!,
+			"normal powerlevel": `${this.powerlevel.toFixed(1)} dBm`,
+			"output power at 0 dBm": `${this.measured0dBm.toFixed(1)} dBm`,
 		};
+		delete message.payload;
+		ret.message = message;
+		return ret;
+	}
+}
+
+// =============================================================================
+
+export interface SerialAPISetup_SetPowerlevelOptions
+	extends MessageBaseOptions {
+	powerlevel: number;
+	measured0dBm: number;
+}
+
+export class SerialAPISetup_SetPowerlevelRequest extends SerialAPISetupRequest {
+	public constructor(
+		driver: Driver,
+		options:
+			| MessageDeserializationOptions
+			| SerialAPISetup_SetPowerlevelOptions,
+	) {
+		super(driver, options);
+		this.command = SerialAPISetupCommand.SetPowerlevel;
+
+		if (gotDeserializationOptions(options)) {
+			throw new ZWaveError(
+				`${this.constructor.name}: deserialization not implemented`,
+				ZWaveErrorCodes.Deserialization_NotImplemented,
+			);
+		} else {
+			if (options.powerlevel < -12.8 || options.powerlevel > 12.7) {
+				throw new ZWaveError(
+					`The normal powerlevel must be between -12.8 and +12.7 dBm`,
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
+			if (options.measured0dBm < -12.8 || options.measured0dBm > 12.7) {
+				throw new ZWaveError(
+					`The measured output power at 0 dBm must be between -12.8 and +12.7 dBm`,
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
+			this.powerlevel = options.powerlevel;
+			this.measured0dBm = options.measured0dBm;
+		}
+	}
+
+	public powerlevel: number;
+	public measured0dBm: number;
+
+	public serialize(): Buffer {
+		this.payload = Buffer.from([
+			// The values are in 0.1 dBm
+			Math.round(this.powerlevel * 10),
+			Math.round(this.measured0dBm * 10),
+		]);
+		return super.serialize();
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		const ret = { ...super.toLogEntry() };
+		const message: MessageRecord = {
+			...ret.message!,
+			"normal powerlevel": `${this.powerlevel.toFixed(1)} dBm`,
+			"output power at 0 dBm": `${this.measured0dBm.toFixed(1)} dBm`,
+		};
+		delete message.payload;
+		ret.message = message;
+		return ret;
+	}
+}
+
+export class SerialAPISetup_SetPowerlevelResponse
+	extends SerialAPISetupResponse
+	implements SuccessIndicator {
+	public constructor(driver: Driver, options: MessageDeserializationOptions) {
+		super(driver, options);
+		this.success = this.payload[0] !== 0;
+	}
+
+	isOK(): boolean {
+		return this.success;
+	}
+
+	public readonly success: boolean;
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		const ret = { ...super.toLogEntry() };
+		const message = ret.message!;
+		message.success = this.success;
+		delete message.payload;
+		return ret;
 	}
 }


### PR DESCRIPTION
With this PR, we automatically configure supporting sticks to give extended TX status reports we'll be using in a later step.
Furthermore, this adds the methods get/setPowerlevel, get/setRFRegion to configure the stick's radio.

fixes: #1673
fixes: #1674
fixes: #1357