### PR TITLE
feat(config): add parameters for primary and secondary strobe to Wink Siren

### DIFF
--- a/packages/config/config/devices/0x017f/siren.json
+++ b/packages/config/config/devices/0x017f/siren.json
@@ -244,11 +244,11 @@
 			"defaultValue": 0,
 			"options": [
 				{
-					"label": "Strobe Disabled",
+					"label": "Disable",
 					"value": 0
 				},
 				{
-					"label": "Strobe Enabled",
+					"label": "Enable",
 					"value": 1
 				}
 			]
@@ -261,11 +261,11 @@
 			"defaultValue": 0,
 			"options": [
 				{
-					"label": "Strobe Disabled",
+					"label": "Disable",
 					"value": 0
 				},
 				{
-					"label": "Strobe Enabled",
+					"label": "Enable",
 					"value": 1
 				}
 			]

--- a/packages/config/config/devices/0x017f/siren.json
+++ b/packages/config/config/devices/0x017f/siren.json
@@ -237,11 +237,38 @@
 			]
 		},
 		"8": {
-			"label": "Power Level",
+			"label": "Primary Strobe (LED Ring)",
 			"valueSize": 1,
 			"minValue": 0,
-			"maxValue": 0,
-			"defaultValue": 0
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Strobe Disabled",
+					"value": 0
+				},
+				{
+					"label": "Strobe Enabled",
+					"value": 1
+				}
+			]
+		},
+		"9": {
+			"label": "Secondary Strobe (LED Ring)",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Strobe Disabled",
+					"value": 0
+				},
+				{
+					"label": "Strobe Enabled",
+					"value": 1
+				}
+			]
 		}
 	}
 }


### PR DESCRIPTION
Fixed parameter 8 and added parameter 9 for primary and secondary strobe (LED Ring) notifications.  If enabled the strobe will flash accompanying the notification.