### PR TITLE
feat(config): support defining associations on endpoints in config files, use for ZDB5100

### DIFF
--- a/docs/config-files/conditional-settings.md
+++ b/docs/config-files/conditional-settings.md
@@ -17,6 +17,7 @@ The logic supports the JavaScript operators `<`, `<=`, `>`, `>=` and `===`, as w
 
 You can use `"$if"` in the following locations:
 
+-   Inside endpoint definitions
 -   Inside association groups
 -   Inside config parameters
 -   Inside config parameter options

--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -69,7 +69,7 @@ Can be used to add instructions for the user to a device:
 
 ## `endpoints`
 
-Endpoint-specific configuration - for now this only includes associations. Example:
+Optional endpoint-specific configuration. For now this only includes associations. Example:
 
 ```json
 "endpoints": {

--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -11,6 +11,7 @@ The following properties are defined and should always be present in the same or
 | `devices`           | An array of product type and product ID combinations, [see below](#devices) for details.                                                                                                                   |
 | `firmwareVersion`   | The firmware version range this config file is valid for, [see below](#firmwareVersion) for details.                                                                                                       |
 | `supportsZWavePlus` | (deprecated)                                                                                                                                                                                               |
+| `endpoints`         | Endpoint-specific configuration, [see below](#endpoints) for details. If this is present, `associations` must be specified on endpoint `"0"` instead of on the root level.                                 |
 | `associations`      | The association groups the device supports, [see below](#associations) for details. Only needs to be present if the device does not support Z-Wave+ or requires changes to the default association config. |
 | `paramInformation`  | A dictionary of the configuration parameters the device supports. [See below](#paramInformation) for details.                                                                                              |
 | `proprietary`       | A dictionary of settings for the proprietary CC. The settings depend on each proprietary CC implementation.                                                                                                |
@@ -66,6 +67,26 @@ Can be used to add instructions for the user to a device:
 }
 ```
 
+## `endpoints`
+
+Endpoint-specific configuration - for now this only includes associations. Example:
+
+```json
+"endpoints": {
+	"0": {
+		"associations": {
+			// Association definitions for endpoint 0, see below for details
+		}
+	},
+	"1": {
+		"associations": {
+			// Association definitions for endpoint 1, see below for details
+		}
+	},
+	// etc.
+}
+```
+
 ## `associations`
 
 For devices which do not allow auto-discovering associations, the associations must be defined in the config file.
