### PR TITLE
fix(config): update Devolo Siren param 31

### DIFF
--- a/packages/config/config/devices/0x0175/ph-pse02.json
+++ b/packages/config/config/devices/0x0175/ph-pse02.json
@@ -80,7 +80,13 @@
 			"defaultValue": 6,
 			"readOnly": false,
 			"writeOnly": false,
-			"allowManualEntry": true
+			"allowManualEntry": true,
+			"options": [
+				{
+					"label": "Never stop.",
+					"value": 0
+				}
+			]
 		}
 	}
 }

--- a/packages/config/config/devices/0x0175/ph-pse02.json
+++ b/packages/config/config/devices/0x0175/ph-pse02.json
@@ -72,7 +72,8 @@
 		},
 		"31": {
 			"label": "Alarm Duration",
-			"description": "Play alarm sound duration.",
+			"description": "Play alarm sound duration (30s * this value)",
+			"unit": "*30 seconds",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 127,

--- a/packages/config/config/devices/0x0175/ph-pse02.json
+++ b/packages/config/config/devices/0x0175/ph-pse02.json
@@ -72,8 +72,7 @@
 		},
 		"31": {
 			"label": "Alarm Duration",
-			"description": "Play alarm sound duration (30s * this value)",
-			"unit": "*30 seconds",
+			"unit": "30 seconds",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 127,
@@ -83,7 +82,7 @@
 			"allowManualEntry": true,
 			"options": [
 				{
-					"label": "Never stop.",
+					"label": "Never stop",
 					"value": 0
 				}
 			]


### PR DESCRIPTION
This value is actually used on the devices as multiples of 30 seconds.
1 = 30 seconds
2 = 60 seconds
3 = 90 seconds etc etc

Not sure if unit is best here, but let me know and I'll remove one or the other.
Have also added an Option (0) - which causes the siren to never stop on its own.