### PR TITLE
fix(config): add v1 alarm mapping for Yale YRD120

### DIFF
--- a/packages/config/config/devices/0x0129/yrd120.json
+++ b/packages/config/config/devices/0x0129/yrd120.json
@@ -40,5 +40,39 @@
 		"8": {
 			"$import": "templates/yale_template.json#operating_mode"
 		}
+	},
+	"compat": {
+		"alarmMapping": [
+			{
+				"$import": "templates/yale_template.json#alarm_map_keypad_limit"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_manual_unlock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_rf_unlock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_keypad_unlock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_manual_lock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_rf_lock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_keypad_lock"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_deadbolt_jammed"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_low_battery"
+			},
+			{
+				"$import": "templates/yale_template.json#alarm_map_auto_relock"
+			}
+		]
 	}
 }


### PR DESCRIPTION
The Yale YRD120 lock uses the same v1 notifications as the YRD220/240 and YRL210.  This patch adds the compat section to the YRD120 config.
