### PR TITLE
feat: add valueChangeOptions as an optional metadata parameter

### DIFF
--- a/docs/api/valueid.md
+++ b/docs/api/valueid.md
@@ -51,6 +51,7 @@ interface ValueMetadataAny {
 	description?: string;
 	label?: string;
 	ccSpecific?: Record<string, any>;
+	setValueOptions?: string[];
 }
 ```
 
@@ -60,6 +61,7 @@ interface ValueMetadataAny {
 -   `description`: A description of the value
 -   `label`: A human-readable label for the property
 -   `ccSpecific`: CC specific information to help identify this value [(see below)](#CC-specific-fields)
+-   `setValueOptions`: Parameters that can be passed as `options` to the [`setValue`](api/node.md#setvalue) command for this value.
 
 ### Value types
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -42,6 +42,9 @@
     "semver": "^7.3.2",
     "winston": "^3.3.3"
   },
+  "devDependencies": {
+    "@zwave-js/maintenance": "7.9.0"
+  },
   "scripts": {
     "prebuild": "yarn ts maintenance/prebuild.ts",
     "build": "tsc -b tsconfig.build.json",

--- a/packages/core/src/values/Metadata.ts
+++ b/packages/core/src/values/Metadata.ts
@@ -38,6 +38,15 @@ export type ValueType =
 	| "buffer"
 	| "any";
 
+/**
+ * Defines options that can be provided when changing a value on a device via its value ID.
+ * Each implementation will choose the options that are relevant for it, so the same options can be used everywhere.
+ */
+export interface ValueChangeOptions {
+	/** A duration to be used for transitions like dimming lights or activating scenes. */
+	transitionDuration: Duration | string;
+}
+
 export interface ValueMetadataAny {
 	/** The type of the value */
 	type: ValueType;
@@ -53,8 +62,8 @@ export interface ValueMetadataAny {
 	label?: string;
 	/** CC-specific information to help identify this value */
 	ccSpecific?: Record<string, any>;
-	/** Options that can be included in a setValue call for this value. */
-	setValueOptions?: string[];
+	/** Options that can be provided when changing this value on a device via its value ID. */
+	valueChangeOptions?: (keyof ValueChangeOptions)[];
 }
 
 export interface ValueMetadataNumeric extends ValueMetadataAny {

--- a/packages/core/src/values/Metadata.ts
+++ b/packages/core/src/values/Metadata.ts
@@ -53,6 +53,8 @@ export interface ValueMetadataAny {
 	label?: string;
 	/** CC-specific information to help identify this value */
 	ccSpecific?: Record<string, any>;
+	/** Options that can be included in a setValue call for this value. */
+	setValueOptions?: string[];
 }
 
 export interface ValueMetadataNumeric extends ValueMetadataAny {

--- a/packages/maintenance/package.json
+++ b/packages/maintenance/package.json
@@ -32,5 +32,9 @@
     "build": "tsc -b tsconfig.build.json",
     "clean": "yarn run build -- --clean",
     "watch": "yarn run build -- --watch --pretty"
+  },
+  "devDependencies": {
+    "@zwave-js/core": "7.9.0",
+    "@zwave-js/shared": "7.9.0"
   }
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -32,5 +32,8 @@
     "build": "tsc -b tsconfig.build.json",
     "clean": "yarn run build -- --clean",
     "watch": "yarn run build -- --watch --pretty"
+  },
+  "devDependencies": {
+    "@zwave-js/core": "7.9.0"
   }
 }

--- a/packages/zwave-js/src/lib/commandclass/API.ts
+++ b/packages/zwave-js/src/lib/commandclass/API.ts
@@ -1,4 +1,4 @@
-import type { Duration, ValueID } from "@zwave-js/core";
+import type { ValueChangeOptions, ValueID } from "@zwave-js/core";
 import {
 	CommandClasses,
 	Maybe,
@@ -29,10 +29,7 @@ export type SetValueImplementation = (
  * Each implementation will choose the options that are relevant for it, so you can use the same options everywhere.
  * @publicAPI
  */
-export type SetValueAPIOptions = Partial<{
-	/** A duration to be used for transitions like dimming lights or activating scenes. */
-	transitionDuration: Duration | string;
-}>;
+export type SetValueAPIOptions = Partial<ValueChangeOptions>;
 
 /** Used to identify the method on the CC API class that handles polling values from nodes */
 export const POLL_VALUE: unique symbol = Symbol.for("CCAPI_POLL_VALUE");

--- a/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
@@ -326,6 +326,7 @@ export class BinarySwitchCCReport extends BinarySwitchCC {
 	@ccValueMetadata({
 		...ValueMetadata.Boolean,
 		label: "Target value",
+		setValueOptions: ["transitionDuration"],
 	})
 	public get targetValue(): boolean | undefined {
 		return this._targetValue;

--- a/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
@@ -326,7 +326,7 @@ export class BinarySwitchCCReport extends BinarySwitchCC {
 	@ccValueMetadata({
 		...ValueMetadata.Boolean,
 		label: "Target value",
-		setValueOptions: ["transitionDuration"],
+		valueChangeOptions: ["transitionDuration"],
 	})
 	public get targetValue(): boolean | undefined {
 		return this._targetValue;

--- a/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
@@ -84,7 +84,8 @@ const ColorComponentMap = {
 };
 type ColorKey = keyof typeof ColorComponentMap;
 
-const hexColorRegex = /^#?(?<red>[0-9a-f]{2})(?<green>[0-9a-f]{2})(?<blue>[0-9a-f]{2})$/i;
+const hexColorRegex =
+	/^#?(?<red>[0-9a-f]{2})(?<green>[0-9a-f]{2})(?<blue>[0-9a-f]{2})$/i;
 
 // Accept both the kebabCase names and numeric components as table keys
 /**
@@ -196,10 +197,11 @@ export class ColorSwitchCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 		});
-		const response = await this.driver.sendCommand<ColorSwitchCCSupportedReport>(
-			cc,
-			this.commandOptions,
-		);
+		const response =
+			await this.driver.sendCommand<ColorSwitchCCSupportedReport>(
+				cc,
+				this.commandOptions,
+			);
 		return response?.supportedColorComponents;
 	}
 

--- a/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
@@ -549,7 +549,7 @@ export class ColorSwitchCC extends CommandClass {
 		valueDB.setMetadata(getTargetColorValueID(this.endpointIndex), {
 			...ValueMetadata.Any,
 			label: `Target Color`,
-			setValueOptions: ["transitionDuration"],
+			valueChangeOptions: ["transitionDuration"],
 		});
 
 		// Create the collective HEX color values

--- a/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
@@ -84,8 +84,7 @@ const ColorComponentMap = {
 };
 type ColorKey = keyof typeof ColorComponentMap;
 
-const hexColorRegex =
-	/^#?(?<red>[0-9a-f]{2})(?<green>[0-9a-f]{2})(?<blue>[0-9a-f]{2})$/i;
+const hexColorRegex = /^#?(?<red>[0-9a-f]{2})(?<green>[0-9a-f]{2})(?<blue>[0-9a-f]{2})$/i;
 
 // Accept both the kebabCase names and numeric components as table keys
 /**
@@ -197,11 +196,10 @@ export class ColorSwitchCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 		});
-		const response =
-			await this.driver.sendCommand<ColorSwitchCCSupportedReport>(
-				cc,
-				this.commandOptions,
-			);
+		const response = await this.driver.sendCommand<ColorSwitchCCSupportedReport>(
+			cc,
+			this.commandOptions,
+		);
 		return response?.supportedColorComponents;
 	}
 
@@ -549,6 +547,7 @@ export class ColorSwitchCC extends CommandClass {
 		valueDB.setMetadata(getTargetColorValueID(this.endpointIndex), {
 			...ValueMetadata.Any,
 			label: `Target Color`,
+			setValueOptions: ["transitionDuration"],
 		});
 
 		// Create the collective HEX color values

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -135,11 +135,10 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 		});
-		const response =
-			await this.driver.sendCommand<MultilevelSwitchCCReport>(
-				cc,
-				this.commandOptions,
-			);
+		const response = await this.driver.sendCommand<MultilevelSwitchCCReport>(
+			cc,
+			this.commandOptions,
+		);
 		if (response) {
 			return pick(response, ["currentValue", "targetValue", "duration"]);
 		}
@@ -213,8 +212,9 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 
 		if (mayUseSupervision) {
 			// Try to supervise the command execution
-			const supervisionResult =
-				await this.driver.trySendCommandSupervised(cc);
+			const supervisionResult = await this.driver.trySendCommandSupervised(
+				cc,
+			);
 
 			if (supervisionResult?.status === SupervisionStatus.Fail) {
 				throw new ZWaveError(
@@ -253,8 +253,9 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 
 		if (mayUseSupervision) {
 			// Try to supervise the command execution
-			const supervisionResult =
-				await this.driver.trySendCommandSupervised(cc);
+			const supervisionResult = await this.driver.trySendCommandSupervised(
+				cc,
+			);
 
 			if (supervisionResult?.status === SupervisionStatus.Fail) {
 				throw new ZWaveError(
@@ -285,11 +286,10 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 		});
-		const response =
-			await this.driver.sendCommand<MultilevelSwitchCCSupportedReport>(
-				cc,
-				this.commandOptions,
-			);
+		const response = await this.driver.sendCommand<MultilevelSwitchCCSupportedReport>(
+			cc,
+			this.commandOptions,
+		);
 		return response?.switchType;
 	}
 
@@ -351,12 +351,12 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 						value <= 99
 					) {
 						// Figure out which nodes were affected by this command
-						const affectedNodes =
-							this.endpoint.node.physicalNodes.filter((node) =>
+						const affectedNodes = this.endpoint.node.physicalNodes.filter(
+							(node) =>
 								node
 									.getEndpoint(this.endpoint.index)
 									?.supportsCC(this.ccId),
-							);
+						);
 						// and optimistically update the currentValue
 						for (const node of affectedNodes) {
 							node.valueDB?.setValue(
@@ -635,6 +635,7 @@ export class MultilevelSwitchCCReport extends MultilevelSwitchCC {
 	@ccValueMetadata({
 		...ValueMetadata.Level,
 		label: "Target value",
+		setValueOptions: ["transitionDuration"],
 	})
 	public readonly targetValue: number | undefined;
 

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -635,7 +635,7 @@ export class MultilevelSwitchCCReport extends MultilevelSwitchCC {
 	@ccValueMetadata({
 		...ValueMetadata.Level,
 		label: "Target value",
-		setValueOptions: ["transitionDuration"],
+		valueChangeOptions: ["transitionDuration"],
 	})
 	public readonly targetValue: number | undefined;
 

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -135,10 +135,11 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 		});
-		const response = await this.driver.sendCommand<MultilevelSwitchCCReport>(
-			cc,
-			this.commandOptions,
-		);
+		const response =
+			await this.driver.sendCommand<MultilevelSwitchCCReport>(
+				cc,
+				this.commandOptions,
+			);
 		if (response) {
 			return pick(response, ["currentValue", "targetValue", "duration"]);
 		}
@@ -212,9 +213,8 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 
 		if (mayUseSupervision) {
 			// Try to supervise the command execution
-			const supervisionResult = await this.driver.trySendCommandSupervised(
-				cc,
-			);
+			const supervisionResult =
+				await this.driver.trySendCommandSupervised(cc);
 
 			if (supervisionResult?.status === SupervisionStatus.Fail) {
 				throw new ZWaveError(
@@ -253,9 +253,8 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 
 		if (mayUseSupervision) {
 			// Try to supervise the command execution
-			const supervisionResult = await this.driver.trySendCommandSupervised(
-				cc,
-			);
+			const supervisionResult =
+				await this.driver.trySendCommandSupervised(cc);
 
 			if (supervisionResult?.status === SupervisionStatus.Fail) {
 				throw new ZWaveError(
@@ -286,10 +285,11 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 		});
-		const response = await this.driver.sendCommand<MultilevelSwitchCCSupportedReport>(
-			cc,
-			this.commandOptions,
-		);
+		const response =
+			await this.driver.sendCommand<MultilevelSwitchCCSupportedReport>(
+				cc,
+				this.commandOptions,
+			);
 		return response?.switchType;
 	}
 
@@ -351,12 +351,12 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 						value <= 99
 					) {
 						// Figure out which nodes were affected by this command
-						const affectedNodes = this.endpoint.node.physicalNodes.filter(
-							(node) =>
+						const affectedNodes =
+							this.endpoint.node.physicalNodes.filter((node) =>
 								node
 									.getEndpoint(this.endpoint.index)
 									?.supportsCC(this.ccId),
-						);
+							);
 						// and optimistically update the currentValue
 						for (const node of affectedNodes) {
 							node.valueDB?.setValue(

--- a/packages/zwave-js/src/lib/commandclass/SceneActivationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneActivationCC.ts
@@ -137,7 +137,7 @@ export class SceneActivationCCSet extends SceneActivationCC {
 		...ValueMetadata.UInt8,
 		min: 1,
 		label: "Scene ID",
-		setValueOptions: ["transitionDuration"],
+		valueChangeOptions: ["transitionDuration"],
 	})
 	public sceneId: number;
 

--- a/packages/zwave-js/src/lib/commandclass/SceneActivationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneActivationCC.ts
@@ -137,6 +137,7 @@ export class SceneActivationCCSet extends SceneActivationCC {
 		...ValueMetadata.UInt8,
 		min: 1,
 		label: "Scene ID",
+		setValueOptions: ["transitionDuration"],
 	})
 	public sceneId: number;
 


### PR DESCRIPTION
As discussed here: https://github.com/zwave-js/node-zwave-js/issues/1321#issuecomment-760086568

This would make it easier for us to build logic to determine when we can use the `transitionDuration` option