### PR TITLE
fix: correct parameter reference in DSB28 file

### DIFF
--- a/packages/config/config/devices/0x0086/dsb28.json
+++ b/packages/config/config/devices/0x0086/dsb28.json
@@ -64,7 +64,7 @@
 			"$import": "templates/aeotec_template.json#power_threshold_clamp3"
 		},
 		"8": {
-			"$import": "templates/aeotec_template.json#power_threshold_wholehem"
+			"$import": "templates/aeotec_template.json#percent_threshold_wholehem"
 		},
 		"9": {
 			"$import": "templates/aeotec_template.json#percent_threshold_clamp1"


### PR DESCRIPTION
Closes #2626. Confirmed in the manual.