### PR TITLE
feat: define external config DB location with `ZWAVEJS_EXTERNAL_CONFIG` env var

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -20,6 +20,7 @@
 -   Advanced usage
 
     -   [Send custom messages](usage/custom.md)
+    -   [External config DB location](usage/external-config.md)
 
 -   Troubleshooting
 

--- a/docs/api/CCs/_sidebar.md
+++ b/docs/api/CCs/_sidebar.md
@@ -70,6 +70,7 @@
 -   Advanced usage
 
     -   [Send custom messages](usage/custom.md)
+    -   [External config DB location](usage/external-config.md)
 
 -   Troubleshooting
 

--- a/docs/usage/external-config.md
+++ b/docs/usage/external-config.md
@@ -1,0 +1,7 @@
+# Specifying an external config DB location
+
+Especially in Docker setups, the internal configuration DB location is not persisted for the lifetime of the application. This means that nightly configuration updates can get lost, either through re-creation of the container or on downstream updates.
+
+By specifying the `ZWAVEJS_EXTERNAL_CONFIG` env variable to an external location, you can tell `zwave-js` to store its configuration DB there. Whenever `zwave-js` (re)loads the configuration on startup or after config updates, it will check if the external config dir is up to date and compatible with the current version. If not, the external config dir gets wiped and re-written.
+
+> [!ATTENTION] This directory is meant to be **read-only** from a user perspective. Custom and test configurations should go into the directory defined by the driver option [`deviceConfigPriorityDir`](api/driver.md#ZWaveOptions).

--- a/packages/config/src/DeviceClasses.ts
+++ b/packages/config/src/DeviceClasses.ts
@@ -11,18 +11,28 @@ import { isArray, isObject } from "alcalzone-shared/typeguards";
 import { pathExists, readFile } from "fs-extra";
 import JSON5 from "json5";
 import path from "path";
-import { configDir, hexKeyRegexNDigits, throwInvalidConfig } from "./utils";
-
-const configPath = path.join(configDir, "deviceClasses.json");
+import {
+	configDir,
+	externalConfigDir,
+	hexKeyRegexNDigits,
+	throwInvalidConfig,
+} from "./utils";
 
 export type BasicDeviceClassMap = ReadonlyMap<number, string>;
 export type GenericDeviceClassMap = ReadonlyMap<number, GenericDeviceClass>;
 
 /** @internal */
-export async function loadDeviceClassesInternal(): Promise<{
+export async function loadDeviceClassesInternal(
+	externalConfig?: boolean,
+): Promise<{
 	basicDeviceClasses: BasicDeviceClassMap;
 	genericDeviceClasses: GenericDeviceClassMap;
 }> {
+	const configPath = path.join(
+		(externalConfig && externalConfigDir) || configDir,
+		"deviceClasses.json",
+	);
+
 	if (!(await pathExists(configPath))) {
 		throw new ZWaveError(
 			"The device classes config file does not exist!",

--- a/packages/config/src/Indicators.ts
+++ b/packages/config/src/Indicators.ts
@@ -10,18 +10,28 @@ import { isObject } from "alcalzone-shared/typeguards";
 import { pathExists, readFile } from "fs-extra";
 import JSON5 from "json5";
 import path from "path";
-import { configDir, hexKeyRegexNDigits, throwInvalidConfig } from "./utils";
-
-const indicatorsConfigPath = path.join(configDir, "indicators.json");
+import {
+	configDir,
+	externalConfigDir,
+	hexKeyRegexNDigits,
+	throwInvalidConfig,
+} from "./utils";
 
 export type IndicatorMap = ReadonlyMap<number, string>;
 export type IndicatorPropertiesMap = ReadonlyMap<number, IndicatorProperty>;
 
 /** @internal */
-export async function loadIndicatorsInternal(): Promise<{
+export async function loadIndicatorsInternal(
+	externalConfig?: boolean,
+): Promise<{
 	indicators: IndicatorMap;
 	properties: IndicatorPropertiesMap;
 }> {
+	const indicatorsConfigPath = path.join(
+		(externalConfig && externalConfigDir) || configDir,
+		"indicators.json",
+	);
+
 	if (!(await pathExists(indicatorsConfigPath))) {
 		throw new ZWaveError(
 			"The config file does not exist!",

--- a/packages/config/src/Manufacturers.ts
+++ b/packages/config/src/Manufacturers.ts
@@ -5,13 +5,24 @@ import { isObject } from "alcalzone-shared/typeguards";
 import { pathExists, readFile, writeFile } from "fs-extra";
 import JSON5 from "json5";
 import path from "path";
-import { configDir, hexKeyRegex4Digits, throwInvalidConfig } from "./utils";
+import {
+	configDir,
+	externalConfigDir,
+	hexKeyRegex4Digits,
+	throwInvalidConfig,
+} from "./utils";
 
-const configPath = path.join(configDir, "manufacturers.json");
 export type ManufacturersMap = Map<number, string>;
 
 /** @internal */
-export async function loadManufacturersInternal(): Promise<ManufacturersMap> {
+export async function loadManufacturersInternal(
+	externalConfig?: boolean,
+): Promise<ManufacturersMap> {
+	const configPath = path.join(
+		(externalConfig && externalConfigDir) || configDir,
+		"manufacturers.json",
+	);
+
 	if (!(await pathExists(configPath))) {
 		throw new ZWaveError(
 			"The manufacturer config file does not exist!",
@@ -72,5 +83,6 @@ export async function saveManufacturersInternal(
 		data[formatId(id)] = name;
 	}
 
+	const configPath = path.join(configDir, "manufacturers.json");
 	await writeFile(configPath, stringify(data, "\t") + "\n");
 }

--- a/packages/config/src/Meters.ts
+++ b/packages/config/src/Meters.ts
@@ -5,13 +5,24 @@ import { isObject } from "alcalzone-shared/typeguards";
 import { pathExists, readFile } from "fs-extra";
 import JSON5 from "json5";
 import path from "path";
-import { configDir, hexKeyRegexNDigits, throwInvalidConfig } from "./utils";
+import {
+	configDir,
+	externalConfigDir,
+	hexKeyRegexNDigits,
+	throwInvalidConfig,
+} from "./utils";
 
-const configPath = path.join(configDir, "meters.json");
 export type MeterMap = ReadonlyMap<number, Meter>;
 
 /** @internal */
-export async function loadMetersInternal(): Promise<MeterMap> {
+export async function loadMetersInternal(
+	externalConfig?: boolean,
+): Promise<MeterMap> {
+	const configPath = path.join(
+		(externalConfig && externalConfigDir) || configDir,
+		"meters.json",
+	);
+
 	if (!(await pathExists(configPath))) {
 		throw new ZWaveError(
 			"The config file does not exist!",

--- a/packages/config/src/Notifications.ts
+++ b/packages/config/src/Notifications.ts
@@ -5,7 +5,12 @@ import { isArray, isObject } from "alcalzone-shared/typeguards";
 import { pathExists, readFile } from "fs-extra";
 import JSON5 from "json5";
 import path from "path";
-import { configDir, hexKeyRegexNDigits, throwInvalidConfig } from "./utils";
+import {
+	configDir,
+	externalConfigDir,
+	hexKeyRegexNDigits,
+	throwInvalidConfig,
+} from "./utils";
 
 interface NotificationStateDefinition {
 	type: "state";
@@ -27,11 +32,17 @@ export type NotificationValueDefinition = (
 	parameter?: NotificationParameter;
 };
 
-const configPath = path.join(configDir, "notifications.json");
 export type NotificationMap = ReadonlyMap<number, Notification>;
 
 /** @internal */
-export async function loadNotificationsInternal(): Promise<NotificationMap> {
+export async function loadNotificationsInternal(
+	externalConfig?: boolean,
+): Promise<NotificationMap> {
+	const configPath = path.join(
+		(externalConfig && externalConfigDir) || configDir,
+		"notifications.json",
+	);
+
 	if (!(await pathExists(configPath))) {
 		throw new ZWaveError(
 			"The config file does not exist!",

--- a/packages/config/src/Scales.ts
+++ b/packages/config/src/Scales.ts
@@ -5,15 +5,25 @@ import { isObject } from "alcalzone-shared/typeguards";
 import { pathExists, readFile } from "fs-extra";
 import JSON5 from "json5";
 import path from "path";
-import { configDir, hexKeyRegexNDigits, throwInvalidConfig } from "./utils";
-
-const configPath = path.join(configDir, "scales.json");
+import {
+	configDir,
+	externalConfigDir,
+	hexKeyRegexNDigits,
+	throwInvalidConfig,
+} from "./utils";
 
 export type ScaleGroup = ReadonlyMap<number, Scale>;
 export type NamedScalesGroupMap = ReadonlyMap<string, ScaleGroup>;
 
 /** @internal */
-export async function loadNamedScalesInternal(): Promise<NamedScalesGroupMap> {
+export async function loadNamedScalesInternal(
+	externalConfig?: boolean,
+): Promise<NamedScalesGroupMap> {
+	const configPath = path.join(
+		(externalConfig && externalConfigDir) || configDir,
+		"scales.json",
+	);
+
 	if (!(await pathExists(configPath))) {
 		throw new ZWaveError(
 			"The named scales config file does not exist!",

--- a/packages/config/src/SensorTypes.ts
+++ b/packages/config/src/SensorTypes.ts
@@ -7,16 +7,25 @@ import JSON5 from "json5";
 import path from "path";
 import type { ConfigManager } from "./ConfigManager";
 import { Scale } from "./Scales";
-import { configDir, hexKeyRegexNDigits, throwInvalidConfig } from "./utils";
-
-const configPath = path.join(configDir, "sensorTypes.json");
+import {
+	configDir,
+	externalConfigDir,
+	hexKeyRegexNDigits,
+	throwInvalidConfig,
+} from "./utils";
 
 export type SensorTypeMap = ReadonlyMap<number, SensorType>;
 
 /** @internal */
 export async function loadSensorTypesInternal(
 	manager: ConfigManager,
+	externalConfig?: boolean,
 ): Promise<SensorTypeMap> {
+	const configPath = path.join(
+		(externalConfig && externalConfigDir) || configDir,
+		"sensorTypes.json",
+	);
+
 	if (!(await pathExists(configPath))) {
 		throw new ZWaveError(
 			"The sensor types config file does not exist!",

--- a/packages/config/src/utils.ts
+++ b/packages/config/src/utils.ts
@@ -1,10 +1,19 @@
 import { ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
 import { formatId } from "@zwave-js/shared";
+import * as fs from "fs-extra";
 import path from "path";
 import * as semver from "semver";
 import type { DeviceConfigIndexEntry } from "./Devices";
 
+/** The absolute path of the embedded configuration directory */
 export const configDir = path.resolve(__dirname, "../config");
+/** The (optional) absolute path of an external configuration directory */
+export const externalConfigDir = (() => {
+	const extPath = process.env.ZWAVEJS_EXTERNAL_CONFIG;
+	if (!extPath || !fs.existsSync(extPath)) return;
+	return extPath;
+})();
+
 export const hexKeyRegexNDigits = /^0x[a-fA-F0-9]+$/;
 export const hexKeyRegex4Digits = /^0x[a-fA-F0-9]{4}$/;
 export const hexKeyRegex2Digits = /^0x[a-fA-F0-9]{2}$/;
@@ -47,4 +56,52 @@ export function getDeviceEntryPredicate(
 /** Pads a firmware version string, so it can be compared with semver */
 export function padVersion(version: string): string {
 	return version + ".0";
+}
+
+/**
+ * Synchronizes or updates the external config directory and returns whether the directory is in a state that can be used
+ */
+export async function syncExternalConfigDir(): Promise<boolean> {
+	if (!externalConfigDir) return false;
+	const externalVersionFilename = path.join(externalConfigDir, "version");
+	const currentVersion = (await fs.readJSON("../package.json")).version;
+	const updateRange = `>${currentVersion} <${semver.inc(
+		currentVersion,
+		"patch",
+	)}`;
+
+	// We remember the config version that was copied there in a file called "version"
+	// If that either...
+	// ...isn't there,
+	// ...can't be read,
+	// ...doesn't contain a matching version (>= current && nightly)
+	// wipe the external config dir and recreate it
+	let wipe = false;
+	try {
+		const version = await fs.readFile(externalVersionFilename, "utf8");
+		if (!semver.valid(version)) {
+			wipe = true;
+		} else if (
+			!semver.satisfies(version, updateRange, { includePrerelease: true })
+		) {
+			wipe = true;
+		}
+	} catch {
+		wipe = true;
+	}
+
+	// Nothing to wipe, the external dir is good to go
+	if (!wipe) return true;
+
+	// Wipe and override the external dir
+	try {
+		await fs.emptyDir(externalConfigDir);
+		await fs.copy(configDir, externalConfigDir);
+		await fs.writeFile(externalVersionFilename, currentVersion, "utf8");
+	} catch {
+		// Something went wrong
+		return false;
+	}
+
+	return true;
 }


### PR DESCRIPTION
This PR adds support for storing the embedded config DB in an external location, e.g. for use with Docker. To do so, specify the target directory using the `ZWAVEJS_EXTERNAL_CONFIG` env variable.

Whenever `zwave-js` (re)loads the configuration, it will check if the external config dir is up to date and compatible with the current version. If not, it gets wiped and re-written.

**Note:** This directory is meant to be readonly from a user perspective. Custom and test configurations are meant to be placed in the `deviceConfigPriorityDir`.