### PR TITLE
fix(config): add missing param 1 config option to Jasco 35931

### DIFF
--- a/packages/config/config/devices/0x0063/35931.json
+++ b/packages/config/config/devices/0x0063/35931.json
@@ -28,11 +28,11 @@
 					"value": 0
 				},
 				{
-					"label": "Last brightness setting",
+					"label": "Last non-zero brightness",
 					"value": 1
 				},
 				{
-					"label": "Last lamp status",
+					"label": "Previous state",
 					"value": 2
 				}
 			]

--- a/packages/config/config/devices/0x0063/35931.json
+++ b/packages/config/config/devices/0x0063/35931.json
@@ -19,7 +19,7 @@
 			"label": "Dim level when light is turned ON",
 			"valueSize": 1,
 			"minValue": 0,
-			"maxValue": 1,
+			"maxValue": 2,
 			"defaultValue": 0,
 			"allowManualEntry": false,
 			"options": [
@@ -30,6 +30,10 @@
 				{
 					"label": "Last brightness setting",
 					"value": 1
+				},
+				{
+					"label": "Last lamp status",
+					"value": 2
 				}
 			]
 		},

--- a/packages/config/config/devices/0x0063/35931_39723.json
+++ b/packages/config/config/devices/0x0063/35931_39723.json
@@ -1,7 +1,7 @@
 {
 	"manufacturer": "GE/Jasco",
 	"manufacturerId": "0x0063",
-	"label": "35931",
+	"label": "35931 / 39723",
 	"description": "Enbrighten 60W Dimmable Light Bulb",
 	"devices": [
 		{


### PR DESCRIPTION
Parameter 1 controls the power-on behavior of the light (i.e. after a power outage). Right now the available options both involve the light coming on after power is restored, but there is another option that restores the light's previous state (which means if it was off before losing power, it will stay off after power is restored).

I found the 3rd option listed here: http://manuals-backend.z-wave.info/make.php?lang=en&sku=39723&cert=ZC10-17075703, but was unable to find any other detailed documentation for this device. However, I own multiple of these devices and have already tested this change on my local zwave-js instance.

This is an important option IMO - I've woken up in the middle of the night because my bedroom lights came on after a power fluctuation 😆