### PR TITLE
feat: add ability to specify string as CC set duration instead of only Duration

### DIFF
--- a/packages/core/src/values/Duration.test.ts
+++ b/packages/core/src/values/Duration.test.ts
@@ -154,34 +154,53 @@ describe("lib/util/Duration", () => {
 		});
 
 		it(`should return a duration for seconds`, () => {
-			expect(Duration.parseString("10s")).toEqual(new Duration(10, "seconds"));
-			expect(Duration.parseString("25s")).toEqual(new Duration(25, "seconds"));
-			expect(Duration.parseString("33S")).toEqual(new Duration(33, "seconds"));
+			expect(Duration.parseString("10s")).toEqual(
+				new Duration(10, "seconds"),
+			);
+			expect(Duration.parseString("25s")).toEqual(
+				new Duration(25, "seconds"),
+			);
+			expect(Duration.parseString("33S")).toEqual(
+				new Duration(33, "seconds"),
+			);
 		});
 
 		it(`should return a duration for minutes`, () => {
-			expect(Duration.parseString("17m")).toEqual(new Duration(17, "minutes"));
-			expect(Duration.parseString("22m")).toEqual(new Duration(22, "minutes"));
-			expect(Duration.parseString("99M")).toEqual(new Duration(99, "minutes"));
+			expect(Duration.parseString("17m")).toEqual(
+				new Duration(17, "minutes"),
+			);
+			expect(Duration.parseString("22m")).toEqual(
+				new Duration(22, "minutes"),
+			);
+			expect(Duration.parseString("99M")).toEqual(
+				new Duration(99, "minutes"),
+			);
 		});
 
 		it(`should return a duration for combined seconds and minutes`, () => {
-			expect(Duration.parseString("19m18s")).toEqual(new Duration(19 * 60 + 18, "seconds"));
-			expect(Duration.parseString("1m10s")).toEqual(new Duration(60 + 10, "seconds"));
-			expect(Duration.parseString("0m9s")).toEqual(new Duration(9, "seconds"));
+			expect(Duration.parseString("19m18s")).toEqual(
+				new Duration(19 * 60 + 18, "seconds"),
+			);
+			expect(Duration.parseString("1m10s")).toEqual(
+				new Duration(60 + 10, "seconds"),
+			);
+			expect(Duration.parseString("0m9s")).toEqual(
+				new Duration(9, "seconds"),
+			);
 		});
 	});
 
 	describe("getStringOrDuration()", () => {
 		it(`should return duration when string is passed`, () => {
 			expect(Duration.getStringOrDuration("")).toEqual(undefined);
-			expect(Duration.getStringOrDuration("88s")).toEqual(new Duration(88, "seconds"));
+			expect(Duration.getStringOrDuration("88s")).toEqual(
+				new Duration(88, "seconds"),
+			);
 		});
 
 		it(`should return passed duration when duration is passed`, () => {
-			const duration = new Duration(137, "minutes")
+			const duration = new Duration(137, "minutes");
 			expect(Duration.getStringOrDuration(duration)).toBe(duration);
 		});
 	});
-
 });

--- a/packages/core/src/values/Duration.test.ts
+++ b/packages/core/src/values/Duration.test.ts
@@ -144,4 +144,44 @@ describe("lib/util/Duration", () => {
 			}
 		});
 	});
