### PR TITLE
fix(node): also hide Basic CC after restoring from cache

### DIFF
--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3423,8 +3423,17 @@ protocol version:      ${this._protocolVersion}`;
 			}
 		}
 
-		// And restore the device config
+		// Restore the device config
 		await this.loadDeviceConfig();
+
+		// And remove the Basic CC if it should be hidden
+		// TODO: Do this as part of loadDeviceConfig
+		const compat = this._deviceConfig?.compat;
+		if (!compat?.disableBasicMapping && !compat?.treatBasicSetAsEvent) {
+			for (const endpoint of this.getAllEndpoints()) {
+				endpoint.hideBasicCCInFavorOfActuatorCCs();
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
We hide the Basic CC in favor of better CCs during the interview, but we failed to do so after a cache restore.

fixes: https://github.com/zwave-js/node-zwave-js/issues/2536