### PR TITLE
feat(config): add Heatit ZM Single Relay 16A

### DIFF
--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -151,6 +151,7 @@
 			"description": "Time to turn relay on after having been turned off",
 			
 			"valueSize": 4,
+          "unit": "seconds",
 			"minValue": 0,
 			"maxValue": 86400,
 			"defaultValue": 0,

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -174,7 +174,7 @@
 			"unsigned": true,
 			"options": [
 				{
-					"label": "Auto on disabled",
+					"label": "Disable",
 					"value": 0
 				}
 			]

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -150,8 +150,8 @@
 			]
 		},
 		"7": {
-			"label": "Automatic Turn Off",
-			"description": "Time to turn relay off after having been turned on (1-86400 seconds)",
+			"label": "Auto-Off Delay",
+			"unit": "seconds",
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 86400,

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -96,7 +96,7 @@
 					"value": 0
 				},
 				{
-					"label": "Button sends meter report + relay status, load can be only controlled wirelessly",
+					"label": "Button only sends status",
 					"value": 1
 				}
 			]

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -129,7 +129,7 @@
 			]
 		},
 		"6": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev",
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"7": {
 			"label": "Auto-Off Delay",

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -201,7 +201,6 @@
 		},
 		"10": {
 			"label": "Meter Report Interval",
-			"description": "30 seconds – 32767 seconds",
 			"valueSize": 2,
 			"unit": "seconds",
 			"minValue": 30,

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -40,7 +40,7 @@
 	"paramInformation": {
 		"1": {
 			"label": "Load Limit",
-			"description": "1-16 A",
+			"description": "1-16",
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 16,

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -1,7 +1,7 @@
 {
 	"manufacturer": "HeatIt",
 	"manufacturerId": "0x019b",
-	"label": "ZM SINGLE RELAY 16",
+	"label": "4512671",
 	"description": "Heatit ZM Single Relay 16A",
 	"devices": [
 		{

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -130,7 +130,7 @@
 			]
 		},
 		"6": {
-			"$import": "templates/master_template.json#state_after_power_failure_off_on_prev
+			"$import": "templates/master_template.json#state_after_power_failure_off_on_prev",
 				}
 			]
 		},

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -92,7 +92,7 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Button turns load on/off and sends meter report + relay status",
+					"label": "Button turns on/off and sends status",
 					"value": 0
 				},
 				{

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -149,7 +149,7 @@
 		"8": {
 			"label": "Auto-On Delay",
 			"description": "Time to turn relay on after having been turned off",
-			"unit": "seconds",
+			
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 86400,

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -127,25 +127,7 @@
 			]
 		},
 		"6": {
-			"label": "Restore Power Level",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Always off on restored power",
-					"value": 0
-				},
-				{
-					"label": "Always on on restored power",
-					"value": 1
-				},
-				{
-					"label": "Restore last state on restored power (default)",
-					"value": 2
+			"$import": "templates/master_template.json#state_after_power_failure_off_on_prev
 				}
 			]
 		},

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -149,9 +149,9 @@
 		"8": {
 			"label": "Auto-On Delay",
 			"description": "Time to turn relay on after having been turned off",
-			
+
 			"valueSize": 4,
-          "unit": "seconds",
+			"unit": "seconds",
 			"minValue": 0,
 			"maxValue": 86400,
 			"defaultValue": 0,

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -189,11 +189,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Disabled",
+					"label": "Disable",
 					"value": 0
 				},
 				{
-					"label": "Enabled",
+					"label": "Enable",
 					"value": 1
 				}
 			]

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -133,7 +133,6 @@
 		},
 		"7": {
 			"label": "Auto-Off Delay",
-			"unit": "seconds",
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 86400,

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -29,7 +29,7 @@
 			"maxNodes": 5
 		},
 		"4": {
-			"label": "External Relay Control S2",
+			"label": "External Relay Control: Basic Set S2",
 			"maxNodes": 5
 		},
 		"5": {

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -134,6 +134,7 @@
 		"7": {
 			"label": "Auto-Off Delay",
 			"valueSize": 4,
+			"unit": "seconds",
 			"minValue": 0,
 			"maxValue": 86400,
 			"defaultValue": 0,

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -109,7 +109,7 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Sends scene controller for s2. s1 disabled",
+					"label": "S2 Only",
 					"value": 0
 				},
 				{

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -130,8 +130,6 @@
 		},
 		"6": {
 			"$import": "templates/master_template.json#state_after_power_failure_off_on_prev",
-				}
-			]
 		},
 		"7": {
 			"label": "Auto-Off Delay",

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -40,7 +40,6 @@
 	"paramInformation": {
 		"1": {
 			"label": "Load Limit",
-			"description": "1-16",
 			"valueSize": 1,
 			"unit": "A",
 			"minValue": 1,

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -25,7 +25,7 @@
 			"maxNodes": 5
 		},
 		"3": {
-			"label": "Control External Start/Stop S2",
+			"label": "External Relay Control: Start/Stop Multilevel Set S1",
 			"maxNodes": 5
 		},
 		"4": {

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -53,6 +53,7 @@
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 32767,
+			"unit": "seconds",
 			"defaultValue": 20,
 			"unsigned": true,
 			"options": [

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -149,7 +149,6 @@
 		"8": {
 			"label": "Auto-On Delay",
 			"description": "Time to turn relay on after having been turned off",
-
 			"valueSize": 4,
 			"unit": "seconds",
 			"minValue": 0,

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -1,0 +1,228 @@
+{
+	"manufacturer": "HeatIt",
+	"manufacturerId": "0x019b",
+	"label": "ZM SINGLE RELAY 16",
+	"description": "Heatit ZM Single Relay 16A",
+	"devices": [
+		{
+			"productType": "0x0004",
+			"productId": "0x3500",
+			"zwaveAllianceId": 4062
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "External Relay Control S1",
+			"maxNodes": 5
+		},
+		"3": {
+			"label": "Control External Start/Stop S2",
+			"maxNodes": 5
+		},
+		"4": {
+			"label": "External Relay Control S2",
+			"maxNodes": 5
+		},
+		"5": {
+			"label": "Control External Start/Stop S2",
+			"maxNodes": 5
+		}
+	},
+	"paramInformation": {
+		"1": {
+			"label": "Load Limit",
+			"description": "1-16 A",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 16,
+			"defaultValue": 16,
+			"unsigned": true
+		},
+		"2": {
+			"label": "Power Shutdown Actions",
+			"description": "0: Disabled, 1-32767: minute(s) delay before attempting to turn back on",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 32767,
+			"defaultValue": 20,
+			"unsigned": true,
+			"options": [
+				{
+					"label": "Disabled and will not retry. User needs to manually turn on afterwards. If temperature overload is on, device will not turn on until device has cooled down",
+					"value": 0
+				}
+			]
+		},
+		"3": {
+			"label": "Switch Type",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Momentary switch",
+					"value": 0
+				},
+				{
+					"label": "Toggle switch",
+					"value": 1
+				}
+			]
+		},
+		"4": {
+			"label": "S1/Button Operation",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Button turns load on/off and sends meter report + relay status",
+					"value": 0
+				},
+				{
+					"label": "Button sends meter report + relay status, load can be only controlled wirelessly",
+					"value": 1
+				}
+			]
+		},
+		"5": {
+			"label": "Scene Notifications",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 3,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Sends scene controller for s2. s1 disabled",
+					"value": 0
+				},
+				{
+					"label": "Sends scene controller for s1. s2 disabled",
+					"value": 1
+				},
+				{
+					"label": "Sends scene controller for s1 and s2",
+					"value": 2
+				},
+				{
+					"label": "Scene controller deactivated",
+					"value": 3
+				}
+			]
+		},
+		"6": {
+			"label": "Restore Power Level",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 2,
+			"defaultValue": 2,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Always off on restored power",
+					"value": 0
+				},
+				{
+					"label": "Always on on restored power",
+					"value": 1
+				},
+				{
+					"label": "Restore last state on restored power (default)",
+					"value": 2
+				}
+			]
+		},
+		"7": {
+			"label": "Automatic Turn Off",
+			"description": "Time to turn relay off after having been turned on (1-86400 seconds)",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 86400,
+			"defaultValue": 0,
+			"unsigned": true,
+			"options": [
+				{
+					"label": "Auto off disabled",
+					"value": 0
+				}
+			]
+		},
+		"8": {
+			"label": "Automatic Turn On",
+			"description": "Time to turn relay on after having been turned off (1-86400 seconds)",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 86400,
+			"defaultValue": 0,
+			"unsigned": true,
+			"options": [
+				{
+					"label": "Auto on disabled",
+					"value": 0
+				}
+			]
+		},
+		"9": {
+			"label": "Inverted Output",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disabled",
+					"value": 0
+				},
+				{
+					"label": "Enabled",
+					"value": 1
+				}
+			]
+		},
+		"10": {
+			"label": "Meter Report Interval",
+			"description": "30 seconds – 32767 seconds",
+			"valueSize": 2,
+			"unit": "seconds",
+			"minValue": 30,
+			"maxValue": 32767,
+			"defaultValue": 900,
+			"unsigned": true
+		},
+		"11": {
+			"label": "Meter Report Delta Value",
+			"description": "5-3600 W",
+			"valueSize": 2,
+			"minValue": 5,
+			"maxValue": 3600,
+			"defaultValue": 75,
+			"unsigned": true
+		}
+	},
+	"metadata": {
+		"inclusion": "The primary controller/gateway has a mode for adding devices. Please refer to your primary controller manual on how to set the primary controller in add mode. The device may only be added to the network if the primary controller is in add mode.\n\nThere are two ways to add the Heatit ZM Single Relay 16A to a Z-Wave network.\n\n*Method 1: Standard (Manual)\nAdd mode is indicated on the device by a blinking green LED. This lasts until timeout occurs after 90 seconds, or until the module has been added to the network.\nThe LED will light up for 3 seconds if adding is successful.\n\nMethod 2: SmartStart (Automatic)\nSmartStart enabled products may be added to a Z-Wave network by scanning the Z-Wave QR-Code on the product if your primary controller supports SmartStart inclusion. No further action is required and the SmartStart product will be added automatically after being powered on within range of the primary controller",
+		"exclusion": "The primary controller/gateway has a mode for removing devices. Please refer to your primary controller manual on how to set the primary controller in remove mode. The device may only be removed from the network if the primary controller is in remove mode.\n\nRemove mode is indicated on the device by a blinking green LED. This lasts until timeout occurs after 90 seconds, or until the module has been removed from the network.\nThe LED will light up for 3 seconds if removing is successful",
+		"reset": "Press and hold the configuration button. After 3 seconds the LED will start to blink in green. After 20 seconds the LED will stop blinking and emit a constant light. You may now release the button. \n\nNB! Please use this procedure only when the primary controller/ gateway is missing or otherwise inoperable",
+		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=product_documents/4062/Manual_Heatit%20ZM%20Single%20Relay%2016A_Ver%202020-A_ENG.pdf"
+	}
+}

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -113,7 +113,7 @@
 					"value": 0
 				},
 				{
-					"label": "Sends scene controller for s1. s2 disabled",
+					"label": "S1 Only",
 					"value": 1
 				},
 				{

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -48,8 +48,7 @@
 			"unsigned": true
 		},
 		"2": {
-			"label": "Power Shutdown Actions",
-			"description": "0: Disabled, 1-32767: minute(s) delay before attempting to turn back on",
+			"label": "Turn On Delay After Emergency Off",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 32767,

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -50,6 +50,7 @@
 		"2": {
 			"label": "Turn On Delay After Emergency Off",
 			"valueSize": 2,
+			"unit": "seconds",
 			"minValue": 0,
 			"maxValue": 32767,
 			"unit": "seconds",

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -117,7 +117,7 @@
 					"value": 1
 				},
 				{
-					"label": "Sends scene controller for s1 and s2",
+					"label": "S1 & S2",
 					"value": 2
 				},
 				{

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -129,7 +129,7 @@
 			]
 		},
 		"6": {
-			"$import": "templates/master_template.json#state_after_power_failure_off_on_prev",
+			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev",
 		},
 		"7": {
 			"label": "Auto-Off Delay",

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -33,7 +33,7 @@
 			"maxNodes": 5
 		},
 		"5": {
-			"label": "Control External Start/Stop S2",
+			"label": "External Relay Control: Start/Stop Multilevel Set S2",
 			"maxNodes": 5
 		}
 	},

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -121,7 +121,7 @@
 					"value": 2
 				},
 				{
-					"label": "Scene controller deactivated",
+					"label": "None",
 					"value": 3
 				}
 			]

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -102,7 +102,8 @@
 			]
 		},
 		"5": {
-			"label": "Scene Notifications",
+			"label": "Central Scene Notifications",
+			"description": "Configure which buttons cause notifications to be sent",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 3,

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -56,7 +56,7 @@
 			"unsigned": true,
 			"options": [
 				{
-					"label": "Disabled and will not retry. User needs to manually turn on afterwards. If temperature overload is on, device will not turn on until device has cooled down",
+					"label": "Disable",
 					"value": 0
 				}
 			]

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -53,7 +53,6 @@
 			"unit": "seconds",
 			"minValue": 0,
 			"maxValue": 32767,
-			"unit": "seconds",
 			"defaultValue": 20,
 			"unsigned": true,
 			"options": [

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -42,6 +42,7 @@
 			"label": "Load Limit",
 			"description": "1-16",
 			"valueSize": 1,
+			"unit": "A",
 			"minValue": 1,
 			"maxValue": 16,
 			"defaultValue": 16,

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -159,7 +159,7 @@
 			"unsigned": true,
 			"options": [
 				{
-					"label": "Auto off disabled",
+					"label": "Disable",
 					"value": 0
 				}
 			]

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -211,8 +211,8 @@
 		},
 		"11": {
 			"label": "Meter Report Delta Value",
-			"description": "5-3600 W",
 			"valueSize": 2,
+			"unit": "W",
 			"minValue": 5,
 			"maxValue": 3600,
 			"defaultValue": 75,

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -165,8 +165,9 @@
 			]
 		},
 		"8": {
-			"label": "Automatic Turn On",
-			"description": "Time to turn relay on after having been turned off (1-86400 seconds)",
+			"label": "Auto-On Delay",
+			"description": "Time to turn relay on after having been turned off",
+			"unit": "seconds",
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 86400,

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -21,7 +21,7 @@
 			"isLifeline": true
 		},
 		"2": {
-			"label": "External Relay Control S1",
+			"label": "External Relay Control: Basic Set S1",
 			"maxNodes": 5
 		},
 		"3": {


### PR DESCRIPTION
Adds a config file for Heatit ZM Single Relay 16, and thus fixes #2924. It is based on the autogenerated config in #3003.

closes: #3003