### PR TITLE
fix: correctly decode signed partial config param values 

### DIFF
--- a/packages/core/src/util/misc.ts
+++ b/packages/core/src/util/misc.ts
@@ -69,3 +69,24 @@ export function getMinimumShiftForBitMask(mask: number): number {
 	}
 	return i;
 }
+
+/**
+ * Determines how many wide a given bit mask is
+ * Example:
+ * ```txt
+ *   Mask = 00110000
+ *            ^^---- => 2 bits
+ *
+ *   Mask = 00110001
+ *            ^....^ => 6 bits
+ * ```
+ */
+export function getBitMaskWidth(mask: number): number {
+	mask = mask >>> getMinimumShiftForBitMask(mask);
+	let i = 0;
+	while (mask > 0) {
+		mask >>>= 1;
+		i++;
+	}
+	return i;
+}

--- a/packages/core/src/values/Primitive.test.ts
+++ b/packages/core/src/values/Primitive.test.ts
@@ -10,6 +10,7 @@ import {
 	parseMaybeBoolean,
 	parseMaybeNumber,
 	parseNumber,
+	parsePartial,
 	unknownBoolean,
 	unknownNumber,
 } from "./Primitive";
@@ -379,6 +380,54 @@ describe("lib/values/Primitive", () => {
 				4294967296,
 				Number.MAX_SAFE_INTEGER,
 			].forEach(test);
+		});
+	});
+
+	describe.only("parsePartial()", () => {
+		it("should work correctly for unsigned partials", () => {
+			const tests = [
+				{
+					value: 0b11110000,
+					bitMask: 0b00111100,
+					expected: 0b1100,
+				},
+				{
+					value: -128, // 10000000
+					bitMask: 0b11000000,
+					expected: 2,
+				},
+			];
+			for (const { value, bitMask, expected } of tests) {
+				expect(parsePartial(value, bitMask, false)).toBe(expected);
+			}
+		});
+
+		it("should work correctly for signed partials", () => {
+			const tests = [
+				{
+					value: 0b11_1110_00,
+					bitMask: 0b00_1111_00,
+					expected: -2, // 1...110
+				},
+				{
+					value: -8, // same as above
+					bitMask: 0b00_1111_00,
+					expected: -2, // 1...110
+				},
+				{
+					value: 0b11_1110_00,
+					bitMask: 0b11_0000_00,
+					expected: -1, // 1...1
+				},
+				{
+					value: 0b11_0110_00,
+					bitMask: 0b00_1111_00,
+					expected: 6,
+				},
+			];
+			for (const { value, bitMask, expected } of tests) {
+				expect(parsePartial(value, bitMask, true)).toBe(expected);
+			}
 		});
 	});
 });

--- a/packages/core/src/values/Primitive.test.ts
+++ b/packages/core/src/values/Primitive.test.ts
@@ -3,6 +3,7 @@ import { assertZWaveError } from "../test/assertZWaveError";
 import {
 	encodeBitMask,
 	encodeFloatWithScale,
+	encodePartial,
 	getMinIntegerSize,
 	parseBitMask,
 	parseBoolean,
@@ -383,7 +384,7 @@ describe("lib/values/Primitive", () => {
 		});
 	});
 
-	describe.only("parsePartial()", () => {
+	describe("parsePartial()", () => {
 		it("should work correctly for unsigned partials", () => {
 			const tests = [
 				{
@@ -427,6 +428,35 @@ describe("lib/values/Primitive", () => {
 			];
 			for (const { value, bitMask, expected } of tests) {
 				expect(parsePartial(value, bitMask, true)).toBe(expected);
+			}
+		});
+	});
+
+	describe("encodePartial()", () => {
+		it("should work correctly for signed and unsigned partials", () => {
+			const tests = [
+				{
+					fullValue: 0b11_01_1111,
+					partialValue: 0b10,
+					bitMask: 0b00_11_0000,
+					expected: 0b11_10_1111,
+				},
+				{
+					fullValue: 0b11_01_1111,
+					partialValue: -2, // same as above, but interpreted as signed
+					bitMask: 0b00_11_0000,
+					expected: 0b11_10_1111,
+				},
+			];
+			for (const {
+				fullValue,
+				partialValue,
+				bitMask,
+				expected,
+			} of tests) {
+				expect(encodePartial(fullValue, partialValue, bitMask)).toBe(
+					expected,
+				);
 			}
 		});
 	});

--- a/packages/core/src/values/Primitive.ts
+++ b/packages/core/src/values/Primitive.ts
@@ -174,6 +174,19 @@ export function encodeBitMask(values: number[], maxValue: number): Buffer {
 	return ret;
 }
 
+/**
+ * Parses a partial value from a "full" value. Example:
+ * ```txt
+ *   Value = 01110000
+ *   Mask  = 00110000
+ *   ----------------
+ *             11     => 3 (unsigned) or -1 (signed)
+ * ```
+ *
+ * @param value The full value the partial should be extracted from
+ * @param bitMask The bit mask selecting the partial value
+ * @param signed Whether the partial value should be interpreted as signed
+ */
 export function parsePartial(
 	value: number,
 	bitMask: number,
@@ -188,4 +201,29 @@ export function parsePartial(
 		ret = ~(~ret & (bitMask >>> shift));
 	}
 	return ret;
+}
+
+/**
+ * Encodes a partial value into a "full" value. Example:
+ * ```txt
+ *   Value   = 01··0000
+ * + Partial =   10     (2 or -2 depending on signed interpretation)
+ *   Mask    = 00110000
+ *   ------------------
+ *             01100000
+ * ```
+ *
+ * @param fullValue The full value the partial should be merged into
+ * @param partialValue The partial to be merged
+ * @param bitMask The bit mask selecting the partial value
+ */
+export function encodePartial(
+	fullValue: number,
+	partialValue: number,
+	bitMask: number,
+): number {
+	return (
+		(fullValue & ~bitMask) |
+		((partialValue << getMinimumShiftForBitMask(bitMask)) & bitMask)
+	);
 }


### PR DESCRIPTION
Our parsing routine for signed partial params was not correct. Even if the partial param was signed, we still parsed the partial value as an unsigned value. An example would be a 1-byte partial with a range of -128..127. The -128 (0x80) would be parsed as +128 in that case.

closes: #2832