### PR TITLE
feat(config): add Sunricher ZV9001K4-RGBW

### DIFF
--- a/packages/config/config/devices/0x0330/zv9001k4-rgbw.json
+++ b/packages/config/config/devices/0x0330/zv9001k4-rgbw.json
@@ -2,7 +2,7 @@
 	"manufacturer": "Sunricher",
 	"manufacturerId": "0x0330",
 	"label": "ZV9001K4-RGBW",
-	"description": "Touch Panel RGBW Z Wave Wall Controller",
+	"description": "Touch Panel RGBW Wall Controller",
 	"devices": [
 		{
 			"productType": "0x0300",
@@ -12,6 +12,5 @@
 	"firmwareVersion": {
 		"min": "0.0",
 		"max": "255.255"
-	},
-	"supportsZWavePlus": true
+	}
 }

--- a/packages/config/config/devices/0x0330/zv9001k4-rgbw.json
+++ b/packages/config/config/devices/0x0330/zv9001k4-rgbw.json
@@ -1,0 +1,17 @@
+{
+	"manufacturer": "Sunricher",
+	"manufacturerId": "0x0330",
+	"label": "ZV9001K4-RGBW",
+	"description": "Touch Panel RGBW Z Wave Wall Controller",
+	"devices": [
+		{
+			"productType": "0x0300",
+			"productId": "0xa30c"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"supportsZWavePlus": true
+}


### PR DESCRIPTION
The remote control is a Z-Wave device that can both control other Z-Wave devices and activate scenes in Gateways. Although it is controlling other devices, the device cannot act as Z-Wave network controller (primary or secondary) and will always need a Z-Wave network controller to be included into a Z-Wave network. It also supports the Over The Air (OTA) feature for the product’s firmware upgrade.