@@ -98,6 +119,66 @@ The property looks as follows:
 ```
 
 The `isLifeline` key is used to determine which group sends the controller device status updates.
+
+To define associations for other endpoints than the root endpoint, you **must** specify `"associations"` inside the `"endpoints"` property.
+If the same associations exist on the root endpoint and other endpoints, it is **recommended** to self-reference them via `$import`s.
+
+> [!ATTENTION] Make sure to disable the `isLifeline` flag on endpoints if the **same** lifeline group is shared between multiple endpoints.
+
+Example:
+
+```json
+"endpoints": {
+	"0": {
+		"associations": {
+			"1": {
+				"label": "Lifeline",
+				"maxNodes": 5,
+				"isLifeline": true
+			},
+			"2": {
+				"label": "Button 1",
+				"maxNodes": 5
+			},
+			"3": {
+				"label": "Button 2",
+				"maxNodes": 5
+			},
+		}
+	},
+	"1": {
+		"associations": {
+			"1": {
+				// This group is shared with the root endpoint. Reference it from there, but don't auto-assign multiple times.
+				"$import": "#endpoints/0/associations/1",
+				"isLifeline": false
+			},
+			"2": {
+				// This association also exists as group 2 on the root endpoint, so we reference it
+				"$import": "#endpoints/0/associations/2"
+			}
+		}
+	},
+	"2": {
+		"associations": {
+			"1": {
+				// This group is shared with the root endpoint. Reference it from there, but don't auto-assign multiple times.
+				"$import": "#endpoints/0/associations/1",
+				"isLifeline": false
+			},
+			"2": {
+				// This association also exists as group 3 on the root endpoint, so we reference it
+				"$import": "#endpoints/0/associations/3"
+			},
+			"3": {
+				// This association only exists on endpoint 2
+				"label": "Button 2: Double Tap",
+				"maxNodes": 5
+			}
+		}
+	}
+}
+```
 
 ## `paramInformation`
 

--- a/maintenance/schemas/device-config.json
+++ b/maintenance/schemas/device-config.json
@@ -74,45 +74,8 @@
 		"supportsZWavePlus": {
 			"const": true
 		},
-		"associations": {
-			"type": "object",
-			"description": "Define association groups for devices that don't support Z-Wave+ or modify the reported associations for devices that do.",
-			"properties": {
-				"$import": { "$ref": "#/definitions/import" }
-			},
-			"patternProperties": {
-				"^\\d+$": {
-					"type": "object",
-					"properties": {
-						"$if": { "$ref": "#/definitions/condition" },
-						"label": {
-							"type": "string",
-							"description": "How this association group is called"
-						},
-						"description": {
-							"type": "string",
-							"description": "What this association group does"
-						},
-						"maxNodes": {
-							"type": "number",
-							"description": "How many nodes may be assigned to this group",
-							"minimum": 1
-						},
-						"isLifeline": {
-							"const": true,
-							"description": "Whether this is a Lifeline group. SHOULD exist exactly once, some nodes require more groups to report everything."
-						},
-						"noEndpoint": {
-							"const": true,
-							"description": "Whether node id associations must be used for this group, even if the device supports endpoint associations"
-						}
-					},
-					"required": ["label", "maxNodes"],
-					"additionalProperties": false
-				}
-			},
-			"additionalProperties": false
-		},
+		"endpoints": { "$ref": "#/definitions/endpoints" },
+		"associations": { "$ref": "#/definitions/associations" },
 		"paramInformation": {
 			"type": "object",
 			"description": "Defines all the existing configuration parameters",
@@ -364,6 +327,69 @@
 		"condition": {
 			"type": "string",
 			"description": "A condition that must be fulfilled for this entry to exit."
+		},
+		"endpoints": {
+			"type": "object",
+			"description": "Endpoint-specific configuration",
+			"patternProperties": {
+				"^\\d+$": {
+					"type": "object",
+					"properties": {
+						"$import": { "$ref": "#/definitions/import" },
+						"$if": { "$ref": "#/definitions/condition" },
+						"associations": { "$ref": "#/definitions/associations" }
+					},
+					"additionalProperties": false
+				},
+				"additionalProperties": false
+			}
+		},
+		"associations": {
+			"type": "object",
+			"description": "Define association groups for devices that don't support Z-Wave+ or modify the reported associations for devices that do.",
+			"properties": {
+				"$import": { "$ref": "#/definitions/import" }
+			},
+			"patternProperties": {
+				"^\\d+$": {
+					"type": "object",
+					"properties": {
+						"$import": { "$ref": "#/definitions/import" },
+						"$if": { "$ref": "#/definitions/condition" },
+						"label": {
+							"type": "string",
+							"description": "How this association group is called"
+						},
+						"description": {
+							"type": "string",
+							"description": "What this association group does"
+						},
+						"maxNodes": {
+							"type": "number",
+							"description": "How many nodes may be assigned to this group",
+							"minimum": 1
+						},
+						"isLifeline": {
+							"type": "boolean",
+							"description": "Whether this is a Lifeline group. SHOULD exist exactly once, some nodes require more groups to report everything."
+						},
+						"noEndpoint": {
+							"const": true,
+							"description": "Whether node id associations must be used for this group, even if the device supports endpoint associations"
+						}
+					},
+					"anyOf": [
+						{
+							"required": ["label", "maxNodes"]
+						},
+						{
+							"required": ["$import"]
+						}
+					],
+					"additionalProperties": false
+				}
+			},
+			"additionalProperties": false
 		},
 		"ccInfo": {
 			"type": "object",

--- a/packages/config/config/devices/0x0234/zdb5100.json
+++ b/packages/config/config/devices/0x0234/zdb5100.json
@@ -16,63 +16,151 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
-	"associations": {
+	"endpoints": {
+		"0": {
+			"associations": {
+				"1": {
+					"label": "Lifeline",
+					"maxNodes": 5,
+					"isLifeline": true
+				},
+				"2": {
+					"label": "Button 1 (Basic Report)",
+					"maxNodes": 5
+				},
+				"3": {
+					"label": "Button 1 (Binary Switch Set)",
+					"maxNodes": 5
+				},
+				"4": {
+					"label": "Button 1 (Multilevel Set)",
+					"maxNodes": 5
+				},
+				"5": {
+					"label": "Button 2 (Basic Report)",
+					"maxNodes": 5
+				},
+				"6": {
+					"label": "Button 2 (Binary Switch Set)",
+					"maxNodes": 5
+				},
+				"7": {
+					"label": "Button 2 (Multilevel Set)",
+					"maxNodes": 5
+				},
+				"8": {
+					"label": "Button 3 (Basic Report)",
+					"maxNodes": 5
+				},
+				"9": {
+					"label": "Button 3  (Binary Switch Set)",
+					"maxNodes": 5
+				},
+				"10": {
+					"label": "Button 3 (Multilevel Set)",
+					"maxNodes": 5
+				},
+				"11": {
+					"label": "Button 4 (Basic Report)",
+					"maxNodes": 5
+				},
+				"12": {
+					"label": "Button 4 (Binary Switch Set)",
+					"maxNodes": 5
+				},
+				"13": {
+					"label": "Button 4 (Multilevel Set)",
+					"maxNodes": 5
+				},
+				"14": {
+					"label": "Dimmer (Basic Report)",
+					"maxNodes": 5
+				}
+			}
+		},
 		"1": {
-			"label": "Lifeline",
-			"maxNodes": 5,
-			"isLifeline": true
+			"associations": {
+				"1": {
+					"$import": "#endpoints/0/associations/1",
+					// This group is shared with the root endpoint, don't auto-assign multiple times
+					"isLifeline": false
+				},
+				"2": {
+					"$import": "#endpoints/0/associations/2"
+				},
+				"3": {
+					"$import": "#endpoints/0/associations/3"
+				},
+				"4": {
+					"$import": "#endpoints/0/associations/4"
+				}
+			}
 		},
 		"2": {
-			"label": "Button 1 (Basic Report)",
-			"maxNodes": 5
+			"associations": {
+				"1": {
+					"$import": "#endpoints/0/associations/1",
+					// This group is shared with the root endpoint, don't auto-assign multiple times
+					"isLifeline": false
+				},
+				"2": {
+					"$import": "#endpoints/0/associations/5"
+				},
+				"3": {
+					"$import": "#endpoints/0/associations/6"
+				},
+				"4": {
+					"$import": "#endpoints/0/associations/7"
+				}
+			}
 		},
 		"3": {
-			"label": "Button 1 (Binary Switch Set)",
-			"maxNodes": 5
+			"associations": {
+				"1": {
+					"$import": "#endpoints/0/associations/1",
+					// This group is shared with the root endpoint, don't auto-assign multiple times
+					"isLifeline": false
+				},
+				"2": {
+					"$import": "#endpoints/0/associations/8"
+				},
+				"3": {
+					"$import": "#endpoints/0/associations/9"
+				},
+				"4": {
+					"$import": "#endpoints/0/associations/10"
+				}
+			}
 		},
 		"4": {
-			"label": "Button 1 (Multilevel Set)",
-			"maxNodes": 5
+			"associations": {
+				"1": {
+					"$import": "#endpoints/0/associations/1",
+					// This group is shared with the root endpoint, don't auto-assign multiple times
+					"isLifeline": false
+				},
+				"2": {
+					"$import": "#endpoints/0/associations/11"
+				},
+				"3": {
+					"$import": "#endpoints/0/associations/12"
+				},
+				"4": {
+					"$import": "#endpoints/0/associations/13"
+				}
+			}
 		},
 		"5": {
-			"label": "Button 2 (Basic Report)",
-			"maxNodes": 5
-		},
-		"6": {
-			"label": "Button 2 (Binary Switch Set)",
-			"maxNodes": 5
-		},
-		"7": {
-			"label": "Button 2 (Multilevel Set)",
-			"maxNodes": 5
-		},
-		"8": {
-			"label": "Button 3 (Basic Report)",
-			"maxNodes": 5
-		},
-		"9": {
-			"label": "Button 3  (Binary Switch Set)",
-			"maxNodes": 5
-		},
-		"10": {
-			"label": "Button 3 (Multilevel Set)",
-			"maxNodes": 5
-		},
-		"11": {
-			"label": "Button 4 (Basic Report)",
-			"maxNodes": 5
-		},
-		"12": {
-			"label": "Button 4 (Binary Switch Set)",
-			"maxNodes": 5
-		},
-		"13": {
-			"label": "Button 4 (Multilevel Set)",
-			"maxNodes": 5
-		},
-		"14": {
-			"label": "Dimmer (Basic Report)",
-			"maxNodes": 5
+			"associations": {
+				"1": {
+					"$import": "#endpoints/0/associations/1",
+					// This group is shared with the root endpoint, don't auto-assign multiple times
+					"isLifeline": false
+				},
+				"2": {
+					"$import": "#endpoints/0/associations/14"
+				}
+			}
 		}
 	},
 	"paramInformation": {

--- a/packages/config/maintenance/lintConfigFiles.ts
+++ b/packages/config/maintenance/lintConfigFiles.ts
@@ -747,6 +747,14 @@ Did you mean to use ${opt.value >>> shiftAmount}?`,
 				}
 			}
 		}
