### PR TITLE
feat(config): add device configuration for Aeotec ZWA011

### DIFF
--- a/packages/config/config/devices/0x0371/zwa011.json
+++ b/packages/config/config/devices/0x0371/zwa011.json
@@ -1,0 +1,202 @@
+{
+	"manufacturer": "Aeotec Ltd.",
+	"manufacturerId": "0x0371",
+	"label": "ZWA011",
+	"description": "Door/Window Sensor 7",
+	"devices": [
+		{
+			"productType": "0x0102",
+			"productId": "0x000b"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"supportsZWavePlus": true,
+	"paramInformation": {
+		"3": {
+			"label": "Sensor State Polarity",
+			"description": "Defines state when the magnet is close to the sensor.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Closed when the magnet is near",
+					"value": 0
+				},
+				{
+					"label": "Opened when the magnet is near",
+					"value": 1
+				}
+			]
+		},
+		"4": {
+			"label": "Visual LED Indications",
+			"description": "Defines when the red LED will indicate events.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 7,
+			"defaultValue": 7,
+			"options": [
+				{
+					"label": "No indications",
+					"value": 0
+				},
+				{
+					"label": "Indication of opening/closing status change",
+					"value": 1
+				},
+				{
+					"label": "Indication of wake up",
+					"value": 2
+				},
+				{
+					"label": "Indication of device tampering",
+					"value": 4
+				}
+			]
+		},
+		"5": {
+			"label": "Range Test after double click",
+			"description": "Allows to enable the activation of a Z-Wave range.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disabled",
+					"value": 0
+				},
+				{
+					"label": "Enabled",
+					"value": 1
+				}
+			]
+		},
+		"6": {
+			"label": "2nd Association Group Trigger",
+			"description": "Sending a BASIC command to all devices of Association Group 2",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 2,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Switch after ‘Open‘ and ‘Close‘",
+					"value": 0
+				},
+				{
+					"label": "Switch after ‘Open‘",
+					"value": 1
+				},
+				{
+					"label": "Switch after ‘Close‘",
+					"value": 2
+				}
+			]
+		},
+		"7": {
+			"label": "Command Sent to Devices of Association Group 2",
+			"description": "This parameter defines which commands is sent to 2nd Association Group",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 2,
+			"defaultValue": 2,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "On",
+					"value": 0
+				},
+				{
+					"label": "Off",
+					"value": 1
+				},
+				{
+					"label": "On and Off",
+					"value": 2
+				}
+			]
+		},
+		"8": {
+			"label": "BASIC command value sent to 2nd Assoc Group on On",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 255,
+			"unsigned": true
+		},
+		"9": {
+			"label": "BASIC command value sent to 2nd Assoc Group on Off",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"unsigned": true
+		},
+		"10": {
+			"label": "Time Delay of ‘On‘ command frame",
+			"unit": "Seconds",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 32400,
+			"defaultValue": 0
+		},
+		"11": {
+			"label": "Time Delay of ‘Off‘ command frame",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 32400,
+			"defaultValue": 0
+		},
+		"12": {
+			"label": "Delay of Tamper Alarm Cancellation",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 32400,
+			"defaultValue": 0
+		},
+		"13": {
+			"label": "Reporting Tamper Alarm Cancellation",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Do not send Report",
+					"value": 0
+				},
+				{
+					"label": "Send Report",
+					"value": 1
+				}
+			]
+		},
+		"15": {
+			"label": "Factory reset",
+			"description": "Helps reset configuration parameters and device to factory defaults",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1431655765,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Reset Parameter",
+					"value": 1
+				},
+				{
+					"label": "Factory default (exclude the device)",
+					"value": 1431655765
+				}
+			]
+		}
+	}
+}

--- a/packages/config/config/devices/0x0371/zwa011.json
+++ b/packages/config/config/devices/0x0371/zwa011.json
@@ -186,17 +186,7 @@
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1431655765,
-			"defaultValue": 0,
-			"options": [
-				{
-					"label": "Reset Parameter",
-					"value": 1
-				},
-				{
-					"label": "Factory default (exclude the device)",
-					"value": 1431655765
-				}
-			]
+			"defaultValue": 0
 		}
 	}
 }


### PR DESCRIPTION
Configuration defined by un-parsed data in zwavejs2mqtt dashboard (product type and ID), plus official user guide (https://help.aeotec.com/support/solutions/articles/6000230382-door-window-sensor-7-basic-user-guide-zwa011-)