### PR TITLE
fix: eliminate @zwave-js/maintenance devDependency

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -47,8 +47,5 @@
     "build": "tsc -b tsconfig.build.json",
     "clean": "tsc -b tsconfig.build.json --clean",
     "watch": "yarn run build -- --watch --pretty"
-  },
-  "devDependencies": {
-    "@zwave-js/maintenance": "7.0.0"
   }
 }

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -7,16 +7,12 @@
 			"path": "../core/tsconfig.build.json"
 		},
 		{
+			"path": "../maintenance/tsconfig.build.json"
+		},
+		{
 			"path": "../shared/tsconfig.build.json"
 		}
 	],
-	"include": [
-		"gulpfile.ts",
-		"maintenance/**/*.ts",
-		"src/**/*.ts"
-	],
-	"exclude": [
-		"build/**",
-		"node_modules/**"
-	]
+	"include": ["gulpfile.ts", "maintenance/**/*.ts", "src/**/*.ts"],
+	"exclude": ["build/**", "node_modules/**"]
 }

--- a/packages/zwave-js/package.json
+++ b/packages/zwave-js/package.json
@@ -84,8 +84,5 @@
     "clean": "tsc -b tsconfig.build.json --clean",
     "prewatch": "gulp prebuild",
     "watch": "tsc -b tsconfig.build.json --watch --pretty"
-  },
-  "devDependencies": {
-    "@zwave-js/maintenance": "7.0.0"
   }
 }


### PR DESCRIPTION
This should alleviate some problems when installing @zwave-js/config directly.