### PR TITLE
feat: partially decode dropped commands and log them as good as possible

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/CommandClass.ts
+++ b/packages/zwave-js/src/lib/commandclass/CommandClass.ts
@@ -994,7 +994,7 @@ export class InvalidCC extends CommandClass {
 
 	public toLogEntry(): MessageOrCCLogEntry {
 		return {
-			tags: ["Invalid CC"],
+			tags: [`${getCCName(this.ccId)} CC`, "INVALID"],
 			message: this.reason
 				? {
 						error: this.reason,

--- a/packages/zwave-js/src/lib/commandclass/CommandClass.ts
+++ b/packages/zwave-js/src/lib/commandclass/CommandClass.ts
@@ -36,6 +36,10 @@ import {
 	EncapsulatingCommandClass,
 	isEncapsulatingCommandClass,
 } from "./EncapsulatingCommandClass";
+import {
+	ICommandClassContainer,
+	isCommandClassContainer,
+} from "./ICommandClassContainer";
 
 export type MulticastDestination = [number, number, ...number[]];
 
@@ -137,6 +141,8 @@ export class CommandClass {
 			this.ccCommand = ccCommand;
 			this.payload = payload;
 		}
+
+		if (this instanceof InvalidCC) return;
 
 		if (this.isSinglecast() && this.nodeId !== NODE_ID_BROADCAST) {
 			// For singlecast CCs, set the CC version as high as possible
@@ -332,8 +338,24 @@ export class CommandClass {
 	): CommandClass {
 		// Fall back to unspecified command class in case we receive one that is not implemented
 		const Constructor = CommandClass.getConstructor(options.data);
-		const ret = new Constructor(driver, options);
-		return ret;
+		try {
+			const ret = new Constructor(driver, options);
+			return ret;
+		} catch (e: unknown) {
+			// Indicate invalid payloads with a special CC type
+			if (
+				isZWaveError(e) &&
+				e.code === ZWaveErrorCodes.PacketFormat_InvalidPayload
+			) {
+				return new InvalidCC(driver, {
+					nodeId: options.fromEncapsulation
+						? options.encapCC.nodeId
+						: options.nodeId,
+					ccId: CommandClass.getCommandClass(options.data),
+				});
+			}
+			throw e;
+		}
 	}
 
 	/** Generates a representation of this CC for the log */
@@ -955,6 +977,42 @@ export class CommandClass {
 			}
 		}
 		return false;
+	}
+}
+
+export interface InvalidCCCreationOptions extends CommandClassCreationOptions {
+	reason?: string;
+}
+
+export class InvalidCC extends CommandClass {
+	public constructor(driver: Driver, options: InvalidCCCreationOptions) {
+		super(driver, options);
+		this.reason = options.reason;
+	}
+
+	public readonly reason?: string;
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			tags: ["Invalid CC"],
+			message: this.reason
+				? {
+						error: this.reason,
+				  }
+				: undefined,
+		};
+	}
+}
+
+export function assertValidCCs(container: ICommandClassContainer): void {
+	if (container.command instanceof InvalidCC) {
+		throw new ZWaveError(
+			"The message payload is invalid!",
+			ZWaveErrorCodes.PacketFormat_InvalidPayload,
+			container.command.reason,
+		);
+	} else if (isCommandClassContainer(container.command)) {
+		assertValidCCs(container.command);
 	}
 }
 

--- a/packages/zwave-js/src/lib/commandclass/NotificationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/NotificationCC.ts
@@ -38,6 +38,7 @@ import {
 	expectedCCResponse,
 	gotDeserializationOptions,
 	implementedVersion,
+	InvalidCC,
 } from "./CommandClass";
 import { UserCodeCommand } from "./UserCodeCC";
 
@@ -1009,6 +1010,8 @@ export class NotificationCCReport extends NotificationCC {
 						fromEncapsulation: true,
 						encapCC: this,
 					});
