### PR TITLE
iblinds V3.1 Update

### DIFF
--- a/packages/config/config/devices/0x0287/iblindsv3_06.json
+++ b/packages/config/config/devices/0x0287/iblindsv3_06.json
@@ -11,7 +11,7 @@
 	],
 	"firmwareVersion": {
 		"min": "0.0",
-		"max": "3.06"
+		"max": "3.6"
 	},
 	"associations": {
 		"1": {

--- a/packages/config/config/devices/0x0287/iblindsv3_06.json
+++ b/packages/config/config/devices/0x0287/iblindsv3_06.json
@@ -11,7 +11,7 @@
 	],
 	"firmwareVersion": {
 		"min": "0.0",
-		"max": "255.255"
+		"max": "3.06"
 	},
 	"associations": {
 		"1": {

--- a/packages/config/config/devices/0x0287/iblindsv3_1.json
+++ b/packages/config/config/devices/0x0287/iblindsv3_1.json
@@ -1,0 +1,111 @@
+{
+	"manufacturer": "HAB Home Intelligence LLC",
+	"manufacturerId": "0x0287",
+	"label": "iblinds V3",
+	"description": "Window Blind Controller",
+	"devices": [
+		{
+			"productType": "0x0004",
+			"productId": "0x0072"
+		}
+	],
+	"firmwareVersion": {
+		"min": "3.1",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 1,
+			"isLifeline": true
+		}
+	},
+	"paramInformation": {
+		"1": {
+			"label": "Close Interval",
+			"description": "Auto Calibration Tightness. Lower value = tighter, Higher value = looser (MUST BE RECALIBRATED). Range: 16-32",
+			"valueSize": 1,
+			"minValue": 16,
+			"maxValue": 32,
+			"defaultValue": 22,
+			"unsigned": true
+		},
+		"2": {
+			"label": "Reverse Direction",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "No",
+					"value": 0
+				},
+				{
+					"label": "Yes",
+					"value": 1
+				}
+			]
+		},
+		"3": {
+			"label": "Send Reports",
+			"description": "Used to disable Z-Wave Report. This is useful for systems that poll iblinds immediately after sending a position command. Disable if this an immediate report is causing iblinds motor to function improperly.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Enabled",
+					"value": 0
+				},
+				{
+					"label": "Disabled",
+					"value": 1
+				}
+			]
+		},
+		"4": {
+			"label": "Default ON Value",
+			"description": "Value that iblinds will open to by default",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 100,
+			"defaultValue": 50,
+			"unsigned": true
+		},
+		"5": {
+			"label": "Reset Button Disable",
+			"description": "Will disable the reset button on the motor, preventing it from accidentally being pressed",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "No",
+					"value": 0
+				},
+				{
+					"label": "Yes",
+					"value": 1
+				}
+			]
+		},
+		"6": {
+			"label": "Speed",
+			"description": "How fast iblinds will close in seconds",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 100,
+			"defaultValue": 0,
+			"unsigned": true
+		}
+	}
+}

--- a/packages/config/config/devices/0x0287/iblindsv3_10.json
+++ b/packages/config/config/devices/0x0287/iblindsv3_10.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"firmwareVersion": {
-		"min": "3.1",
+		"min": "3.10",
 		"max": "255.255"
 	},
 	"associations": {


### PR DESCRIPTION
Firmware for the V3 will be updated to have a new product ID.
This is for a hardware change in the newer V3 models.
Models unaffected are <V3.06 or sold previous to June 2021
V3.1+ are now product ID 0x0072