### PR TITLE
fix(config): add support for clearing inovelli notifications

### DIFF
--- a/packages/config/config/devices/0x031e/lzw30-sn.json
+++ b/packages/config/config/devices/0x031e/lzw30-sn.json
@@ -441,7 +441,7 @@
 		},
 		"8[0xff0000]": {
 			"label": "LED Effect Duration",
-			"description": "1 to 60 = seconds, 61 to 120 = minutes (minus 60), 121 - 254 = hours (minus 120), 255 = indefinitely",
+			"description": "0 = disabled, 1 to 60 = seconds, 61 to 120 = minutes (minus 60), 121 - 254 = hours (minus 120), 255 = indefinitely",
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,

--- a/packages/config/config/devices/0x031e/lzw31-sn.json
+++ b/packages/config/config/devices/0x031e/lzw31-sn.json
@@ -501,7 +501,7 @@
 		},
 		"16[0xff0000]": {
 			"label": "LED Effect Duration",
-			"description": "1 to 60 = seconds, 61 to 120 = minutes (minus 60), 121 - 254 = hours (minus 120), 255 = indefinitely",
+			"description": "0 = disabled, 1 to 60 = seconds, 61 to 120 = minutes (minus 60), 121 - 254 = hours (minus 120), 255 = indefinitely",
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,

--- a/packages/config/config/devices/0x031e/lzw36.json
+++ b/packages/config/config/devices/0x031e/lzw36.json
@@ -639,9 +639,9 @@
 		},
 		"24[0xff0000]": {
 			"label": "Light LED Effect Duration",
-			"description": "1 to 60 = seconds, 61 to 120 = minutes (minus 60), 121 - 254 = hours (minus 120), 255 = indefinitely",
+			"description": "0 = disabled, 1 to 60 = seconds, 61 to 120 = minutes (minus 60), 121 - 254 = hours (minus 120), 255 = indefinitely",
 			"valueSize": 4,
-			"minValue": 1,
+			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 255,
 			"unsigned": true
@@ -781,9 +781,9 @@
 		},
 		"25[0xff0000]": {
 			"label": "Fan LED Effect Duration",
-			"description": "1 to 60 = seconds, 61 to 120 = minutes (minus 60), 121 - 254 = hours (minus 120), 255 = indefinitely",
+			"description": "0 = disabled, 1 to 60 = seconds, 61 to 120 = minutes (minus 60), 121 - 254 = hours (minus 120), 255 = indefinitely",
 			"valueSize": 4,
-			"minValue": 1,
+			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 255,
 			"unsigned": true


### PR DESCRIPTION
0 is actually a valid value for inovelli notification timeouts, it was silently allowed on all but the lzw36.
Setting 0 clears a notification if one is present.