### PR TITLE
fix(config): add additional device ID to CT101 thermostat

### DIFF
--- a/packages/config/config/devices/0x0098/ct101.json
+++ b/packages/config/config/devices/0x0098/ct101.json
@@ -20,6 +20,10 @@
 		{
 			"productType": "0x6501",
 			"productId": "0x000d"
+		},
+		{
+			"productType": "0x6501",
+			"productId": "0x00fd"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
Added my CT101 that has a different product ID from my other CT101 for some reason. Same manufacturer and type IDs, only the product ID is different.