### PR TITLE
fix(log): correct label in MeterGet log

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/MeterCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MeterCC.ts
@@ -727,7 +727,7 @@ export class MeterCCGet extends MeterCC {
 				getTypeValueId(this.endpointIndex),
 			);
 			if (type != undefined) {
-				message.duration = this.driver.configManager.lookupMeterScale(
+				message.scale = this.driver.configManager.lookupMeterScale(
 					type,
 					this.scale,
 				).label;


### PR DESCRIPTION
"duration" was a copy-paste error 😅