### PR TITLE
feat(config): add alarm mapping for First Alert ZCOMBO

### DIFF
--- a/packages/config/config/devices/0x0138/zcombo.json
+++ b/packages/config/config/devices/0x0138/zcombo.json
@@ -45,5 +45,79 @@
 				}
 			]
 		}
+	},
+	"compat":{
+		"alarmMapping":[
+			{
+				"from":{
+					"alarmType": 1,
+					"alarmLevel": 255
+				},
+				"to":{
+					"notificationType": 1,
+					"notificationEvent": 2
+				}
+			},
+			{
+				"from":{
+					"alarmType": 1,
+					"alarmLevel": 0
+				},
+				"to":{
+					"notificationType": 1,
+					"notificationEvent": 0
+				}
+			},
+			{
+				"from":{
+					"alarmType": 2,
+					"alarmLevel": 255
+				},
+				"to":{
+					"notificationType": 2,
+					"notificationEvent": 2
+				}
+			},
+			{
+				"from":{
+					"alarmType": 2,
+					"alarmLevel": 0
+				},
+				"to":{
+					"notificationType": 2,
+					"notificationEvent": 0
+				}
+			},
+			{
+				"from":{
+					"alarmType": 12,
+					"alarmLevel": 255
+				},
+				"to":{
+					"notificationType": 1,
+					"notificationEvent": 3
+				}
+			},
+			{
+				"from":{
+					"alarmType": 12,
+					"alarmLevel": 0
+				},
+				"to":{
+					"notificationType": 1,
+					"notificationEvent": 0
+				}
+			},
+			{
+				"from":{
+					"alarmType": 13,
+					"alarmLevel": 255
+				},
+				"to":{
+					"notificationType": 1,
+					"notificationEvent": 0
+				}
+			}
+		]
 	}
 }

--- a/packages/config/config/devices/0x0138/zcombo.json
+++ b/packages/config/config/devices/0x0138/zcombo.json
@@ -46,74 +46,74 @@
 			]
 		}
 	},
-	"compat":{
-		"alarmMapping":[
+	"compat": {
+		"alarmMapping": [
 			{
-				"from":{
+				"from": {
 					"alarmType": 1,
 					"alarmLevel": 255
 				},
-				"to":{
+				"to": {
 					"notificationType": 1,
 					"notificationEvent": 2
 				}
 			},
 			{
-				"from":{
+				"from": {
 					"alarmType": 1,
 					"alarmLevel": 0
 				},
-				"to":{
+				"to": {
 					"notificationType": 1,
 					"notificationEvent": 0
 				}
 			},
 			{
-				"from":{
+				"from": {
 					"alarmType": 2,
 					"alarmLevel": 255
 				},
-				"to":{
+				"to": {
 					"notificationType": 2,
 					"notificationEvent": 2
 				}
 			},
 			{
-				"from":{
+				"from": {
 					"alarmType": 2,
 					"alarmLevel": 0
 				},
-				"to":{
+				"to": {
 					"notificationType": 2,
 					"notificationEvent": 0
 				}
 			},
 			{
-				"from":{
+				"from": {
 					"alarmType": 12,
 					"alarmLevel": 255
 				},
-				"to":{
+				"to": {
 					"notificationType": 1,
 					"notificationEvent": 3
 				}
 			},
 			{
-				"from":{
+				"from": {
 					"alarmType": 12,
 					"alarmLevel": 0
 				},
-				"to":{
+				"to": {
 					"notificationType": 1,
 					"notificationEvent": 0
 				}
 			},
 			{
-				"from":{
+				"from": {
 					"alarmType": 13,
 					"alarmLevel": 255
 				},
-				"to":{
+				"to": {
 					"notificationType": 1,
 					"notificationEvent": 0
 				}


### PR DESCRIPTION
Marking this as draft for two reasons:
I'd like to add whatever the rest of the values for `AlarmType`, if I can find documentation on what they are. (types 3-11 inclusive)
It's late and I don't trust myself.

Random Notes:
The device shows alarm 13 at 255 on reboot It does not appear to set alarmtype to 13 at any time after reboot
The devices only has one test state, so I've assigned it to the smoke alarm, since I don't think I can map it to both.