### PR TITLE
feat: add log file rotation

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,8 @@
     "moment": "^2.29.0",
     "moment-timezone": "^0.5.33",
     "nrf-intel-hex": "^1.3.0",
-    "winston": "^3.3.3"
+    "winston": "^3.3.3",
+    "winston-daily-rotate-file": "^4.5.5"
   },
   "scripts": {
     "build": "tsc -b tsconfig.build.json",

--- a/packages/core/src/log/shared.ts
+++ b/packages/core/src/log/shared.ts
@@ -4,11 +4,9 @@ import type { Format, TransformableInfo, TransformFunction } from "logform";
 import * as path from "path";
 import { configs, MESSAGE } from "triple-beam";
 import winston, { Logger } from "winston";
+import DailyRotateFile from "winston-daily-rotate-file";
 import type Transport from "winston-transport";
-import type {
-	ConsoleTransportInstance,
-	FileTransportInstance,
-} from "winston/lib/winston/transports";
+import type { ConsoleTransportInstance } from "winston/lib/winston/transports";
 import { colorizer } from "./Colorizer";
 
 const { combine, timestamp, label } = winston.format;
@@ -108,7 +106,7 @@ function stringToNodeList(nodes?: string): number[] | undefined {
 }
 
 export class ZWaveLogContainer extends winston.Container {
-	private fileTransport: FileTransportInstance | undefined;
+	private fileTransport: DailyRotateFile | undefined;
 	private consoleTransport: ConsoleTransportInstance | undefined;
 	private loglevelVisibleCache = new Map<string, boolean>();
 
@@ -121,9 +119,9 @@ export class ZWaveLogContainer extends winston.Container {
 		filename: require.main
 			? path.join(
 					path.dirname(require.main.filename),
-					`zwave-${process.pid}.log`,
+					`zwavejs_%DATE%.log`,
 			  )
-			: path.join(__dirname, "../../..", `zwave-${process.pid}.log`),
+			: path.join(__dirname, "../../..", `zwave_%DATE%.log`),
 		forceConsole: false,
 	};
 
@@ -159,6 +157,12 @@ export class ZWaveLogContainer extends winston.Container {
 		const changedLogLevel =
 			config.level != undefined && config.level !== this.logConfig.level;
 
+		if (
+			config.filename != undefined &&
+			!config.filename.includes("%DATE%")
+		) {
+			config.filename += "_%DATE%.log";
+		}
 		const changedFilename =
 			config.filename != undefined &&
 			config.filename !== this.logConfig.filename;
@@ -242,8 +246,6 @@ export class ZWaveLogContainer extends winston.Container {
 		const ret: Transport[] = [];
 		if (this.logConfig.enabled && this.logConfig.logToFile) {
 			if (!this.fileTransport) {
-				console.log(`Logging to file:
-	${this.logConfig.filename}`);
 				this.fileTransport = this.createFileTransport();
 			}
 			ret.push(this.fileTransport);
@@ -278,12 +280,21 @@ export class ZWaveLogContainer extends winston.Container {
 		return !this.logConfig.enabled;
 	}
 
-	private createFileTransport(): FileTransportInstance {
-		return new winston.transports.File({
+	private createFileTransport(): DailyRotateFile {
+		const ret = new DailyRotateFile({
 			filename: this.logConfig.filename,
+			datePattern: "YYYY-MM-DD",
+			zippedArchive: true,
+			maxSize: "100m",
+			maxFiles: "7d",
 			format: createDefaultTransportFormat(false, false),
 			silent: this.isFileTransportSilent(),
 		});
+		ret.on("new", (newFilename: string) => {
+			console.log(`Logging to file:
+	${newFilename}`);
+		});
+		return ret;
 	}
 
 	/**

--- a/yarn.lock
+++ b/yarn.lock
@@ -5256,6 +5256,13 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
+file-stream-rotator@^0.5.7:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/file-stream-rotator/-/file-stream-rotator-0.5.7.tgz#868a2e5966f7640a17dd86eda0e4467c089f6286"
+  integrity sha512-VYb3HZ/GiAGUCrfeakO8Mp54YGswNUHvL7P09WQcXAJNSj3iQ5QraYSp3cIn1MUyw6uzfgN/EFOarCNa4JvUHQ==
+  dependencies:
+    moment "^2.11.2"
+
 file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
@@ -7999,7 +8006,7 @@ moment-timezone@^0.5.33:
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.9.0", moment@^2.29.0:
+"moment@>= 2.9.0", moment@^2.11.2, moment@^2.29.0:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
@@ -8387,6 +8394,11 @@ object-copy@^0.1.0:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
+
+object-hash@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.1.1.tgz#9447d0279b4fcf80cff3259bf66a1dc73afabe09"
+  integrity sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ==
 
 object-inspect@^1.9.0:
   version "1.9.0"
@@ -11095,6 +11107,16 @@ wide-align@^1.1.0:
   integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
   dependencies:
     string-width "^1.0.2 || 2"
+
+winston-daily-rotate-file@^4.5.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/winston-daily-rotate-file/-/winston-daily-rotate-file-4.5.5.tgz#cfa3a89f4eb0e4126917592b375759b772bcd972"
+  integrity sha512-ds0WahIjiDhKCiMXmY799pDBW+58ByqIBtUcsqr4oDoXrAI3Zn+hbgFdUxzMfqA93OG0mPLYVMiotqTgE/WeWQ==
+  dependencies:
+    file-stream-rotator "^0.5.7"
+    object-hash "^2.0.1"
+    triple-beam "^1.3.0"
+    winston-transport "^4.4.0"
 
 winston-transport@^4.4.0:
   version "4.4.0"


### PR DESCRIPTION
This PR adds support for log file rotation through `winston-daily-rotate-file`. The logfiles are now called `zwavejs_%DATE%.log`, where `%DATE%` gets automatically replaced with the current date in `YYYY-MM-DD` format. Logfiles are rotated every day and kept for 7 days, old logfiles get gzipped to save some space.

fixes: #2569