### PR TITLE
fix(config): incorrect bitmask for parameters 41, 49, and 50 of Aeotec ZW100

### DIFF
--- a/packages/config/config/devices/0x0086/zw100.json
+++ b/packages/config/config/devices/0x0086/zw100.json
@@ -100,13 +100,13 @@
 			"$if": "firmwareVersion > 1.6 && firmwareVersion <= 1.9",
 			"$import": "templates/aeotec_template.json#celsius_fahrenheit",
 			"label": "Temperature Threshold Unit",
-			"valueSize": 3
+			"valueSize": 1
 		},
 		"41[0xffff00]": {
 			"$if": "firmwareVersion > 1.6 && firmwareVersion <= 1.9",
 			"label": "Temperature Change Threshold",
 			"unit": "0.1 °C/°F",
-			"valueSize": 3,
+			"valueSize": 2,
 			"minValue": 10,
 			"maxValue": 2120,
 			"defaultValue": 20
@@ -115,13 +115,13 @@
 			"$if": "firmwareVersion >= 1.10",
 			"$import": "templates/aeotec_template.json#celsius_fahrenheit",
 			"label": "Temperature Threshold Unit",
-			"valueSize": 4
+			"valueSize": 1
 		},
 		"41[0xffff0000]": {
 			"$if": "firmwareVersion >= 1.10",
 			"label": "Temperature Change Threshold",
 			"unit": "0.1 °C/°F",
-			"valueSize": 4,
+			"valueSize": 2,
 			"minValue": 10,
 			"maxValue": 2120,
 			"defaultValue": 20
@@ -184,12 +184,12 @@
 			"$if": "firmwareVersion < 1.10",
 			"$import": "templates/aeotec_template.json#celsius_fahrenheit",
 			"label": "Upper Temperature Limit Unit",
-			"valueSize": 3
+			"valueSize": 1
 		},
 		"49[0xffff00]": {
 			"$if": "firmwareVersion < 1.10",
 			"label": "Upper Temperature Limit",
-			"valueSize": 3,
+			"valueSize": 2,
 			"unit": "0.1 °C/°F",
 			"minValue": -400,
 			"maxValue": 2120,
@@ -199,12 +199,12 @@
 			"$if": "firmwareVersion >= 1.10",
 			"$import": "templates/aeotec_template.json#celsius_fahrenheit",
 			"label": "Upper Temperature Limit Unit",
-			"valueSize": 4
+			"valueSize": 1
 		},
 		"49[0xffff0000]": {
 			"$if": "firmwareVersion >= 1.10",
 			"label": "Upper Temperature Limit",
-			"valueSize": 4,
+			"valueSize": 2,
 			"unit": "0.1 °C/°F",
 			"minValue": -400,
 			"maxValue": 2120,
@@ -214,12 +214,12 @@
 			"$if": "firmwareVersion < 1.10",
 			"$import": "templates/aeotec_template.json#celsius_fahrenheit",
 			"label": "Lower Temperature Limit Unit",
-			"valueSize": 3
+			"valueSize": 1
 		},
 		"50[0xffff00]": {
 			"$if": "firmwareVersion < 1.10",
 			"label": "Lower Temperature Limit",
-			"valueSize": 3,
+			"valueSize": 2,
 			"unit": "0.1 °C/°F",
 			"minValue": -400,
 			"maxValue": 2120,
@@ -229,12 +229,12 @@
 			"$if": "firmwareVersion >= 1.10",
 			"$import": "templates/aeotec_template.json#celsius_fahrenheit",
 			"label": "Lower Temperature Limit Unit",
-			"valueSize": 3
+			"valueSize": 1
 		},
 		"50[0xffff0000]": {
 			"$if": "firmwareVersion >= 1.10",
 			"label": "Lower Temperature Limit",
-			"valueSize": 3,
+			"valueSize": 1,
 			"unit": "0.1 °C/°F",
 			"minValue": -400,
 			"maxValue": 2120,

--- a/packages/config/config/devices/0x0086/zw100.json
+++ b/packages/config/config/devices/0x0086/zw100.json
@@ -100,13 +100,13 @@
 			"$if": "firmwareVersion > 1.6 && firmwareVersion <= 1.9",
 			"$import": "templates/aeotec_template.json#celsius_fahrenheit",
 			"label": "Temperature Threshold Unit",
-			"valueSize": 1
+			"valueSize": 3
 		},
 		"41[0xffff00]": {
 			"$if": "firmwareVersion > 1.6 && firmwareVersion <= 1.9",
 			"label": "Temperature Change Threshold",
 			"unit": "0.1 °C/°F",
-			"valueSize": 2,
+			"valueSize": 3,
 			"minValue": 10,
 			"maxValue": 2120,
 			"defaultValue": 20
@@ -115,13 +115,13 @@
 			"$if": "firmwareVersion >= 1.10",
 			"$import": "templates/aeotec_template.json#celsius_fahrenheit",
 			"label": "Temperature Threshold Unit",
-			"valueSize": 1
+			"valueSize": 4
 		},
 		"41[0xffff0000]": {
 			"$if": "firmwareVersion >= 1.10",
 			"label": "Temperature Change Threshold",
 			"unit": "0.1 °C/°F",
-			"valueSize": 2,
+			"valueSize": 4,
 			"minValue": 10,
 			"maxValue": 2120,
 			"defaultValue": 20
@@ -184,7 +184,7 @@
 			"$if": "firmwareVersion < 1.10",
 			"$import": "templates/aeotec_template.json#celsius_fahrenheit",
 			"label": "Upper Temperature Limit Unit",
-			"valueSize": 1
+			"valueSize": 2
 		},
 		"49[0xffff00]": {
 			"$if": "firmwareVersion < 1.10",
@@ -199,12 +199,12 @@
 			"$if": "firmwareVersion >= 1.10",
 			"$import": "templates/aeotec_template.json#celsius_fahrenheit",
 			"label": "Upper Temperature Limit Unit",
-			"valueSize": 1
+			"valueSize": 4
 		},
 		"49[0xffff0000]": {
 			"$if": "firmwareVersion >= 1.10",
 			"label": "Upper Temperature Limit",
-			"valueSize": 2,
+			"valueSize": 4,
 			"unit": "0.1 °C/°F",
 			"minValue": -400,
 			"maxValue": 2120,
@@ -214,12 +214,12 @@
 			"$if": "firmwareVersion < 1.10",
 			"$import": "templates/aeotec_template.json#celsius_fahrenheit",
 			"label": "Lower Temperature Limit Unit",
-			"valueSize": 1
+			"valueSize": 3
 		},
 		"50[0xffff00]": {
 			"$if": "firmwareVersion < 1.10",
 			"label": "Lower Temperature Limit",
-			"valueSize": 2,
+			"valueSize": 3,
 			"unit": "0.1 °C/°F",
 			"minValue": -400,
 			"maxValue": 2120,
@@ -229,12 +229,12 @@
 			"$if": "firmwareVersion >= 1.10",
 			"$import": "templates/aeotec_template.json#celsius_fahrenheit",
 			"label": "Lower Temperature Limit Unit",
-			"valueSize": 1
+			"valueSize": 4
 		},
 		"50[0xffff0000]": {
 			"$if": "firmwareVersion >= 1.10",
 			"label": "Lower Temperature Limit",
-			"valueSize": 1,
+			"valueSize": 4,
 			"unit": "0.1 °C/°F",
 			"minValue": -400,
 			"maxValue": 2120,

--- a/packages/config/config/devices/0x0086/zw100.json
+++ b/packages/config/config/devices/0x0086/zw100.json
@@ -184,12 +184,12 @@
 			"$if": "firmwareVersion < 1.10",
 			"$import": "templates/aeotec_template.json#celsius_fahrenheit",
 			"label": "Upper Temperature Limit Unit",
-			"valueSize": 2
+			"valueSize": 3
 		},
 		"49[0xffff00]": {
 			"$if": "firmwareVersion < 1.10",
 			"label": "Upper Temperature Limit",
-			"valueSize": 2,
+			"valueSize": 3,
 			"unit": "0.1 °C/°F",
 			"minValue": -400,
 			"maxValue": 2120,

--- a/packages/config/config/devices/0x0086/zw100.json
+++ b/packages/config/config/devices/0x0086/zw100.json
@@ -96,40 +96,36 @@
 			"maxValue": 2120,
 			"defaultValue": 200
 		},
