### PR TITLE
fix(cc): do not query all user codes during interview

### DIFF
--- a/docs/getting-started/migrating-to-v8.md
+++ b/docs/getting-started/migrating-to-v8.md
@@ -1,0 +1,33 @@
+# Migrating to v7
+
+In version 8.x, we [INSERT XYZ], leading to several breaking changes.
+
+Please follow this guide if you're migrating from v7. If migrating from v6, please see the v7 migration guide first.
+
+## Skip UserCode Querying during Interview
+
+We have changed the default interview behavior for the User Code Command Class to not query all user codes. This is intended to help save device battery as some devices may have hundreds of user codes, leading to significant battery drain during initial pairing of a new device and each subsequent restart.
+
+Using `ZWaveOptions`, the interview behavior can be toggle back to query all codes if you wish to do so. You can still query individual codes after the node enters its `ready` state.
+
+## Restructing of the Driver's ZWaveOptions Object
+
+We have unified all interview behavior options under a single key (`interview`). _This is a breaking change_ if you were previously skipping interviewing by default. The new structure simply wraps the prior key inside `interview` and adds additional options as seen below:
+
+```javascript
+...
+interview: {
+    /**
+     * @internal
+     * Set this to true to skip the controller interview. Useful for testing purposes
+     */
+    skipInterview?: boolean;
+
+    /**
+     * Whether all user code should be queried during the interview of the UserCode CC.
+     * Note that enabling this can cause a lot of traffic during the interview.
+     */
+    queryAllUserCodes?: boolean;
+}
+
+```

--- a/packages/zwave-js/src/lib/commandclass/UserCodeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/UserCodeCC.ts
@@ -756,7 +756,9 @@ export class UserCodeCC extends CommandClass {
 		}
 
 		// Synchronize user codes and settings
-		await this.refreshValues();
+		if (!this.driver.options.skipUserCodeInterview) {
+			await this.refreshValues();
+		}
 
 		// Remember that the interview is complete
 		this.interviewComplete = true;

--- a/packages/zwave-js/src/lib/commandclass/UserCodeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/UserCodeCC.ts
@@ -770,7 +770,7 @@ export class UserCodeCC extends CommandClass {
 		}
 
 		// Synchronize user codes and settings
