### PR TITLE
feat(cc): add multicast support to Configuration CC

### DIFF
--- a/packages/core/src/values/Metadata.ts
+++ b/packages/core/src/values/Metadata.ts
@@ -100,6 +100,9 @@ export interface ValueMetadataDuration extends ValueMetadataAny {
 	default?: Duration;
 }
 
+/**
+ * Defines how a configuration value is encoded
+ */
 export enum ConfigValueFormat {
 	SignedInteger = 0x00,
 	UnsignedInteger = 0x01,

--- a/packages/zwave-js/src/lib/driver/CommandQueueMachine.ts
+++ b/packages/zwave-js/src/lib/driver/CommandQueueMachine.ts
@@ -230,7 +230,7 @@ export function createCommandQueueMachine(
 						);
 					} catch (e) {
 						implementations.log(
-							`Unexpected error during SerialAPI command: ${e}`,
+							`Unexpected error during SerialAPI command: ${e.stack}`,
 							"error",
 						);
 						return Promise.reject(e);


### PR DESCRIPTION
This PR adds multicast support to the Configuration CC. A few limitations are in place:
1. get-type commands (including `scanParametersLegacy`) and polling are still limited to singlecast
2. `resetAll` is still limited to singlecast as a precaution
3. `set` accepts a new parameter for the value format, which defaults to `ConfigValueFormat.SignedInteger` if it is not specified
4. the `setValue` API is limited to singlecast and multicast. Multicast requires all targeted nodes to be interviewed and to have the same parameter definition (value size and format). When setting partial parameters, the current config value of the first node is used as a base to merge the partial values.

fixes: #2651