### PR TITLE
feat(conf): add new power reporting parameter to ZEN25

### DIFF
--- a/packages/config/config/devices/0x027a/zen25.json
+++ b/packages/config/config/devices/0x027a/zen25.json
@@ -290,42 +290,41 @@
 					"value": 3
 				}
 			]
+		},
+		"18": {
+			"$if": "firmwareVersion >= 2.0",
+			"label": "Enable/Disable Power Reports",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 4,
+			"defaultValue": 0,
+			"readOnly": false,
+			"writeOnly": false,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Enable all power monitoring and reporting",
+					"value": 0
+				},
+				{
+					"label": "Disable all power monitoring and reporting",
+					"value": 1
+				},
+				{
+					"label": "Disable power reporting of left outlet",
+					"value": 2
+				},
+				{
+					"label": "Disable power reporting of right outlet",
+					"value": 3
+				},
+				{
+					"label": "Disable power reporting of USB port",
+					"value": 4
+				}
+			]
 		}
 	},
-	"18": {
-		"$if": "firmwareVersion >= 2.0",
-		"label": "Enable/Disable Power Reports",
-		"valueSize": 1,
-		"minValue": 0,
-		"maxValue": 4,
-		"defaultValue": 0,
-		"readOnly": false,
-		"writeOnly": false,
-		"allowManualEntry": false,
-		"options": [
-			{
-				"label": "Enable all power monitoring and reporting",
-				"value": 0
-			},
-			{
-				"label": "Disable all power monitoring and reporting",
-				"value": 1
-			},
-			{
-				"label": "Disable power reporting of left outlet",
-				"value": 2
-			},
-			{
-				"label": "Disable power reporting of right outlet",
-				"value": 3
-			},
-			{
-				"label": "Disable power reporting of USB port",
-				"value": 4
-			}
-		]
-	}
-},
 	"compat": {
 		"preserveRootApplicationCCValueIDs": true
 	}

--- a/packages/config/config/devices/0x027a/zen25.json
+++ b/packages/config/config/devices/0x027a/zen25.json
@@ -293,8 +293,9 @@
 		}
 	},
 	"18": {
+		"$if": "firmwareVersion >= 2.0",
 		"label": "Enable/Disable Power Reports",
-		"description": "Enable or disable power reporting (Requires Firmware 2.0)",
+		"description": "Enable or disable power reporting",
 		"valueSize": 1,
 		"minValue": 0,
 		"maxValue": 4,

--- a/packages/config/config/devices/0x027a/zen25.json
+++ b/packages/config/config/devices/0x027a/zen25.json
@@ -322,7 +322,7 @@
 			{
 				"label": "Disable power reporting of USB port",
 				"value": 4
-			},
+			}
 		]
 	}
 },

--- a/packages/config/config/devices/0x027a/zen25.json
+++ b/packages/config/config/devices/0x027a/zen25.json
@@ -295,7 +295,6 @@
 	"18": {
 		"$if": "firmwareVersion >= 2.0",
 		"label": "Enable/Disable Power Reports",
-		"description": "Enable or disable power reporting",
 		"valueSize": 1,
 		"minValue": 0,
 		"maxValue": 4,

--- a/packages/config/config/devices/0x027a/zen25.json
+++ b/packages/config/config/devices/0x027a/zen25.json
@@ -292,6 +292,40 @@
 			]
 		}
 	},
+	"18": {
+		"label": "Enable/Disable Power Reports",
+		"description": "Enable or disable power reporting (Requires Firmware 2.0)",
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 4,
+		"defaultValue": 0,
+		"readOnly": false,
+		"writeOnly": false,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Enable all power monitoring and reporting",
+				"value": 0
+			},
+			{
+				"label": "Disable all power monitoring and reporting",
+				"value": 1
+			},
+			{
+				"label": "Disable power reporting of left outlet",
+				"value": 2
+			},
+			{
+				"label": "Disable power reporting of right outlet",
+				"value": 3
+			},
+			{
+				"label": "Disable power reporting of USB port",
+				"value": 4
+			},
+		]
+	}
+},
 	"compat": {
 		"preserveRootApplicationCCValueIDs": true
 	}


### PR DESCRIPTION
Hello, this PR adds index 18 to the zen25 device. Parameter 18 was added in [firmware 2.0 by zooz](https://www.support.getzooz.com/kb/article/304-zen25%C2%A0s2-double-plug-change-log/) to control the reporting, as it tends to spam the zwave network.