+
+		// Check that either `endpoints` or `associations` are specified, not both
+		if (conditionalConfig.endpoints && conditionalConfig.associations) {
+			addError(
+				file,
+				`The properties "endpoints" and "associations" cannot be used together. To define associations for the root endpoint, specify them under endpoint "0"!`,
+			);
+		}
 	}
 
 	// Check for duplicate definitions

--- a/packages/config/src/Devices.regression.test.ts
+++ b/packages/config/src/Devices.regression.test.ts
@@ -16,5 +16,34 @@ describe("lib/config/Devices", () => {
 			expect(config).not.toBeUndefined();
 			expect(config?.compat?.addCCs?.get(49)?.endpoints.size).toBe(3);
 		});
+
+		it("Associations on endpoints should work - including imports", async () => {
+			// Logic Group ZDB5100
+
+			// This test might take a while
+			jest.setTimeout(60000);
+
+			const configManager = new ConfigManager();
+			const config = await configManager.lookupDevice(
+				0x0234,
+				0x0003,
+				0x0121,
+				"0.0",
+			);
+			expect(config).not.toBeUndefined();
+			expect(
+				config?.endpoints?.get(1)?.associations?.get(1),
+			).toMatchObject({
+				label: "Lifeline",
+				maxNodes: 5,
+				isLifeline: false,
+			});
+			expect(
+				config?.endpoints?.get(4)?.associations?.get(3),
+			).toMatchObject({
+				label: "Button 4 (Binary Switch Set)",
+				maxNodes: 5,
+			});
+		});
 	});
 });

