### PR TITLE
feat(compat): disable sequence number check in existing compat flag

### DIFF
--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -341,7 +341,7 @@ By default, received `Basic CC::Report` commands are mapped to a more appropriat
 
 ### `disableStrictEntryControlDataValidation`
 
-The specifications mandate strict rules for the data in `Entry Control CC Notifications`, which some devices do not follow, causing the notifications to get dropped. Setting `disableStrictEntryControlDataValidation` to `true` disables these strict checks.
+The specifications mandate strict rules for the data and sequence numbers in `Entry Control CC Notifications`, which some devices do not follow, causing the notifications to get dropped. Setting `disableStrictEntryControlDataValidation` to `true` disables these strict checks.
 
 ### `enableBasicSetMapping`
 

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3114,24 +3114,28 @@ protocol version:      ${this._protocolVersion}`;
 		command: EntryControlCCNotification,
 	): void {
 		if (
-			this.recentEntryControlNotificationSequenceNumbers.includes(
-				command.sequenceNumber,
-			)
+			!this._deviceConfig?.compat?.disableStrictEntryControlDataValidation
 		) {
-			this.driver.controllerLog.logNode(
-				this.id,
-				`Received duplicate Entry Control Notification (sequence number ${command.sequenceNumber}), ignoring...`,
-				"warn",
-			);
-			return;
-		}
+			if (
+				this.recentEntryControlNotificationSequenceNumbers.includes(
+					command.sequenceNumber,
+				)
+			) {
+				this.driver.controllerLog.logNode(
+					this.id,
+					`Received duplicate Entry Control Notification (sequence number ${command.sequenceNumber}), ignoring...`,
+					"warn",
+				);
+				return;
+			}
 
-		// Keep track of the last 5 sequence numbers
-		this.recentEntryControlNotificationSequenceNumbers.unshift(
-			command.sequenceNumber,
-		);
-		if (this.recentEntryControlNotificationSequenceNumbers.length > 5) {
-			this.recentEntryControlNotificationSequenceNumbers.pop();
+			// Keep track of the last 5 sequence numbers
+			this.recentEntryControlNotificationSequenceNumbers.unshift(
+				command.sequenceNumber,
+			);
+			if (this.recentEntryControlNotificationSequenceNumbers.length > 5) {
+				this.recentEntryControlNotificationSequenceNumbers.pop();
+			}
 		}
 
 		// Notify listeners


### PR DESCRIPTION
With this PR, the existing compat flag `disableStrictEntryControlDataValidation` also disables the sequence number check.

fixes: #2677