### PR TITLE
fix(config): enable Basic Set mapping for EverSpring SP103

### DIFF
--- a/packages/config/config/devices/0x0060/hsp02.json
+++ b/packages/config/config/devices/0x0060/hsp02.json
@@ -100,5 +100,9 @@
 			"defaultValue": 15,
 			"unsigned": true
 		}
-	}
+	},
+	"compat": {
+		// The device is a Binary Sensor, but uses Basic Sets to report its status
+		"enableBasicSetMapping": true
+	}	
 }

--- a/packages/config/config/devices/0x0060/hsp02.json
+++ b/packages/config/config/devices/0x0060/hsp02.json
@@ -104,5 +104,5 @@
 	"compat": {
 		// The device is a Binary Sensor, but uses Basic Sets to report its status
 		"enableBasicSetMapping": true
-	}	
+	}
 }


### PR DESCRIPTION
EverSpring SP103 did not update Binary Sensor, but only sends "BasicCC Report". After adding support for Basic Sets, my motion sensor works fine.


```
2021-05-13T14:13:04.194Z SERIAL « 0x01090004002603200100f6                                            (11 bytes)
2021-05-13T14:13:04.195Z SERIAL » [ACK]                                                                   (0x06)
2021-05-13T14:13:04.196Z DRIVER « [Node 038] [REQ] [ApplicationCommand]
                                  └─[BasicCCSet]
                                      target value: 0
2021-05-13T14:13:04.197Z CNTRLR   [Node 038] treating BasicCC::Set as a report
2021-05-13T14:13:04.198Z CNTRLR   [Node 038] [~] [Basic] currentValue: 0 => 0                       [Endpoint 0]
```