--- a/packages/config/src/Devices.ts
+++ b/packages/config/src/Devices.ts
@@ -866,12 +866,12 @@ maxNodes for association ${groupId} is not a number`,
 
 		if (
 			definition.isLifeline != undefined &&
-			definition.isLifeline !== true
+			typeof definition.isLifeline !== "boolean"
 		) {
 			throwInvalidConfig(
 				"devices",
 				`packages/config/config/devices/${filename}:
-isLifeline in association ${groupId} must be either true or left out`,
+isLifeline in association ${groupId} must be a boolean`,
 			);
 		}
 		this.isLifeline = !!definition.isLifeline;

--- a/packages/config/src/Devices.ts
+++ b/packages/config/src/Devices.ts
@@ -426,6 +426,33 @@ firmwareVersion is malformed or invalid`,
 			this.firmwareVersion = { min, max };
 		}
 
+		if (definition.endpoints != undefined) {
+			const endpoints = new Map<number, ConditionalEndpointConfig>();
+			if (!isObject(definition.endpoints)) {
+				throwInvalidConfig(
+					`device`,
+					`packages/config/config/devices/${filename}:
+endpoints is not an object`,
+				);
+			}
+			for (const [key, ep] of entries(definition.endpoints)) {
+				if (!/^\d+$/.test(key)) {
+					throwInvalidConfig(
+						`device`,
+						`packages/config/config/devices/${filename}:
+found non-numeric endpoint index "${key}" in endpoints`,
+					);
+				}
+
+				const epIndex = parseInt(key, 10);
+				endpoints.set(
+					epIndex,
+					new ConditionalEndpointConfig(filename, epIndex, ep),
+				);
+			}
+			this.endpoints = endpoints;
+		}
+
 		if (definition.associations != undefined) {
 			const associations = new Map<
 				number,
@@ -580,6 +607,7 @@ metadata is not an object`,
 		productId: number;
 	}[];
 	public readonly firmwareVersion: FirmwareVersionRange;
