### PR TITLE
feat: add options to configure preferred sensor scales

### DIFF
--- a/docs/api/CCs/MultilevelSensor.md
+++ b/docs/api/CCs/MultilevelSensor.md
@@ -13,6 +13,10 @@ async get(): Promise<
 
 async get(
 	sensorType: number,
+): Promise<MultilevelSensorValue | undefined>;
+
+async get(
+	sensorType: number,
 	scale: number,
 ): Promise<number | undefined>;
 ```

--- a/docs/api/config-manager.md
+++ b/docs/api/config-manager.md
@@ -371,3 +371,52 @@ getNotificationName(notificationType: number): string;
 Returns the defined label for a given notification type
 
 > [!NOTE] `loadNotifications` must be used first.
+
+## ConfigManager properties
+
+### `namedScales`
+
+```ts
+readonly namedScales: NamedScalesGroupMap;
+```
+
+A map of the defined named sensor scales, which can be used to configure the user-preferred scales.
+
+<!-- #import NamedScalesGroupMap from "@zwave-js/config" -->
+
+```ts
+type NamedScalesGroupMap = ReadonlyMap<string, ScaleGroup>;
+```
+
+<!-- #import ScaleGroup from "@zwave-js/config" with comments -->
+
+```ts
+type ScaleGroup = ReadonlyMap<number, Scale> & {
+	/** The name of the scale group if it is named */
+	readonly name?: string;
+};
+```
+
+### `sensorTypes`
+
+```ts
+readonly sensorTypes: SensorTypeMap;
+```
+
+A map (numeric sensor type -> sensor type definition) of the known sensor types and their scales.
+
+<!-- #import SensorTypeMap from "@zwave-js/config" -->
+
+```ts
+type SensorTypeMap = ReadonlyMap<number, SensorType>;
+```
+
+<!-- #import SensorType from "@zwave-js/config" -->
+
+```ts
+interface SensorType {
+	readonly key: number;
+	readonly label: string;
+	readonly scales: ScaleGroup;
+}
+```

--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -236,6 +236,14 @@ getLogConfig(): LogConfig
 
 Returns the current logging configuration.
 
+### `setPreferredScales`
+
+```ts
+setPreferredScales(scales: ZWaveOptions["preferences"]["scales"]): void
+```
+
+Configures a new set of preferred sensor scales without having to restart the driver. The `scales` argument has the same type as `preferences.scales` in [`ZWaveOptions`](#ZWaveOptions).
+
 ### `checkForConfigUpdates`
 
 ```ts