+
+	describe("parseString()", () => {
+		it(`should return undefined for unknown value`, () => {
+			expect(Duration.parseString("")).toEqual(undefined);
+			expect(Duration.parseString("15")).toEqual(undefined);
+			expect(Duration.parseString("33h")).toEqual(undefined);
+			expect(Duration.parseString("not_a_number")).toEqual(undefined);
+		});
+
+		it(`should return a duration for seconds`, () => {
+			expect(Duration.parseString("10s")).toEqual(new Duration(10, "seconds"));
+			expect(Duration.parseString("25s")).toEqual(new Duration(25, "seconds"));
+			expect(Duration.parseString("33S")).toEqual(new Duration(33, "seconds"));
+		});
+
+		it(`should return a duration for minutes`, () => {
+			expect(Duration.parseString("17m")).toEqual(new Duration(17, "minutes"));
+			expect(Duration.parseString("22m")).toEqual(new Duration(22, "minutes"));
+			expect(Duration.parseString("99M")).toEqual(new Duration(99, "minutes"));
+		});
+
+		it(`should return a duration for combined seconds and minutes`, () => {
+			expect(Duration.parseString("19m18s")).toEqual(new Duration(19 * 60 + 18, "seconds"));
+			expect(Duration.parseString("1m10s")).toEqual(new Duration(60 + 10, "seconds"));
+			expect(Duration.parseString("0m9s")).toEqual(new Duration(9, "seconds"));
+		});
+	});
+
+	describe("getStringOrDuration()", () => {
+		it(`should return duration when string is passed`, () => {
+			expect(Duration.getStringOrDuration("")).toEqual(undefined);
+			expect(Duration.getStringOrDuration("88s")).toEqual(new Duration(88, "seconds"));
+		});
+
+		it(`should return passed duration when duration is passed`, () => {
+			const duration = new Duration(137, "minutes")
+			expect(Duration.getStringOrDuration(duration)).toBe(duration);
+		});
+	});
+
 });