-		if (this.driver.options.interview?.queryAllUserCodes) {
+		if (this.driver.options.interview.queryAllUserCodes) {
 			await this.refreshValues();
 		}
 

--- a/packages/zwave-js/src/lib/commandclass/UserCodeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/UserCodeCC.ts
@@ -272,7 +272,7 @@ function setUserCodeMetadata(
 		});
 	}
 	const codeMetadata: ValueMetadata = {
-		...(typeof userCode === "object"
+		...(Buffer.isBuffer(userCode)
 			? ValueMetadata.Buffer
 			: ValueMetadata.String),
 		minLength: 4,

--- a/packages/zwave-js/src/lib/driver/Driver.test.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.test.ts
@@ -51,7 +51,7 @@ describe("lib/driver/Driver => ", () => {
 	describe("starting it => ", () => {
 		it("should open a new serialport", async () => {
 			const driver = new Driver(PORT_ADDRESS, {
-				skipInterview: true,
+				interview: { skipInterview: true },
 				logConfig: { enabled: false },
 			});
 			// swallow error events during testing
@@ -66,7 +66,7 @@ describe("lib/driver/Driver => ", () => {
 
 		it("should only work once", async () => {
 			const driver = new Driver(PORT_ADDRESS, {
-				skipInterview: true,
+				interview: { skipInterview: true },
 				logConfig: { enabled: false },
 			});
 			// swallow error events during testing
@@ -82,7 +82,7 @@ describe("lib/driver/Driver => ", () => {
 
 		it("the start promise should only be fulfilled after the port was opened", async () => {
 			const driver = new Driver(PORT_ADDRESS, {
-				skipInterview: true,
+				interview: { skipInterview: true },
 				logConfig: { enabled: false },
 			});
 			// swallow error events during testing
@@ -99,7 +99,7 @@ describe("lib/driver/Driver => ", () => {
 
 		it("the start promise should be rejected if the port opening fails", async () => {
 			const driver = new Driver(PORT_ADDRESS, {
-				skipInterview: true,
+				interview: { skipInterview: true },
 				logConfig: { enabled: false },
 			});
 			// swallow error events during testing
@@ -118,7 +118,7 @@ describe("lib/driver/Driver => ", () => {
 
 		it("after a failed start, starting again should not be possible", async () => {
 			const driver = new Driver(PORT_ADDRESS, {
-				skipInterview: true,
+				interview: { skipInterview: true },
 				logConfig: { enabled: false },
 			});
 			// swallow error events during testing
@@ -142,7 +142,7 @@ describe("lib/driver/Driver => ", () => {
 
 		it(`should throw if no "error" handler is attached`, async () => {
 			const driver = new Driver(PORT_ADDRESS, {
-				skipInterview: true,
+				interview: { skipInterview: true },
 				logConfig: { enabled: false },
 			});
 			// start the driver
@@ -155,7 +155,7 @@ describe("lib/driver/Driver => ", () => {
 	describe.skip("sending messages => ", () => {
 		it("should not be possible if the driver wasn't started", async () => {
 			const driver = new Driver(PORT_ADDRESS, {
-				skipInterview: true,
+				interview: { skipInterview: true },
 				logConfig: { enabled: false },
 			});
 			// swallow error events during testing
@@ -171,7 +171,7 @@ describe("lib/driver/Driver => ", () => {
 
 		it("should not be possible if the driver hasn't completed starting", async () => {
 			const driver = new Driver(PORT_ADDRESS, {
-				skipInterview: true,
+				interview: { skipInterview: true },
 				logConfig: { enabled: false },
 			});
 			// swallow error events during testing
@@ -190,7 +190,7 @@ describe("lib/driver/Driver => ", () => {
 
 		it("should not be possible if the driver failed to start", async () => {
 			const driver = new Driver(PORT_ADDRESS, {
-				skipInterview: true,
+				interview: { skipInterview: true },
 				logConfig: { enabled: false },
 			});
 			// swallow error events during testing

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -158,7 +158,10 @@ const defaultOptions: ZWaveOptions = {
 	},
 	preserveUnknownValues: false,
 	disableOptimisticValueUpdate: false,
-	skipInterview: false,
+	interview: {
+		skipInterview: false,
+		queryAllUserCodes: false,
+	},
 	storage: {
 		driver: fsExtra,
 		cacheDir: path.resolve(__dirname, "../../..", "cache"),
@@ -753,7 +756,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> {
 			}
 		};
 
-		if (!this.options.skipInterview) {
+		if (!this.options.interview.skipInterview) {
 			// Interview the controller.
 			await this._controller.interview(initValueDBs, async () => {
 				// Try to restore the network information from the cache
@@ -787,7 +790,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> {
 		this._nodesReady.clear();
 		this._nodesReadyEventEmitted = false;
 
-		if (!this.options.skipInterview) {
+		if (!this.options.interview.skipInterview) {
 			// Now interview all nodes
 			// First complete the controller interview
 			const controllerNode = this._controller.nodes.get(
@@ -1215,7 +1218,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> {
 	/** This is called when a new node has been added to the network */
 	private onNodeAdded(node: ZWaveNode): void {
 		this.addNodeEventHandlers(node);
-		if (!this.options.skipInterview) {
+		if (!this.options.interview.skipInterview) {
 			// Interview the node
 			// don't await the interview, because it may take a very long time
 			// if a node is asleep

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -59,8 +59,8 @@ export interface ZWaveOptions {
 	 */
 	skipInterview?: boolean;
 
-	/** Allows you to skip user code interview */
-	skipUserCodeInterview?: boolean;
+	/** Allows you to query all user code during the interview of the UserCode CC */
+	queryAllUserCodes?: boolean;
 
 	storage: {
 		/** Allows you to replace the default file system driver used to store and read the cache */

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -53,15 +53,19 @@ export interface ZWaveOptions {
 	 */
 	logConfig?: LogConfig;
 
-	/**
-	 * @internal
-	 * Set this to true to skip the controller interview. Useful for testing purposes
-	 */
-	skipInterview?: boolean;
+	interview: {
+		/**
+		 * @internal
+		 * Set this to true to skip the controller interview. Useful for testing purposes
+		 */
+		skipInterview?: boolean;
 
-	/** Allows you to query all user code during the interview of the UserCode CC */
-	queryAllUserCodes?: boolean;
-
+		/**
+		 * Whether all user code should be queried during the interview of the UserCode CC.
+		 * Note that enabling this can cause a lot of traffic during the interview.
+		 */
+		queryAllUserCodes?: boolean;
+	};
 	storage: {
 		/** Allows you to replace the default file system driver used to store and read the cache */
 		driver: FileSystem;

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -59,6 +59,9 @@ export interface ZWaveOptions {
 	 */
 	skipInterview?: boolean;
 
+	/** Allows you to skip user code interview */
+	skipUserCodeInterview?: boolean;
+
 	storage: {
 		/** Allows you to replace the default file system driver used to store and read the cache */
 		driver: FileSystem;

--- a/packages/zwave-js/src/lib/test/utils.ts
+++ b/packages/zwave-js/src/lib/test/utils.ts
@@ -32,7 +32,7 @@ export async function createAndStartDriver(
 
 	const driver = new Driver(PORT_ADDRESS, {
 		...options,
-		skipInterview: true,
+		interview: { skipInterview: true },
 	});
 	driver.on("error", () => {
 		/* swallow error events during testing */


### PR DESCRIPTION
This PR is a proposed solution for #2727. More specifically, we expose the ability to skip the interviewing of user code by setting a `skipUserCodeInterview` flag in the ZWaveOptions being passed to the driver. 