@@ -471,7 +479,7 @@ This interface specifies the optional options object that is passed to the `Driv
 
 <!-- #import ZWaveOptions from "zwave-js" with comments -->
 
-```ts
+````ts
 interface ZWaveOptions {
 	/** Specify timeouts in milliseconds */
 	timeouts: {
@@ -560,8 +568,38 @@ interface ZWaveOptions {
 	 * Default: `false`
 	 */
 	disableOptimisticValueUpdate?: boolean;
+
+	preferences: {
+		/**
+		 * The preferred scales to use when querying sensors. The key is either:
+		 * - the name of a named scale group, e.g. "temperature", which applies to every sensor type that uses this scale group.
+		 * - or the numeric sensor type to specify the scale for a single sensor type
+		 *
+		 * Single-type preferences have a higher priority than named ones. For example, the following preference
+		 * ```js
+		 * {
+		 *     temperature: "°F",
+		 *     0x01: "°C",
+		 * }
+		 * ```
+		 * will result in using the Fahrenheit scale for all temperature sensors, except the air temperature (0x01).
+		 *
+		 * The value must match what is defined in the sensor type config file and contain either:
+		 * - the label (e.g. "Celsius", "Fahrenheit")
+		 * - the unit (e.g. "°C", "°F")
+		 * - or the numeric key of the scale (e.g. 0 or 1).
+		 *
+		 * Default:
+		 * ```js
+		 * {
+		 *     temperature: "Celsius"
+		 * }
+		 * ```
+		 */
+		scales: Partial<Record<string | number, string | number>>;
+	};
 }
-```
+````
 
 The timeout values `ack` and `byte` are sent to the Z-Wave stick using the `SetSerialApiTimeouts` command. Change them only if you know what you're doing.
 The `report` timeout is used by this library to determine how long to wait for a node's response.

--- a/packages/config/maintenance/lintConfigFiles.ts
+++ b/packages/config/maintenance/lintConfigFiles.ts
@@ -945,7 +945,7 @@ The first occurence of this device is in file config/devices/${index[firstIndex]
 
 async function lintNamedScales(): Promise<void> {
 	await configManager.loadNamedScales();
-	const definitions = configManager["namedScales"]!;
+	const definitions = configManager["namedScales"];
 
 	if (!definitions.has("temperature")) {
 		throw new Error(`Named scale "temperature" is missing!`);

--- a/packages/config/src/ConfigManager.ts
+++ b/packages/config/src/ConfigManager.ts
@@ -275,7 +275,7 @@ export class ConfigManager {
 		return this.namedScales.get(name);
 	}
 
-	/** Looks up a scale definition for a given sensor type */
+	/** Looks up a scale definition for a given scale type */
 	public lookupNamedScale(name: string, scale: number): Scale {
 		const group = this.lookupNamedScaleGroup(name);
 		return group?.get(scale) ?? getDefaultScale(scale);

--- a/packages/config/src/ConfigManager.ts
+++ b/packages/config/src/ConfigManager.ts
@@ -87,8 +87,29 @@ export class ConfigManager {
 	private indicators: IndicatorMap | undefined;
 	private indicatorProperties: IndicatorPropertiesMap | undefined;
 	private manufacturers: ManufacturersMap | undefined;
-	private namedScales: NamedScalesGroupMap | undefined;
-	private sensorTypes: SensorTypeMap | undefined;
+
+	private _namedScales: NamedScalesGroupMap | undefined;
+	public get namedScales(): NamedScalesGroupMap {
+		if (!this._namedScales) {
+			throw new ZWaveError(
+				"The config has not been loaded yet!",
+				ZWaveErrorCodes.Driver_NotReady,
+			);
+		}
+		return this._namedScales;
+	}
+
+	private _sensorTypes: SensorTypeMap | undefined;
+	public get sensorTypes(): SensorTypeMap {
+		if (!this._sensorTypes) {
+			throw new ZWaveError(
+				"The config has not been loaded yet!",
+				ZWaveErrorCodes.Driver_NotReady,
+			);
+		}
+		return this._sensorTypes;
+	}
+
 	private meters: MeterMap | undefined;
 	private basicDeviceClasses: BasicDeviceClassMap | undefined;
 	private genericDeviceClasses: GenericDeviceClassMap | undefined;
@@ -241,7 +262,7 @@ export class ConfigManager {
 
 	public async loadNamedScales(): Promise<void> {
 		try {
-			this.namedScales = await loadNamedScalesInternal(
+			this._namedScales = await loadNamedScalesInternal(
 				this.useExternalConfig,
 			);
 		} catch (e: unknown) {
@@ -253,7 +274,7 @@ export class ConfigManager {
 						"error",
 					);
 				}
-				if (!this.namedScales) this.namedScales = new Map();
+				if (!this._namedScales) this._namedScales = new Map();
 			} else {
 				// This is an unexpected error
 				throw e;
@@ -265,14 +286,14 @@ export class ConfigManager {
 	 * Looks up all scales defined under a given name
 	 */
 	public lookupNamedScaleGroup(name: string): ScaleGroup | undefined {
-		if (!this.namedScales) {
+		if (!this._namedScales) {
 			throw new ZWaveError(
 				"The config has not been loaded yet!",
 				ZWaveErrorCodes.Driver_NotReady,
 			);
 		}
 
-		return this.namedScales.get(name);
+		return this._namedScales.get(name);
 	}
 
 	/** Looks up a scale definition for a given scale type */
@@ -283,7 +304,7 @@ export class ConfigManager {
 
 	public async loadSensorTypes(): Promise<void> {
 		try {
-			this.sensorTypes = await loadSensorTypesInternal(
+			this._sensorTypes = await loadSensorTypesInternal(
 				this,
 				this.useExternalConfig,
 			);
@@ -296,7 +317,7 @@ export class ConfigManager {
 						"error",
 					);
 				}
-				if (!this.sensorTypes) this.sensorTypes = new Map();
+				if (!this._sensorTypes) this._sensorTypes = new Map();
 			} else {
 				// This is an unexpected error
 				throw e;
@@ -308,14 +329,14 @@ export class ConfigManager {
 	 * Looks up the configuration for a given sensor type
 	 */
 	public lookupSensorType(sensorType: number): SensorType | undefined {
-		if (!this.sensorTypes) {
+		if (!this._sensorTypes) {
 			throw new ZWaveError(
 				"The config has not been loaded yet!",
 				ZWaveErrorCodes.Driver_NotReady,
 			);
 		}
 
-		return this.sensorTypes.get(sensorType);
+		return this._sensorTypes.get(sensorType);
 	}
 
 	/** Looks up a scale definition for a given sensor type */

--- a/packages/config/src/Scales.ts
+++ b/packages/config/src/Scales.ts
@@ -12,7 +12,10 @@ import {
 	throwInvalidConfig,
 } from "./utils";
 
-export type ScaleGroup = ReadonlyMap<number, Scale>;
+export type ScaleGroup = ReadonlyMap<number, Scale> & {
+	/** The name of the scale group if it is named */
+	readonly name?: string;
+};
 export type NamedScalesGroupMap = ReadonlyMap<string, ScaleGroup>;
 
 /** @internal */
@@ -41,7 +44,7 @@ export async function loadNamedScalesInternal(
 			);
 		}
 
-		const namedScales = new Map();
+		const namedScales = new Map<string, ScaleGroup>();
 		for (const [name, scales] of entries(definition)) {
 			if (!/[\w\d]+/.test(name)) {
 				throwInvalidConfig(
@@ -49,7 +52,11 @@ export async function loadNamedScalesInternal(
 					`Name ${name} contains other characters than letters and numbers`,
 				);
 			}
-			const named = new Map<number, Scale>();
+			const named: Map<number, Scale> & { name?: string } = new Map<
+				number,
+				Scale
+			>();
+			named.name = name;
 			for (const [key, scaleDefinition] of entries(
 				scales as JSONObject,
 			)) {

--- a/packages/config/src/SensorTypes.ts
+++ b/packages/config/src/SensorTypes.ts
@@ -6,7 +6,7 @@ import { pathExists, readFile } from "fs-extra";
 import JSON5 from "json5";
 import path from "path";
 import type { ConfigManager } from "./ConfigManager";
-import { Scale } from "./Scales";
+import { Scale, ScaleGroup } from "./Scales";
 import {
 	configDir,
 	externalConfigDir,
@@ -131,5 +131,5 @@ export class SensorType {
 
 	public readonly key: number;
 	public readonly label: string;
-	public readonly scales: ReadonlyMap<number, Scale>;
+	public readonly scales: ScaleGroup;
 }

--- a/packages/maintenance/src/generateTypedDocs.ts
+++ b/packages/maintenance/src/generateTypedDocs.ts
@@ -200,7 +200,7 @@ interface ImportRange {
 }
 
 const importRegex =
-	/(?<import><!-- #import (?<symbol>.*?) from "(?<module>.*?)"(?: with (?<options>[\w\-, ]*?))? -->)(?:[\s\r\n]*```ts[\r\n]*(?<source>(.|\n)*?)```)?/g;
+	/(?<import><!-- #import (?<symbol>.*?) from "(?<module>.*?)"(?: with (?<options>[\w\-, ]*?))? -->)(?:[\s\r\n]*(^`{3,4})ts[\r\n]*(?<source>(.|\n)*?)\5)?/gm;
 
 export function findImportRanges(docFile: string): ImportRange[] {
 	const matches = [...docFile.matchAll(importRegex)];

--- a/packages/shared/src/misc.ts
+++ b/packages/shared/src/misc.ts
@@ -62,3 +62,27 @@ export function throttle<T extends any[]>(
 		}
 	};
 }
