### PR TITLE
feat: add node deviceDatabaseUrl property

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -584,10 +584,10 @@ readonly deviceConfig: DeviceConfig | undefined
 
 Contains additional information about this node, loaded from a [config file](/development/config-files.md#device-configuration-files).
 
-### `dbUrl`
+### `deviceDatabaseUrl`
 
 ```ts
-readonly dbUrl: string
+readonly deviceDatabaseUrl: string
 ```
 
 The URL to the device in the device database.

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -584,6 +584,14 @@ readonly deviceConfig: DeviceConfig | undefined
 
 Contains additional information about this node, loaded from a [config file](/development/config-files.md#device-configuration-files).
 
+### `dbUrl`
+
+```ts
+readonly dbUrl: string
+```
+
+The URL to the device in the device database.
+
 ### `keepAwake`
 
 ```ts

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -587,7 +587,7 @@ Contains additional information about this node, loaded from a [config file](/de
 ### `deviceDatabaseUrl`
 
 ```ts
-readonly deviceDatabaseUrl: string
+readonly deviceDatabaseUrl: string | undefined
 ```
 
 The URL to the device in the device database.

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -615,6 +615,14 @@ export class ZWaveNode extends Endpoint {
 		return this._deviceConfig?.label;
 	}
 
+	public get dbUrl(): string {
+		const manufacturerId = num2hex(this.manufacturerId);
+		const productType = num2hex(this.productType);
+		const productId = num2hex(this.productId);
+		const firmwareVersion = this.firmwareVersion || "0.0";
+		return `https://devices.zwave-js.io/?jumpTo=${manufacturerId}:${productType}:${productId}:${firmwareVersion}`;
+	}
+
 	private _neighbors: readonly number[] = [];
 	/**
 	 * The IDs of all direct neighbors of this node

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -617,15 +617,16 @@ export class ZWaveNode extends Endpoint {
 
 	public get deviceDatabaseUrl(): string | undefined {
 		if (
-			(this.manufacturerId && this.productType && this.productId) ==
-			undefined
-		)
-			return undefined;
-		const manufacturerId = num2hex(this.manufacturerId);
-		const productType = num2hex(this.productType);
-		const productId = num2hex(this.productId);
-		const firmwareVersion = this.firmwareVersion || "0.0";
-		return `https://devices.zwave-js.io/?jumpTo=${manufacturerId}:${productType}:${productId}:${firmwareVersion}`;
+			this.manufacturerId != undefined &&
+			this.productType != undefined &&
+			this.productId != undefined
+		) {
+			const manufacturerId = num2hex(this.manufacturerId);
+			const productType = num2hex(this.productType);
+			const productId = num2hex(this.productId);
+			const firmwareVersion = this.firmwareVersion || "0.0";
+			return `https://devices.zwave-js.io/?jumpTo=${manufacturerId}:${productType}:${productId}:${firmwareVersion}`;
+		}
 	}
 
 	private _neighbors: readonly number[] = [];

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -615,7 +615,10 @@ export class ZWaveNode extends Endpoint {
 		return this._deviceConfig?.label;
 	}
 
-	public get deviceDatabaseUrl(): string {
+	public get deviceDatabaseUrl(): string | undefined {
+		if (this.manufacturerId === undefined || this.productType === undefined || this.productId === undefined) {
+			return undefined;
+		}
 		const manufacturerId = num2hex(this.manufacturerId);
 		const productType = num2hex(this.productType);
 		const productId = num2hex(this.productId);

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -616,7 +616,7 @@ export class ZWaveNode extends Endpoint {
 	}
 
 	public get deviceDatabaseUrl(): string | undefined {
-		if (this.manufacturerId === undefined || this.productType === undefined || this.productId === undefined) return undefined;
+		if ((this.manufacturerId && this.productType && this.productId) == undefined) return undefined;
 		const manufacturerId = num2hex(this.manufacturerId);
 		const productType = num2hex(this.productType);
 		const productId = num2hex(this.productId);

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -616,7 +616,11 @@ export class ZWaveNode extends Endpoint {
 	}
 
 	public get deviceDatabaseUrl(): string | undefined {
-		if ((this.manufacturerId && this.productType && this.productId) == undefined) return undefined;
+		if (
+			(this.manufacturerId && this.productType && this.productId) ==
+			undefined
+		)
+			return undefined;
 		const manufacturerId = num2hex(this.manufacturerId);
 		const productType = num2hex(this.productType);
 		const productId = num2hex(this.productId);

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -616,9 +616,7 @@ export class ZWaveNode extends Endpoint {
 	}
 
 	public get deviceDatabaseUrl(): string | undefined {
-		if (this.manufacturerId === undefined || this.productType === undefined || this.productId === undefined) {
-			return undefined;
-		}
+		if (this.manufacturerId === undefined || this.productType === undefined || this.productId === undefined) return undefined;
 		const manufacturerId = num2hex(this.manufacturerId);
 		const productType = num2hex(this.productType);
 		const productId = num2hex(this.productId);

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -615,7 +615,7 @@ export class ZWaveNode extends Endpoint {
 		return this._deviceConfig?.label;
 	}
 
-	public get dbUrl(): string {
+	public get deviceDatabaseUrl(): string {
 		const manufacturerId = num2hex(this.manufacturerId);
 		const productType = num2hex(this.productType);
 		const productId = num2hex(this.productId);

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -29,6 +29,7 @@ import {
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
 import {
+	formatId,
 	getEnumMemberName,
 	JSONObject,
 	Mixin,
@@ -621,9 +622,9 @@ export class ZWaveNode extends Endpoint {
 			this.productType != undefined &&
 			this.productId != undefined
 		) {
-			const manufacturerId = num2hex(this.manufacturerId);
-			const productType = num2hex(this.productType);
-			const productId = num2hex(this.productId);
+			const manufacturerId = formatId(this.manufacturerId);
+			const productType = formatId(this.productType);
+			const productId = formatId(this.productId);
 			const firmwareVersion = this.firmwareVersion || "0.0";
 			return `https://devices.zwave-js.io/?jumpTo=${manufacturerId}:${productType}:${productId}:${firmwareVersion}`;
 		}


### PR DESCRIPTION
As I mentioned in Discord, I think it would be useful to have the device DB URL in node-zwave-js. That way each downstream project doesn't have to generate it on its own.