+					validatePayload(!(cc instanceof InvalidCC));
+
 					let json = cc.toJSON();
 					// If a CC has no good toJSON() representation, we're only interested in the payload
 					if (

--- a/packages/zwave-js/src/lib/test/driver/invalidPayloadLog.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/invalidPayloadLog.test.ts
@@ -90,7 +90,7 @@ describe("regression tests", () => {
 		await wait(10);
 		assertMessage(spyTransport, {
 			callNumber: 1,
-			predicate: (msg) => msg.includes("└─[Invalid CC]"),
+			predicate: (msg) => msg.includes("└─[Binary Sensor CC] [INVALID]"),
 		});
 		expect(serialport.lastWrite).toEqual(ACK);
 	});

--- a/packages/zwave-js/src/lib/test/driver/invalidPayloadLog.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/invalidPayloadLog.test.ts
@@ -1,0 +1,97 @@
+import {
+	createDefaultTransportFormat,
+	ZWaveLogContainer,
+} from "@zwave-js/core";
+import { MessageHeaders, MockSerialPort } from "@zwave-js/serial";
+import { assertMessage, SpyTransport } from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import MockDate from "mockdate";
+import type { Driver } from "../../driver/Driver";
+import { DriverLogger } from "../../log/Driver";
+import { ZWaveNode } from "../../node/Node";
+import { createAndStartDriver } from "../utils";
+import { isFunctionSupported_NoBridge } from "./fixtures";
+
+describe("regression tests", () => {
+	let driver: Driver;
+	let serialport: MockSerialPort;
+	process.env.LOGLEVEL = "debug";
+	let driverLogger: DriverLogger;
+	let spyTransport: SpyTransport;
+
+	// Replace all defined transports with a spy transport
+	beforeAll(() => {
+		spyTransport = new SpyTransport();
+		spyTransport.format = createDefaultTransportFormat(true, true);
+		driverLogger = new DriverLogger(
+			new ZWaveLogContainer({
+				transports: [spyTransport],
+			}),
+		);
+		// Uncomment this to debug the log outputs manually
+		// wasSilenced = unsilence(driverLogger);
+
+		MockDate.set(new Date().setHours(0, 0, 0, 0));
+	});
+
+	// Don't spam the console when performing the other tests not related to logging
+	afterAll(() => {
+		driverLogger.container.updateConfiguration({ enabled: false });
+		MockDate.reset();
+	});
+
+	beforeEach(() => {
+		spyTransport.spy.mockClear();
+	});
+
+	beforeEach(async () => {
+		({ driver, serialport } = await createAndStartDriver());
+
+		driver["_controller"] = {
+			ownNodeId: 1,
+			nodes: new Map(),
+		} as any;
+		driver["_driverLog"] = driverLogger;
+	});
+
+	afterEach(async () => {
+		await driver.destroy();
+		driver.removeAllListeners();
+	});
+
+	it("when an invalid CC is received, this is printed in the logs", async () => {
+		jest.setTimeout(5000);
+		// Use the normal SendData commands
+		driver[
+			"_controller"
+		]!.isFunctionSupported = isFunctionSupported_NoBridge;
+
+		const node33 = new ZWaveNode(33, driver);
+		(driver.controller.nodes as Map<number, ZWaveNode>).set(
+			node33.id,
+			node33,
+		);
+		// Add event handlers for the nodes
+		for (const node of driver.controller.nodes.values()) {
+			driver["addNodeEventHandlers"](node);
+		}
+
+		node33["_isListening"] = true;
+		node33["_isFrequentListening"] = false;
+		node33.markAsAlive();
+
+		const ACK = Buffer.from([MessageHeaders.ACK]);
+
+		//  « [Node 033] [REQ] [ApplicationCommand]
+		//    └─[BinarySensorCCReport]
+		//        type:  Motion
+		//        value: true
+		serialport.receiveData(Buffer.from("010800040021043003e5", "hex"));
+		await wait(10);
+		assertMessage(spyTransport, {
+			callNumber: 1,
+			predicate: (msg) => msg.includes("└─[Invalid CC]"),
+		});
+		expect(serialport.lastWrite).toEqual(ACK);
+	});
+});


### PR DESCRIPTION
This PR provides some insight into dropped commands instead of just printing: `Dropping message with invalid data: 0xbada55c0ffeeb4be...`.
Now we keep the work we already did while decoding the messages and print their structure (and if possible the reason for failure) as deep as we can, e.g.:
```
« [Node 033] [REQ] [ApplicationCommand]
  └─[Security CC] [INVALID]
      error: The nonce 0x23 has expired
```