### PR TITLE
refactor(config): template "state after power failure" setting

### DIFF
--- a/packages/config/config/devices/0x0086/dsc10.json
+++ b/packages/config/config/devices/0x0086/dsc10.json
@@ -30,7 +30,7 @@
 			"$import": "templates/aeotec_template.json#current_overload"
 		},
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure"
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"80": {
 			"$import": "templates/aeotec_template.json#enable_notifications"

--- a/packages/config/config/devices/0x0086/dsc14.json
+++ b/packages/config/config/devices/0x0086/dsc14.json
@@ -38,7 +38,7 @@
 			"unit": "ms"
 		},
 		"7": {
-			"$import": "../templates/master_template.json#state_after_power_failure",
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off",
 			"options": [
 				{
 					"label": "Stop",

--- a/packages/config/config/devices/0x0086/zw075.json
+++ b/packages/config/config/devices/0x0086/zw075.json
@@ -52,7 +52,7 @@
 		},
 		"20": {
 			"$if": "firmwareVersion >= 4.0",
-			"$import": "../templates/master_template.json#state_after_power_failure"
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"80": {
 			"$import": "templates/aeotec_template.json#enable_notifications"

--- a/packages/config/config/devices/0x0086/zw078.json
+++ b/packages/config/config/devices/0x0086/zw078.json
@@ -44,7 +44,7 @@
 			"$import": "templates/aeotec_template.json#current_overload"
 		},
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure"
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"80": {
 			"$import": "/templates/aeotec_template.json#enable_notifications"

--- a/packages/config/config/devices/0x0086/zw096.json
+++ b/packages/config/config/devices/0x0086/zw096.json
@@ -49,7 +49,7 @@
 			"$import": "templates/aeotec_template.json#current_overload"
 		},
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure"
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"80": {
 			"$import": "templates/aeotec_template.json#enable_notifications"

--- a/packages/config/config/devices/0x0086/zw098.json
+++ b/packages/config/config/devices/0x0086/zw098.json
@@ -62,7 +62,7 @@
 			"unsigned": true
 		},
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure"
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"32": {
 			"label": "Color Change Report Type",

--- a/packages/config/config/devices/0x0086/zw099.json
+++ b/packages/config/config/devices/0x0086/zw099.json
@@ -38,7 +38,7 @@
 			"$import": "templates/aeotec_template.json#current_overload"
 		},
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure"
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"80": {
 			"$import": "templates/aeotec_template.json#enable_notifications_0-3"

--- a/packages/config/config/devices/0x0086/zw111.json
+++ b/packages/config/config/devices/0x0086/zw111.json
@@ -64,7 +64,7 @@
 			"$import": "templates/aeotec_template.json#overheat_protection"
 		},
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure"
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"80": {
 			"$import": "templates/aeotec_template.json#enable_notifications_0-4"

--- a/packages/config/config/devices/0x0086/zw116.json
+++ b/packages/config/config/devices/0x0086/zw116.json
@@ -60,7 +60,7 @@
 			"$import": "templates/aeotec_template.json#overheat_protection"
 		},
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure"
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"80": {
 			"$import": "templates/aeotec_template.json#enable_notifications_0-3"

--- a/packages/config/config/devices/0x0086/zw121.json
+++ b/packages/config/config/devices/0x0086/zw121.json
@@ -31,7 +31,7 @@
 	},
 	"paramInformation": {
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure"
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"32": {
 			"label": "Report Type",

--- a/packages/config/config/devices/0x0086/zw132.json
+++ b/packages/config/config/devices/0x0086/zw132.json
@@ -58,7 +58,7 @@
 			"$import": "templates/aeotec_template.json#overheat_protection"
 		},
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure"
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"80": {
 			"$import": "templates/aeotec_template.json#enable_notifications_0-3"

--- a/packages/config/config/devices/0x0086/zw139.json
+++ b/packages/config/config/devices/0x0086/zw139.json
@@ -55,7 +55,7 @@
 			"$import": "templates/aeotec_template.json#overheat_protection"
 		},
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure"
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"80": {
 			"$import": "templates/aeotec_template.json#enable_notifications_0-3"

--- a/packages/config/config/devices/0x0086/zw140.json
+++ b/packages/config/config/devices/0x0086/zw140.json
@@ -55,7 +55,7 @@
 			"$import": "templates/aeotec_template.json#overheat_protection"
 		},
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure"
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"80": {
 			"$import": "templates/aeotec_template.json#enable_notifications_0-3"

--- a/packages/config/config/devices/0x0107/fibefgs-213.json
+++ b/packages/config/config/devices/0x0107/fibefgs-213.json
@@ -16,22 +16,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"9": {
-			"label": "Restore state after power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "off after power loss",
-					"value": 0
-				},
-				{
-					"label": "restore last state",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"10": {
 			"label": "First channel operating mode",

--- a/packages/config/config/devices/0x010f/fgd211_0.0-1.8.json
+++ b/packages/config/config/devices/0x010f/fgd211_0.0-1.8.json
@@ -211,23 +211,7 @@
 			]
 		},
 		"16": {
-			"label": "Saving state before power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "State NOT saved at power failure",
-					"value": 0
-				},
-				{
-					"label": "State saved at power failure",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"17": {
 			"label": "3-way switch",

--- a/packages/config/config/devices/0x010f/fgd211_1.9-1.11.json
+++ b/packages/config/config/devices/0x010f/fgd211_1.9-1.11.json
@@ -211,23 +211,7 @@
 			]
 		},
 		"16": {
-			"label": "Saving state before power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "State NOT saved at power failure",
-					"value": 0
-				},
-				{
-					"label": "State saved at power failure",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"17": {
 			"label": "3-way switch",

--- a/packages/config/config/devices/0x010f/fgd211_2.1.json
+++ b/packages/config/config/devices/0x010f/fgd211_2.1.json
@@ -217,23 +217,7 @@
 			]
 		},
 		"16": {
-			"label": "Saving state before power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "State NOT saved at power failure",
-					"value": 0
-				},
-				{
-					"label": "State saved at power failure.",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"17": {
 			"label": "3-way switch function",

--- a/packages/config/config/devices/0x010f/fgd212_0.0-3.4.json
+++ b/packages/config/config/devices/0x010f/fgd212_0.0-3.4.json
@@ -111,23 +111,7 @@
 			"defaultValue": 5
 		},
 		"9": {
-			"label": "Saving state before power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "State not saved, outputs OFF",
-					"value": 0
-				},
-				{
-					"label": "State saved, outputs to previous",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"10": {
 			"label": "Timer functionality (auto - off).",

--- a/packages/config/config/devices/0x010f/fgd212_3.5.json
+++ b/packages/config/config/devices/0x010f/fgd212_3.5.json
@@ -94,23 +94,7 @@
 			"defaultValue": 5
 		},
 		"9": {
-			"label": "Saving state before power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "All outputs are set to OFF upon power restore",
-					"value": 0
-				},
-				{
-					"label": "Outputs set to previous state upon power restore",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"10": {
 			"label": "Timer functionality (auto - off)",

--- a/packages/config/config/devices/0x010f/fgrgbw-442.json
+++ b/packages/config/config/devices/0x010f/fgrgbw-442.json
@@ -28,22 +28,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"1": {
-			"label": "Remember device status before the power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "device remains switched off",
-					"value": 0
-				},
-				{
-					"label": "restore the state",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"20": {
 			"label": "Input 1 - operating mode",

--- a/packages/config/config/devices/0x010f/fgrgbw.json
+++ b/packages/config/config/devices/0x010f/fgrgbw.json
@@ -181,23 +181,7 @@
 			"unsigned": true
 		},
 		"16": {
-			"label": "Remember device status after power failure",
-			"description": "Define how will the Plug react after the power supply is back on.",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Do not remember state",
-					"value": 0
-				},
-				{
-					"label": "Remember state before power failure",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"30": {
 			"label": "Alarm response",

--- a/packages/config/config/devices/0x010f/fgs211_0.0-2.0.json
+++ b/packages/config/config/devices/0x010f/fgs211_0.0-2.0.json
@@ -206,23 +206,7 @@
 			]
 		},
 		"16": {
-			"label": "Saving state before power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "State NOT saved at power failure",
-					"value": 0
-				},
-				{
-					"label": "State saved at power failure",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"30": {
 			"label": "Relay 1: Response to General Alarm",

--- a/packages/config/config/devices/0x010f/fgs211_2.1.json
+++ b/packages/config/config/devices/0x010f/fgs211_2.1.json
@@ -206,23 +206,7 @@
 			]
 		},
 		"16": {
-			"label": "Saving state before power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "State NOT saved at power failure",
-					"value": 0
-				},
-				{
-					"label": "State saved at power failure",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"30": {
 			"label": "Relay 1: Response to General Alarm",

--- a/packages/config/config/devices/0x010f/fgs212.json
+++ b/packages/config/config/devices/0x010f/fgs212.json
@@ -173,23 +173,7 @@
 			]
 		},
 		"16": {
-			"label": "Saving state before power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "State NOT saved at pwr failure, outputs set ...",
-					"value": 0
-				},
-				{
-					"label": "State saved at pwr failure, outputs are set to ...",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"30": {
 			"label": "Relay 1: Response to General Alarm",

--- a/packages/config/config/devices/0x010f/fgs213.json
+++ b/packages/config/config/devices/0x010f/fgs213.json
@@ -28,22 +28,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"9": {
-			"label": "Restore state after power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "off after power loss",
-					"value": 0
-				},
-				{
-					"label": "restore last state",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"10": {
 			"label": "First channel operating mode",

--- a/packages/config/config/devices/0x010f/fgs221_1.4-1.8.json
+++ b/packages/config/config/devices/0x010f/fgs221_1.4-1.8.json
@@ -248,23 +248,7 @@
 			]
 		},
 		"16": {
-			"label": "Saving state before power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "State NOT saved at power failure",
-					"value": 0
-				},
-				{
-					"label": "State saved at power failure",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"30": {
 			"label": "Relay 1: Response to General Alarm",

--- a/packages/config/config/devices/0x010f/fgs221_1.9-1.11.json
+++ b/packages/config/config/devices/0x010f/fgs221_1.9-1.11.json
@@ -234,23 +234,7 @@
 			]
 		},
 		"16": {
-			"label": "Saving state before power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "State NOT saved at power failure",
-					"value": 0
-				},
-				{
-					"label": "State saved at power failure",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"30": {
 			"label": "Relay 1: Response to General Alarm",

--- a/packages/config/config/devices/0x010f/fgs221_2.1-2.3.json
+++ b/packages/config/config/devices/0x010f/fgs221_2.1-2.3.json
@@ -242,24 +242,7 @@
 			]
 		},
 		"16": {
-			"label": "Saving state of the device after power failure",
-			"description": "Returns to the last position saved",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Switch does not save state after power failure",
-					"value": 0
-				},
-				{
-					"label": "Fibaro Switch saves its state before power failure",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"30": {
 			"label": "Relay 1: Response to General Alarm",

--- a/packages/config/config/devices/0x010f/fgs222.json
+++ b/packages/config/config/devices/0x010f/fgs222.json
@@ -222,23 +222,7 @@
 			]
 		},
 		"16": {
-			"label": "Saving state before power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "State NOT saved at power failure",
-					"value": 0
-				},
-				{
-					"label": "State saved at power failure",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"30": {
 			"label": "Relay 1: Response to General Alarm",

--- a/packages/config/config/devices/0x010f/fgs223.json
+++ b/packages/config/config/devices/0x010f/fgs223.json
@@ -59,23 +59,7 @@
 	},
 	"paramInformation": {
 		"9": {
-			"label": "Restore state after power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "State NOT saved at power failure, all outputs are set to OFF upon power restore",
-					"value": 0
-				},
-				{
-					"label": "State saved at power failure, all outputs are set to previous state upon power restore",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"10": {
 			"label": "First channel - operating mode",

--- a/packages/config/config/devices/0x010f/fgwp101.json
+++ b/packages/config/config/devices/0x010f/fgwp101.json
@@ -55,24 +55,7 @@
 			]
 		},
 		"16": {
-			"label": "Remember device status after power failure",
-			"description": "Define how will the Plug react after the power supply is back on.",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Do not remember state",
-					"value": 0
-				},
-				{
-					"label": "Remember state before power failure",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"34": {
 			"label": "Reaction to alarms",

--- a/packages/config/config/devices/0x010f/fgwp102_2.1-2.5.json
+++ b/packages/config/config/devices/0x010f/fgwp102_2.1-2.5.json
@@ -40,24 +40,7 @@
 			]
 		},
 		"16": {
-			"label": "Remember device status after power failure",
-			"description": "Define how the plug reacts after the power supply is back on.",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Do not remember state",
-					"value": 0
-				},
-				{
-					"label": "Remember state before power failure",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"34": {
 			"label": "Reaction to alarms",

--- a/packages/config/config/devices/0x010f/fgwp102_3.2.json
+++ b/packages/config/config/devices/0x010f/fgwp102_3.2.json
@@ -43,23 +43,7 @@
 			]
 		},
 		"2": {
-			"label": "Remember device status before the power failure",
-			"description": "determines how the Wall Plug will react in the event of power supply failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "device remains switched off",
-					"value": 0
-				},
-				{
-					"label": "Remember state before power failure",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "Overload safety switch",

--- a/packages/config/config/devices/0x010f/fgwpb-121.json
+++ b/packages/config/config/devices/0x010f/fgwpb-121.json
@@ -19,23 +19,7 @@
 	},
 	"paramInformation": {
 		"2": {
-			"label": "Power Failure",
-			"description": "Remember device status before the power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Switched Off",
-					"value": 0
-				},
-				{
-					"label": "Restore State",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "Overload",

--- a/packages/config/config/devices/0x010f/fgwpg-121.json
+++ b/packages/config/config/devices/0x010f/fgwpg-121.json
@@ -15,23 +15,7 @@
 	},
 	"paramInformation": {
 		"2": {
-			"label": "Power Failure",
-			"description": "Remember device status before the power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Switched Off",
-					"value": 0
-				},
-				{
-					"label": "Restore State",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "Overload",

--- a/packages/config/config/devices/0x0118/tze96.json
+++ b/packages/config/config/devices/0x0118/tze96.json
@@ -16,23 +16,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"4": {
-			"label": "Power failure",
-			"description": "Remember device status before the power failure.",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Switched OFF",
-					"value": 0
-				},
-				{
-					"label": "Restore state",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		}
 	}
 }

--- a/packages/config/config/devices/0x0154/700793.json
+++ b/packages/config/config/devices/0x0154/700793.json
@@ -23,26 +23,8 @@
 	},
 	"paramInformation": {
 		"1": {
-			"label": "Condition after power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Always Off",
-					"value": 0
-				},
-				{
-					"label": "Always On",
-					"value": 1
-				},
-				{
-					"label": "Last state",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev",
+			"defaultValue": 0
 		}
 	}
 }

--- a/packages/config/config/devices/0x0154/pope700397.json
+++ b/packages/config/config/devices/0x0154/pope700397.json
@@ -90,22 +90,7 @@
 			]
 		},
 		"5": {
-			"label": "Status after Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Always off",
-					"value": 0
-				},
-				{
-					"label": "Return to last switching state",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"21": {
 			"label": "LED Color on OFF state",

--- a/packages/config/config/devices/0x0159/smart_plug_16a.json
+++ b/packages/config/config/devices/0x0159/smart_plug_16a.json
@@ -90,22 +90,7 @@
 			]
 		},
 		"30": {
-			"label": "Restore state ofter power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Restore state after power failure",
-					"value": 0
-				},
-				{
-					"label": "Do not restore state after power failure",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power Consumption (Watt) Reporting Threshold",

--- a/packages/config/config/devices/0x0159/zmnhaa.json
+++ b/packages/config/config/devices/0x0159/zmnhaa.json
@@ -129,23 +129,7 @@
 			"unsigned": true
 		},
 		"30": {
-			"label": "Relay state after a power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 0,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Last saved state",
-					"value": 0
-				},
-				{
-					"label": "Power OFF",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power reporting in Watts on percentage change",

--- a/packages/config/config/devices/0x0159/zmnhad.json
+++ b/packages/config/config/devices/0x0159/zmnhad.json
@@ -137,23 +137,7 @@
 			]
 		},
 		"30": {
-			"label": "Save the relay state after a power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 0,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Module saves its state before power failure",
-					"value": 0
-				},
-				{
-					"label": "Module stays OFF after a power failure",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power reporting in Watts on power change",

--- a/packages/config/config/devices/0x0159/zmnhba.json
+++ b/packages/config/config/devices/0x0159/zmnhba.json
@@ -111,23 +111,7 @@
 			"unsigned": true
 		},
 		"30": {
-			"label": "Saving Q1 and Q2 after a power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 0,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Saves state before power failure",
-					"value": 0
-				},
-				{
-					"label": "Do not save state after a power failure",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power reporting in Watts on power change for Q1",

--- a/packages/config/config/devices/0x0159/zmnhbd.json
+++ b/packages/config/config/devices/0x0159/zmnhbd.json
@@ -156,23 +156,7 @@
 			"unsigned": true
 		},
 		"30": {
-			"label": "Saving the state after a power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 0,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Saves its state before power failure",
-					"value": 0
-				},
-				{
-					"label": "Does not save the state after a power failure",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power reporting in Watts for Q1",

--- a/packages/config/config/devices/0x0159/zmnhda.json
+++ b/packages/config/config/devices/0x0159/zmnhda.json
@@ -119,23 +119,7 @@
 			]
 		},
 		"30": {
-			"label": "State of the device after a power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 0,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Saves its state before power failure",
-					"value": 0
-				},
-				{
-					"label": "OFF",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power reporting in Watts on power change",

--- a/packages/config/config/devices/0x0159/zmnhdd.json
+++ b/packages/config/config/devices/0x0159/zmnhdd.json
@@ -238,23 +238,7 @@
 			]
 		},
 		"30": {
-			"label": "Saving the state after a power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 0,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Save state enabled",
-					"value": 0
-				},
-				{
-					"label": "Save state disabled",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power reporting in watts on power change",

--- a/packages/config/config/devices/0x0159/zmnhhd.json
+++ b/packages/config/config/devices/0x0159/zmnhhd.json
@@ -85,22 +85,7 @@
 			]
 		},
 		"30": {
-			"label": "Restore on/off status for load after power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Save last on/off status",
-					"value": 0
-				},
-				{
-					"label": "Don't save last on/off status",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power Consumption Threshold",

--- a/packages/config/config/devices/0x0159/zmnhia.json
+++ b/packages/config/config/devices/0x0159/zmnhia.json
@@ -181,23 +181,7 @@
 			"unsigned": true
 		},
 		"30": {
-			"label": "Saving the state after a power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 0,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Module saves its state",
-					"value": 0
-				},
-				{
-					"label": "Module does not save state",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power reporting in Watts on power change for Q1",

--- a/packages/config/config/devices/0x0159/zmnhja.json
+++ b/packages/config/config/devices/0x0159/zmnhja.json
@@ -265,22 +265,7 @@
 			]
 		},
 		"30": {
-			"label": "Saving the state after a power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "The module saves its state before power failure",
-					"value": 0
-				},
-				{
-					"label": "The module does not save the state",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
 		}
 	}
 }

--- a/packages/config/config/devices/0x0159/zmnhjd.json
+++ b/packages/config/config/devices/0x0159/zmnhjd.json
@@ -265,22 +265,7 @@
 			]
 		},
 		"30": {
-			"label": "Saving the state after a power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "The module saves its state before power failure",
-					"value": 0
-				},
-				{
-					"label": "The module does not save the state",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
 		}
 	}
 }

