### PR TITLE
refactor: replace `node.neighbors` property with `controller.getNodeNeighbors` method

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -41,6 +41,14 @@ async stopExclusion(): Promise<boolean>
 
 Stops the exclusion process to remove a node from the network.The returned promise resolves to `true` if stopping the exclusion was successful, `false` if it failed or if it was not active.
 
+### `getNodeNeighbors`
+
+```ts
+async getNodeNeighbors(nodeId: number): Promise<readonly number[]>
+```
+
+Returns the known list of neighbors for a node.
+
 ### `healNode`
 
 ```ts

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -584,14 +584,6 @@ readonly deviceConfig: DeviceConfig | undefined
 
 Contains additional information about this node, loaded from a [config file](/development/config-files.md#device-configuration-files).
 
-### `neighbors`
-
-```ts
-readonly neighbors: number[]
-```
-
-The IDs of all nodes this node is connected to or is communicating through.
-
 ### `keepAwake`
 
 ```ts

--- a/packages/zwave-js/src/lib/controller/GetRoutingInfoMessages.ts
+++ b/packages/zwave-js/src/lib/controller/GetRoutingInfoMessages.ts
@@ -28,18 +28,18 @@ interface GetRoutingInfoRequestOptions extends MessageBaseOptions {
 export class GetRoutingInfoRequest extends Message {
 	public constructor(driver: Driver, options: GetRoutingInfoRequestOptions) {
 		super(driver, options);
-		this.nodeId = options.nodeId;
+		this.sourceNodeId = options.nodeId;
 		this.removeNonRepeaters = !!options.removeNonRepeaters;
 		this.removeBadLinks = !!options.removeBadLinks;
 	}
 
-	public nodeId: number;
+	public sourceNodeId: number;
 	public removeNonRepeaters: boolean;
 	public removeBadLinks: boolean;
 
 	public serialize(): Buffer {
 		this.payload = Buffer.from([
-			this.nodeId,
+			this.sourceNodeId,
 			this.removeNonRepeaters ? 1 : 0,
 			this.removeBadLinks ? 1 : 0,
 			0, // callbackId - this must be 0 as per the docs
@@ -49,7 +49,7 @@ export class GetRoutingInfoRequest extends Message {
 
 	public toJSON(): JSONObject {
 		return super.toJSONInherited({
-			nodeId: this.nodeId,
+			nodeId: this.sourceNodeId,
 			removeNonRepeaters: this.removeNonRepeaters,
 			removeBadLinks: this.removeBadLinks,
 		});

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1331,22 +1331,6 @@ export class Driver extends EventEmitter {
 						"error",
 					);
 				});
-
-			// Remove the node id from all cached neighbor lists and asynchronously make the affected nodes update their neighbor lists
-			for (const otherNode of this.controller.nodes.values()) {
-				if (
-					otherNode !== node &&
-					otherNode.neighbors.includes(node.id)
-				) {
-					otherNode.removeNodeFromCachedNeighbors(node.id);
-					otherNode.queryNeighborsInternal().catch((err) => {
-						this.driverLog.print(
-							`Failed to update neighbors for node ${otherNode.id}: ${err.message}`,
-							"warn",
-						);
-					});
-				}
-			}
 		}
 
 		// And clean up all remaining resources used by the node

--- a/packages/zwave-js/src/lib/node/Node.test.ts
+++ b/packages/zwave-js/src/lib/node/Node.test.ts
@@ -490,7 +490,7 @@ describe("lib/node/Node", () => {
 				const request: GetRoutingInfoRequest =
 					fakeDriver.sendMessage.mock.calls[0][0];
 				expect(request).toBeInstanceOf(GetRoutingInfoRequest);
-				expect(request.nodeId).toBe(node.id);
+				expect(request.sourceNodeId).toBe(node.id);
 			});
 
 			it("should remember the neighbor list", async () => {

--- a/packages/zwave-js/src/lib/node/Node.test.ts
+++ b/packages/zwave-js/src/lib/node/Node.test.ts
@@ -24,10 +24,6 @@ import {
 	GetNodeProtocolInfoRequest,
 	GetNodeProtocolInfoResponse,
 } from "../controller/GetNodeProtocolInfoMessages";
-import {
-	GetRoutingInfoRequest,
-	GetRoutingInfoResponse,
-} from "../controller/GetRoutingInfoMessages";
 import { SendDataRequest } from "../controller/SendDataMessages";
 import type { Driver } from "../driver/Driver";
 import { assertCC } from "../test/assertCC";
@@ -471,37 +467,37 @@ describe("lib/node/Node", () => {
 		// 	it.todo("Test the behavior when the request succeeds");
 		// });
 
-		describe(`queryNeighbors()`, () => {
-			let expected: GetRoutingInfoResponse;
+		// describe(`queryNeighbors()`, () => {
+		// 	let expected: GetRoutingInfoResponse;
 
-			beforeAll(() => {
-				fakeDriver.sendMessage.mockClear();
+		// 	beforeAll(() => {
+		// 		fakeDriver.sendMessage.mockClear();
 
-				expected = {
-					nodeIds: [1, 4, 5],
-				} as GetRoutingInfoResponse;
-				fakeDriver.sendMessage.mockResolvedValue(expected);
-			});
+		// 		expected = {
+		// 			nodeIds: [1, 4, 5],
+		// 		} as GetRoutingInfoResponse;
+		// 		fakeDriver.sendMessage.mockResolvedValue(expected);
+		// 	});
 
-			it("should send a GetRoutingInfoRequest", async () => {
-				await node["queryNeighbors"]();
+		// 	it("should send a GetRoutingInfoRequest", async () => {
+		// 		await node["queryNeighbors"]();
 
-				expect(fakeDriver.sendMessage).toBeCalled();
-				const request: GetRoutingInfoRequest =
-					fakeDriver.sendMessage.mock.calls[0][0];
-				expect(request).toBeInstanceOf(GetRoutingInfoRequest);
-				expect(request.sourceNodeId).toBe(node.id);
-			});
+		// 		expect(fakeDriver.sendMessage).toBeCalled();
+		// 		const request: GetRoutingInfoRequest =
+		// 			fakeDriver.sendMessage.mock.calls[0][0];
+		// 		expect(request).toBeInstanceOf(GetRoutingInfoRequest);
+		// 		expect(request.sourceNodeId).toBe(node.id);
+		// 	});
 
-			it("should remember the neighbor list", async () => {
-				await node["queryNeighbors"]();
-				expect(node.neighbors).toContainAllValues(expected.nodeIds);
-			});
+		// 	it("should remember the neighbor list", async () => {
+		// 		await node["queryNeighbors"]();
+		// 		expect(node.neighbors).toContainAllValues(expected.nodeIds);
+		// 	});
 
-			it("should set the interview stage to Neighbors", () => {
-				expect(node.interviewStage).toBe(InterviewStage.Neighbors);
-			});
-		});
+		// 	it("should set the interview stage to Neighbors", () => {
+		// 		expect(node.interviewStage).toBe(InterviewStage.Neighbors);
+		// 	});
+		// });
 
 		describe("interview sequence", () => {
 			let originalMethods: Partial<Record<keyof TestNode, any>>;


### PR DESCRIPTION
It has been found that the `neighbors` property of a node is prone to be outdated. Since querying the up to date node neighbors from the controller is a matter of milliseconds, the property will be replaced with a controller method to retrieve the neighbors.

This PR adds the `controller.getNodeNeighbors` method and deprecates the `node.neighbors` property to be removed in the next major release.

fixes: #2552 
fixes: https://github.com/zwave-js/node-zwave-js/issues/2335
(once z2m has support for the new method)