### PR TITLE
fix(cc): create V1 alarm metadata on demand

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/NotificationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/NotificationCC.ts
@@ -889,16 +889,24 @@ export class NotificationCCReport extends NotificationCC {
 
 		const valueDB = this.getValueDB();
 		if (this.alarmType != undefined) {
-			valueDB.setValue(
-				getAlarmTypeValueId(this.endpointIndex),
-				this.alarmType,
-			);
+			const valueId = getAlarmTypeValueId(this.endpointIndex);
+			if (!valueDB.hasMetadata(valueId)) {
+				valueDB.setMetadata(valueId, {
+					...ValueMetadata.ReadOnlyUInt8,
+					label: "Alarm Type",
+				});
+			}
+			valueDB.setValue(valueId, this.alarmType);
 		}
 		if (this.alarmLevel != undefined) {
-			valueDB.setValue(
-				getAlarmLevelValueId(this.endpointIndex),
-				this.alarmLevel,
-			);
+			const valueId = getAlarmLevelValueId(this.endpointIndex);
+			if (!valueDB.hasMetadata(valueId)) {
+				valueDB.setMetadata(valueId, {
+					...ValueMetadata.ReadOnlyUInt8,
+					label: "Alarm Level",
+				});
+			}
+			valueDB.setValue(valueId, this.alarmLevel);
 		}
 
 		return true;


### PR DESCRIPTION
Doing this during the interview is not enough. Apparently it is okay to claim not to support V1 alarms and then use them.

fixes: https://github.com/home-assistant/core/issues/51532