### PR TITLE
fix(config): add Alarm Mapping to Yale YRD220, YRL210, and YRL220

### DIFF
--- a/packages/config/config/devices/0x0129/yrd220.json
+++ b/packages/config/config/devices/0x0129/yrd220.json
@@ -71,5 +71,39 @@
 		"15": {
 			"$import": "templates/yale_template.json#reset_factory"
 		}
-	}
+	},
+	"compat": {
+		"alarmMapping": [
+			{
+				"$import": "templates/yale_template.json#alarm_map_keypad_limit"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_manual_unlock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_rf_unlock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_keypad_unlock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_manual_lock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_rf_lock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_keypad_lock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_deadbolt_jammed"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_low_battery"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_auto_relock"
+			}
+		]
+	}A
 }

--- a/packages/config/config/devices/0x0129/yrd220.json
+++ b/packages/config/config/devices/0x0129/yrd220.json
@@ -105,5 +105,5 @@
 				"$import": "templates/yale_template.json#alarm_map_auto_relock"
 			}
 		]
-	}A
+	}
 }

--- a/packages/config/config/devices/0x0129/yrl210.json
+++ b/packages/config/config/devices/0x0129/yrl210.json
@@ -42,5 +42,39 @@
 		"8": {
 			"$import": "templates/yale_template.json#operating_mode"
 		}
+	},
+	"compat": {
+		"alarmMapping": [
+			{
+				"$import": "templates/yale_template.json#alarm_map_keypad_limit"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_manual_unlock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_rf_unlock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_keypad_unlock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_manual_lock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_rf_lock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_keypad_lock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_deadbolt_jammed"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_low_battery"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_auto_relock"
+			}
+		]
 	}
 }

--- a/packages/config/config/devices/0x0129/yrl220.json
+++ b/packages/config/config/devices/0x0129/yrl220.json
@@ -67,5 +67,39 @@
 		"15": {
 			"$import": "templates/yale_template.json#reset_factory"
 		}
+	},
+	"compat": {
+		"alarmMapping": [
+			{
+				"$import": "templates/yale_template.json#alarm_map_keypad_limit"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_manual_unlock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_rf_unlock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_keypad_unlock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_manual_lock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_rf_lock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_keypad_lock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_deadbolt_jammed"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_low_battery"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_auto_relock"
+			}
+		]
 	}
 }


### PR DESCRIPTION
I have confirmed that all 3 of these locks share the exact Alarm Mappings of previous Yale Zwave locks of the 100 series. I used the existing templates.

fixes: https://github.com/zwave-js/node-zwave-js/issues/2826