--- a/packages/core/src/values/Duration.test.ts
+++ b/packages/core/src/values/Duration.test.ts
@@ -146,7 +146,7 @@ describe("lib/util/Duration", () => {
 	});
 
 	describe("parseString()", () => {
-		it(`should return undefined for unknown value`, () => {
+		it(`should return undefined for unknown or unrepresentable values`, () => {
 			expect(Duration.parseString("")).toEqual(undefined);
 			expect(Duration.parseString("15")).toEqual(undefined);
 			expect(Duration.parseString("33h")).toEqual(undefined);
@@ -177,9 +177,18 @@ describe("lib/util/Duration", () => {
 			);
 		});
 
-		it(`should return a duration for combined seconds and minutes`, () => {
+		it(`should return a duration for hours`, () => {
+			expect(Duration.parseString("2h")).toEqual(
+				new Duration(120, "minutes"),
+			);
+			expect(Duration.parseString("1h8s")).toEqual(
+				new Duration(60, "minutes"),
+			);
+		});
+
+		it(`should return the nearest possible duration for combined seconds and minutes`, () => {
 			expect(Duration.parseString("19m18s")).toEqual(
-				new Duration(19 * 60 + 18, "seconds"),
+				new Duration(19, "minutes"),
 			);
 			expect(Duration.parseString("1m10s")).toEqual(
 				new Duration(60 + 10, "seconds"),
@@ -190,17 +199,15 @@ describe("lib/util/Duration", () => {
 		});
 	});
 
-	describe("getStringOrDuration()", () => {
-		it(`should return duration when string is passed`, () => {
-			expect(Duration.getStringOrDuration("")).toEqual(undefined);
-			expect(Duration.getStringOrDuration("88s")).toEqual(
-				new Duration(88, "seconds"),
-			);
+	describe("from()", () => {
+		it(`should return a duration when a string is passed`, () => {
+			expect(Duration.from("")).toEqual(undefined);
+			expect(Duration.from("88s")).toEqual(new Duration(88, "seconds"));
 		});
 
-		it(`should return passed duration when duration is passed`, () => {
+		it(`should return the passed duration when a duration instance is passed`, () => {
 			const duration = new Duration(137, "minutes");
-			expect(Duration.getStringOrDuration(duration)).toBe(duration);
+			expect(Duration.from(duration)).toBe(duration);
 		});
 	});
 });

--- a/packages/core/src/values/Duration.ts
+++ b/packages/core/src/values/Duration.ts
@@ -1,7 +1,6 @@
 import type { JSONObject } from "@zwave-js/shared";
 import { clamp } from "alcalzone-shared/math";
 import { ZWaveError, ZWaveErrorCodes } from "../error/ZWaveError";
-import { parseNumber } from "./Primitive";
 
 export type DurationUnit = "seconds" | "minutes" | "unknown" | "default";
 
@@ -50,8 +49,8 @@ export class Duration {
 
 	/** Parse user-friendly duration string in format "Xs", "Xm" or "XmYs". For example "10m20s". */
 	public static parseString(text: string): Duration | undefined {
-		const parsedString = text.match(/^(?:([0-9]+)[mM])?(?:([0-9]+)[sS])?$/);
-		
+		const parsedString = /^(?:([0-9]+)[mM])?(?:([0-9]+)[sS])?$/.exec(text);
+
 		if (!parsedString) {
 			return undefined;
 		}
@@ -60,7 +59,10 @@ export class Duration {
 		const secondsString = parsedString[2];
 
 		if (minutesString && secondsString) {
-			return new Duration(60 * parseInt(minutesString) + parseInt(secondsString), "seconds");
+			return new Duration(
+				60 * parseInt(minutesString) + parseInt(secondsString),
+				"seconds",
+			);
 		} else if (minutesString) {
 			return new Duration(parseInt(minutesString), "minutes");
 		} else if (secondsString) {
@@ -71,11 +73,12 @@ export class Duration {
 	}
 
 	/** Get either user-friendly duration string in format "Xs", "Xm" or "XmYs". Or direct duration */
-	public static getStringOrDuration(input?: Duration | string): Duration | undefined {
+	public static getStringOrDuration(
+		input?: Duration | string,
+	): Duration | undefined {
 		if (input instanceof Duration) {
 			return input;
-		}
-		else if (input) {
+		} else if (input) {
 			return Duration.parseString(input);
 		} else {
 			return undefined;

--- a/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
@@ -94,7 +94,7 @@ export class BinarySwitchCCAPI extends CCAPI {
 	/**
 	 * Sets the switch to the given value
 	 * @param targetValue The target value to set
-	 * @param duration The duration after which the target value should be reached. Only supported in V2 and above
+	 * @param duration The duration after which the target value should be reached. Can be a Duration instance or a user-friendly duration string like `"1m17s"`. Only supported in V2 and above.
 	 */
 	public async set(
 		targetValue: boolean,

--- a/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
@@ -109,7 +109,7 @@ export class BinarySwitchCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 			targetValue,
-			duration: Duration.getStringOrDuration(duration),
+			duration: Duration.from(duration),
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
 	}

--- a/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
@@ -96,7 +96,7 @@ export class BinarySwitchCCAPI extends CCAPI {
 	 * @param targetValue The target value to set
 	 * @param duration The duration after which the target value should be reached. Only supported in V2 and above
 	 */
-	public async set(targetValue: boolean, duration?: Duration): Promise<void> {
+	public async set(targetValue: boolean, duration?: Duration | string): Promise<void> {
 		this.assertSupportsCommand(
 			BinarySwitchCommand,
 			BinarySwitchCommand.Set,
@@ -106,7 +106,7 @@ export class BinarySwitchCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 			targetValue,
-			duration,
+			duration: Duration.getStringOrDuration(duration),
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
 	}

--- a/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
@@ -96,7 +96,10 @@ export class BinarySwitchCCAPI extends CCAPI {
 	 * @param targetValue The target value to set
 	 * @param duration The duration after which the target value should be reached. Only supported in V2 and above
 	 */
-	public async set(targetValue: boolean, duration?: Duration | string): Promise<void> {
+	public async set(
+		targetValue: boolean,
+		duration?: Duration | string,
+	): Promise<void> {
 		this.assertSupportsCommand(
 			BinarySwitchCommand,
 			BinarySwitchCommand.Set,

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -154,7 +154,7 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 	 */
 	public async set(
 		targetValue: number,
-		duration?: Duration,
+		duration?: Duration | string,
 	): Promise<boolean> {
 		this.assertSupportsCommand(
 			MultilevelSwitchCommand,
@@ -165,7 +165,7 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 			targetValue,
-			duration,
+			duration: Duration.getStringOrDuration(duration),
 		});
 
 		// Multilevel Switch commands may take some time to be executed.

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -149,7 +149,7 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 	/**
 	 * Sets the switch to a new value
 	 * @param targetValue The new target value for the switch
-	 * @param duration The optional duration to reach the target value. Available in V2+
+	 * @param duration The duration after which the target value should be reached. Can be a Duration instance or a user-friendly duration string like `"1m17s"`. Only supported in V2 and above.
 	 * @returns A promise indicating whether the command was completed
 	 */
 	public async set(

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -165,7 +165,7 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 			targetValue,
-			duration: Duration.getStringOrDuration(duration),
+			duration: Duration.from(duration),
 		});
 
 		// Multilevel Switch commands may take some time to be executed.

--- a/packages/zwave-js/src/lib/commandclass/SceneActivationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneActivationCC.ts
@@ -81,7 +81,7 @@ export class SceneActivationCCAPI extends CCAPI {
 
 	public async set(
 		sceneId: number,
-		dimmingDuration?: Duration,
+		dimmingDuration?: Duration | string,
 	): Promise<void> {
 		this.assertSupportsCommand(
 			SceneActivationCommand,
@@ -92,7 +92,7 @@ export class SceneActivationCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 			sceneId,
-			dimmingDuration,
+			dimmingDuration: Duration.getStringOrDuration(dimmingDuration),
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
 	}

--- a/packages/zwave-js/src/lib/commandclass/SceneActivationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneActivationCC.ts
@@ -92,7 +92,7 @@ export class SceneActivationCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 			sceneId,
-			dimmingDuration: Duration.getStringOrDuration(dimmingDuration),
+			dimmingDuration: Duration.from(dimmingDuration),
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
 	}

--- a/packages/zwave-js/src/lib/commandclass/SceneActivationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneActivationCC.ts
@@ -57,13 +57,8 @@ export enum SceneActivationCommand {
 @API(CommandClasses["Scene Activation"])
 export class SceneActivationCCAPI extends CCAPI {
 	public supportsCommand(_cmd: SceneActivationCommand): Maybe<boolean> {
-		// There is only one command
+		// There is only one mandatory command
 		return true;
-		// switch (cmd) {
-		// 	case SceneActivationCommand.Set:
-		// 		return true; // This is mandatory
-		// }
-		// return super.supportsCommand(cmd);
 	}
 
 	protected [SET_VALUE]: SetValueImplementation = async (
@@ -79,6 +74,10 @@ export class SceneActivationCCAPI extends CCAPI {
 		await this.set(value);
 	};
 
+	/**
+	 * Activates the Scene with the given ID
+	 * @param duration The duration specifying how long the transition should take. Can be a Duration instance or a user-friendly duration string like `"1m17s"`.
+	 */
 	public async set(
 		sceneId: number,
 		dimmingDuration?: Duration | string,


### PR DESCRIPTION
This is a continuation of the https://github.com/zwave-js/zwavejs2mqtt/pull/1159. Idea is to be able to pass duration to the `sendCommand/set` mqtt command, as a workaround for the https://github.com/zwave-js/node-zwave-js/issues/1321.

For example, this mqtt command is supposed to set the level of the light to the 99 in 10 seconds:

```
{
    "args": [
        {
            "nodeId": 11,
            "commandClass": 38,
            "property": ""
        },
        "set",
        [
            99,
	    "10s"
        ]
    ]
}
```

However, I'm a bit stumped here. From what I can see, `sendCommand` just calls the `set` method directly, so I modified the arguments of the set method and added duration string parsing. But upon trying to send above command, I get this error message:

```
2021-05-12 16:56:39.946 INFO ZWAVE: Message dropped because of an unexpected error: this.duration.serializeSet is not a function sendCommand {
  success: false,
  message: 'Message dropped because of an unexpected error: this.duration.serializeSet is not a function'
}
```

Any idea what did I miss? Thanks.