### PR TITLE
feat: emit a driver event when the log config is updated

### DIFF
--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -303,11 +303,12 @@ Returns `true` after the `"all nodes ready"` event has been emitted. This is use
 
 The `Driver` class inherits from the Node.js [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) and thus also supports its methods like `on`, `removeListener`, etc. The following events are implemented:
 
-| Event               | Description                                                                                                                                                                                          |
-| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `"error"`           | Is emitted when the underlying serial port emits an error or invalid data is received. You **must** add a listener for this event, otherwise unhandled `"error"` events will crash your application! |
-| `"driver ready"`    | Is emitted after the controller interview is completed but before the node interview is started.                                                                                                     |
-| `"all nodes ready"` | Is emitted when all nodes are safe to be used (i.e. the `"ready"` event has been emitted for all nodes).                                                                                             |
+| Event                  | Description                                                                                                                                                                                          |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"error"`              | Is emitted when the underlying serial port emits an error or invalid data is received. You **must** add a listener for this event, otherwise unhandled `"error"` events will crash your application! |
+| `"driver ready"`       | Is emitted after the controller interview is completed but before the node interview is started.                                                                                                     |
+| `"all nodes ready"`    | Is emitted when all nodes are safe to be used (i.e. the `"ready"` event has been emitted for all nodes).                                                                                             |
+| `"log config updated"` | Is emitted when the log config has been updated. Includes the updated log config as an argument to the callback.                                                                                     |
 
 ## Interfaces
 

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -323,6 +323,7 @@ export type SendSupervisedCommandOptions = SendCommandOptions &
 export interface DriverEventCallbacks {
 	"driver ready": () => void;
 	"all nodes ready": () => void;
+	"log config updated": (config: LogConfig) => void;
 	error: (err: Error) => void;
 }
 
@@ -568,6 +569,7 @@ export class Driver extends EventEmitter {
 	/** Updates the logging configuration without having to restart the driver. */
 	public updateLogConfig(config: DeepPartial<LogConfig>): void {
 		this._logContainer.updateConfiguration(config);
+		this.emit("log config updated", this._logContainer.getConfiguration());
 	}
 
 	/** Returns the current logging configuration. */


### PR DESCRIPTION
With `zwave-js-server`, there can be multiple clients that could each be storing the state of the log config internally (we do this in HA). If one client updates the log config, there's currently no way for the other clients to know without polling the log config regularly.