+
+/**
+ * Merges the user-defined options with the default options
+ */
+export function mergeDeep(
+	target: Record<string, any> | undefined,
+	source: Record<string, any>,
+): Record<string, any> {
+	target = target || {};
+	for (const [key, value] of Object.entries(source)) {
+		if (!(key in target)) {
+			target[key] = value;
+		} else {
+			if (typeof value === "object") {
+				// merge objects
+				target[key] = mergeDeep(target[key], value);
+			} else if (typeof target[key] === "undefined") {
+				// don't override single keys
+				target[key] = value;
+			}
+		}
+	}
+	return target;
+}

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -102,4 +102,34 @@ export interface ZWaveOptions {
 	 * Default: `false`
 	 */
 	disableOptimisticValueUpdate?: boolean;
+
+	preferences: {
+		/**
+		 * The preferred scales to use when querying sensors. The key is either:
+		 * - the name of a named scale group, e.g. "temperature", which applies to every sensor type that uses this scale group.
+		 * - or the numeric sensor type to specify the scale for a single sensor type
+		 *
+		 * Single-type preferences have a higher priority than named ones. For example, the following preference
+		 * ```js
+		 * {
+		 *     temperature: "°F",
+		 *     0x01: "°C",
+		 * }
+		 * ```
+		 * will result in using the Fahrenheit scale for all temperature sensors, except the air temperature (0x01).
+		 *
+		 * The value must match what is defined in the sensor type config file and contain either:
+		 * - the label (e.g. "Celsius", "Fahrenheit")
+		 * - the unit (e.g. "°C", "°F")
+		 * - or the numeric key of the scale (e.g. 0 or 1).
+		 *
+		 * Default:
+		 * ```js
+		 * {
+		 *     temperature: "Celsius"
+		 * }
+		 * ```
+		 */
+		scales: Partial<Record<string | number, string | number>>;
+	};
 }


