### PR TITLE
fix(config): enable Basic Set mapping in Aeotec ZW100 and Fantem FT100

### DIFF
--- a/packages/config/config/devices/0x0086/zw100.json
+++ b/packages/config/config/devices/0x0086/zw100.json
@@ -475,6 +475,10 @@
 			"$import": "templates/aeotec_template.json#factory_reset_exclude"
 		}
 	},
+	"compat": {
+		// In the default configuration this device sends Basic CC Sets instead of Binary Sensor Reports
+		"enableBasicSetMapping": true
+	},
 	"metadata": {
 		"inclusion": "Turn the primary controller of Z-Wave network into inclusion mode, short press the product’s Z-Wave button that you can find in the back of the product",
 		"exclusion": "Turn the primary controller of Z-Wave network into exclusion mode, short press the product’s Z-Wave button that you can find in back of the product",

--- a/packages/config/config/devices/0x016a/ft100.json
+++ b/packages/config/config/devices/0x016a/ft100.json
@@ -459,6 +459,10 @@
 			"$import": "../0x0086/templates/aeotec_template.json#factory_reset_exclude"
 		}
 	},
+	"compat": {
+		// In the default configuration this device sends Basic CC Sets instead of Binary Sensor Reports
+		"enableBasicSetMapping": true
+	},
 	"metadata": {
 		"inclusion": "Turn the primary controller of Z-Wave network into inclusion mode, short press the product’s Z-Wave button that you can find in the back of the product",
 		"exclusion": "Turn the primary controller of Z-Wave network into exclusion mode, short press the product’s Z-Wave button that you can find in back of the product",


### PR DESCRIPTION
fixes: #2635