### PR TITLE
fix(config): corrected lifeline label for Aeon ZW100

### DIFF
--- a/packages/config/config/devices/0x0086/zw100.json
+++ b/packages/config/config/devices/0x0086/zw100.json
@@ -38,7 +38,7 @@
 	},
 	"associations": {
 		"1": {
-			"label": "Group 1",
+			"label": "Lifeline",
 			"maxNodes": 5,
 			"isLifeline": true
 		},


### PR DESCRIPTION
Corrected label for aeon zw100.