### PR TITLE
fix(config): enable auto-idling notifications for MH9-CO2

### DIFF
--- a/packages/config/config/devices/0x015f/mh9-co2-wa.json
+++ b/packages/config/config/devices/0x015f/mh9-co2-wa.json
@@ -84,5 +84,8 @@
 				}
 			]
 		}
+	},
+	"compat": {
+		"forceNotificationIdleReset": true
 	}
 }

--- a/packages/config/config/devices/0x015f/mh9-co2-wd.json
+++ b/packages/config/config/devices/0x015f/mh9-co2-wd.json
@@ -38,5 +38,8 @@
 			"maxValue": 2000,
 			"defaultValue": 1000
 		}
+	},
+	"compat": {
+		"forceNotificationIdleReset": true
 	}
 }


### PR DESCRIPTION
mh9-co2 will not reset notification to idle, it will only resend alert each 30 seconds if threshold is crossed.

Seems that this is cause notification version is 3:

```
      "ccSpecific": {
        "notificationType": 3
      },
```