### PR TITLE
chore: replace moment with dayjs, moment-timezone with a binary search

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,8 +35,7 @@
     "@zwave-js/shared": "7.7.3",
     "alcalzone-shared": "^3.0.4",
     "ansi-colors": "^4.1.1",
-    "moment": "^2.29.0",
-    "moment-timezone": "^0.5.33",
+    "dayjs": "^1.10.5",
     "nrf-intel-hex": "^1.3.0",
     "winston": "^3.3.3",
     "winston-daily-rotate-file": "^4.5.5"

--- a/packages/core/src/util/date.test.ts
+++ b/packages/core/src/util/date.test.ts
@@ -1,0 +1,31 @@
+import { formatDate, getDSTInfo } from "./date";
+
+describe("formatDate()", () => {
+	it("should work correctly", () => {
+		expect(formatDate(new Date(2021, 5, 15), "YYYY-MM-DD")).toEqual(
+			"2021-06-15",
+		);
+	});
+});
+
+describe("getDSTInfo()", () => {
+	if (Intl.DateTimeFormat().resolvedOptions().timeZone === "Europe/Berlin") {
+		it("should work correctly", () => {
+			let dstInfo = getDSTInfo(new Date("2021-05-15T01:00:00.000Z"));
+			expect(dstInfo).toEqual({
+				dstOffset: 120,
+				endDate: new Date("2021-10-31T01:00:00.000Z"),
+				standardOffset: 60,
+				startDate: new Date("2021-03-28T01:00:00.000Z"),
+			});
+
+			dstInfo = getDSTInfo(new Date("2020-11-12T01:00:00.000Z"));
+			expect(dstInfo).toEqual({
+				dstOffset: 120,
+				endDate: new Date("2020-10-25T01:00:00.000Z"),
+				standardOffset: 60,
+				startDate: new Date("2021-03-28T01:00:00.000Z"),
+			});
+		});
+	}
+});

--- a/packages/zwave-js/src/lib/commandclass/TimeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/TimeCC.ts
@@ -2,7 +2,6 @@ import {
 	CommandClasses,
 	DSTInfo,
 	formatDate,
-	getDefaultDSTInfo,
 	getDSTInfo,
 	Maybe,
 	MessageOrCCLogEntry,
@@ -152,7 +151,7 @@ export class TimeCC extends CommandClass {
 				direction: "outbound",
 			});
 			// Set the correct timezone on this node
-			const timezone = getDSTInfo() || getDefaultDSTInfo();
+			const timezone = getDSTInfo();
 			await api.setTimezone(timezone);
 		}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4386,6 +4386,11 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
+dayjs@^1.10.5:
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.5.tgz#5600df4548fc2453b3f163ebb2abbe965ccfb986"
+  integrity sha512-BUFis41ikLz+65iH6LHQCDm4YPMj5r1YFLdupPIyM4SGcXMmtiLQ7U37i+hGS8urIuqe7I/ou3IS1jVc4nbN4g==
+
 debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
@@ -7559,14 +7564,7 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moment-timezone@^0.5.33:
-  version "0.5.33"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.33.tgz#b252fd6bb57f341c9b59a5ab61a8e51a73bbd22c"
-  integrity sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==
-  dependencies:
-    moment ">= 2.9.0"
-
-"moment@>= 2.9.0", moment@^2.11.2, moment@^2.29.0:
+moment@^2.11.2:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==


### PR DESCRIPTION
fixes: https://github.com/zwave-js/node-zwave-js/issues/2865
and removes about 5.4 MB from our dependencies (at least theoretically)