### PR TITLE
fix(config): add languages to Ring Keypad v2

### DIFF
--- a/packages/config/config/devices/0x0346/keypad_v2.json
+++ b/packages/config/config/devices/0x0346/keypad_v2.json
@@ -205,7 +205,7 @@
 					"label": "French",
 					"value": 2
 				},
-				{	
+				{
 					"label": "Spanish",
 					"value": 5
 				}

--- a/packages/config/config/devices/0x0346/keypad_v2.json
+++ b/packages/config/config/devices/0x0346/keypad_v2.json
@@ -203,7 +203,7 @@
 				},
 				{
 					"label": "French",
-					"value": 2,
+					"value": 2
 				},
 				{	
 					"label": "Spanish",

--- a/packages/config/config/devices/0x0346/keypad_v2.json
+++ b/packages/config/config/devices/0x0346/keypad_v2.json
@@ -200,6 +200,14 @@
 				{
 					"label": "English",
 					"value": 0
+				},
+				{
+					"label": "French",
+					"value": 2,
+				},
+				{	
+					"label": "Spanish"
+					"value": 5
 				}
 			]
 		},

--- a/packages/config/config/devices/0x0346/keypad_v2.json
+++ b/packages/config/config/devices/0x0346/keypad_v2.json
@@ -206,7 +206,7 @@
 					"value": 2,
 				},
 				{	
-					"label": "Spanish"
+					"label": "Spanish",
 					"value": 5
 				}
 			]


### PR DESCRIPTION
Testing with a keypad shows that the three supported languages are 0 (English), 2 (French) and 5 (Spanish).  This matches the 0x37 bitmap of supported languages.