### PR TITLE
refactor(config): rename noEndpoint to multiChannel, reverse meaning

### DIFF
--- a/docs/api/config-manager.md
+++ b/docs/api/config-manager.md
@@ -308,7 +308,7 @@ interface ConditionalAssociationConfig {
 	readonly description?: string | undefined;
 	readonly maxNodes: number;
 	readonly isLifeline: boolean;
-	readonly noEndpoint: boolean;
+	readonly multiChannel: boolean;
 }
 ```
 

--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -112,7 +112,7 @@ The property looks as follows:
 		"description": "A description what group #2 does", // optional, only add this if it adds additional value
 		"maxNodes": 1, // SHOULD be 1 for the lifeline, some devices support more nodes
 		"isLifeline": true, // Whether this is the Lifeline group. SHOULD exist exactly once, some nodes require more groups to report everything
-		"noEndpoint": true, // Whether node id associations must be used for this group, even if the device supports endpoint associations, (optional)
+		"multiChannel": false, // Set this to false to force node id associations for this group, even if endpoint associations are supported. Default: `true`
 	},
 	// ... more groups ...
 }

--- a/maintenance/schemas/device-config.json
+++ b/maintenance/schemas/device-config.json
@@ -373,9 +373,9 @@
 							"type": "boolean",
 							"description": "Whether this is a Lifeline group. SHOULD exist exactly once, some nodes require more groups to report everything."
 						},
-						"noEndpoint": {
-							"const": true,
-							"description": "Whether node id associations must be used for this group, even if the device supports endpoint associations"
+						"multiChannel": {
+							"const": false,
+							"description": "Set this to `false` to force node id associations for this group, even if endpoint associations are supported."
 						}
 					},
 					"anyOf": [

--- a/packages/config/config/devices/0x0086/zw095.json
+++ b/packages/config/config/devices/0x0086/zw095.json
@@ -26,7 +26,8 @@
 			"label": "Lifeline",
 			"maxNodes": 5,
 			"isLifeline": true,
-			"noEndpoint": true
+			// The device does not like Endpoint Associations for the lifeline
+			"multiChannel": false
 		}
 	},
 	"paramInformation": {

--- a/packages/config/config/devices/0x0086/zw132.json
+++ b/packages/config/config/devices/0x0086/zw132.json
@@ -37,7 +37,7 @@
 			"maxNodes": 5,
 			"isLifeline": true,
 			// The device does not like Endpoint Associations for the lifeline
-			"noEndpoint": true
+			"multiChannel": false
 		},
 		"2": {
 			"label": "Forward Received Commands",

--- a/packages/config/config/devices/0x0086/zw139.json
+++ b/packages/config/config/devices/0x0086/zw139.json
@@ -36,7 +36,8 @@
 			"label": "Lifeline",
 			"maxNodes": 5,
 			"isLifeline": true,
-			"noEndpoint": true
+			// The device does not like Endpoint Associations for the lifeline
+			"multiChannel": false
 		},
 		"2": {
 			"label": "Forward Received Commands",

--- a/packages/config/config/devices/0x0086/zw140.json
+++ b/packages/config/config/devices/0x0086/zw140.json
@@ -36,7 +36,8 @@
 			"label": "Lifeline",
 			"maxNodes": 5,
 			"isLifeline": true,
-			"noEndpoint": true
+			// The device does not like Endpoint Associations for the lifeline
+			"multiChannel": false
 		},
 		"2": {
 			"label": "Forward Received Commands",

--- a/packages/config/config/devices/0x0175/mt2761.json
+++ b/packages/config/config/devices/0x0175/mt2761.json
@@ -19,10 +19,11 @@
 	"supportsZWavePlus": true,
 	"associations": {
 		"1": {
-			"label": "Z-Wave Plus Lifeline",
+			"label": "Lifeline",
 			"maxNodes": 1,
 			"isLifeline": true,
-			"noEndpoint": true
+			// The device does not like Endpoint Associations for the lifeline
+			"multiChannel": false
 		},
 		"2": {
 			"label": "Basic on/off - triggered at change of the input I1 state and reflecting its state.",
@@ -56,7 +57,8 @@
 			"label": "Multilevel sensor report - triggered at change of temperature sensor.",
 			"maxNodes": 16,
 			"isLifeline": true,
-			"noEndpoint": true
+			// The device does not like Endpoint Associations for the lifeline
+			"multiChannel": false
 		}
 	},
 	"paramInformation": {

--- a/packages/config/src/Devices.ts
+++ b/packages/config/src/Devices.ts
@@ -877,16 +877,17 @@ isLifeline in association ${groupId} must be a boolean`,
 		this.isLifeline = !!definition.isLifeline;
 
 		if (
-			definition.noEndpoint != undefined &&
-			definition.noEndpoint !== true
+			definition.multiChannel != undefined &&
+			definition.multiChannel !== false
 		) {
 			throwInvalidConfig(
 				"devices",
 				`packages/config/config/devices/${filename}:
-noEndpoint in association ${groupId} must be either true or left out`,
+multiChannel in association ${groupId} must be either false or left out`,
 			);
 		}
-		this.noEndpoint = !!definition.noEndpoint;
+		// Default to multi channel associations
+		this.multiChannel = definition.multiChannel ?? true;
 	}
 
 	public readonly condition?: string;
@@ -901,7 +902,7 @@ noEndpoint in association ${groupId} must be either true or left out`,
 	 */
 	public readonly isLifeline: boolean;
 	/** Some devices support multi channel associations but require some of its groups to use node id associations */
-	public readonly noEndpoint: boolean;
+	public readonly multiChannel: boolean;
 
 	public evaluateCondition(
 		deviceId?: DeviceID,
@@ -920,7 +921,7 @@ noEndpoint in association ${groupId} must be either true or left out`,
 			"description",
 			"maxNodes",
 			"isLifeline",
-			"noEndpoint",
+			"multiChannel",
 		]);
 	}
 }

--- a/packages/zwave-js/src/lib/commandclass/MultiChannelAssociationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultiChannelAssociationCC.ts
@@ -479,10 +479,10 @@ export class MultiChannelAssociationCC extends CommandClass {
 					const mustUseNodeAssociation =
 						!supportsMultiChannel ||
 						node.deviceConfig?.associations?.get(group)
-							?.noEndpoint ||
+							?.multiChannel === false ||
 						node.deviceConfig?.endpoints
 							?.get(0)
-							?.associations?.get(group)?.noEndpoint;
+							?.associations?.get(group)?.multiChannel === false;
 
 					const nodeIdsValueId = groupSupportsMultiChannel
 						? getNodeIdsValueId(this.endpointIndex, group)

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -2362,7 +2362,7 @@ ${associatedNodes.join(", ")}`,
 		const groupIsMultiChannel =
 			!!mcInstance &&
 			group <= mcGroupCount &&
-			!node.deviceConfig?.associations?.get(group)?.noEndpoint;
+			node.deviceConfig?.associations?.get(group)?.multiChannel !== false;
 
 		if (groupIsMultiChannel) {
 			// Check that all associations are allowed


### PR DESCRIPTION
This is the last remaining step for #2494.
`noEndpoint` seemed confusing when specified on an endpoint, so `multiChannel: false` is closer to the intended meaning of the flag.

Fixes: #2494