### PR TITLE
fix: override source endpoint with destination when compat flag is set

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/MultiChannelCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultiChannelCC.ts
@@ -1034,6 +1034,14 @@ export class MultiChannelCCCommandEncapsulation extends MultiChannelCC {
 			this.destination = options.destination;
 			// If the encapsulated command requires security, so does this one
 			if (this.encapsulated.secure) this.secure = true;
+			if (
+				this.getNodeUnsafe()?.deviceConfig?.compat
+					?.treatDestinationEndpointAsSource
+			) {
+				// This device incorrectly responds from the endpoint we've passed as our source endpoint
+				if (typeof this.destination === "number")
+					this.endpointIndex = this.destination;
+			}
 		}
 	}
 


### PR DESCRIPTION
fixes: #2917

@katiuskt can you test this please? => https://zwave-js.github.io/zwavejs2mqtt/#/troubleshooting/docker_custom_builds?id=build

Use branch `greenwave-stuff` for `ZWJ_BRANCH`