### PR TITLE
fix(config): add additional product ID for Willis Electric NZW30T

### DIFF
--- a/packages/config/config/devices/0x015d/nzw30t.json
+++ b/packages/config/config/devices/0x015d/nzw30t.json
@@ -9,6 +9,10 @@
 			"productId": "0x1e00"
 		},
 		{
+			"productType": "0x1e01",
+			"productId": "0x1e01"
+		},
+		{
 			"productType": "0x1e02",
 			"productId": "0x1e02"
 		}


### PR DESCRIPTION
This is a switch that I have, that want to add support for. It appears entirely identical to the other Willis Electric switches I have that report a device ID of 0x1e00. Thanks!