### PR TITLE
feat: support bulk-setting normal and partial config parameters, support bulk-getting and -resetting

### DIFF
--- a/docs/api/CCs/Configuration.md
+++ b/docs/api/CCs/Configuration.md
@@ -21,6 +21,26 @@ This may timeout and return `undefined` if the node does not respond.
 If the node replied with a different parameter number, a `ConfigurationCCError`
 is thrown with the `argument` property set to the reported parameter number.
 
+### `getBulk`
+
+```ts
+async getBulk(
+	options: {
+		parameter: number;
+		bitMask?: number;
+	}[],
+): Promise<
+	{
+		parameter: number;
+		bitMask?: number;
+		value: ConfigValue | undefined;
+	}[]
+>;
+```
+
+Requests the current value of the config parameters from the device.
+When the node does not respond due to a timeout, the `value` in the returned array will be `undefined`.
+
 ### `set`
 
 ```ts
@@ -28,8 +48,10 @@ async set(
 	parameter: number,
 	value: ConfigValue,
 	valueSize: 1 | 2 | 4,
-	valueFormat: ConfigValueFormat = ConfigValueFormat.SignedInteger,
+	valueFormat?: ConfigValueFormat,
 ): Promise<void>;
+
+async set(options: ConfigurationCCAPISetOptions): Promise<void>;
 ```
 
 Sets a new value for a given config parameter of the device.
@@ -38,16 +60,11 @@ Sets a new value for a given config parameter of the device.
 
 ```ts
 async setBulk(
-	values: {
-		parameter: number;
-		value: ConfigValue;
-		valueSize: 1 | 2 | 4;
-		valueFormat?: ConfigValueFormat;
-	}[],
+	values: ConfigurationCCAPISetOptions[],
 ): Promise<void>;
 ```
 
-Sets a new value for multiple config parameters of the device. Uses BulkSet if supported, otherwise falls back to individual Set commands.
+Sets new values for multiple config parameters of the device. Uses the `BulkSet` command if supported, otherwise falls back to individual `Set` commands.
 
 ### `reset`
 

--- a/docs/api/CCs/Configuration.md
+++ b/docs/api/CCs/Configuration.md
@@ -34,6 +34,21 @@ async set(
 
 Sets a new value for a given config parameter of the device.
 
+### `setBulk`
+
+```ts
+async setBulk(
+	values: {
+		parameter: number;
+		value: ConfigValue;
+		valueSize: 1 | 2 | 4;
+		valueFormat?: ConfigValueFormat;
+	}[],
+): Promise<void>;
+```
+
+Sets a new value for multiple config parameters of the device. Uses BulkSet if supported, otherwise falls back to individual Set commands.
+
 ### `reset`
 
 ```ts
@@ -41,6 +56,16 @@ async reset(parameter: number): Promise<void>;
 ```
 
 Resets a configuration parameter to its default value.
+
+WARNING: This will throw on legacy devices (ConfigurationCC v3 and below).
+
+### `resetBulk`
+
+```ts
+async resetBulk(parameters: number[]): Promise<void>;
+```
+
+Resets multiple configuration parameters to their default value. Uses BulkSet if supported, otherwise falls back to individual Set commands.
 
 WARNING: This will throw on legacy devices (ConfigurationCC v3 and below).
 

--- a/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
@@ -127,6 +127,7 @@ export type ConfigurationCCAPISetOptions = {
 			value: number;
 	  }
 );
+
 type NormalizedConfigurationCCAPISetOptions = {
 	parameter: number;
 	valueSize: 1 | 2 | 4;


### PR DESCRIPTION
This PR adds support for bulk-setting configuration parameters. Partial parameters are handled automatically and merged with the known "full" value. If a node does not support the BulkSet command, individual Set commands are used instead.

Additionally, this PR adds the `resetBulk` and `getBulk` methods, both of which automatically fall back to individual commands if there is no bulk support on the node. The `set` method has gained another overload
```ts
set(options: ConfigurationCCAPISetOptions): Promise<void>

export type ConfigurationCCAPISetOptions = {
	parameter: number;
} & (
	| {
			// Variant 1: Normal parameter, defined in a config file
			bitMask?: undefined;
			value: ConfigValue;
	  }
	| {
			// Variant 2: Normal parameter, not defined in a config file
			bitMask?: undefined;
			value: ConfigValue;
			valueSize: 1 | 2 | 4;
			valueFormat: ConfigValueFormat;
	  }
	| {
			// Variant 3: Partial parameter, must be defined in a config file
			bitMask: number;
			value: number;
	  }
);
```
which allows passing the three different call variants as an object. The old overload
```ts
set(
	parameter: number,
	value: ConfigValue,
	valueSize: 1 | 2 | 4,
	valueFormat?: ConfigValueFormat,
): Promise<void>
```
is now deprecated.

For example, this call
```ts
	await node.commandClasses.Configuration.setBulk([
		{
			parameter: 101,
			bitMask: 0x01,
			value: 1,
		},
		{
			parameter: 101,
			bitMask: 0x10,
			value: 0,
		},
		{
			parameter: 101,
			bitMask: 0x20,
			value: 1,
		},
		{
			parameter: 101,
			bitMask: 0x40,
			value: 0,
		},
		{
			parameter: 101,
			bitMask: 0x80,
			value: 1,
		},
		{
			parameter: 102,
			bitMask: 0x01,
			value: 0,
		},
		{
			parameter: 102,
			bitMask: 0x10,
			value: 0,
		},
		{
			parameter: 102,
			bitMask: 0x20,
			value: 0,
		},
		{
			parameter: 102,
			bitMask: 0x40,
			value: 1,
		},
		{
			parameter: 102,
			bitMask: 0x80,
			value: 1,
		},
	]);
});
```
causes the following two Set commands on a node that supports Configuration CC V1:
```
└─[ConfigurationCCSet]
    parameter #:      101
    reset to default: false
    value size:       4
    value format:     UnsignedInteger
    value:            161

└─[ConfigurationCCSet]
    parameter #:      102
    reset to default: false
    value size:       4
    value format:     UnsignedInteger
    value:            192
```

Note that unlike the `setValue` API, the `commandClasses` API does not automatically verify the value changes, so the above will have to be followed up by a `getBulk` for parameters 101 and 102 or the individual partials..., which would in this case return 
```jsonc
[
  { parameter: 101, bitMask: 1, value: 1 },
  { parameter: 101, bitMask: 16, value: 0 },
  { parameter: 101, bitMask: 32, value: 1 },
  { parameter: 101, bitMask: 64, value: 0 },
  { parameter: 101, bitMask: 128, value: 1 },
  { parameter: 102, bitMask: 1, value: 0 },
  { parameter: 102, bitMask: 16, value: 0 },
  { parameter: 102, bitMask: 32, value: 0 },
  { parameter: 102, bitMask: 64, value: 1 },
  { parameter: 102, bitMask: 128, value: 1 }
]
```

fixes: https://github.com/zwave-js/node-zwave-js/issues/2278
fixes: https://github.com/zwave-js/node-zwave-js/issues/2279
fixes: https://github.com/zwave-js/node-zwave-js/issues/1644
fixes: https://github.com/zwave-js/node-zwave-js/issues/1347