### PR TITLE
fix(config): rename primary association groups to "Lifeline" for Yale Door Locks

### DIFF
--- a/packages/config/config/devices/0x0129/yale_smart_door_lock_z-wave_module.json
+++ b/packages/config/config/devices/0x0129/yale_smart_door_lock_z-wave_module.json
@@ -21,7 +21,7 @@
 	},
 	"associations": {
 		"1": {
-			"label": "Alarm Reports",
+			"label": "Lifeline",
 			"maxNodes": 4,
 			"isLifeline": true
 		}

--- a/packages/config/config/devices/0x0129/yrd110.json
+++ b/packages/config/config/devices/0x0129/yrd110.json
@@ -17,7 +17,6 @@
 	"associations": {
 		"1": {
 			"label": "Lifeline",
-			"description": "Group that will receive alarm notices from the lock",
 			"maxNodes": 5,
 			"isLifeline": true
 		}

--- a/packages/config/config/devices/0x0129/yrd110.json
+++ b/packages/config/config/devices/0x0129/yrd110.json
@@ -16,7 +16,7 @@
 	},
 	"associations": {
 		"1": {
-			"label": "Receive Alarms",
+			"label": "Lifeline",
 			"description": "Group that will receive alarm notices from the lock",
 			"maxNodes": 5,
 			"isLifeline": true

--- a/packages/config/config/devices/0x0129/yrd120.json
+++ b/packages/config/config/devices/0x0129/yrd120.json
@@ -16,7 +16,7 @@
 	},
 	"associations": {
 		"1": {
-			"label": "Alarm Reports",
+			"label": "Lifeline",
 			"description": "Alarm reports are sent out to all devices in the association group",
 			"maxNodes": 5,
 			"isLifeline": true

--- a/packages/config/config/devices/0x0129/yrd120.json
+++ b/packages/config/config/devices/0x0129/yrd120.json
@@ -17,7 +17,6 @@
 	"associations": {
 		"1": {
 			"label": "Lifeline",
-			"description": "Alarm reports are sent out to all devices in the association group",
 			"maxNodes": 5,
 			"isLifeline": true
 		}

--- a/packages/config/config/devices/0x0129/yrd210.json
+++ b/packages/config/config/devices/0x0129/yrd210.json
@@ -24,7 +24,7 @@
 	},
 	"associations": {
 		"1": {
-			"label": "Alarm Reports",
+			"label": "Lifeline",
 			"maxNodes": 4,
 			"isLifeline": true
 		}

--- a/packages/config/config/devices/0x0129/yrd220.json
+++ b/packages/config/config/devices/0x0129/yrd220.json
@@ -33,7 +33,6 @@
 	"associations": {
 		"1": {
 			"label": "Lifeline",
-			"description": "Alarm reports are sent out to all devices in the association group",
 			"maxNodes": 5,
 			"isLifeline": true
 		}

--- a/packages/config/config/devices/0x0129/yrd220.json
+++ b/packages/config/config/devices/0x0129/yrd220.json
@@ -32,7 +32,7 @@
 	},
 	"associations": {
 		"1": {
-			"label": "Alarm Reports",
+			"label": "Lifeline",
 			"description": "Alarm reports are sent out to all devices in the association group",
 			"maxNodes": 5,
 			"isLifeline": true

--- a/packages/config/config/devices/0x0129/yrl210.json
+++ b/packages/config/config/devices/0x0129/yrl210.json
@@ -15,7 +15,7 @@
 	},
 	"associations": {
 		"1": {
-			"label": "Alarm Reports",
+			"label": "Lifeline",
 			"maxNodes": 4,
 			"isLifeline": true
 		}

--- a/packages/config/config/devices/0x0129/yrl220.json
+++ b/packages/config/config/devices/0x0129/yrl220.json
@@ -28,7 +28,7 @@
 	},
 	"associations": {
 		"1": {
-			"label": "Alarm Reports",
+			"label": "Lifeline",
 			"description": "Alarm reports are sent out to all devices in the association group",
 			"maxNodes": 5,
 			"isLifeline": true

--- a/packages/config/config/devices/0x0129/yrl220.json
+++ b/packages/config/config/devices/0x0129/yrl220.json
@@ -29,7 +29,6 @@
 	"associations": {
 		"1": {
 			"label": "Lifeline",
-			"description": "Alarm reports are sent out to all devices in the association group",
 			"maxNodes": 5,
 			"isLifeline": true
 		}


### PR DESCRIPTION
According to ZwaveJS documentation > Style guide, The primary reporting group (usually group 1 for Z-Wave Plus) must be called Lifeline.