### PR DESCRIPTION
This PR adds a new option to configure the preferred sensor scales to be used in Multilevel Sensor queries if no sensor scale was provided manually. By default, this is passed as a new driver option `preferences.scales`. From an application perspective it might be preferable to dynamically detect which scales are available, so this is also configurable using the new `driver.setPreferredScales` method.

The option accepts an object where the key is either:
- the name of a named scale group, e.g. "temperature", which applies to every sensor type that uses this scale group.
- or the numeric sensor type to specify the scale for a single sensor type

The value must match what is defined in the sensor type config file and contain either:
- the label (e.g. "Celsius", "Fahrenheit")
- the unit (e.g. "°C", "°F")
- or the numeric key of the scale (e.g. 0 or 1).

Single-type preferences have a higher priority than named ones. For example, the following preference
```js
{
    temperature: "°F",
    0x01: "°C", // Can also use decimal numbers as a key
}
```
will result in using the Fahrenheit scale for all temperature sensors, except the air temperature (`0x01`).

---

The `get` method for the `Multilevel Sensor CC API` now has an additional overload that just takes the sensor type and automatically determines the scale to use.

---

To determine the configured sensor types, the driver's `ConfigurationManager` instance (`driver.configManager`) can be used. It provides the properties `namedScales` for the named scale definitions and `sensorTypes` for the sensor types and their scale definitions.

---

fixes: #2882
fixes: https://github.com/home-assistant/core/issues/45967