### PR TITLE
build: export VirtualEndpoint and VirtualNode

### DIFF
--- a/packages/zwave-js/src/Node.ts
+++ b/packages/zwave-js/src/Node.ts
@@ -12,3 +12,5 @@ export {
 	ProtocolVersion,
 	ZWaveNodeEvents,
 } from "./lib/node/Types";
+export { VirtualEndpoint } from "./lib/node/VirtualEndpoint";
+export { VirtualNode } from "./lib/node/VirtualNode";


### PR DESCRIPTION
We could use this in `zwave-js-server`, otherwise we have to import from `zwave-js/build/lib/node/VirtualEndpoint` and `zwave-js/build/lib/node/VirtualNode` if we want to use these types