--- a/packages/config/config/devices/0x0159/zmnhmd.json
+++ b/packages/config/config/devices/0x0159/zmnhmd.json
@@ -69,22 +69,7 @@
 			]
 		},
 		"30": {
-			"label": "State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Restore previous state",
-					"value": 0
-				},
-				{
-					"label": "Remain off",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"48": {
 			"label": "Total Water Consumption",

--- a/packages/config/config/devices/0x0159/zmnhnd.json
+++ b/packages/config/config/devices/0x0159/zmnhnd.json
@@ -128,23 +128,7 @@
 			]
 		},
 		"30": {
-			"label": "Save state after power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 0,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Saves state before power failure",
-					"value": 0
-				},
-				{
-					"label": "Do not save state after power failure",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"63": {
 			"label": "Output Switch selection",

--- a/packages/config/config/devices/0x0159/zmnhqd.json
+++ b/packages/config/config/devices/0x0159/zmnhqd.json
@@ -88,22 +88,7 @@
 			"defaultValue": 0
 		},
 		"30": {
-			"label": "Restore state on power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "disabled",
-					"value": 0
-				},
-				{
-					"label": "enabled",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"50": {
 			"label": "Enable/disable beeper",

--- a/packages/config/config/devices/0x0159/zmnhsd.json
+++ b/packages/config/config/devices/0x0159/zmnhsd.json
@@ -152,23 +152,7 @@
 			]
 		},
 		"30": {
-			"label": "Save state of after a power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 0,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Save state enabled",
-					"value": 0
-				},
-				{
-					"label": "Save state disabled",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power reporting in watts on power change",

--- a/packages/config/config/devices/0x0159/zmnhud.json
+++ b/packages/config/config/devices/0x0159/zmnhud.json
@@ -265,22 +265,7 @@
 			]
 		},
 		"30": {
-			"label": "Device state after pwr failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "The module saves its state before power failure",
-					"value": 0
-				},
-				{
-					"label": "The module does not save the state",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
 		}
 	}
 }