-		"41[0x0f]": [
-			{
-				"$if": "firmwareVersion > 1.6 && firmwareVersion <= 1.9",
-				"$import": "templates/aeotec_template.json#celsius_fahrenheit",
-				"label": "Temperature Threshold Unit",
-				"valueSize": 3
-			},
-			{
-				"$if": "firmwareVersion >= 1.10",
-				"$import": "templates/aeotec_template.json#celsius_fahrenheit",
-				"label": "Temperature Threshold Unit",
-				"valueSize": 4
-			}
-		],
-		"41[0xffff00]": [
-			{
-				"$if": "firmwareVersion > 1.6 && firmwareVersion <= 1.9",
-				"label": "Temperature Change Threshold",
-				"unit": "0.1 °C/°F",
-				"valueSize": 3,
-				"minValue": 10,
-				"maxValue": 2120,
-				"defaultValue": 20
-			},
-			{
-				"$if": "firmwareVersion >= 1.10",
-				"label": "Temperature Change Threshold",
-				"unit": "0.1 °C/°F",
-				"valueSize": 4,
-				"minValue": 10,
-				"maxValue": 2120,
-				"defaultValue": 20
-			}
-		],
+		"41[0x0f]": {
+			"$if": "firmwareVersion > 1.6 && firmwareVersion <= 1.9",
+			"$import": "templates/aeotec_template.json#celsius_fahrenheit",
+			"label": "Temperature Threshold Unit",
+			"valueSize": 3
+		},
+		"41[0xffff00]": {
+			"$if": "firmwareVersion > 1.6 && firmwareVersion <= 1.9",
+			"label": "Temperature Change Threshold",
+			"unit": "0.1 °C/°F",
+			"valueSize": 3,
+			"minValue": 10,
+			"maxValue": 2120,
+			"defaultValue": 20
+		},
+		"41[0x0f00]": {
+			"$if": "firmwareVersion >= 1.10",
+			"$import": "templates/aeotec_template.json#celsius_fahrenheit",
+			"label": "Temperature Threshold Unit",
+			"valueSize": 4
+		},
+		"41[0xffff0000]": {
+			"$if": "firmwareVersion >= 1.10",
+			"label": "Temperature Change Threshold",
+			"unit": "0.1 °C/°F",
+			"valueSize": 4,
+			"minValue": 10,
+			"maxValue": 2120,
+			"defaultValue": 20
+		},
 		"42": {
 			"$import": "../templates/master_template.json#base_1-100_nounit",
 			"label": "Humidity Change Threshold",
@@ -184,74 +180,66 @@
 		"48[0x80]": {
 			"$import": "templates/aeotec_template.json#above_ultraviolet_report"
 		},
-		"49[0xff]": [
-			{
-				"$if": "firmwareVersion < 1.10",
-				"$import": "templates/aeotec_template.json#celsius_fahrenheit",
-				"label": "Upper Temperature Limit Unit",
-				"valueSize": 3
-			},
-			{
-				"$if": "firmwareVersion >= 1.10",
-				"$import": "templates/aeotec_template.json#celsius_fahrenheit",
-				"label": "Upper Temperature Limit Unit",
-				"valueSize": 4
-			}
-		],
-		"49[0xffff00]": [
-			{
-				"$if": "firmwareVersion < 1.10",
-				"label": "Upper Temperature Limit",
-				"valueSize": 3,
-				"unit": "0.1 °C/°F",
-				"minValue": -400,
-				"maxValue": 2120,
-				"defaultValue": 280
-			},
-			{
-				"$if": "firmwareVersion >= 1.10",
-				"label": "Upper Temperature Limit",
-				"valueSize": 4,
-				"unit": "0.1 °C/°F",
-				"minValue": -400,
-				"maxValue": 2120,
-				"defaultValue": 280
-			}
-		],
-		"50[0xff]": [
-			{
-				"$if": "firmwareVersion < 1.10",
-				"$import": "templates/aeotec_template.json#celsius_fahrenheit",
-				"label": "Lower Temperature Limit Unit",
-				"valueSize": 3
-			},
-			{
-				"$if": "firmwareVersion >= 1.10",
-				"$import": "templates/aeotec_template.json#celsius_fahrenheit",
-				"label": "Lower Temperature Limit Unit",
-				"valueSize": 3
-			}
-		],
-		"50[0xffff00]": [
-			{
-				"$if": "firmwareVersion < 1.10",
-				"label": "Lower Temperature Limit",
-				"valueSize": 3,
-				"unit": "0.1 °C/°F",
-				"minValue": -400,
-				"maxValue": 2120,
-				"defaultValue": 0
-			},
-			{
-				"$if": "firmwareVersion >= 1.10",
-				"label": "Lower Temperature Limit",
-				"valueSize": 3,
-				"unit": "0.1 °C/°F",
-				"minValue": -400,
-				"maxValue": 2120,
-				"defaultValue": 0
-			}
-		],
+		"49[0xff]": {
+			"$if": "firmwareVersion < 1.10",
+			"$import": "templates/aeotec_template.json#celsius_fahrenheit",
+			"label": "Upper Temperature Limit Unit",
+			"valueSize": 3
+		},
+		"49[0xffff00]": {
+			"$if": "firmwareVersion < 1.10",
+			"label": "Upper Temperature Limit",
+			"valueSize": 3,
+			"unit": "0.1 °C/°F",
+			"minValue": -400,
+			"maxValue": 2120,
+			"defaultValue": 280
+		},
+		"49[0x0f00]": {
+			"$if": "firmwareVersion >= 1.10",
+			"$import": "templates/aeotec_template.json#celsius_fahrenheit",
+			"label": "Upper Temperature Limit Unit",
+			"valueSize": 4
+		},
+		"49[0xffff0000]": {
+			"$if": "firmwareVersion >= 1.10",
+			"label": "Upper Temperature Limit",
+			"valueSize": 4,
+			"unit": "0.1 °C/°F",
+			"minValue": -400,
+			"maxValue": 2120,
+			"defaultValue": 280
+		},
+		"50[0xff]": {
+			"$if": "firmwareVersion < 1.10",
+			"$import": "templates/aeotec_template.json#celsius_fahrenheit",
+			"label": "Lower Temperature Limit Unit",
+			"valueSize": 3
+		},
+		"50[0xffff00]": {
+			"$if": "firmwareVersion < 1.10",
+			"label": "Lower Temperature Limit",
+			"valueSize": 3,
+			"unit": "0.1 °C/°F",
+			"minValue": -400,
+			"maxValue": 2120,
+			"defaultValue": 0
+		},
+		"50[0xf00]": {
+			"$if": "firmwareVersion >= 1.10",
+			"$import": "templates/aeotec_template.json#celsius_fahrenheit",
+			"label": "Lower Temperature Limit Unit",
+			"valueSize": 3
+		},
+		"50[0xffff0000]": {
+			"$if": "firmwareVersion >= 1.10",
+			"label": "Lower Temperature Limit",
+			"valueSize": 3,
+			"unit": "0.1 °C/°F",
+			"minValue": -400,
+			"maxValue": 2120,
+			"defaultValue": 0
+		},
 		"51": {
 			"$import": "../templates/master_template.json#base_0-100_nounit",
 			"label": "Upper Humidity Limit",


### PR DESCRIPTION
See [engineering sheet](https://s3.amazonaws.com/cdn.freshdesk.com/data/helpdesk/attachments/production/6091430603/original/ES%20-%20Multisensor%206%20V1.13.pdf?response-content-type=application%2Fpdf&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAS6FNSMY2RG7BSUFP%2F20210626%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20210626T063457Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=7b5247da8616fbc0fcc41751c444a3b0db1fe8b22c5a45c8debcf49ead2e0e3f) for details. I don't have documentation from versions between 1.09 and 1.14, but there's no indication in the 1.14 docs that it's changed more recently.

Be kind! Never PRed this repo before.