### PR TITLE
fix(config): correct identification of Enerwave ZWN-RSM / ZWN-RSM-Plus variants

### DIFF
--- a/packages/config/config/devices/0x011a/zwn-rsm1-plus.json
+++ b/packages/config/config/devices/0x011a/zwn-rsm1-plus.json
@@ -1,12 +1,17 @@
 {
 	"manufacturer": "Wenzhou MTLC Electric Appliances Co., Ltd.",
 	"manufacturerId": "0x011a",
-	"label": "ZWN-RSM1-PLUS",
+	"label": "ZWN-RSM1 / ZWN-RSM1-PLUS",
 	"description": "Smart Relay Switch Module",
 	"devices": [
 		{
 			"productType": "0x0101",
 			"productId": "0x5605"
+		},
+		{
+			"productType": "0x0111",
+			"productId": "0x0605",
+			"zwaveAllianceId": [1777]
 		}
 	],
 	"firmwareVersion": {

--- a/packages/config/config/devices/0x011a/zwn-rsm2.json
+++ b/packages/config/config/devices/0x011a/zwn-rsm2.json
@@ -1,7 +1,7 @@
 {
 	"manufacturer": "Wenzhou MTLC Electric Appliances Co., Ltd.",
 	"manufacturerId": "0x011a",
-	"label": "ZWN-RSM1 / ZWN-RSM2",
+	"label": "ZWN-RSM2 / ZWN-RSM2-PLUS",
 	"description": "Smart Dual Relay Switch Module",
 	"devices": [
 		{
@@ -10,12 +10,8 @@
 		},
 		{
 			"productType": "0x0111",
-			"productId": "0x0605",
-			"zwaveAllianceId": [1777, 2242]
-		},
-		{
-			"productType": "0x0111",
-			"productId": "0x0606"
+			"productId": "0x0606",
+			"zwaveAllianceId": [2242]
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
Fixes #2835 