+	public readonly endpoints?: ReadonlyMap<number, ConditionalEndpointConfig>;
 	public readonly associations?: ReadonlyMap<
 		number,
 		ConditionalAssociationConfig
@@ -602,6 +630,15 @@ metadata is not an object`,
 			for (const [group, assoc] of this.associations) {
 				const evaluated = assoc.evaluateCondition(deviceId);
 				if (evaluated) associations.set(group, evaluated);
+			}
+		}
+
+		let endpoints: Map<number, EndpointConfig> | undefined;
+		if (this.endpoints) {
+			endpoints = new Map();
+			for (const [group, assoc] of this.endpoints) {
+				const evaluated = assoc.evaluateCondition(deviceId);
+				if (evaluated) endpoints.set(group, evaluated);
 			}
 		}
 
@@ -630,6 +667,7 @@ metadata is not an object`,
 			this.description,
 			this.devices,
 			this.firmwareVersion,
+			endpoints,
 			associations,
 			paramInformation,
 			this.proprietary,
@@ -662,6 +700,7 @@ export class DeviceConfig {
 			productId: number;
 		}[],
 		public readonly firmwareVersion: FirmwareVersionRange,
+		public readonly endpoints?: ReadonlyMap<number, EndpointConfig>,
 		public readonly associations?: ReadonlyMap<number, AssociationConfig>,
 		public readonly paramInformation?: ParamInfoMap,
 		/**
@@ -683,6 +722,100 @@ export class DeviceConfig {
 	/** Whether this is an embedded configuration or not */
 	public readonly isEmbedded: boolean;
 }
