### PR TITLE
fix(config): remove Popp 701202 FW version limits

### DIFF
--- a/packages/config/config/devices/0x0154/pope701202.json
+++ b/packages/config/config/devices/0x0154/pope701202.json
@@ -12,8 +12,8 @@
 		}
 	],
 	"firmwareVersion": {
-		"min": "1.0",
-		"max": "1.0"
+		"min": "0.0",
+		"max": "255.255"
 	},
 	"supportsZWavePlus": true,
 	"paramInformation": {


### PR DESCRIPTION
Popp & Co POPE701202 Mold detector exists with firmware version 1.2, and it works fine with this config file when firmwareVersion limitation to version 1.0 only is removed.

Linked to discussion [#2517](https://github.com/zwave-js/node-zwave-js/discussions/2517)