### PR TITLE
fix(config): remove duplicate association group for Shenzhen Neo AB01Z

### DIFF
--- a/packages/config/config/devices/0x0258/nas-ab01z.json
+++ b/packages/config/config/devices/0x0258/nas-ab01z.json
@@ -30,17 +30,11 @@
 	"associations": {
 		"1": {
 			"label": "Group 1",
-			"maxNodes": 5,
-			"isLifeline": true
+			"maxNodes": 5
 		},
 		"2": {
 			"label": "Group 2",
-			"maxNodes": 5,
-			"isLifeline": true
-		},
-		"3": {
-			"label": "Group2",
-			"maxNodes": 5,
+			"maxNodes": 1,
 			"isLifeline": true
 		}
 	},


### PR DESCRIPTION
Fix - isLifeline to only be on Group 2 per manual
Fix - maxNodes to be 1 for Group 2 per manual

<img width="1187" alt="Screen Shot 2021-05-03 at 8 27 10 pm" src="https://user-images.githubusercontent.com/5012263/116868432-20a65700-ac52-11eb-89f4-62aab54c7fec.png">
