### PR TITLE
feat(config): define partial parameters for Fibaro FGT001, add additional parameters for MH9 CO2

### DIFF
--- a/packages/config/config/devices/0x010f/fgt001.json
+++ b/packages/config/config/devices/0x010f/fgt001.json
@@ -19,7 +19,7 @@
 	},
 	"paramInformation": {
 		"1": {
-			"label": "Override Schedule duration",
+			"label": "Override Schedule Duration",
 			"description": "Duration of Override Schedule after turning knob",
 			"unit": "minutes",
 			"valueSize": 4,
@@ -29,18 +29,18 @@
 		},
 		"2[0x01]": {
 			"$import": "../templates/master_template.json#base_enable_disable",
-			"label": "Open window detector (normal)",
+			"label": "Open Window Detector (Normal)",
 			"defaultValue": 1,
 			"valueSize": 4
 		},
 		"2[0x02]": {
 			"$import": "../templates/master_template.json#base_enable_disable",
-			"label": "Open window detector (rapid)",
+			"label": "Open Window Detector (Rapid)",
 			"valueSize": 4
 		},
 		"2[0x04]": {
 			"$import": "../templates/master_template.json#base_enable_disable",
-			"label": "Increase receiver sensitivity",
+			"label": "Increase Receiver Sensitivity",
 			"description": "Increase receiver sensitivity, but shortens battery life",
 			"valueSize": 4
 		},
@@ -52,59 +52,59 @@
 		},
 		"2[0x10]": {
 			"$import": "../templates/master_template.json#base_enable_disable",
-			"label": "Protect setting Full ON/OFF",
+			"label": "Protect Setting Full ON/OFF",
 			"description": "Protect from setting Full ON and Full OFF mode by turning the knob manually",
 			"valueSize": 4
 		},
 		"2[0x20]": {
 			"$if": "firmwareVersion >= 4.7",
 			"$import": "../templates/master_template.json#base_enable_disable",
-			"label": "Vertical mount",
+			"label": "Vertical Mount",
 			"description": "Device mounted in vertical position",
 			"valueSize": 4
 		},
 		"2[0x40]": {
 			"$if": "firmwareVersion >= 4.7",
 			"$import": "../templates/master_template.json#base_enable_disable",
-			"label": "Moderate regulator behaviour",
+			"label": "Moderate Regulator Behaviour",
 			"description": "Set moderate regulator behaviour instead of rapid",
 			"valueSize": 4
 		},
 		"2[0x80]": {
 			"$if": "firmwareVersion >= 4.7",
 			"$import": "../templates/master_template.json#base_enable_disable",
-			"label": "Inverted knob operation",
+			"label": "Inverted Knob Operation",
 			"valueSize": 4
 		},
 		"2[0x100]": {
 			"$if": "firmwareVersion >= 4.7",
 			"$import": "../templates/master_template.json#base_enable_disable",
-			"label": "Heating medium demand reports",
+			"label": "Heating Medium Demand Reports",
 			"valueSize": 4
 		},
 		"2[0x200]": {
 			"$if": "firmwareVersion >= 4.7",
 			"$import": "../templates/master_template.json#base_enable_disable",
-			"label": "Detecting heating system failures",
+			"label": "Detecting Heating System Failures",
 			"valueSize": 4
 		},
 		"3[0x01]": {
 			"$import": "../templates/master_template.json#base_true_false",
-			"label": "Temperature sensor",
+			"label": "Temperature Sensor",
 			"description": "Optional temperature sensor connected and operational",
 			"valueSize": 4,
 			"readOnly": true
 		},
 		"3[0x02]": {
 			"$import": "../templates/master_template.json#base_true_false",
-			"label": "Open window detected",
+			"label": "Open Window Detected",
 			"valueSize": 4,
 			"readOnly": true
 		},
 		"3[0x04]": {
 			"$if": "firmwareVersion >= 4.7",
 			"$import": "../templates/master_template.json#base_true_false",
-			"label": "Provide heat",
+			"label": "Provide Heat",
 			"description": "Provide heat in order to maintain set temperature",
 			"valueSize": 4,
 			"readOnly": true
@@ -112,7 +112,7 @@
 		"3[0x08]": {
 			"$if": "firmwareVersion >= 4.7",
 			"$import": "../templates/master_template.json#base_true_false",
-			"label": "Malfunctioning heating system",
+			"label": "Malfunctioning Heating System",
 			"description": "Malfunctioning heating system - cannot reach set temperature",
 			"valueSize": 4,
 			"readOnly": true

--- a/packages/config/config/devices/0x010f/fgt001.json
+++ b/packages/config/config/devices/0x010f/fgt001.json
@@ -18,6 +18,15 @@
 		"max": "255.255"
 	},
 	"supportsZWavePlus": true,
+	"compat": {
+		"commandClasses": {
+			"remove": {
+				"0x80": {
+					"endpoints": [0]
+				}
+			}
+		}
+	},
 	"paramInformation": {
 		"1": {
 			"label": "Override Schedule duration",
@@ -28,22 +37,121 @@
 			"maxValue": 10000,
 			"defaultValue": 240
 		},
-		"2": {
-			"label": "Additional functions",
-			"description": "This parameter allows to enable different additional functions of the device.",
-			"valueSize": 4,
-			"minValue": 0,
-			"maxValue": 31,
-			"defaultValue": 1
+		"2[0x01]": {
+			"label": "Enable open window detector (normal)",
+			"$import": "../templates/master_template.json#base_enable_disable",
+			"defaultValue": 1,
+			"valueSize": 4
 		},
-		"3": {
-			"label": "Additional functions status (READ-ONLY)",
-			"description": "This parameter allows to check statuses of different additional functions.",
+		"2[0x02]": {
+			"label": "Enable open window detector (rapid)",
+			"$import": "../templates/master_template.json#base_enable_disable",
+			"valueSize": 4
+		},
+		"2[0x04]": {
+			"label": "Increase receiver sensitivity",
+			"description": "This paramater allows to increase receiver sensitivity, but shortens battery life",
+			"$import": "../templates/master_template.json#base_enable_disable",
+			"valueSize": 4
+		},
+		"2[0x08]": {
+			"label": "Enable remote LED",
+			"description": "Enable LED indications when controlling remotely",
+			"$import": "../templates/master_template.json#base_enable_disable",
+			"valueSize": 4
+		},
+		"2[0x10]": {
+			"label": "Protect setting Full ON/OFF",
+			"description": "Protect from setting Full ON and Full OFF mode by turning the knob manually",
+			"$import": "../templates/master_template.json#base_enable_disable",
+			"valueSize": 4
+		},
+		"2[0x20]": {
+			"$if": "firmwareVersion >= 4.7",
+			"label": "Vertical mount",
+			"description": "Device mounted in vertical position",
+			"$import": "../templates/master_template.json#base_enable_disable",
+			"valueSize": 4
+		},
+		"2[0x40]": {
+			"$if": "firmwareVersion >= 4.7",
+			"label": "Moderate regulator behaviour",
+			"description": "Set moderate regulator behaviour instead of rapid",
+			"$import": "../templates/master_template.json#base_enable_disable",
+			"valueSize": 4
+		},
+		"2[0x80]": {
+			"$if": "firmwareVersion >= 4.7",
+			"label": "Inverted knob operation",
+			"$import": "../templates/master_template.json#base_enable_disable",
+			"valueSize": 4
+		},
+		"2[0x100]": {
+			"$if": "firmwareVersion >= 4.7",
+			"label": "Heating medium demand reports",
+			"$import": "../templates/master_template.json#base_enable_disable",
+			"valueSize": 4
+		},
+		"2[0x200]": {
+			"$if": "firmwareVersion >= 4.7",
+			"label": "Detecting heating system failures",
+			"$import": "../templates/master_template.json#base_enable_disable",
+			"valueSize": 4
+		},
+		"3[0x01]": {
+			"label": "Temperature sensor",
+			"description": "Optional temperature sensor connected and operational",
+			"$import": "../templates/master_template.json#base_true_false",
 			"valueSize": 4,
-			"minValue": 0,
-			"maxValue": 3,
-			"defaultValue": 0,
 			"readOnly": true
+		},
+		"3[0x02]": {
+			"label": "Open window detected",
+			"$import": "../templates/master_template.json#base_true_false",
+			"valueSize": 4,
+			"readOnly": true
+		},
+		"3[0x04]": {
+			"$if": "firmwareVersion >= 4.7",
+			"label": "Provide heat in order to maintain set temperature",
+			"$import": "../templates/master_template.json#base_true_false",
+			"valueSize": 4,
+			"readOnly": true
+		},
+		"3[0x08]": {
+			"$if": "firmwareVersion >= 4.7",
+			"label": "Malfunctioning heating system",
+			"description": "Malfunctioning heating system (cannot reach set temperature)",
+			"$import": "../templates/master_template.json#base_true_false",
+			"valueSize": 4,
+			"readOnly": true
+		}
+	},
+	"endpoints": {
+		"0": {
+			"associations": {
+				"1": {
+					"label": "Lifeline",
+					"maxNodes": 1,
+					"isLifeline": true
+				}
+			}
+		},
+		"1": {
+			"associations": {
+				"1": {
+					"$import": "#endpoints/0/associations/1",
+					"isLifeline": false
+				}
+			}
+		},
+		"2": {
+			"associations": {
+				"1": {
+					"$import": "#endpoints/0/associations/1",
+					"isLifeline": false
+				}
+			}
 		}
 	}
 }

--- a/packages/config/config/devices/0x010f/fgt001.json
+++ b/packages/config/config/devices/0x010f/fgt001.json
@@ -17,16 +17,6 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
-	"supportsZWavePlus": true,
-	"compat": {
-		"commandClasses": {
-			"remove": {
-				"0x80": {
-					"endpoints": [0]
-				}
-			}
-		}
-	},
 	"paramInformation": {
 		"1": {
 			"label": "Override Schedule duration",
@@ -38,118 +28,104 @@
 			"defaultValue": 240
 		},
 		"2[0x01]": {
-			"label": "Enable open window detector (normal)",
 			"$import": "../templates/master_template.json#base_enable_disable",
+			"label": "Open window detector (normal)",
 			"defaultValue": 1,
 			"valueSize": 4
 		},
 		"2[0x02]": {
-			"label": "Enable open window detector (rapid)",
 			"$import": "../templates/master_template.json#base_enable_disable",
+			"label": "Open window detector (rapid)",
 			"valueSize": 4
 		},
 		"2[0x04]": {
-			"label": "Increase receiver sensitivity",
-			"description": "This paramater allows to increase receiver sensitivity, but shortens battery life",
 			"$import": "../templates/master_template.json#base_enable_disable",
+			"label": "Increase receiver sensitivity",
+			"description": "Increase receiver sensitivity, but shortens battery life",
 			"valueSize": 4
 		},
 		"2[0x08]": {
-			"label": "Enable remote LED",
-			"description": "Enable LED indications when controlling remotely",
 			"$import": "../templates/master_template.json#base_enable_disable",
+			"label": "Remote LED",
+			"description": "Enable LED indications when controlling remotely",
 			"valueSize": 4
 		},
 		"2[0x10]": {
+			"$import": "../templates/master_template.json#base_enable_disable",
 			"label": "Protect setting Full ON/OFF",
 			"description": "Protect from setting Full ON and Full OFF mode by turning the knob manually",
-			"$import": "../templates/master_template.json#base_enable_disable",
 			"valueSize": 4
 		},
 		"2[0x20]": {
 			"$if": "firmwareVersion >= 4.7",
+			"$import": "../templates/master_template.json#base_enable_disable",
 			"label": "Vertical mount",
 			"description": "Device mounted in vertical position",
-			"$import": "../templates/master_template.json#base_enable_disable",
 			"valueSize": 4
 		},
 		"2[0x40]": {
 			"$if": "firmwareVersion >= 4.7",
+			"$import": "../templates/master_template.json#base_enable_disable",
 			"label": "Moderate regulator behaviour",
 			"description": "Set moderate regulator behaviour instead of rapid",
-			"$import": "../templates/master_template.json#base_enable_disable",
 			"valueSize": 4
 		},
 		"2[0x80]": {
 			"$if": "firmwareVersion >= 4.7",
-			"label": "Inverted knob operation",
 			"$import": "../templates/master_template.json#base_enable_disable",
+			"label": "Inverted knob operation",
 			"valueSize": 4
 		},
 		"2[0x100]": {
 			"$if": "firmwareVersion >= 4.7",
-			"label": "Heating medium demand reports",
 			"$import": "../templates/master_template.json#base_enable_disable",
+			"label": "Heating medium demand reports",
 			"valueSize": 4
 		},
 		"2[0x200]": {
 			"$if": "firmwareVersion >= 4.7",
-			"label": "Detecting heating system failures",
 			"$import": "../templates/master_template.json#base_enable_disable",
+			"label": "Detecting heating system failures",
 			"valueSize": 4
 		},
 		"3[0x01]": {
+			"$import": "../templates/master_template.json#base_true_false",
 			"label": "Temperature sensor",
 			"description": "Optional temperature sensor connected and operational",
-			"$import": "../templates/master_template.json#base_true_false",
 			"valueSize": 4,
 			"readOnly": true
 		},
 		"3[0x02]": {
-			"label": "Open window detected",
 			"$import": "../templates/master_template.json#base_true_false",
+			"label": "Open window detected",
 			"valueSize": 4,
 			"readOnly": true
 		},
 		"3[0x04]": {
 			"$if": "firmwareVersion >= 4.7",
-			"label": "Provide heat in order to maintain set temperature",
 			"$import": "../templates/master_template.json#base_true_false",
+			"label": "Provide heat",
+			"description": "Provide heat in order to maintain set temperature",
 			"valueSize": 4,
 			"readOnly": true
 		},
 		"3[0x08]": {
 			"$if": "firmwareVersion >= 4.7",
-			"label": "Malfunctioning heating system",
-			"description": "Malfunctioning heating system (cannot reach set temperature)",
 			"$import": "../templates/master_template.json#base_true_false",
+			"label": "Malfunctioning heating system",
+			"description": "Malfunctioning heating system - cannot reach set temperature",
 			"valueSize": 4,
 			"readOnly": true
 		}
 	},
-	"endpoints": {
-		"0": {
-			"associations": {
-				"1": {
-					"label": "Lifeline",
-					"maxNodes": 1,
-					"isLifeline": true
-				}
-			}
-		},
-		"1": {
-			"associations": {
-				"1": {
-					"$import": "#endpoints/0/associations/1",
-					"isLifeline": false
-				}
-			}
-		},
-		"2": {
-			"associations": {
-				"1": {
-					"$import": "#endpoints/0/associations/1",
-					"isLifeline": false
+	"compat": {
+		"commandClasses": {
+			"remove": {
+				// Root endpoint duplicates endpoint 1
+				// We need to delete battery class on either root or 1st endpoint
+				// in order to see only one main battery value
+				"0x80": {
+					"endpoints": [0]
 				}
 			}
 		}

--- a/packages/config/config/devices/0x010f/fgt001.json
+++ b/packages/config/config/devices/0x010f/fgt001.json
@@ -30,7 +30,7 @@
 		"2[0x01]": {
 			"$import": "../templates/master_template.json#base_enable_disable",
 			"label": "Open Window Detector (Normal)",
-			"defaultValue": 1,
+			"defaultValue": 1, // Enable
 			"valueSize": 4
 		},
 		"2[0x02]": {
@@ -121,9 +121,7 @@
 	"compat": {
 		"commandClasses": {
 			"remove": {
-				// Root endpoint duplicates endpoint 1
-				// We need to delete battery class on either root or 1st endpoint
-				// in order to see only one main battery value
+				// Root endpoint duplicates endpoint 1, causing duplicated Battery CC values
 				"0x80": {
 					"endpoints": [0]
 				}

--- a/packages/config/config/devices/0x015f/mh9-co2-wa.json
+++ b/packages/config/config/devices/0x015f/mh9-co2-wa.json
@@ -13,7 +13,6 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
-	"supportsZWavePlus": true,
 	"paramInformation": {
 		"1": {
 			"label": "CO2 Notification Threshold",
@@ -23,41 +22,70 @@
 			"defaultValue": 1000
 		},
 		"2": {
-			"label": "CO2 reporting threshold",
-			"description": "0 report disabled, base on 5ppm unit, 10 by default, 10*5ppm=50ppm",
+			"label": "CO2 Reporting Threshold",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 10,
-			"unsigned": true
+			"unsigned": true,
+			"unit": "5ppm",
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
 		},
 		"3": {
-			"label": "Temperature reporting threshold",
-			"description": "0 report disabled, base on 0.5C unit, 1 by default, 1*0.5C=0.5C",
+			"label": "Temperature Reporting Threshold",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 1,
-			"unsigned": true
+			"unsigned": true,
+			"unit": "0.5C",
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
 		},
 		"4": {
-			"label": "Humidity reporting threshold",
-			"description": "0 report disabled, base on 1% unit, 2 by default, 2*1C=2C",
+			"label": "Humidity Reporting Threshold",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 100,
 			"defaultValue": 2,
-			"unsigned": true
+			"unsigned": true,
+			"unit": "%",
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
 		},
 		"255": {
 			"label": "Factory setting",
-			"description": "Restore the factory setting - write only, set to 85 to reset",
+			"description": "Restore the factory setting",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 0,
 			"unsigned": true,
-			"writeOnly": true
+			"writeOnly": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Idle",
+					"value": 0
+				},
+				{
+					"label": "Reset",
+					"value": 85
+				}
+			]
 		}
 	}
 }

--- a/packages/config/config/devices/0x015f/mh9-co2-wa.json
+++ b/packages/config/config/devices/0x015f/mh9-co2-wa.json
@@ -19,8 +19,45 @@
 			"label": "CO2 Notification Threshold",
 			"valueSize": 2,
 			"minValue": 1,
-			"maxValue": 2000,
+			"maxValue": 5000,
 			"defaultValue": 1000
+		},
+		"2": {
+			"label": "CO2 reporting threshold",
+			"description": "0 report disabled, base on 5ppm unit, 10 by default, 10*5ppm=50ppm",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 10,
+			"unsigned": true
+		},
+		"3": {
+			"label": "Temperature reporting threshold",
+			"description": "0 report disabled, base on 0.5C unit, 1 by default, 1*0.5C=0.5C",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 1,
+			"unsigned": true
+		},
+		"4": {
+			"label": "Humidity reporting threshold",
+			"description": "0 report disabled, base on 1% unit, 2 by default, 2*1C=2C",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 100,
+			"defaultValue": 2,
+			"unsigned": true
+		},
+		"255": {
+			"label": "Factory setting",
+			"description": "Restore the factory setting - write only, set to 85 to reset",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"unsigned": true,
+			"writeOnly": true
 		}
 	}
 }

--- a/packages/config/config/devices/0x015f/mh9-co2-wa.json
+++ b/packages/config/config/devices/0x015f/mh9-co2-wa.json
@@ -19,7 +19,8 @@
 			"valueSize": 2,
 			"minValue": 1,
 			"maxValue": 5000,
-			"defaultValue": 1000
+			"defaultValue": 1000,
+			"unit": "ppm"
 		},
 		"2": {
 			"label": "CO2 Reporting Threshold",
@@ -28,7 +29,7 @@
 			"maxValue": 255,
 			"defaultValue": 10,
 			"unsigned": true,
-			"unit": "5ppm",
+			"unit": "5 ppm",
 			"options": [
 				{
 					"label": "Disable",
@@ -43,7 +44,7 @@
 			"maxValue": 255,
 			"defaultValue": 1,
 			"unsigned": true,
-			"unit": "0.5C",
+			"unit": "0.5 °C",
 			"options": [
 				{
 					"label": "Disable",
@@ -67,7 +68,7 @@
 			]
 		},
 		"255": {
-			"label": "Factory setting",
+			"label": "Factory Setting",
 			"description": "Restore the factory setting",
 			"valueSize": 1,
 			"minValue": 0,
@@ -77,10 +78,6 @@
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [
-				{
-					"label": "Idle",
-					"value": 0
-				},
 				{
 					"label": "Reset",
 					"value": 85


### PR DESCRIPTION
This is my first PR and it is considered as draft for now.

## Changes:
* Partial parameters for fgt001 according to manuals and tested them on my own devices.
* Additional parameters for mcohome mh9-co2 sensors.

## Questions:

### Associations and notifications

It seems that I don't completely understand how associations works in zwavejs or I don't undestand how they are shown in zwavejs2mqtt. fgt001 have only one association group (lifeline) and I've added associations merge for all endpoints, but I'm not sure if I'm doing this right, cause nothing changed in zwavejs2mqtt panel.

As I understand (am I right?) associations are related to 'notification' section in zwavejs2mqtt. And I can see following for fgt001 devices:

- [5-113-1-Power Management-unknown] Power Management (property) - editable field with value 254
- [5-113-1-System-unknown] System (property) - editable field with value 254
- [5-113-1-Power Management-Battery load status] Battery load status - r/o field with value undefined
- [5-113-1-Power Management-Battery level status] Battery level status - r/o field with value undefined
- [5-113-1-System-Hardware status] Hardware status - r/o field with value undefined
- [5-113-2-Power Management-Battery maintenance status] Battery maintenance status - r/o field with value undefined
- [5-113-2-Power Management-unknown] Power Management (property) - editable field with value 254 AND (!) this field is not available after first interview - it will appear only after clicking 'refresh' button in zwavejs2mqtt.

I think that it is expected to have editable association groups with single or multiple subscribers inside....

Also fgt001 manual have following specs for notification events:

For endpoint 1:
- power management, events:
  - charge battery soon (0x0e)
  - charge battery now (0x0f)
  - battery is charging (0x0c)
  - battery is full charged (0x0d)
- system, events:
  - system hardware failure, event parameters:
    - external sensor remove (0x02)
    - motor error (0x03)
    - calibration error (0x04)

For endpoint 2:
- power management, events:
  - replace battery soon (0x0a)
  - replace battery now (0x0b)

And I can't correlate all values in notification view with this information...

### Mapping root to endpoint

We've already discussed this in 'question' issue. This devices duplicates root (single channel) in endpoint 1. I just checked open-zwave code and they have option in device description to map root to endpoint. For now I've added command class remove for root channel for battery class, cause it was duplicated in panel.

### MH9-CO2

This is simple. I have 5 such devices and two of them recognized as '-WA' and others as '-WD' devices. Generally all of them are '-WA' devices, cause difference between '-WA' and '-WD' is only in power supply (12V vs 220V) according to mcohom site. Real difference is in device hw revision. One ('-WA' in zwavejs) is zwave plus with additional features/parameters and second one is older without 'plus'.

### Basic command class

Don't know how to deal with this right now. For fgt001 current value is always undefined, for mh9 current value have 'some' integer value... maybe it is related to 'air quality', but I'm not able to correlate unfortunatelly.... Also I can see writeable target value for both....

### Endpoints

It seems that open-zwave have configurable endpoint names - maybe it's good idea for zwavejs also ? :)