### PR TITLE
fix(config): remove invalid device ID for MINI KEYPAD RFID

### DIFF
--- a/packages/config/config/devices/0x0097/mini_keypad_rfid.json
+++ b/packages/config/config/devices/0x0097/mini_keypad_rfid.json
@@ -5,10 +5,6 @@
 	"description": "Keypad with alarm activation rfid tag",
 	"devices": [
 		{
-			"productType": "0x4501",
-			"productId": "0x6131"
-		},
-		{
 			"productType": "0x6131",
 			"productId": "0x4101"
 		},


### PR DESCRIPTION
This one was backwards