### PR TITLE
fix(serial): detect when socket disconnects and destroy driver

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -642,7 +642,7 @@ export class Driver extends EventEmitter {
 			.on("data", this.serialport_onData.bind(this))
 			.on("error", (err) => {
 				this.driverLog.print(
-					`serial port errored: ${err.message}`,
+					`Serial port errored: ${err.message}`,
 					"error",
 				);
 				if (this._isOpen) {


### PR DESCRIPTION
With this change, serial-over-tcp ports will be monitored with the keepAlive option. Once the connection goes down, this causes the socket to be closed after a few seconds.

Because the driver and controller state may go out of sync in this case, a closed socket will destroy the driver instance, which must be handled by the application - e.g. by restarting or shutting down.

fixes: https://github.com/zwave-js/zwavejs2mqtt/issues/1167