--- a/packages/config/config/devices/0x0159/zmnhvd.json
+++ b/packages/config/config/devices/0x0159/zmnhvd.json
@@ -72,22 +72,7 @@
 			"defaultValue": 0
 		},
 		"30": {
-			"label": "Saving the state after a power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Module saves it state",
-					"value": 0
-				},
-				{
-					"label": "Module turns OFF",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"52": {
 			"label": "Auto or manual selection",

--- a/packages/config/config/devices/0x015d/zen20.json
+++ b/packages/config/config/devices/0x015d/zen20.json
@@ -28,26 +28,7 @@
 	},
 	"paramInformation": {
 		"1": {
-			"label": "On/Off Status Recovery After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Remember Previous State After Power Failure",
-					"value": 0
-				},
-				{
-					"label": "Power Strip Automatically ON After Power Failure",
-					"value": 1
-				},
-				{
-					"label": "Power Strip Automatically OFF After Power Failure",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"2": {
 			"label": "Power Wattage Report Value Threshold",

--- a/packages/config/config/devices/0x015f/mh-dt311_411.json
+++ b/packages/config/config/devices/0x015f/mh-dt311_411.json
@@ -42,23 +42,7 @@
 	},
 	"paramInformation": {
 		"1": {
-			"label": "Recover State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"2": {
 			"label": "Dimming Mode",

--- a/packages/config/config/devices/0x015f/mh-p220.json
+++ b/packages/config/config/devices/0x015f/mh-p220.json
@@ -23,22 +23,7 @@
 	},
 	"paramInformation": {
 		"1": {
-			"label": "Restore State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"2": {
 			"label": "External Switch Type",

--- a/packages/config/config/devices/0x015f/mh-s212.json
+++ b/packages/config/config/devices/0x015f/mh-s212.json
@@ -26,22 +26,7 @@
 	},
 	"paramInformation": {
 		"1": {
-			"label": "Restore State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"2": {
 			"label": "External Switch Type",

--- a/packages/config/config/devices/0x015f/mh-s311h.json
+++ b/packages/config/config/devices/0x015f/mh-s311h.json
@@ -20,12 +20,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"2": {
-			"label": "Switch state saved or not when power failure",
-			"description": "0=Saved 1=not saved",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "ALL ON/ALL OFF",

--- a/packages/config/config/devices/0x015f/mh-s312.json
+++ b/packages/config/config/devices/0x015f/mh-s312.json
@@ -42,12 +42,7 @@
 	},
 	"paramInformation": {
 		"2": {
-			"label": "Switch state saved or not when power failure",
-			"description": "1=Saved 0=not saved",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "ALL ON/ALL OFF",

--- a/packages/config/config/devices/0x015f/mh-s314-1502.json
+++ b/packages/config/config/devices/0x015f/mh-s314-1502.json
@@ -39,23 +39,7 @@
 	},
 	"paramInformation": {
 		"2": {
-			"label": "Recover State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disabled",
-					"value": 0
-				},
-				{
-					"label": "Enabled",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "All On/All Off",

--- a/packages/config/config/devices/0x015f/mh-s314.json
+++ b/packages/config/config/devices/0x015f/mh-s314.json
@@ -42,23 +42,7 @@
 	},
 	"paramInformation": {
 		"2": {
-			"label": "Recover State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disabled",
-					"value": 0
-				},
-				{
-					"label": "Enabled",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "All On/All Off",

--- a/packages/config/config/devices/0x015f/mh-s411-1302.json
+++ b/packages/config/config/devices/0x015f/mh-s411-1302.json
@@ -26,23 +26,7 @@
 	},
 	"paramInformation": {
 		"1": {
-			"label": "Recover State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disabled",
-					"value": 0
-				},
-				{
-					"label": "Enabled",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		}
 	}
 }

--- a/packages/config/config/devices/0x015f/mh-s411-1502.json
+++ b/packages/config/config/devices/0x015f/mh-s411-1502.json
@@ -26,23 +26,7 @@
 	},
 	"paramInformation": {
 		"2": {
-			"label": "Recover State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disabled",
-					"value": 0
-				},
-				{
-					"label": "Enabled",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "All On/All Off",

--- a/packages/config/config/devices/0x015f/mh-s412-1302.json
+++ b/packages/config/config/devices/0x015f/mh-s412-1302.json
@@ -30,23 +30,7 @@
 	},
 	"paramInformation": {
 		"1": {
-			"label": "Recover State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disabled",
-					"value": 0
-				},
-				{
-					"label": "Enabled",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		}
 	}
 }

--- a/packages/config/config/devices/0x015f/mh-s412-1502.json
+++ b/packages/config/config/devices/0x015f/mh-s412-1502.json
@@ -30,23 +30,7 @@
 	},
 	"paramInformation": {
 		"2": {
-			"label": "Recover State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disabled",
-					"value": 0
-				},
-				{
-					"label": "Enabled",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "All On/All Off",

--- a/packages/config/config/devices/0x015f/mh-s511.json
+++ b/packages/config/config/devices/0x015f/mh-s511.json
@@ -15,22 +15,7 @@
 	},
 	"paramInformation": {
 		"2": {
-			"label": "Restore State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "All On / All Off",

--- a/packages/config/config/devices/0x015f/mh-s512.json
+++ b/packages/config/config/devices/0x015f/mh-s512.json
@@ -15,22 +15,7 @@
 	},
 	"paramInformation": {
 		"2": {
-			"label": "Restore State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "All On / All Off",

--- a/packages/config/config/devices/0x015f/mh-s513.json
+++ b/packages/config/config/devices/0x015f/mh-s513.json
@@ -15,22 +15,7 @@
 	},
 	"paramInformation": {
 		"2": {
-			"label": "Restore State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "All On / All Off",

--- a/packages/config/config/devices/0x015f/mh-s521.json
+++ b/packages/config/config/devices/0x015f/mh-s521.json
@@ -20,23 +20,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"2": {
-			"label": "Power Failure State",
-			"description": "switch will be off when powered again",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "not saved",
-					"value": 0
-				},
-				{
-					"label": "saved",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "ALL ON/ALL OFF",

--- a/packages/config/config/devices/0x0165/asp-3-1.json
+++ b/packages/config/config/devices/0x0165/asp-3-1.json
@@ -16,25 +16,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"1": {
-			"label": "Default State",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 63,
-			"defaultValue": 2,
-			"options": [
-				{
-					"label": "OFF",
-					"value": 0
-				},
-				{
-					"label": "ON",
-					"value": 1
-				},
-				{
-					"label": "Status before Power Failure",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"2": {
 			"label": "Power Failure",

--- a/packages/config/config/devices/0x016a/ft111.json
+++ b/packages/config/config/devices/0x016a/ft111.json
@@ -50,7 +50,7 @@
 			"$import": "../0x0086/templates/aeotec_template.json#overheat_protection"
 		},
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure"
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"80": {
 			"$import": "../0x0086/templates/aeotec_template.json#enable_notifications_0-4"

--- a/packages/config/config/devices/0x0175/mt2759.json
+++ b/packages/config/config/devices/0x0175/mt2759.json
@@ -146,23 +146,7 @@
 			]
 		},
 		"30": {
-			"label": "Saving the state",
-			"description": "Saving the state of the relay after a power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "HC Switch relay module saves its state",
-					"value": 0
-				},
-				{
-					"label": "HC Switch relay module returns to \"off\" position",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power reporting (W) on power change",

--- a/packages/config/config/devices/0x0175/mt2760.json
+++ b/packages/config/config/devices/0x0175/mt2760.json
@@ -238,23 +238,7 @@
 			]
 		},
 		"30": {
-			"label": "Saving the state after a power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 0,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Save state enabled",
-					"value": 0
-				},
-				{
-					"label": "Save state disabled",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power reporting in watts on power change",

--- a/packages/config/config/devices/0x0176/tzwp-100.json
+++ b/packages/config/config/devices/0x0176/tzwp-100.json
@@ -29,27 +29,7 @@
 			"unsigned": true
 		},
 		"2": {
-			"label": "Device status after power failure",
-			"description": "Define how the plug will react after the power supply is back on",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Always off",
-					"value": 0
-				},
-				{
-					"label": "Remember status",
-					"value": 1
-				},
-				{
-					"label": "Always on",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev_on"
 		},
 		"3": {
 			"label": "LED indicator",

--- a/packages/config/config/devices/0x0176/tzwp-102.json
+++ b/packages/config/config/devices/0x0176/tzwp-102.json
@@ -35,26 +35,7 @@
 			]
 		},
 		"2": {
-			"label": "device status after power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Remember Status",
-					"value": 0
-				},
-				{
-					"label": "Always ON",
-					"value": 1
-				},
-				{
-					"label": "Always OFF",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"3": {
 			"label": "Send Status When Load Changes",

--- a/packages/config/config/devices/0x0208/hkzw-so01.json
+++ b/packages/config/config/devices/0x0208/hkzw-so01.json
@@ -24,26 +24,7 @@
 			"defaultValue": 1
 		},
 		"21": {
-			"label": "Device Status after Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Previous state",
-					"value": 0
-				},
-				{
-					"label": "On",
-					"value": 1
-				},
-				{
-					"label": "Off",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"24": {
 			"label": "Notification on Load Change",

--- a/packages/config/config/devices/0x0208/hkzw-so05.json
+++ b/packages/config/config/devices/0x0208/hkzw-so05.json
@@ -36,27 +36,7 @@
 			]
 		},
 		"21": {
-			"label": "Device Status After Power Failure.",
-			"description": "Define how the Plug reacts after the power supply is back on.",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Memorizes its state after a power failure",
-					"value": 0
-				},
-				{
-					"label": "Always on after power failure.",
-					"value": 1
-				},
-				{
-					"label": "Always off after power failure.",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"24": {
 			"label": "Load Status Change Notification",

--- a/packages/config/config/devices/0x0208/hkzw_so03.json
+++ b/packages/config/config/devices/0x0208/hkzw_so03.json
@@ -35,26 +35,7 @@
 			]
 		},
 		"21": {
-			"label": "On/Off Status Recovery After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Remember Status",
-					"value": 0
-				},
-				{
-					"label": "Turn ON (default)",
-					"value": 1
-				},
-				{
-					"label": "Turn OFF",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"24": {
 			"label": "On/Off Status Change Notifications",

--- a/packages/config/config/devices/0x0258/nas-wr01z.json
+++ b/packages/config/config/devices/0x0258/nas-wr01z.json
@@ -100,22 +100,7 @@
 			"defaultValue": 5
 		},
 		"7": {
-			"label": "Remember relay ON/OFF status after power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Do not remember",
-					"value": 0
-				},
-				{
-					"label": "Remember",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"8": {
 			"label": "Timed auto-off",

--- a/packages/config/config/devices/0x0258/nas-wr01ze.json
+++ b/packages/config/config/devices/0x0258/nas-wr01ze.json
@@ -20,22 +20,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"1": {
-			"label": "Remember relay ON/OFF status after power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Do not remember",
-					"value": 0
-				},
-				{
-					"label": "Remember",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"2": {
 			"label": "Top button function",

--- a/packages/config/config/devices/0x027a/zen06.json
+++ b/packages/config/config/devices/0x027a/zen06.json
@@ -41,27 +41,7 @@
 			]
 		},
 		"21": {
-			"label": "On/Off Status Recovery After Power Failure",
-			"description": "Recovery state for power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Previous setting",
-					"value": 0
-				},
-				{
-					"label": "ON",
-					"value": 1
-				},
-				{
-					"label": "OFF",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"24": {
 			"label": "On/Off Status Change Notifications",

--- a/packages/config/config/devices/0x027a/zen07.json
+++ b/packages/config/config/devices/0x027a/zen07.json
@@ -90,23 +90,7 @@
 			"defaultValue": 5
 		},
 		"7": {
-			"label": "On/Off Status Recovery After Power Failure",
-			"description": "Choose the recovery state for your Mini Plug if power outage occurs",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "OFF once power is restored",
-					"value": 0
-				},
-				{
-					"label": "Remembers the status",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"8": {
 			"label": "Auto Turn-Off Timer Enable",

--- a/packages/config/config/devices/0x027a/zen15.json
+++ b/packages/config/config/devices/0x027a/zen15.json
@@ -34,27 +34,7 @@
 			]
 		},
 		"21": {
-			"label": "On/Off Status Recovery After Power Failure",
-			"description": "Choose the recovery state for your Power Switch if power outage occurs.",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Previous state",
-					"value": 0
-				},
-				{
-					"label": "ON",
-					"value": 1
-				},
-				{
-					"label": "OFF",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"24": {
 			"label": "On/Off Status Change Notifications",

--- a/packages/config/config/devices/0x027a/zen20.json
+++ b/packages/config/config/devices/0x027a/zen20.json
@@ -16,26 +16,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"1": {
-			"label": "On/Off Status Recovery After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Remember Previous State After Power Failure",
-					"value": 0
-				},
-				{
-					"label": "Power Strip Automatically ON After Power Failure",
-					"value": 1
-				},
-				{
-					"label": "Power Strip Automatically OFF After Power Failure",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"2": {
 			"label": "Power Wattage Report Value Threshold",

--- a/packages/config/config/devices/0x027a/zen21_3.0-3.3.json
+++ b/packages/config/config/devices/0x027a/zen21_3.0-3.3.json
@@ -121,26 +121,7 @@
 			"defaultValue": 60
 		},
 		"8": {
-			"label": "Status after Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Forced to off",
-					"value": 0
-				},
-				{
-					"label": "Forced to on",
-					"value": 1
-				},
-				{
-					"label": "Prior state",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"$if": "firmwareVersion >= 3.1",

--- a/packages/config/config/devices/0x027a/zen21_3.4.json
+++ b/packages/config/config/devices/0x027a/zen21_3.4.json
@@ -201,26 +201,7 @@
 			]
 		},
 		"8": {
-			"label": "Status after Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Forced to off",
-					"value": 0
-				},
-				{
-					"label": "Forced to on",
-					"value": 1
-				},
-				{
-					"label": "Prior state",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Enable/Disable Scene Control",

--- a/packages/config/config/devices/0x027a/zen22_1.7-1.7.json
+++ b/packages/config/config/devices/0x027a/zen22_1.7-1.7.json
@@ -79,26 +79,7 @@
 			]
 		},
 		"8": {
-			"label": "Status after Power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Forced to off",
-					"value": 0
-				},
-				{
-					"label": "Forced to on",
-					"value": 1
-				},
-				{
-					"label": "Prior State",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		}
 	}
 }

--- a/packages/config/config/devices/0x027a/zen22_3.0-3.0.json
+++ b/packages/config/config/devices/0x027a/zen22_3.0-3.0.json
@@ -196,26 +196,7 @@
 			]
 		},
 		"8": {
-			"label": "Status after Power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Forced to off",
-					"value": 0
-				},
-				{
-					"label": "Forced to on",
-					"value": 1
-				},
-				{
-					"label": "Prior State",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Dimmer Ramp Rate",

--- a/packages/config/config/devices/0x027a/zen22_3.1-3.2.json
+++ b/packages/config/config/devices/0x027a/zen22_3.1-3.2.json
@@ -196,26 +196,7 @@
 			]
 		},
 		"8": {
-			"label": "Status after Power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Forced to off",
-					"value": 0
-				},
-				{
-					"label": "Forced to on",
-					"value": 1
-				},
-				{
-					"label": "Prior State",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Dimmer Ramp Rate",

--- a/packages/config/config/devices/0x027a/zen22_3.3-3.3.json
+++ b/packages/config/config/devices/0x027a/zen22_3.3-3.3.json
@@ -196,26 +196,7 @@
 			]
 		},
 		"8": {
-			"label": "Status after Power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Forced to off",
-					"value": 0
-				},
-				{
-					"label": "Forced to on",
-					"value": 1
-				},
-				{
-					"label": "Prior State",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Dimmer Ramp Rate",

--- a/packages/config/config/devices/0x027a/zen22_3.4-3.4.json
+++ b/packages/config/config/devices/0x027a/zen22_3.4-3.4.json
@@ -196,26 +196,7 @@
 			]
 		},
 		"8": {
-			"label": "Status after Power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Forced to off",
-					"value": 0
-				},
-				{
-					"label": "Forced to on",
-					"value": 1
-				},
-				{
-					"label": "Prior State",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Dimmer Ramp Rate",

--- a/packages/config/config/devices/0x027a/zen22_3.5-3.6.json
+++ b/packages/config/config/devices/0x027a/zen22_3.5-3.6.json
@@ -196,26 +196,7 @@
 			]
 		},
 		"8": {
-			"label": "Status after Power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Forced to off",
-					"value": 0
-				},
-				{
-					"label": "Forced to on",
-					"value": 1
-				},
-				{
-					"label": "Prior State",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Dimmer Ramp Rate",

--- a/packages/config/config/devices/0x027a/zen22_3.7-19.0.json
+++ b/packages/config/config/devices/0x027a/zen22_3.7-19.0.json
@@ -196,26 +196,7 @@
 			]
 		},
 		"8": {
-			"label": "Status after Power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Forced to off",
-					"value": 0
-				},
-				{
-					"label": "Forced to on",
-					"value": 1
-				},
-				{
-					"label": "Prior State",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Dimmer Ramp Rate",

--- a/packages/config/config/devices/0x027a/zen23_3.0.json
+++ b/packages/config/config/devices/0x027a/zen23_3.0.json
@@ -105,26 +105,7 @@
 			"defaultValue": 60
 		},
 		"8": {
-			"label": "Status After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Forced to OFF",
-					"value": 0
-				},
-				{
-					"label": "Forced to ON",
-					"value": 1
-				},
-				{
-					"label": "Restore Previous Status",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Enable/Disable Scene Control",

--- a/packages/config/config/devices/0x027a/zen23_4.0.json
+++ b/packages/config/config/devices/0x027a/zen23_4.0.json
@@ -105,26 +105,7 @@
 			"defaultValue": 60
 		},
 		"8": {
-			"label": "Status After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Forced to OFF",
-					"value": 0
-				},
-				{
-					"label": "Forced to ON",
-					"value": 1
-				},
-				{
-					"label": "Restore Previous Status",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Enable/Disable Scene Control",

--- a/packages/config/config/devices/0x027a/zen24_3.0-3.255.json
+++ b/packages/config/config/devices/0x027a/zen24_3.0-3.255.json
@@ -101,26 +101,7 @@
 			"defaultValue": 60
 		},
 		"8": {
-			"label": "Status After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Forced to OFF",
-					"value": 0
-				},
-				{
-					"label": "Forced to ON",
-					"value": 1
-				},
-				{
-					"label": "Restore Previous Status",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Ramp Rate Control",

--- a/packages/config/config/devices/0x027a/zen24_4.0.json
+++ b/packages/config/config/devices/0x027a/zen24_4.0.json
@@ -105,26 +105,7 @@
 			"defaultValue": 60
 		},
 		"8": {
-			"label": "Status After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Forced to OFF",
-					"value": 0
-				},
-				{
-					"label": "Forced to ON",
-					"value": 1
-				},
-				{
-					"label": "Restore Previous Status",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Ramp Rate Control",

--- a/packages/config/config/devices/0x027a/zen26_1.0-1.0.json
+++ b/packages/config/config/devices/0x027a/zen26_1.0-1.0.json
@@ -79,26 +79,7 @@
 			"defaultValue": 60
 		},
 		"8": {
-			"label": "Switch State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "On",
-					"value": 1
-				},
-				{
-					"label": "Previous State",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		}
 	}
 }

--- a/packages/config/config/devices/0x027a/zen26_2.0-2.1.json
+++ b/packages/config/config/devices/0x027a/zen26_2.0-2.1.json
@@ -194,26 +194,7 @@
 			]
 		},
 		"8": {
-			"label": "Switch State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "On",
-					"value": 1
-				},
-				{
-					"label": "Previous State",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"10": {
 			"label": "Scene Control",

--- a/packages/config/config/devices/0x027a/zen26_2.2-2.2.json
+++ b/packages/config/config/devices/0x027a/zen26_2.2-2.2.json
@@ -194,26 +194,7 @@
 			]
 		},
 		"8": {
-			"label": "Switch State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "On",
-					"value": 1
-				},
-				{
-					"label": "Previous State",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"10": {
 			"label": "Scene Control",

--- a/packages/config/config/devices/0x027a/zen26_2.3.json
+++ b/packages/config/config/devices/0x027a/zen26_2.3.json
@@ -206,26 +206,7 @@
 			]
 		},
 		"8": {
-			"label": "Switch State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "On",
-					"value": 1
-				},
-				{
-					"label": "Previous State",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"10": {
 			"label": "Enable/Disable Scene Control",

--- a/packages/config/config/devices/0x027a/zen27_1.0-1.0.json
+++ b/packages/config/config/devices/0x027a/zen27_1.0-1.0.json
@@ -122,26 +122,7 @@
 			"defaultValue": 30
 		},
 		"8": {
-			"label": "Dimmer State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "On",
-					"value": 1
-				},
-				{
-					"label": "Previous State",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Ramp Rate Control",

--- a/packages/config/config/devices/0x027a/zen27_2.0-2.0.json
+++ b/packages/config/config/devices/0x027a/zen27_2.0-2.0.json
@@ -194,26 +194,7 @@
 			]
 		},
 		"8": {
-			"label": "Dimmer State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "On",
-					"value": 1
-				},
-				{
-					"label": "Previous State",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Ramp Rate Control",

--- a/packages/config/config/devices/0x027a/zen27_2.1-2.6.json
+++ b/packages/config/config/devices/0x027a/zen27_2.1-2.6.json
@@ -194,26 +194,7 @@
 			]
 		},
 		"8": {
-			"label": "Dimmer State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "On",
-					"value": 1
-				},
-				{
-					"label": "Previous State",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Ramp Rate Control",

--- a/packages/config/config/devices/0x027a/zen27_2.7-2.7.json
+++ b/packages/config/config/devices/0x027a/zen27_2.7-2.7.json
@@ -194,26 +194,7 @@
 			]
 		},
 		"8": {
-			"label": "Dimmer State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "On",
-					"value": 1
-				},
-				{
-					"label": "Previous State",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Ramp Rate Control",

--- a/packages/config/config/devices/0x027a/zen27_2.8.json
+++ b/packages/config/config/devices/0x027a/zen27_2.8.json
@@ -210,26 +210,7 @@
 			]
 		},
 		"8": {
-			"label": "Dimmer State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "On",
-					"value": 1
-				},
-				{
-					"label": "Previous State",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Ramp Rate Control",

--- a/packages/config/config/devices/0x027a/zen31.json
+++ b/packages/config/config/devices/0x027a/zen31.json
@@ -67,15 +67,15 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "forced to OFF",
+					"label": "Always off",
 					"value": 0
 				},
 				{
-					"label": "restore to previous state",
+					"label": "Previous state",
 					"value": 1
 				},
 				{
-					"label": "forced to on",
+					"label": "Always on",
 					"value": 2
 				}
 			]

--- a/packages/config/config/devices/0x027a/zen32.json
+++ b/packages/config/config/devices/0x027a/zen32.json
@@ -465,27 +465,7 @@
 			"unsigned": true
 		},
 		"18": {
-			"label": "Status After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 0,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Relay and buttons - Prior state",
-					"value": 0
-				},
-				{
-					"label": "All off",
-					"value": 1
-				},
-				{
-					"label": "All on",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_off_on"
 		},
 		"19": {
 			"label": "Relay Control",

--- a/packages/config/config/devices/0x027a/zen71.json
+++ b/packages/config/config/devices/0x027a/zen71.json
@@ -93,27 +93,7 @@
 			"defaultValue": 0
 		},
 		"8": {
-			"label": "On Off Status After Power Failure",
-			"description": "How switch reacts to power failures",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Forced to off (regardless of state prior to power outage)",
-					"value": 0
-				},
-				{
-					"label": "Forced to on (regardless of state prior to power outage)",
-					"value": 1
-				},
-				{
-					"label": "Remembers and restores on/off status after power failure",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Enable/Disable Scene Control",

--- a/packages/config/config/devices/0x027a/zen72.json
+++ b/packages/config/config/devices/0x027a/zen72.json
@@ -144,26 +144,7 @@
 			"defaultValue": 0
 		},
 		"8": {
-			"label": "Dimmer State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "On",
-					"value": 1
-				},
-				{
-					"label": "Previous state",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Ramp Rate Control",

--- a/packages/config/config/devices/0x027a/zen73.json
+++ b/packages/config/config/devices/0x027a/zen73.json
@@ -107,27 +107,7 @@
 			]
 		},
 		"8": {
-			"label": "Status After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Turn off",
-					"value": 0
-				},
-				{
-					"label": "Turn on",
-					"value": 1
-				},
-				{
-					"label": "Previous state",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"10": {
 			"label": "Scene Control",

--- a/packages/config/config/devices/0x027a/zen74.json
+++ b/packages/config/config/devices/0x027a/zen74.json
@@ -84,27 +84,7 @@
 			]
 		},
 		"8": {
-			"label": "Status After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Turn off",
-					"value": 0
-				},
-				{
-					"label": "Turn on",
-					"value": 1
-				},
-				{
-					"label": "Previous state",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Ramp Rate Control (Manual)",

--- a/packages/config/config/devices/0x027a/zen76.json
+++ b/packages/config/config/devices/0x027a/zen76.json
@@ -212,26 +212,7 @@
 			]
 		},
 		"8": {
-			"label": "Switch State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "On",
-					"value": 1
-				},
-				{
-					"label": "Previous State",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"10": {
 			"label": "Scene Control",

--- a/packages/config/config/devices/0x027a/zen77.json
+++ b/packages/config/config/devices/0x027a/zen77.json
@@ -216,26 +216,7 @@
 			]
 		},
 		"8": {
-			"label": "Dimmer State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "On",
-					"value": 1
-				},
-				{
-					"label": "Previous State",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Ramp Rate Control",

--- a/packages/config/config/devices/0x0312/mp22z.json
+++ b/packages/config/config/devices/0x0312/mp22z.json
@@ -69,26 +69,8 @@
 			]
 		},
 		"6": {
-			"label": "State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 0,
-			"unsigned": true,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "On",
-					"value": 1
-				},
-				{
-					"label": "Previous State",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev",
+			"defaultValue": 0
 		}
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x0312/ms10z.json
+++ b/packages/config/config/devices/0x0312/ms10z.json
@@ -212,27 +212,7 @@
 			]
 		},
 		"8": {
-			"label": "State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "On",
-					"value": 1
-				},
-				{
-					"label": "Previous state",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Enable/Disable Local Control",

--- a/packages/config/config/devices/0x0312/ms12z.json
+++ b/packages/config/config/devices/0x0312/ms12z.json
@@ -212,27 +212,7 @@
 			]
 		},
 		"8": {
-			"label": "State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "On",
-					"value": 1
-				},
-				{
-					"label": "Previous state",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Enable/Disable Local Control",

--- a/packages/config/config/devices/0x0312/ms13z.json
+++ b/packages/config/config/devices/0x0312/ms13z.json
@@ -212,27 +212,7 @@
 			]
 		},
 		"8": {
-			"label": "State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "On",
-					"value": 1
-				},
-				{
-					"label": "Previous state",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Dimmer Speed (Manual)",

--- a/packages/config/config/devices/0x0312/z97.json
+++ b/packages/config/config/devices/0x0312/z97.json
@@ -89,26 +89,7 @@
 			"unsigned": true
 		},
 		"6": {
-			"label": "Restore State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Outlet off",
-					"value": 0
-				},
-				{
-					"label": "Outlet on",
-					"value": 1
-				},
-				{
-					"label": "Outlet previous state",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		}
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x0312/zw30.json
+++ b/packages/config/config/devices/0x0312/zw30.json
@@ -207,27 +207,7 @@
 			]
 		},
 		"8": {
-			"label": "State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "On",
-					"value": 1
-				},
-				{
-					"label": "Previous state",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Enable/Disable Local Control",

--- a/packages/config/config/devices/0x0312/zw31.json
+++ b/packages/config/config/devices/0x0312/zw31.json
@@ -222,27 +222,7 @@
 			]
 		},
 		"8": {
-			"label": "State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "On",
-					"value": 1
-				},
-				{
-					"label": "Previous state",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Dimmer Speed (Manual)",

--- a/packages/config/config/devices/0x031e/lzw45.json
+++ b/packages/config/config/devices/0x031e/lzw45.json
@@ -140,14 +140,7 @@
 			"unsigned": true
 		},
 		"10": {
-			"label": "State after power Restored",
-			"description": "The state the switch should return to once power is restored after power failure.",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"unsigned": true,
-			"allowManualEntry": false,
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev",
 			"options": [
 				{
 					"label": "Off",
@@ -158,7 +151,7 @@
 					"value": 1
 				},
 				{
-					"label": "Previous",
+					"label": "Previous state",
 					"value": 2
 				}
 			]

--- a/packages/config/config/devices/0x0330/zv2400tac-sl-a.json
+++ b/packages/config/config/devices/0x0330/zv2400tac-sl-a.json
@@ -16,26 +16,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"2": {
-			"label": "State before power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "shutoff load",
-					"value": 0
-				},
-				{
-					"label": "turn on load",
-					"value": 1
-				},
-				{
-					"label": "save load state before power failure",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"3": {
 			"label": "Send Basic report",

--- a/packages/config/config/devices/0x0330/zv2835rac-nf.json
+++ b/packages/config/config/devices/0x0330/zv2835rac-nf.json
@@ -16,26 +16,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"2": {
-			"label": "State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "On",
-					"value": 1
-				},
-				{
-					"label": "Previous State",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"3": {
 			"label": "Send Basic Report",

--- a/packages/config/config/devices/0x0330/zv9102fa-cct.json
+++ b/packages/config/config/devices/0x0330/zv9102fa-cct.json
@@ -16,11 +16,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"2": {
-			"label": "Save state on power failure",
-			"description": "Shut off load (default), turn on load or restore saved state after power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev",
 			"defaultValue": 0
 		},
 		"3": {

--- a/packages/config/config/devices/0x0371/zw141.json
+++ b/packages/config/config/devices/0x0371/zw141.json
@@ -16,7 +16,7 @@
 	},
 	"paramInformation": {
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure",
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off",
 			"options": [
 				{
 					"label": "Current position",

--- a/packages/config/config/devices/0x0403/shha10000.json
+++ b/packages/config/config/devices/0x0403/shha10000.json
@@ -34,26 +34,7 @@
 			]
 		},
 		"2": {
-			"label": "Device Status After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "State before failure",
-					"value": 0
-				},
-				{
-					"label": "On",
-					"value": 1
-				},
-				{
-					"label": "Off",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"3": {
 			"label": "Notification Load Status Change",

--- a/packages/config/config/devices/0x0431/ecodim.json
+++ b/packages/config/config/devices/0x0431/ecodim.json
@@ -39,28 +39,8 @@
 	},
 	"paramInformation": {
 		"1": {
-			"label": "State After Power Restored",
-			"description": "The state the switch should return to once power is restored after power failure.",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 0,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 0
-				},
-				{
-					"label": "On",
-					"value": 1
-				},
-				{
-					"label": "Returns to level before Power Outage",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev",
+			"defaultValue": 0
 		},
 		"2": {
 			"label": "Notification when Load status change",

--- a/packages/config/config/devices/0x0433/q-light_puck.json
+++ b/packages/config/config/devices/0x0433/q-light_puck.json
@@ -96,24 +96,7 @@
 			"unsigned": true
 		},
 		"7": {
-			"label": "Memory function after power failure",
-			"description": "Set the desired value from 0 to 1 to turn on/off the memory function.Setting this value to 0 turns off the dimmer's Memory fucntion.Setting this value to 1 truns on the dimmer's Memory function.",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Device does not save the state before a power failure, it returns to off position",
-					"value": 0
-				},
-				{
-					"label": "Device restores it's state before power failure",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"8": {
 			"label": "Switch type",

--- a/packages/config/config/devices/0x0433/q-light_zerodim.json
+++ b/packages/config/config/devices/0x0433/q-light_zerodim.json
@@ -87,24 +87,7 @@
 			"unsigned": true
 		},
 		"7": {
-			"label": "Memory function after power failure",
-			"description": "Set the desired value from 0 to 1 to turn on/off the memory function.Setting this value to 0 turns off the dimmer's Memory fucntion.Setting this value to 1 truns on the dimmer's Memory function.",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Device does not save the state before a power failure, it returns to off position",
-					"value": 0
-				},
-				{
-					"label": "Device restores it's state before power failure",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"8": {
 			"label": "Scene ID set",

--- a/packages/config/config/devices/0x0433/q-light_zerodim_2pol.json
+++ b/packages/config/config/devices/0x0433/q-light_zerodim_2pol.json
@@ -87,24 +87,7 @@
 			"unsigned": true
 		},
 		"7": {
-			"label": "Memory function after power failure",
-			"description": "Set the desired value from 0 to 1 to turn on/off the memory function.Setting this value to 0 turns off the dimmer's Memory fucntion.Setting this value to 1 truns on the dimmer's Memory function.",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Device does not save the state before a power failure, it returns to off position",
-					"value": 0
-				},
-				{
-					"label": "Device restores it's state before power failure",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"8": {
 			"label": "Scene ID set",

--- a/packages/config/config/devices/0x0438/dimmer2-400w.json
+++ b/packages/config/config/devices/0x0438/dimmer2-400w.json
@@ -15,26 +15,7 @@
 	},
 	"paramInformation": {
 		"2": {
-			"label": "State After Power Failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Turn off",
-					"value": 0
-				},
-				{
-					"label": "Turn on",
-					"value": 1
-				},
-				{
-					"label": "Restore previous state",
-					"value": 2
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"3": {
 			"label": "Send Basic Report",

--- a/packages/config/config/devices/0x5254/zdm-80.json
+++ b/packages/config/config/devices/0x5254/zdm-80.json
@@ -54,22 +54,7 @@
 			]
 		},
 		"5": {
-			"label": "Switch state after power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Switch is OFF",
-					"value": 0
-				},
-				{
-					"label": "Switch saves its state before power failure.",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"13": {
 			"label": "Double click option",

--- a/packages/config/config/devices/0x5254/zds-210na.json
+++ b/packages/config/config/devices/0x5254/zds-210na.json
@@ -26,22 +26,7 @@
 	},
 	"paramInformation": {
 		"5": {
-			"label": "State after power failure",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Switch OFF",
-					"value": 0
-				},
-				{
-					"label": "Switch saves its state before power failure",
-					"value": 1
-				}
-			]
+			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"13": {
 			"label": "Double click option",

--- a/packages/config/config/devices/templates/master_template.json
+++ b/packages/config/config/devices/templates/master_template.json
@@ -253,7 +253,51 @@
 			}
 		]
 	},
-	"state_after_power_failure": {
+	"state_after_power_failure_off_on_prev": {
+		"label": "State After Power Failure",
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 2,
+		"defaultValue": 2,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Always off",
+				"value": 0
+			},
+			{
+				"label": "Always on",
+				"value": 1
+			},
+			{
+				"label": "Previous state",
+				"value": 2
+			}
+		]
+	},
+	"state_after_power_failure_off_prev_on": {
+		"label": "State After Power Failure",
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 2,
+		"defaultValue": 1,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Always off",
+				"value": 0
+			},
+			{
+				"label": "Previous state",
+				"value": 1
+			},
+			{
+				"label": "Always on",
+				"value": 2
+			}
+		]
+	},
+	"state_after_power_failure_prev_off_on": {
 		"label": "State After Power Failure",
 		"valueSize": 1,
 		"minValue": 0,
@@ -272,6 +316,64 @@
 			{
 				"label": "Always off",
 				"value": 2
+			}
+		]
+	},
+	"state_after_power_failure_prev_on_off": {
+		"label": "State After Power Failure",
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 2,
+		"defaultValue": 0,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Previous state",
+				"value": 0
+			},
+			{
+				"label": "Always on",
+				"value": 1
+			},
+			{
+				"label": "Always off",
+				"value": 2
+			}
+		]
+	},
+	"state_after_power_failure_off_prev": {
+		"label": "State After Power Failure",
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 1,
+		"defaultValue": 1,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Always off",
+				"value": 0
+			},
+			{
+				"label": "Previous state",
+				"value": 1
+			}
+		]
+	},
+	"state_after_power_failure_prev_off": {
+		"label": "State After Power Failure",
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 1,
+		"defaultValue": 0,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Previous state",
+				"value": 0
+			},
+			{
+				"label": "Always off",
+				"value": 1
 			}
 		]
 	},


### PR DESCRIPTION
I've added more variants (2 and 3 way) for the "state after power failure" and $import-ed them where possible.