### PR TITLE
chore: upgrade JsonlDB to v1.3.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,7 @@
     "node": ">=10.0.0"
   },
   "dependencies": {
-    "@alcalzone/jsonl-db": "^1.2.5",
+    "@alcalzone/jsonl-db": "^1.3.0",
     "@zwave-js/shared": "7.7.3",
     "alcalzone-shared": "^3.0.4",
     "ansi-colors": "^4.1.1",

--- a/packages/zwave-js/package.json
+++ b/packages/zwave-js/package.json
@@ -60,7 +60,7 @@
     "node": ">=10.0.0"
   },
   "dependencies": {
-    "@alcalzone/jsonl-db": "^1.2.5",
+    "@alcalzone/jsonl-db": "^1.3.0",
     "@alcalzone/pak": "^0.6.0",
     "@sentry/integrations": "^6.5.1",
     "@sentry/node": "^6.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,10 +36,10 @@
   resolved "https://registry.yarnpkg.com/@actions/io/-/io-1.0.2.tgz#2f614b6e69ce14d191180451eb38e6576a6e6b27"
   integrity sha512-J8KuFqVPr3p6U8W93DOXlXW6zFvrQAJANdS+vw0YhusLIq+bszW8zmK2Fh1C2kDPX8FMvwIl1OUcFgvJoXLbAg==
 
-"@alcalzone/jsonl-db@^1.2.5":
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/@alcalzone/jsonl-db/-/jsonl-db-1.2.5.tgz#c05e4346568d64a8d115b13ed80f131405160919"
-  integrity sha512-3DODBBUZq16bPIoOVf8CF46pLvZn1NXo+vPv+uPpuKMc88yL2oFNiR36AVky8BDj+tvgm/PmuiBCAG1necK+LQ==
+"@alcalzone/jsonl-db@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@alcalzone/jsonl-db/-/jsonl-db-1.3.0.tgz#bb91e4d4c1ab023203cb9da9545bd8ffd34a935b"
+  integrity sha512-08pUuomJ7FBGtF2AKuqNVSgwJn7LdsaR3dDXttYaD2zF7CzVJvWED7QNAyxLUP8Wo0SPioN6UTESVHam7DYqlA==
   dependencies:
     alcalzone-shared "^3.0.4"
     fs-extra "^9.1.0"


### PR DESCRIPTION
This hopefully fixes the last edge cases of cache corruption, where the system (Docker?) crashes shortly after or during a DB compression, leaving renamed/orphaned filesystem entries for the DB files.