### PR TITLE
fix(cc): do not delete V1 alarm values when mapping notification

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/NotificationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/NotificationCC.ts
@@ -810,11 +810,14 @@ export class NotificationCCReport extends NotificationCC {
 								}
 							}
 						}
-						this.alarmType = undefined;
-						this.alarmLevel = undefined;
+						// After mapping we do not set the legacy V1 values to undefined
+						// Otherwise, adding a new mapping will be a breaking change
 					}
 				}
 			}
+
+			// Store the V1 alarm values if they exist
+			this.persistValues();
 		} else {
 			// Create a notification to send
 			if ("alarmType" in options) {

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -2456,17 +2456,15 @@ protocol version:      ${this._protocolVersion}`;
 	 * Handles the receipt of a Notification Report
 	 */
 	private handleNotificationReport(command: NotificationCCReport): void {
-		if (command.alarmType) {
-			// This is a V1 alarm, just store the only two values it has
-			command.persistValues();
-			return;
-		} else if (command.notificationType == undefined) {
-			this.driver.controllerLog.logNode(this.id, {
-				message: `received unsupported notification ${stringify(
-					command,
-				)}`,
-				direction: "inbound",
-			});
+		if (command.notificationType == undefined) {
+			if (command.alarmType == undefined) {
+				this.driver.controllerLog.logNode(this.id, {
+					message: `received unsupported notification ${stringify(
+						command,
+					)}`,
+					direction: "inbound",
+				});
+			}
 			return;
 		}
 


### PR DESCRIPTION
Deleting the alarm values causes each new mapping to be a breaking change, so we shouldn't do this.

related to https://github.com/zwave-js/node-zwave-js/issues/2409#issuecomment-823638655

fixes: #2605