### PR TITLE
feat(cc): optimistically update values after multicast commands

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/BasicCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BasicCC.ts
@@ -132,8 +132,15 @@ export class BasicCCAPI extends CCAPI {
 						value,
 					);
 				}
+			} else if (value === 255) {
+				// We generally don't want to poll for multicasts because of how much traffic it can cause
+				// However, when setting the value 255 (ON), we don't know the actual state
+
+				// We query currentValue instead of targetValue to make sure that unsolicited updates cancel the scheduled poll
+				// wotan-disable-next-line no-useless-predicate
+				if (property === "targetValue") property = "currentValue";
+				this.schedulePoll({ property });
 			}
-			// For multicasts, do not schedule a refresh - this could cause a LOT of traffic
 		}
 	};
 

--- a/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
@@ -17,6 +17,7 @@ import { entries } from "alcalzone-shared/objects";
 import { isObject } from "alcalzone-shared/typeguards";
 import type { Driver } from "../driver/Driver";
 import { MessagePriority } from "../message/Constants";
+import type { ZWaveNode } from "../node/Node";
 import {
 	CCAPI,
 	PollValueImplementation,
@@ -235,72 +236,90 @@ export class ColorSwitchCCAPI extends CCAPI {
 		// TODO: The API methods should not modify the value DB directly, but to do so
 		// this requires a nicer way of synchronizing hexColor with the others
 		if (this.isSinglecast()) {
-			const valueDB = this.endpoint.getNodeUnsafe()?.valueDB;
-			if (valueDB) {
+			const node = this.endpoint.getNodeUnsafe();
+			if (node) {
 				// Update each color component separately and record the changes to the compound value
-				let updatedRGB = false;
-				const currentCompoundValue =
-					valueDB.getValue<Partial<Record<ColorKey, number>>>(
-						getCurrentColorValueID(this.endpoint.index),
-					) ?? {};
-				const targetCompoundValue =
-					valueDB.getValue<Partial<Record<ColorKey, number>>>(
-						getCurrentColorValueID(this.endpoint.index),
-					) ?? {};
-				for (const [key, value] of entries(cc.colorTable)) {
-					const component = colorTableKeyToComponent(key);
-					if (
-						component === ColorComponent.Red ||
-						component === ColorComponent.Green ||
-						component === ColorComponent.Blue
-					) {
-						updatedRGB = true;
-					}
-
-					valueDB.setValue(
-						getCurrentColorValueID(this.endpoint.index, component),
-						value,
-					);
-
-					// Update the compound value
-					if (key in ColorComponentMap) {
-						currentCompoundValue[key as ColorKey] = value;
-						targetCompoundValue[key as ColorKey] = value;
-					}
-				}
-				// And store the updated compound values
-				valueDB.setValue(
-					getCurrentColorValueID(this.endpoint.index),
-					currentCompoundValue,
-				);
-				valueDB.setValue(
-					getTargetColorValueID(this.endpoint.index),
-					targetCompoundValue,
-				);
-
-				// and hex color if necessary
-				const supportsHex = valueDB.getValue<boolean>(
-					getSupportsHexColorValueID(this.endpoint.index),
-				);
-				if (supportsHex && updatedRGB) {
-					const hexValueId = getHexColorValueID(this.endpoint.index);
-					const [r, g, b] = [
-						ColorComponent.Red,
-						ColorComponent.Green,
-						ColorComponent.Blue,
-					].map(
-						(c) =>
-							valueDB.getValue<number>(
-								getCurrentColorValueID(this.endpoint.index, c),
-							) ?? 0,
-					);
-					const hexValue = (r << 16) | (g << 8) | b;
-					valueDB.setValue(
-						hexValueId,
-						hexValue.toString(16).padStart(6, "0"),
-					);
-				}
+				this.updateCurrentColor(node, cc.colorTable);
 			}
+		} else if (this.isMulticast()) {
+			// Figure out which nodes were affected by this command
+			const affectedNodes = this.endpoint.node.physicalNodes.filter(
+				(node) =>
+					node
+						.getEndpoint(this.endpoint.index)
+						?.supportsCC(this.ccId),
+			);
+			// and optimistically update the currentColor
+			for (const node of affectedNodes) {
+				this.updateCurrentColor(node, cc.colorTable);
+			}
+		}
+	}
+
+	/** Updates the current color for a given node by merging in the given changes */
+	private updateCurrentColor(node: ZWaveNode, colorTable: ColorTable) {
+		const valueDB = node.valueDB;
+		let updatedRGB = false;
+		const currentCompoundValue =
+			valueDB.getValue<Partial<Record<ColorKey, number>>>(
+				getCurrentColorValueID(this.endpoint.index),
+			) ?? {};
+		const targetCompoundValue =
+			valueDB.getValue<Partial<Record<ColorKey, number>>>(
+				getCurrentColorValueID(this.endpoint.index),
+			) ?? {};
+		for (const [key, value] of entries(colorTable)) {
+			const component = colorTableKeyToComponent(key);
+			if (
+				component === ColorComponent.Red ||
+				component === ColorComponent.Green ||
+				component === ColorComponent.Blue
+			) {
+				updatedRGB = true;
+			}
+
+			valueDB.setValue(
+				getCurrentColorValueID(this.endpoint.index, component),
+				value,
+			);
+
+			// Update the compound value
+			if (key in ColorComponentMap) {
+				currentCompoundValue[key as ColorKey] = value;
+				targetCompoundValue[key as ColorKey] = value;
+			}
+		}
+		// And store the updated compound values
+		valueDB.setValue(
+			getCurrentColorValueID(this.endpoint.index),
+			currentCompoundValue,
+		);
+		valueDB.setValue(
+			getTargetColorValueID(this.endpoint.index),
+			targetCompoundValue,
+		);
+
+		// and hex color if necessary
+		const supportsHex = valueDB.getValue<boolean>(
+			getSupportsHexColorValueID(this.endpoint.index),
+		);
+		if (supportsHex && updatedRGB) {
+			const hexValueId = getHexColorValueID(this.endpoint.index);
+			const [r, g, b] = [
+				ColorComponent.Red,
+				ColorComponent.Green,
+				ColorComponent.Blue,
+			].map(
+				(c) =>
+					valueDB.getValue<number>(
+						getCurrentColorValueID(this.endpoint.index, c),
+					) ?? 0,
+			);
+			const hexValue = (r << 16) | (g << 8) | b;
+			valueDB.setValue(
+				hexValueId,
+				hexValue.toString(16).padStart(6, "0"),
+			);
 		}
 	}
 

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -365,8 +365,21 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 								value,
 							);
 						}
