### PR TITLE
fix(config): allow manual entry for tone duration for Aeotec Doorbell and Siren

### DIFF
--- a/packages/config/config/devices/0x0086/templates/aeotec_template.json
+++ b/packages/config/config/devices/0x0086/templates/aeotec_template.json
@@ -2040,7 +2040,7 @@
 		"maxValue": 255,
 		"defaultValue": 0,
 		"unsigned": true,
-		"allowManualEntry": false,
+		"allowManualEntry": true,
 		"options": [
 			{
 				"label": "Original tone length",

--- a/packages/config/config/devices/0x0086/templates/aeotec_template.json
+++ b/packages/config/config/devices/0x0086/templates/aeotec_template.json
@@ -2040,7 +2040,6 @@
 		"maxValue": 255,
 		"defaultValue": 0,
 		"unsigned": true,
-		"allowManualEntry": true,
 		"options": [
 			{
 				"label": "Original tone length",


### PR DESCRIPTION
Allow manual entries for Aeotec tone duration settings. Allowed values according to the device manuals:
- 0 = Original tone duration
- 1-254 = Tone duration in seconds
- 255 = Last used configuration value.