### PR TITLE
fix(config): correct valueSize for param 64 on Aeotec ZW100 / Fantem FT100

### DIFF
--- a/packages/config/config/devices/0x0086/zw100.json
+++ b/packages/config/config/devices/0x0086/zw100.json
@@ -393,7 +393,8 @@
 		},
 		"64": {
 			"$import": "templates/aeotec_template.json#celsius_fahrenheit",
-			"label": "Automatic Temperature Reporting Unit"
+			"label": "Automatic Temperature Reporting Unit",
+			"valueSize": 1
 		},
 		"100": {
 			"$import": "templates/aeotec_template.json#reset_parameters",

--- a/packages/config/config/devices/0x016a/ft100.json
+++ b/packages/config/config/devices/0x016a/ft100.json
@@ -389,7 +389,8 @@
 		},
 		"64": {
 			"$import": "../0x0086/templates/aeotec_template.json#celsius_fahrenheit",
-			"label": "Automatic Temperature Reporting Unit"
+			"label": "Automatic Temperature Reporting Unit",
+			"valueSize": 1
 		},
 		"100": {
 			"$import": "../0x0086/templates/aeotec_template.json#reset_parameters",


### PR DESCRIPTION
Template value size was different from the expected size on the device. Thank's @marcus-j-davies for helping me track this one down.