+					} else if (value === 255) {
+						// We generally don't want to poll for multicasts because of how much traffic it can cause
+						// However, when setting the value 255 (ON), we don't know the actual state
+
+						// We query currentValue instead of targetValue to make sure that unsolicited updates cancel the scheduled poll
+						// wotan-disable-next-line no-useless-predicate
+						if (property === "targetValue")
+							property = "currentValue";
+						// TODO: #1321
+						const duration = undefined as Duration | undefined;
+						this.schedulePoll(
+							{ property },
+							duration?.toMilliseconds(),
+						);
 					}
-					// For multicasts, do not schedule a refresh - this could cause a LOT of traffic
 				}
 			}
 		} else if (switchTypeProperties.includes(property as string)) {

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -312,32 +312,61 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 
 			// If the command did not fail, assume that it succeeded and update the currentValue accordingly
 			// so UIs have immediate feedback
-			if (this.isSinglecast() && completed) {
-				// Only update currentValue for valid target values
-				if (
-					!this.driver.options.disableOptimisticValueUpdate &&
-					value >= 0 &&
-					value <= 99
-				) {
-					const valueDB = this.endpoint.getNodeUnsafe()?.valueDB;
-					valueDB?.setValue(
-						getCurrentValueValueId(this.endpoint.index),
-						value,
-					);
-				}
+			if (completed) {
+				if (this.isSinglecast()) {
+					// Only update currentValue for valid target values
+					if (
+						!this.driver.options.disableOptimisticValueUpdate &&
+						value >= 0 &&
+						value <= 99
+					) {
+						const valueDB = this.endpoint.getNodeUnsafe()?.valueDB;
+						valueDB?.setValue(
+							getCurrentValueValueId(this.endpoint.index),
+							value,
+						);
+					}
 
-				// Verify the current value after a delay if the node does not support Supervision
-				if (
-					!this.endpoint
-						.getNodeUnsafe()
-						?.supportsCC(CommandClasses.Supervision)
-				) {
-					// TODO: #1321
-					const duration = undefined as Duration | undefined;
-					// We query currentValue instead of targetValue to make sure that unsolicited updates cancel the scheduled poll
-					// wotan-disable-next-line no-useless-predicate
-					if (property === "targetValue") property = "currentValue";
-					this.schedulePoll({ property }, duration?.toMilliseconds());
+					// Verify the current value after a delay if the node does not support Supervision
+					if (
+						!this.endpoint
+							.getNodeUnsafe()
+							?.supportsCC(CommandClasses.Supervision)
+					) {
+						// TODO: #1321
+						const duration = undefined as Duration | undefined;
+						// We query currentValue instead of targetValue to make sure that unsolicited updates cancel the scheduled poll
+						// wotan-disable-next-line no-useless-predicate
+						if (property === "targetValue")
+							property = "currentValue";
+						this.schedulePoll(
+							{ property },
+							duration?.toMilliseconds(),
+						);
+					}
+				} else if (this.isMulticast()) {
+					// Only update currentValue for valid target values
+					if (
+						!this.driver.options.disableOptimisticValueUpdate &&
+						value >= 0 &&
+						value <= 99
+					) {
+						// Figure out which nodes were affected by this command
+						const affectedNodes = this.endpoint.node.physicalNodes.filter(
+							(node) =>
+								node
+									.getEndpoint(this.endpoint.index)
+									?.supportsCC(this.ccId),
+						);
+						// and optimistically update the currentValue
+						for (const node of affectedNodes) {
+							node.valueDB?.setValue(
+								getCurrentValueValueId(this.endpoint.index),
+								value,
+							);
+						}
+					}
+					// For multicasts, do not schedule a refresh - this could cause a LOT of traffic
 				}
 			}
 		} else if (switchTypeProperties.includes(property as string)) {

--- a/packages/zwave-js/src/lib/node/VirtualNode.ts
+++ b/packages/zwave-js/src/lib/node/VirtualNode.ts
@@ -51,6 +51,20 @@ export class VirtualNode extends VirtualEndpoint {
 				},
 				value,
 			);
+			if (api.isSetValueOptimistic(valueId)) {
+				// If the call did not throw, assume that the call was successful and remember the new value
+				// for each node that was affected by this command
+				const affectedNodes = endpointInstance.node.physicalNodes.filter(
+					(node) =>
+						node
+							.getEndpoint(endpointInstance.index)
+							?.supportsCC(valueId.commandClass),
+				);
+				for (const node of affectedNodes) {
+					node.valueDB.setValue(valueId, value);
+				}
+			}
+
 			return true;
 		} catch (e: unknown) {
 			// Define which errors during setValue are expected and won't crash


### PR DESCRIPTION
With this PR, a multicast `setValue` now optimistically updates the changed valueID on every node that supports the corresponding CC when the command succeeded. In addition, `currentValue`/`currentColor` is also updated for the `Basic`, `Binary Switch`, `Color Switch` and `Multilevel Switch` CCs.

The principle is the same as in https://github.com/zwave-js/node-zwave-js/pull/1522 but is now applied to multicast.

fixes: https://github.com/zwave-js/node-zwave-js/issues/1550