+
+export class ConditionalEndpointConfig {
+	public constructor(
+		filename: string,
+		index: number,
+		definition: JSONObject,
+	) {
+		this.index = index;
+
+		if (definition.$if != undefined && typeof definition.$if !== "string") {
+			throwInvalidConfig(
+				"devices",
+				`packages/config/config/devices/${filename}:
+Endpoint ${index} has a non-string $if condition`,
+			);
+		}
+		this.condition = definition.$if;
+
+		if (definition.associations != undefined) {
+			const associations = new Map<
+				number,
+				ConditionalAssociationConfig
+			>();
+			if (!isObject(definition.associations)) {
+				throwInvalidConfig(
+					`device`,
+					`packages/config/config/devices/${filename}:
+Endpoint ${index}: associations is not an object`,
+				);
+			}
+			for (const [key, assocDefinition] of entries(
+				definition.associations,
+			)) {
+				if (!/^[1-9][0-9]*$/.test(key)) {
+					throwInvalidConfig(
+						`device`,
+						`packages/config/config/devices/${filename}:
+Endpoint ${index}: found non-numeric group id "${key}" in associations`,
+					);
+				}
+
+				const keyNum = parseInt(key, 10);
+				associations.set(
+					keyNum,
+					new ConditionalAssociationConfig(
+						filename,
+						keyNum,
+						assocDefinition,
+					),
+				);
+			}
+			this.associations = associations;
+		}
+	}
+
+	public readonly index: number;
+	public readonly condition?: string;
+
+	public readonly associations?: ReadonlyMap<
+		number,
+		ConditionalAssociationConfig
+	>;
+
+	public evaluateCondition(deviceId?: DeviceID): EndpointConfig | undefined {
+		if (
+			deviceId &&
+			this.condition &&
+			!conditionApplies(this.condition, deviceId)
+		) {
+			return;
+		}
+
+		let associations: Map<number, AssociationConfig> | undefined;
+		if (this.associations) {
+			associations = new Map();
+			for (const [group, assoc] of this.associations) {
+				const evaluated = assoc.evaluateCondition(deviceId);
+				if (evaluated) associations.set(group, evaluated);
+			}
+		}
+
+		return {
+			...pick(this, ["index"]),
+			associations,
+		};
+	}
+}
+
+export type EndpointConfig = Omit<
+	ConditionalEndpointConfig,
+	"condition" | "evaluateCondition" | "associations"
+> & {
+	associations: Map<number, AssociationConfig> | undefined;
+};
 
 export class ConditionalAssociationConfig {
 	public constructor(

--- a/packages/zwave-js/src/lib/commandclass/AssociationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/AssociationCC.ts
@@ -1,3 +1,4 @@
+import type { AssociationConfig } from "@zwave-js/config";
 import type { Maybe, MessageRecord, ValueID } from "@zwave-js/core";
 import {
 	CommandClasses,
@@ -87,9 +88,21 @@ export function getLifelineGroupIds(endpoint: Endpoint): number[] {
 	}
 
 	// We have a device config file that tells us which (additional) association to assign
-	if (node.deviceConfig?.associations?.size) {
+	let associations: ReadonlyMap<number, AssociationConfig> | undefined;
+	if (endpoint.index === 0) {
+		// The root endpoint's associations may be configured separately or as part of "endpoints"
+		associations =
+			node.deviceConfig?.associations ??
+			node.deviceConfig?.endpoints?.get(0)?.associations;
+	} else {
+		// The other endpoints can only have a configuration as part of "endpoints"
+		associations = node.deviceConfig?.endpoints?.get(endpoint.index)
+			?.associations;
+	}
+
+	if (associations?.size) {
 		lifelineGroups.push(
-			...[...node.deviceConfig.associations.values()]
+			...[...associations.values()]
 				.filter((a) => a.isLifeline)
 				.map((a) => a.groupId),
 		);

--- a/packages/zwave-js/src/lib/commandclass/MultiChannelAssociationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultiChannelAssociationCC.ts
@@ -478,7 +478,11 @@ export class MultiChannelAssociationCC extends CommandClass {
 					const groupSupportsMultiChannel = group <= mcGroupCount;
 					const mustUseNodeAssociation =
 						!supportsMultiChannel ||
-						node.deviceConfig?.associations?.get(group)?.noEndpoint;
+						node.deviceConfig?.associations?.get(group)
+							?.noEndpoint ||
+						node.deviceConfig?.endpoints
+							?.get(0)
+							?.associations?.get(group)?.noEndpoint;
 
 					const nodeIdsValueId = groupSupportsMultiChannel
 						? getNodeIdsValueId(this.endpointIndex, group)

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -1,3 +1,4 @@
+import type { AssociationConfig } from "@zwave-js/config";
 import {
 	actuatorCCs,
 	CommandClasses,
@@ -2004,7 +2005,22 @@ ${associatedNodes.join(", ")}`,
 				CommandClasses["Association Group Information"],
 			)!;
 			for (let group = 1; group <= groupCount; group++) {
-				const assocConfig = node.deviceConfig?.associations?.get(group);
+				let assocConfig: AssociationConfig | undefined;
+				if (node.deviceConfig) {
+					if (endpointIndex === 0) {
+						// The root endpoint's associations may be configured separately or as part of "endpoints"
+						assocConfig =
+							node.deviceConfig.associations?.get(group) ??
+							node.deviceConfig.endpoints
+								?.get(0)
+								?.associations?.get(group);
+					} else {
+						// The other endpoints can only have a configuration as part of "endpoints"
+						assocConfig = node.deviceConfig.endpoints
+							?.get(endpointIndex)
+							?.associations?.get(group);
+					}
+				}
 				const multiChannel = !!mcInstance && group <= mcGroupCount;
 				ret.set(group, {
 					maxNodes:


### PR DESCRIPTION
This PR adds a new configuration property `"endpoints"`, which allows us to specify endpoint-specific things in config files. For now, this is used to configure associations on endpoints.

`"endpoints"` is optional, but if it is specified, `"associations"` cannot be at the top level anymore and must be under endpoint `0`.

The first file to profit from this is the one for ZDB5100.
Fixes: #2578