### PR TITLE
feat(config): implement ~/ path prefix to reference config dir root

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -79,5 +79,8 @@
 		"**/.pnp.*": true
 	},
 	"eslint.nodePath": ".yarn/sdks",
-	"prettier.prettierPath": ".yarn/sdks/prettier/index.js"
+	"prettier.prettierPath": ".yarn/sdks/prettier/index.js",
+	"[typescript]": {
+		"editor.autoClosingBrackets": "languageDefined"
+	}
 }

--- a/docs/config-files/using-templates.md
+++ b/docs/config-files/using-templates.md
@@ -19,6 +19,17 @@ where
 
 Both parts are optional, so you can import entire files and you can also build self-referencing templates if you leave out the filesystem path.
 
+Whenever possible, you should prefer using `~/` to navigate to the **config root directory** instead of using varying levels of `../`. This avoids broken references when files are moved around:
+
+```json
+{
+	// Prefer this:
+	"$import": "~/templates/master_template.json#selector",
+	// Over this:
+	"$import": "../../../templates/master_template.json#selector"
+}
+```
+
 Properties listed before the `$import` statement may get overwritten by the imports. Properties listed after it will overwrite the imported properties. You can use this to do device-specific additions without having to change the template as a whole.
 
 > [!ATTENTION]

--- a/maintenance/schemas/device-config.json
+++ b/maintenance/schemas/device-config.json
@@ -344,7 +344,7 @@
 		"import": {
 			"type": "string",
 			"description": "Used to import another config file or parts thereof",
-			"pattern": "^((?<dir>([\\w\\d_\\.-]+/)+)?(?<filename>[\\w\\d_-]+\\.json))?(?<selector>#([\\w\\d_-]+/)*[\\w\\d_-]+)?$"
+			"pattern": "^((?<dir>((?:~/)?[\\w\\d_\\.-]+/)+)?(?<filename>[\\w\\d_-]+\\.json))?(?<selector>#([\\w\\d_-]+/)*[\\w\\d_-]+)?$"
 		},
 		"condition": {
 			"type": "string",

--- a/packages/config/config/devices/0x0001/templates/act_template.json
+++ b/packages/config/config/devices/0x0001/templates/act_template.json
@@ -1,38 +1,38 @@
 // ACT/HomePro Templates
 {
 	"ignore_start_level_receiving": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Ignore Start Level (Receiving)",
 		"description": "When enabled, the switch will start dimming from the current level"
 	},
 	"ignore_start_level_transmitting": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Ignore Start Level (Transmitting)",
 		"description": "When enabled, dim commands will ignore the start level",
 		"defaultValue": 1
 	},
 	"suspend_group_4": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Enable / Disable Group 4",
 		"description": "Controls whether commands will be transmitted to Group 4"
 	},
 	"disable_send_level": {
-		"$import": "../../templates/master_template.json#base_enable_disable_inverted",
+		"$import": "~/templates/master_template.json#base_enable_disable_inverted",
 		"label": "Enable / Disable Send Levels After Dim",
 		"description": "Controls whether devices are set to the same level as the ZDW103 after dimming"
 	},
 	"enable_shade_group_1": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Enable / Disable Shade Group 1",
 		"description": "Define whether the device can control shade control devices via Group 1"
 	},
 	"enable_shade_group_2": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Enable / Disable Shade Group 2",
 		"description": "Define whether the device can control shade control devices via Group 2"
 	},
 	"enable_shade_group_3": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Enable / Disable Shade Group 3",
 		"description": "Define whether the device can control shade control devices via Group 3"
 	},
@@ -59,31 +59,31 @@
 		]
 	},
 	"dim_step_zwave": {
-		"$import": "../../templates/master_template.json#base_1-99_nounit",
+		"$import": "~/templates/master_template.json#base_1-99_nounit",
 		"label": "Dimming Steps (Z-Wave)"
 	},
 	"dim_rate_zwave": {
-		"$import": "../../templates/master_template.json#dimming_timing",
+		"$import": "~/templates/master_template.json#dimming_timing",
 		"label": "Dimming Rate (Z-Wave)"
 	},
 	"dim_step_manual": {
-		"$import": "../../templates/master_template.json#base_1-99_nounit",
+		"$import": "~/templates/master_template.json#base_1-99_nounit",
 		"label": "Dimming Steps (Manual)"
 	},
 	"dim_rate_manual": {
-		"$import": "../../templates/master_template.json#dimming_timing",
+		"$import": "~/templates/master_template.json#dimming_timing",
 		"label": "Dimming Rate (Manual)"
 	},
 	"dim_step_all": {
-		"$import": "../../templates/master_template.json#base_1-99_nounit",
+		"$import": "~/templates/master_template.json#base_1-99_nounit",
 		"label": "Dimming Steps (All-On/All-Off)"
 	},
 	"dim_rate_all": {
-		"$import": "../../templates/master_template.json#dimming_timing",
+		"$import": "~/templates/master_template.json#dimming_timing",
 		"label": "Dimming Rate (All-On/All-Off)"
 	},
 	"disable_group_4": {
-		"$import": "../../templates/master_template.json#base_enable_disable_inverted",
+		"$import": "~/templates/master_template.json#base_enable_disable_inverted",
 		"label": "Enable / Disable Group 4 Dimming",
 		"description": "Controls whether dimming commands are transmitted to Group 4"
 	}

--- a/packages/config/config/devices/0x0001/zdm230.json
+++ b/packages/config/config/devices/0x0001/zdm230.json
@@ -41,7 +41,7 @@
 			"$import": "templates/act_template.json#suspend_group_4"
 		},
 		"3": {
-			"$import": "../templates/master_template.json#led_indicator_two_options_inverted"
+			"$import": "~/templates/master_template.json#led_indicator_two_options_inverted"
 		}
 	}
 }

--- a/packages/config/config/devices/0x0001/zdw103.json
+++ b/packages/config/config/devices/0x0001/zdw103.json
@@ -40,10 +40,10 @@
 			"$import": "templates/act_template.json#suspend_group_4"
 		},
 		"3": {
-			"$import": "../templates/master_template.json#led_indicator_two_options_inverted"
+			"$import": "~/templates/master_template.json#led_indicator_two_options_inverted"
 		},
 		"4": {
-			"$import": "../templates/master_template.json#orientation"
+			"$import": "~/templates/master_template.json#orientation"
 		},
 		"5": {
 			"$import": "templates/act_template.json#ignore_start_level_receiving"

--- a/packages/config/config/devices/0x0001/zdw120.json
+++ b/packages/config/config/devices/0x0001/zdw120.json
@@ -40,10 +40,10 @@
 			"$import": "templates/act_template.json#suspend_group_4"
 		},
 		"3": {
-			"$import": "../templates/master_template.json#led_indicator_two_options_inverted"
+			"$import": "~/templates/master_template.json#led_indicator_two_options_inverted"
 		},
 		"4": {
-			"$import": "../templates/master_template.json#orientation"
+			"$import": "~/templates/master_template.json#orientation"
 		},
 		"5": {
 			"$import": "templates/act_template.json#ignore_start_level_receiving"

--- a/packages/config/config/devices/0x0001/zir000_zir010.json
+++ b/packages/config/config/devices/0x0001/zir000_zir010.json
@@ -64,13 +64,13 @@
 			]
 		},
 		"18": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Delay After Trigger",
 			"description": "Defines the time after motion before the device sets off/idle",
 			"unit": "minutes"
 		},
 		"19": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Enable / Disable Sending Commands",
 			"description": "Allows temporarily disabling sending commands without removing direct associations"
 		},

--- a/packages/config/config/devices/0x0001/zrm230.json
+++ b/packages/config/config/devices/0x0001/zrm230.json
@@ -41,10 +41,10 @@
 			"$import": "templates/act_template.json#suspend_group_4"
 		},
 		"3": {
-			"$import": "../templates/master_template.json#led_indicator_two_options_inverted"
+			"$import": "~/templates/master_template.json#led_indicator_two_options_inverted"
 		},
 		"4": {
-			"$import": "../templates/master_template.json#orientation"
+			"$import": "~/templates/master_template.json#orientation"
 		},
 		"14": {
 			"$import": "templates/act_template.json#enable_shade_group_2"
@@ -56,13 +56,13 @@
 			"$import": "templates/act_template.json#led_indicator"
 		},
 		"20": {
-			"$import": "../templates/master_template.json#base_1-255_nounit",
+			"$import": "~/templates/master_template.json#base_1-255_nounit",
 			"label": "Poll Group 2 Interval",
 			"unit": "minutes",
 			"defaultValue": 2
 		},
 		"22": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Poll Group 2",
 			"defaultValue": 1
 		}

--- a/packages/config/config/devices/0x0001/zrw230.json
+++ b/packages/config/config/devices/0x0001/zrw230.json
@@ -44,10 +44,10 @@
 			"$import": "templates/act_template.json#suspend_group_4"
 		},
 		"3": {
-			"$import": "../templates/master_template.json#led_indicator_two_options_inverted"
+			"$import": "~/templates/master_template.json#led_indicator_two_options_inverted"
 		},
 		"4": {
-			"$import": "../templates/master_template.json#orientation"
+			"$import": "~/templates/master_template.json#orientation"
 		},
 		"14": {
 			"$import": "templates/act_template.json#enable_shade_group_2"

--- a/packages/config/config/devices/0x0001/ztm230.json
+++ b/packages/config/config/devices/0x0001/ztm230.json
@@ -43,10 +43,10 @@
 			"$import": "templates/act_template.json#suspend_group_4"
 		},
 		"3": {
-			"$import": "../templates/master_template.json#led_indicator_two_options_inverted"
+			"$import": "~/templates/master_template.json#led_indicator_two_options_inverted"
 		},
 		"4": {
-			"$import": "../templates/master_template.json#orientation"
+			"$import": "~/templates/master_template.json#orientation"
 		},
 		"5": {
 			"$import": "templates/act_template.json#ignore_start_level_receiving"
@@ -85,17 +85,17 @@
 			"$import": "templates/act_template.json#led_indicator"
 		},
 		"20": {
-			"$import": "../templates/master_template.json#base_1-255_nounit",
+			"$import": "~/templates/master_template.json#base_1-255_nounit",
 			"label": "Poll Group Interval",
 			"unit": "minutes",
 			"defaultValue": 2
 		},
 		"21": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Poll Group 1"
 		},
 		"22": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Poll Group 2",
 			"defaultValue": 1
 		}

--- a/packages/config/config/devices/0x000c/hs-fc200.json
+++ b/packages/config/config/devices/0x000c/hs-fc200.json
@@ -16,10 +16,10 @@
 	},
 	"paramInformation": {
 		"3": {
-			"$import": "../templates/master_template.json#led_indicator_two_options"
+			"$import": "~/templates/master_template.json#led_indicator_two_options"
 		},
 		"4": {
-			"$import": "../templates/master_template.json#orientation"
+			"$import": "~/templates/master_template.json#orientation"
 		},
 		"5": {
 			"$import": "templates/homeseer_template.json#fan_type"
@@ -51,19 +51,19 @@
 			"$import": "templates/homeseer_template.json#blink_frequency"
 		},
 		"31[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Enable / Disable Blinking - LED 1"
 		},
 		"31[0x02]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Enable / Disable Blinking - LED 2"
 		},
 		"31[0x04]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Enable / Disable Blinking - LED 3"
 		},
 		"31[0x08]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Enable / Disable Blinking - LED 4"
 		}
 	},

--- a/packages/config/config/devices/0x000c/hs-fls100.json
+++ b/packages/config/config/devices/0x000c/hs-fls100.json
@@ -26,7 +26,7 @@
 			"label": "Luminance Report Interval"
 		},
 		"4": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Basic Report on Trigger"
 		}
 	},

--- a/packages/config/config/devices/0x000c/hs-ls100.json
+++ b/packages/config/config/devices/0x000c/hs-ls100.json
@@ -22,7 +22,7 @@
 			"$import": "templates/homeseer_template.json#basic_set_value"
 		},
 		"17": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Flood Alarm Interval",
 			"unit": "minutes",
 			"defaultValue": 5
@@ -31,7 +31,7 @@
 			"$import": "templates/homeseer_template.json#enable_shock_alarm"
 		},
 		"19": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Temperature Report Interval",
 			"unit": "minutes"
 		},
@@ -52,7 +52,7 @@
 			"defaultValue": 320
 		},
 		"24": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Enable / Disable Blinking LED",
 			"defaultValue": 1
 		},

--- a/packages/config/config/devices/0x000c/hs-wd100.json
+++ b/packages/config/config/devices/0x000c/hs-wd100.json
@@ -20,10 +20,10 @@
 	},
 	"paramInformation": {
 		"4": {
-			"$import": "../templates/master_template.json#orientation"
+			"$import": "~/templates/master_template.json#orientation"
 		},
 		"7": {
-			"$import": "../templates/master_template.json#base_1-99_nounit",
+			"$import": "~/templates/master_template.json#base_1-99_nounit",
 			"label": "Remote Dimming Level Increment"
 		},
 		"8": {
@@ -31,7 +31,7 @@
 			"label": "Remote Dimming Step Duration"
 		},
 		"9": {
-			"$import": "../templates/master_template.json#base_1-99_nounit",
+			"$import": "~/templates/master_template.json#base_1-99_nounit",
 			"label": "Local Dimming Level Increment"
 		},
 		"10": {

--- a/packages/config/config/devices/0x000c/hs-wd200.json
+++ b/packages/config/config/devices/0x000c/hs-wd200.json
@@ -16,10 +16,10 @@
 	},
 	"paramInformation": {
 		"3": {
-			"$import": "../templates/master_template.json#led_indicator_two_options"
+			"$import": "~/templates/master_template.json#led_indicator_two_options"
 		},
 		"4": {
-			"$import": "../templates/master_template.json#orientation"
+			"$import": "~/templates/master_template.json#orientation"
 		},
 		"11": {
 			"label": "Ramp Rate (Z-Wave)",
@@ -76,31 +76,31 @@
 			"$import": "templates/homeseer_template.json#blink_frequency"
 		},
 		"31[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "LED 1 Blink Status"
 		},
 		"31[0x02]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "LED 2 Blink Status"
 		},
 		"31[0x04]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "LED 3 Blink Status"
 		},
 		"31[0x08]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "LED 4 Blink Status"
 		},
 		"31[0x10]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "LED 5 Blink Status"
 		},
 		"31[0x20]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "LED 6 Blink Status"
 		},
 		"31[0x40]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "LED 7 Blink Status"
 		}
 	},

--- a/packages/config/config/devices/0x000c/hs-ws100.json
+++ b/packages/config/config/devices/0x000c/hs-ws100.json
@@ -16,10 +16,10 @@
 	},
 	"paramInformation": {
 		"3": {
-			"$import": "../templates/master_template.json#led_indicator_three_options"
+			"$import": "~/templates/master_template.json#led_indicator_three_options"
 		},
 		"4": {
-			"$import": "../templates/master_template.json#orientation"
+			"$import": "~/templates/master_template.json#orientation"
 		}
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x000c/hs-ws200.json
+++ b/packages/config/config/devices/0x000c/hs-ws200.json
@@ -16,10 +16,10 @@
 	},
 	"paramInformation": {
 		"3": {
-			"$import": "../templates/master_template.json#led_indicator_two_options"
+			"$import": "~/templates/master_template.json#led_indicator_two_options"
 		},
 		"4": {
-			"$import": "../templates/master_template.json#orientation"
+			"$import": "~/templates/master_template.json#orientation"
 		},
 		"13": {
 			"$import": "templates/homeseer_template.json#status_mode"

--- a/packages/config/config/devices/0x000c/templates/homeseer_template.json
+++ b/packages/config/config/devices/0x000c/templates/homeseer_template.json
@@ -78,31 +78,31 @@
 		]
 	},
 	"status_mode": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Enable / Disable Custom LED Status Mode"
 	},
 	"enable_basic_set_command": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Enable / Disable Basic Set Commands"
 	},
 	"enable_pir_triggers": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Enable PIR/lux Floodlight Triggers"
 	},
 	"enable_pir_trigger_alerts": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "PIR Trigger Alerts"
 	},
 	"enable_notification_buzzer": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Enable Notifcaton Buzzer"
 	},
 	"enable_shock_alarm": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Enable / Disable Shock Alarm"
 	},
 	"dimming_step": {
-		"$import": "../../templates/master_template.json#dimming_timing",
+		"$import": "~/templates/master_template.json#dimming_timing",
 		"valueSize": 2
 	},
 	"basic_set_value": {
@@ -150,7 +150,7 @@
 		]
 	},
 	"blink_frequency": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "Blink Frequency",
 		"description": "Sets the blink frequency for LEDs; 0 for off",
 		"defaultValue": 0
@@ -229,7 +229,7 @@
 		]
 	},
 	"temp_reporting_interval": {
-		"$import": "../../templates/master_template.json#base_1-255_nounit",
+		"$import": "~/templates/master_template.json#base_1-255_nounit",
 		"label": "Temperature reportng interval when on line power",
 		"unit": "seconds",
 		"minValue": 30

--- a/packages/config/config/devices/0x0039/templates/honeywell_template.json
+++ b/packages/config/config/devices/0x0039/templates/honeywell_template.json
@@ -242,7 +242,7 @@
 	},
 	"outdoor_temperature_sensor": {
 		"label": "Outdoor Temperature Sensor",
-		"$import": "../../templates/master_template.json#base_enable_disable"
+		"$import": "~/templates/master_template.json#base_enable_disable"
 	},
 	"heating_equipment_type": {
 		"label": "Equipment Type",
@@ -367,7 +367,7 @@
 	},
 	"auto_changeover": {
 		"label": "Auto Changeover",
-		"$import": "../../templates/master_template.json#base_enable_disable"
+		"$import": "~/templates/master_template.json#base_enable_disable"
 	},
 	"auto_differential": {
 		"label": "Auto Differential",
@@ -379,11 +379,11 @@
 	},
 	"high_cool_stage_finish": {
 		"label": "High Cool Stage Finish",
-		"$import": "../../templates/master_template.json#base_enable_disable"
+		"$import": "~/templates/master_template.json#base_enable_disable"
 	},
 	"high_heat_stage_finish": {
 		"label": "High Heat Stage Finish",
-		"$import": "../../templates/master_template.json#base_enable_disable"
+		"$import": "~/templates/master_template.json#base_enable_disable"
 	},
 	"auxiliary_heat_droop": {
 		"label": "Auxiliary Heat Droop",
@@ -579,7 +579,7 @@
 	},
 	"adaptive_intelligent_recovery": {
 		"label": "Adaptive Intelligent Recovery",
-		"$import": "../../templates/master_template.json#base_enable_disable"
+		"$import": "~/templates/master_template.json#base_enable_disable"
 	},
 	"minimum_cool_temperature": {
 		"label": "Minimum Cool Temperature",
@@ -666,7 +666,7 @@
 	},
 	"daylight_saving": {
 		"label": "Daylight Saving",
-		"$import": "../../templates/master_template.json#base_enable_disable"
+		"$import": "~/templates/master_template.json#base_enable_disable"
 	},
 	"temperature_offset": {
 		"label": "Temperature Offset",

--- a/packages/config/config/devices/0x0039/th6320zw.json
+++ b/packages/config/config/devices/0x0039/th6320zw.json
@@ -19,7 +19,7 @@
 			"$import": "templates/honeywell_template.json#schedule_type"
 		},
 		"2": {
-			"$import": "../templates/master_template.json#temperature_scale"
+			"$import": "~/templates/master_template.json#temperature_scale"
 		},
 		"3": {
 			"$import": "templates/honeywell_template.json#outdoor_temperature_sensor"
@@ -133,7 +133,7 @@
 			"$import": "templates/honeywell_template.json#idle_brightness"
 		},
 		"40": {
-			"$import": "../templates/master_template.json#clock_format"
+			"$import": "~/templates/master_template.json#clock_format"
 		},
 		"41": {
 			"$import": "templates/honeywell_template.json#daylight_saving"

--- a/packages/config/config/devices/0x0086/dsa03202.json
+++ b/packages/config/config/devices/0x0086/dsa03202.json
@@ -70,7 +70,7 @@
 			"label": "Button 8 (Learn) Mode"
 		},
 		"250": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Scene Mode (Secondary Controller)"
 		}
 	},

--- a/packages/config/config/devices/0x0086/dsa22.json
+++ b/packages/config/config/devices/0x0086/dsa22.json
@@ -37,19 +37,19 @@
 	},
 	"paramInformation": {
 		"241": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Button 1 (Upper Left) - Scene Mode"
 		},
 		"242": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Button 2 (Upper Right) - Scene Mode"
 		},
 		"243": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Button 3 (Lower Left) - Scene Mode"
 		},
 		"244": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Button 4 (Lower Right) - Scene Mode"
 		}
 	}

--- a/packages/config/config/devices/0x0086/dsb09.json
+++ b/packages/config/config/devices/0x0086/dsb09.json
@@ -84,12 +84,12 @@
 			"valueSize": 4
 		},
 		"101[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Automatic Report: Group 1 - Battery Report",
 			"valueSize": 4
 		},
 		"101[0x02]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Automatic Report: Group 1 - MultiSensor Wattage (Whole HEM)",
 			"valueSize": 4
 		},
@@ -118,12 +118,12 @@
 			"$import": "templates/aeotec_template.json#auto_report_group1_kwh_clamp3"
 		},
 		"102[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Automatic Report: Group 2 - Battery Report",
 			"valueSize": 4
 		},
 		"102[0x02]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Automatic Report: Group 2 - MultiSensor Wattage (Whole HEM)",
 			"valueSize": 4
 		},
@@ -152,12 +152,12 @@
 			"$import": "templates/aeotec_template.json#auto_report_group2_kwh_clamp3"
 		},
 		"103[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Automatic Report: Group 3 - Battery Report",
 			"valueSize": 4
 		},
 		"103[0x02]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Automatic Report: Group 3 - MultiSensor Wattage (Whole HEM)",
 			"valueSize": 4
 		},

--- a/packages/config/config/devices/0x0086/dsb28.json
+++ b/packages/config/config/devices/0x0086/dsb28.json
@@ -33,7 +33,7 @@
 	},
 	"paramInformation": {
 		"2": {
-			"$import": "../templates/master_template.json#base_0-1_nounit",
+			"$import": "~/templates/master_template.json#base_0-1_nounit",
 			"label": "Energy Detection Mode",
 			"options": [
 				{

--- a/packages/config/config/devices/0x0086/dsb29.json
+++ b/packages/config/config/devices/0x0086/dsb29.json
@@ -37,17 +37,17 @@
 			"$import": "templates/aeotec_template.json#invert_basic_set"
 		},
 		"121[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "On Trigger: Send Battery Report",
 			"valueSize": 4
 		},
 		"121[0x10]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "On Trigger: Send Binary Sensor Report",
 			"valueSize": 4
 		},
 		"121[0x0100]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "On Trigger: Send Basic Report",
 			"valueSize": 4
 		},

--- a/packages/config/config/devices/0x0086/dsb45.json
+++ b/packages/config/config/devices/0x0086/dsb45.json
@@ -36,22 +36,22 @@
 			"$import": "templates/aeotec_template.json#invert_basic_set"
 		},
 		"121[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "On Trigger: Send Battery Report",
 			"valueSize": 4
 		},
 		"121[0x10]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "On Trigger: Send Binary Sensor Report",
 			"valueSize": 4
 		},
 		"121[0x0100]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "On Trigger: Send Basic Report",
 			"valueSize": 4
 		},
 		"121[0x1000]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "On Trigger: Send Alarm",
 			"valueSize": 4
 		},

--- a/packages/config/config/devices/0x0086/dsb54.json
+++ b/packages/config/config/devices/0x0086/dsb54.json
@@ -41,17 +41,17 @@
 			"defaultValue": 86640
 		},
 		"121[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "On Trigger: Send Battery Report",
 			"valueSize": 4
 		},
 		"121[0x10]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "On Trigger: Send Binary Sensor Report",
 			"valueSize": 4
 		},
 		"121[0x0100]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "On Trigger: Send Basic Report",
 			"valueSize": 4
 		},

--- a/packages/config/config/devices/0x0086/dsc06.json
+++ b/packages/config/config/devices/0x0086/dsc06.json
@@ -35,7 +35,7 @@
 			"$import": "templates/aeotec_template.json#enable_notifications"
 		},
 		"90": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Enable Parameters 91-92"
 		},
 		"91": {

--- a/packages/config/config/devices/0x0086/dsc08.json
+++ b/packages/config/config/devices/0x0086/dsc08.json
@@ -34,7 +34,7 @@
 			"$import": "templates/aeotec_template.json#enable_notifications"
 		},
 		"90": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Enable Parameters 91-92"
 		},
 		"91": {

--- a/packages/config/config/devices/0x0086/dsc10.json
+++ b/packages/config/config/devices/0x0086/dsc10.json
@@ -30,7 +30,7 @@
 			"$import": "templates/aeotec_template.json#current_overload"
 		},
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"80": {
 			"$import": "templates/aeotec_template.json#enable_notifications"

--- a/packages/config/config/devices/0x0086/dsc14.json
+++ b/packages/config/config/devices/0x0086/dsc14.json
@@ -38,7 +38,7 @@
 			"unit": "ms"
 		},
 		"7": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off",
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off",
 			"options": [
 				{
 					"label": "Stop",
@@ -55,7 +55,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#base_0-1_nounit",
+			"$import": "~/templates/master_template.json#base_0-1_nounit",
 			"label": "Count of External Buttons/Switches",
 			"options": [
 				{

--- a/packages/config/config/devices/0x0086/dsd31.json
+++ b/packages/config/config/devices/0x0086/dsd31.json
@@ -46,7 +46,7 @@
 			]
 		},
 		"37[0xff]": {
-			"$import": "../templates/master_template.json#volume_three",
+			"$import": "~/templates/master_template.json#volume_three",
 			"valueSize": 2
 		},
 		"80": {

--- a/packages/config/config/devices/0x0086/templates/aeotec_template.json
+++ b/packages/config/config/devices/0x0086/templates/aeotec_template.json
@@ -188,7 +188,7 @@
 		]
 	},
 	"enable_binary_report": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Send Binary Sensor Reports"
 	},
 	"binary_report_type": {
@@ -292,7 +292,7 @@
 		]
 	},
 	"celsius_fahrenheit_0": {
-		"$import": "../../templates/master_template.json#base_0-1_nounit",
+		"$import": "~/templates/master_template.json#base_0-1_nounit",
 		"label": "Temperature Unit",
 		"valueSize": 4,
 		"options": [
@@ -307,52 +307,52 @@
 		]
 	},
 	"selective_reporting": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Selective Reporting",
 		"description": "Report only when the defined threshold is exceeded"
 	},
 	"lock_configuration": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Lock Configuration"
 	},
 	"low_battery_button": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Wireless Button Low Battery Report"
 	},
 	"low_temp_alarm": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Low Temperature Alarm (-15°C)"
 	},
 	"below_temp_report": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Report Below Temperature Threshold"
 	},
 	"below_humidity_report": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Report Below Humidity Threshold"
 	},
 	"below_luminance_report": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Report Below Luminance Threshold"
 	},
 	"below_ultraviolet_report": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Report Below Ultraviolet Threshold"
 	},
 	"above_temp_report": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Report Above Temperature Threshold"
 	},
 	"above_humidity_report": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Report Above Humidity Threshold"
 	},
 	"above_luminance_report": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Report Above Luminance Threshold"
 	},
 	"above_ultraviolet_report": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Report Above Ultraviolet Threshold"
 	},
 	"report_interval": {
@@ -655,7 +655,7 @@
 		]
 	},
 	"invert_state_report": {
-		"$import": "../../templates/master_template.json#base_0-1_nounit",
+		"$import": "~/templates/master_template.json#base_0-1_nounit",
 		"label": "Invert Binary Report Value",
 		"options": [
 			{
@@ -669,7 +669,7 @@
 		]
 	},
 	"invert_basic_set": {
-		"$import": "../../templates/master_template.json#base_0-1_nounit",
+		"$import": "~/templates/master_template.json#base_0-1_nounit",
 		"label": "Invert Basic Set on Open/Close Event",
 		"options": [
 			{
@@ -715,11 +715,11 @@
 		]
 	},
 	"wake_up_10_minutes": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Wake Device for 10 minutes After Power On"
 	},
 	"low_battery_check": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Low Battery Voltage Check"
 	},
 	"low_battery_threshold": {
@@ -742,7 +742,7 @@
 		"unsigned": true
 	},
 	"report_power_voltage": {
-		"$import": "../../templates/master_template.json#base_0-1_nounit",
+		"$import": "~/templates/master_template.json#base_0-1_nounit",
 		"label": "Multilevel Sensor Report Content",
 		"options": [
 			{
@@ -756,11 +756,11 @@
 		]
 	},
 	"send_automatic_reports": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Send Automatic Reports When Exceeding Thresholds"
 	},
 	"current_overload": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Current Overload Protection"
 	},
 	"current_overload_threshold": {
@@ -777,7 +777,7 @@
 		]
 	},
 	"overheat_protection": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Overheat Protection",
 		"description": "Output will be turned off after 30 seconds if internal temperature exceeds 100°C"
 	},
@@ -843,22 +843,22 @@
 		"unsigned": true
 	},
 	"auto_report_kwh": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: kWh",
 		"valueSize": 4
 	},
 	"auto_report_watt": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Power",
 		"valueSize": 4
 	},
 	"auto_report_amp": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Current",
 		"valueSize": 4
 	},
 	"auto_report_v": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Voltage",
 		"valueSize": 4
 	},
@@ -889,392 +889,392 @@
 		"label": "Automatic Reporting Interval: Group 3"
 	},
 	"auto_report_group1_battery": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - Battery",
 		"valueSize": 4
 	},
 	"auto_report_group1_temp": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - Temperature",
 		"valueSize": 4
 	},
 	"auto_report_group1_humidity": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - Humidity",
 		"valueSize": 4
 	},
 	"auto_report_group1_luminance": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - Luminance",
 		"valueSize": 4
 	},
 	"auto_report_group1_ultraviolet": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - Ultraviolet",
 		"valueSize": 4
 	},
 	"auto_report_group1_v": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - Voltage",
 		"valueSize": 4
 	},
 	"auto_report_group1_v_clamp1": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - Voltage (Clamp 1)",
 		"valueSize": 4
 	},
 	"auto_report_group1_v_clamp2": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - Voltage (Clamp 2)",
 		"valueSize": 4
 	},
 	"auto_report_group1_v_clamp3": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - Voltage (Clamp 3)",
 		"valueSize": 4
 	},
 	"auto_report_group1_v_wholehem": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - Voltage (Whole HEM)",
 		"valueSize": 4
 	},
 	"auto_report_group1_amp": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - Current",
 		"valueSize": 4
 	},
 	"auto_report_group1_amp_clamp1": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - Current (Clamp 1)",
 		"valueSize": 4
 	},
 	"auto_report_group1_amp_clamp2": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - Current (Clamp 2)",
 		"valueSize": 4
 	},
 	"auto_report_group1_amp_clamp3": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - Current (Clamp 3)",
 		"valueSize": 4
 	},
 	"auto_report_group1_amp_wholehem": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - Current (Whole HEM)",
 		"valueSize": 4
 	},
 	"auto_report_group1_msrc": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - Multilevel Sensor Report - Power",
 		"valueSize": 4
 	},
 	"auto_report_group1_watt": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - Power",
 		"valueSize": 4
 	},
 	"auto_report_group1_watt_clamp1": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - Power (Clamp 1)",
 		"valueSize": 4
 	},
 	"auto_report_group1_watt_clamp2": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - Power (Clamp 2)",
 		"valueSize": 4
 	},
 	"auto_report_group1_watt_clamp3": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - Power (Clamp 3)",
 		"valueSize": 4
 	},
 	"auto_report_group1_watt_wholehem": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - Power (Whole HEM)",
 		"valueSize": 4
 	},
 	"auto_report_group1_kwh": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - kWh",
 		"valueSize": 4
 	},
 	"auto_report_group1_kwh_clamp1": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - kWh (Clamp 1)",
 		"valueSize": 4
 	},
 	"auto_report_group1_kwh_clamp2": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - kWh (Clamp 2)",
 		"valueSize": 4
 	},
 	"auto_report_group1_kwh_clamp3": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - kWh (Clamp 3)",
 		"valueSize": 4
 	},
 	"auto_report_group1_kwh_wholehem": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 1 - kWh (Whole HEM)",
 		"valueSize": 4
 	},
 	"auto_report_group2_battery": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Battery",
 		"valueSize": 4
 	},
 	"auto_report_group2_temp": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Temperature",
 		"valueSize": 4
 	},
 	"auto_report_group2_humidity": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Humidity",
 		"valueSize": 4
 	},
 	"auto_report_group2_luminance": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Luminance",
 		"valueSize": 4
 	},
 	"auto_report_group2_ultraviolet": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Ultraviolet",
 		"valueSize": 4
 	},
 	"auto_report_group2_v": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Voltage",
 		"valueSize": 4
 	},
 	"auto_report_group2_v_clamp1": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Voltage (Clamp 1)",
 		"valueSize": 4
 	},
 	"auto_report_group2_v_clamp2": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Voltage (Clamp 2)",
 		"valueSize": 4
 	},
 	"auto_report_group2_v_clamp3": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Voltage (Clamp 3)",
 		"valueSize": 4
 	},
 	"auto_report_group2_v_wholehem": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Voltage (Whole HEM)",
 		"valueSize": 4
 	},
 	"auto_report_group2_amp": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Current",
 		"valueSize": 4
 	},
 	"auto_report_group2_amp_clamp1": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Current (Clamp 1)",
 		"valueSize": 4
 	},
 	"auto_report_group2_amp_clamp2": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Current (Clamp 2)",
 		"valueSize": 4
 	},
 	"auto_report_group2_amp_clamp3": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Current (Clamp 3)",
 		"valueSize": 4
 	},
 	"auto_report_group2_amp_wholehem": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Current (Whole HEM)",
 		"valueSize": 4
 	},
 	"auto_report_group2_msrc": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Multilevel Sensor Report - Power",
 		"valueSize": 4
 	},
 	"auto_report_group2_watt": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Power",
 		"valueSize": 4
 	},
 	"auto_report_group2_watt_clamp1": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Power (Clamp 1)",
 		"valueSize": 4
 	},
 	"auto_report_group2_watt_clamp2": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Power (Clamp 2)",
 		"valueSize": 4
 	},
 	"auto_report_group2_watt_clamp3": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Power (Clamp 3)",
 		"valueSize": 4
 	},
 	"auto_report_group2_watt_wholehem": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Power (Whole HEM)",
 		"valueSize": 4
 	},
 	"auto_report_group2_kwh": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - kWh",
 		"valueSize": 4
 	},
 	"auto_report_group2_kwh_clamp1": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - kWh (Clamp 1)",
 		"valueSize": 4
 	},
 	"auto_report_group2_kwh_clamp2": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - kWh (Clamp 2)",
 		"valueSize": 4
 	},
 	"auto_report_group2_kwh_clamp3": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - kWh (Clamp 3)",
 		"valueSize": 4
 	},
 	"auto_report_group2_kwh_wholehem": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - kWh (Whole HEM)",
 		"valueSize": 4
 	},
 	"auto_report_group3_battery": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Battery",
 		"valueSize": 4
 	},
 	"auto_report_group3_temp": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Temperature",
 		"valueSize": 4
 	},
 	"auto_report_group3_humidity": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Humidity",
 		"valueSize": 4
 	},
 	"auto_report_group3_luminance": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Luminance",
 		"valueSize": 4
 	},
 	"auto_report_group3_ultraviolet": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Ultraviolet",
 		"valueSize": 4
 	},
 	"auto_report_group3_v": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Voltage",
 		"valueSize": 4
 	},
 	"auto_report_group3_v_clamp1": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Voltage (Clamp 1)",
 		"valueSize": 4
 	},
 	"auto_report_group3_v_clamp2": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Voltage (Clamp 2)",
 		"valueSize": 4
 	},
 	"auto_report_group3_v_clamp3": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Voltage (Clamp 3)",
 		"valueSize": 4
 	},
 	"auto_report_group3_v_wholehem": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Voltage (Whole HEM)",
 		"valueSize": 4
 	},
 	"auto_report_group3_amp": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Current",
 		"valueSize": 4
 	},
 	"auto_report_group3_amp_clamp1": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Current (Clamp 1)",
 		"valueSize": 4
 	},
 	"auto_report_group3_amp_clamp2": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Current (Clamp 2)",
 		"valueSize": 4
 	},
 	"auto_report_group3_amp_clamp3": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Current (Clamp 3)",
 		"valueSize": 4
 	},
 	"auto_report_group3_amp_wholehem": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Current (Whole HEM)",
 		"valueSize": 4
 	},
 	"auto_report_group3_msrc": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Multilevel Sensor Report - Power",
 		"valueSize": 4
 	},
 	"auto_report_group3_watt": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Power",
 		"valueSize": 4
 	},
 	"auto_report_group3_watt_clamp1": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Power (Clamp 1)",
 		"valueSize": 4
 	},
 	"auto_report_group3_watt_clamp2": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Power (Clamp 2)",
 		"valueSize": 4
 	},
 	"auto_report_group3_watt_clamp3": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Power (Clamp 3)",
 		"valueSize": 4
 	},
 	"auto_report_group3_watt_wholehem": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Power (Whole HEM)",
 		"valueSize": 4
 	},
 	"auto_report_group3_kwh": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - kWh",
 		"valueSize": 4
 	},
 	"auto_report_group3_kwh_clamp1": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - kWh (Clamp 1)",
 		"valueSize": 4
 	},
 	"auto_report_group3_kwh_clamp2": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - kWh (Clamp 2)",
 		"valueSize": 4
 	},
 	"auto_report_group3_kwh_clamp3": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - kWh (Clamp 3)",
 		"valueSize": 4
 	},
 	"auto_report_group3_kwh_wholehem": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - kWh (Whole HEM)",
 		"valueSize": 4
 	},
@@ -1340,7 +1340,7 @@
 		]
 	},
 	"sensor_operation_mode": {
-		"$import": "../../templates/master_template.json#base_0-1_nounit",
+		"$import": "~/templates/master_template.json#base_0-1_nounit",
 		"label": "Sensor Operation Mode",
 		"options": [
 			{
@@ -1354,7 +1354,7 @@
 		]
 	},
 	"range_test_double_click": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Range Test After Double Click"
 	},
 	"association_group_2_trigger": {
@@ -1404,12 +1404,12 @@
 		]
 	},
 	"association_group_2_basic_set_on": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "Association Group 2: Basic Set Value (On)",
 		"defaultValue": 255
 	},
 	"association_group_2_basic_set_off": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "Association Group 2: Basic Set Value (Off)"
 	},
 	"time_delay_on": {
@@ -1440,21 +1440,21 @@
 		"unsigned": true
 	},
 	"report_on_tamper_cancel": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Send Report on Tamper Alarm Cancellation",
 		"defaultValue": 1
 	},
 	"central_scene_functionality": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Central Scene Event Functionality"
 	},
 	"tilt_sensor": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Tilt Sensor",
 		"defaultValue": 1
 	},
 	"tilt_sensor_sensitivity": {
-		"$import": "../../templates/master_template.json#base_0-100_nounit",
+		"$import": "~/templates/master_template.json#base_0-100_nounit",
 		"label": "Tilt Sensor Sensitivity",
 		"defaultValue": 50
 	},
@@ -1467,13 +1467,13 @@
 		"unsigned": true
 	},
 	"wattage_percent_trigger": {
-		"$import": "../../templates/master_template.json#base_0-100_nounit",
+		"$import": "~/templates/master_template.json#base_0-100_nounit",
 		"label": "Minimum Power Percentage Change to Trigger Event",
 		"unit": "%",
 		"defaultValue": 10
 	},
 	"external_switch_two": {
-		"$import": "../../templates/master_template.json#base_0-1_nounit",
+		"$import": "~/templates/master_template.json#base_0-1_nounit",
 		"label": "External Switch Type",
 		"options": [
 			{
@@ -1487,7 +1487,7 @@
 		]
 	},
 	"external_switch_unidentified": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "External Switch Type",
 		"options": [
 			{
@@ -1505,7 +1505,7 @@
 		]
 	},
 	"external_switch_3way": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "External Switch Type",
 		"options": [
 			{
@@ -1558,7 +1558,7 @@
 		]
 	},
 	"switch_mode_state_s1": {
-		"$import": "../../templates/master_template.json#base_0-1_nounit",
+		"$import": "~/templates/master_template.json#base_0-1_nounit",
 		"label": "Switch Mode (S1): State Sync",
 		"allowManualEntry": false,
 		"options": [
@@ -1573,7 +1573,7 @@
 		]
 	},
 	"switch_mode_state_s2": {
-		"$import": "../../templates/master_template.json#base_0-1_nounit",
+		"$import": "~/templates/master_template.json#base_0-1_nounit",
 		"label": "Switch Mode (S2): State Sync",
 		"allowManualEntry": false,
 		"options": [
@@ -1616,15 +1616,15 @@
 		"unsigned": true
 	},
 	"enable_motion_sensor": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Motion Sensor"
 	},
 	"enable_led_indicator": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "LED Indicator"
 	},
 	"led_indicator_two_options": {
-		"$import": "../../templates/master_template.json#led_indicator_two_options",
+		"$import": "~/templates/master_template.json#led_indicator_two_options",
 		"options": [
 			{
 				"label": "On when load is on",
@@ -1637,7 +1637,7 @@
 		]
 	},
 	"led_indicator_three_options": {
-		"$import": "../../templates/master_template.json#led_indicator_three_options",
+		"$import": "~/templates/master_template.json#led_indicator_three_options",
 		"options": [
 			{
 				"label": "On when load is on",
@@ -1654,7 +1654,7 @@
 		]
 	},
 	"led_indicator_three_options_alt": {
-		"$import": "../../templates/master_template.json#led_indicator_three_options",
+		"$import": "~/templates/master_template.json#led_indicator_three_options",
 		"defaultValue": 2,
 		"options": [
 			{
@@ -1672,53 +1672,53 @@
 		]
 	},
 	"led_indicator_open": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "LED Indicator: Open/Close Change",
 		"defaultValue": 1
 	},
 	"led_indicator_wake": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "LED Indicator: Wake Up",
 		"defaultValue": 1
 	},
 	"led_indicator_tamper": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "LED Indicator: Tamper Alarm"
 	},
 	"night_light_blue": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "Night Light: Blue Color",
 		"valueSize": 3,
 		"defaultValue": 221
 	},
 	"night_light_green": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "Night Light: Green Color",
 		"valueSize": 3,
 		"defaultValue": 160
 	},
 	"night_light_red": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "Night Light: Red Color",
 		"valueSize": 3,
 		"defaultValue": 221
 	},
 	"night_light_green_brightness": {
-		"$import": "../../templates/master_template.json#base_0-100_nounit",
+		"$import": "~/templates/master_template.json#base_0-100_nounit",
 		"label": "Night Light: Green Brightness",
 		"valueSize": 3,
 		"unit": "%",
 		"defaultValue": 50
 	},
 	"night_light_yellow_brightness": {
-		"$import": "../../templates/master_template.json#base_0-100_nounit",
+		"$import": "~/templates/master_template.json#base_0-100_nounit",
 		"label": "Night Light: Yellow Brightness",
 		"valueSize": 3,
 		"unit": "%",
 		"defaultValue": 50
 	},
 	"night_light_red_brightness": {
-		"$import": "../../templates/master_template.json#base_0-100_nounit",
+		"$import": "~/templates/master_template.json#base_0-100_nounit",
 		"label": "Night Light: Red Brightness",
 		"valueSize": 3,
 		"unit": "%",
@@ -1819,7 +1819,7 @@
 		]
 	},
 	"dimming_rate_255": {
-		"$import": "../../templates/master_template.json#base_1-255_nounit",
+		"$import": "~/templates/master_template.json#base_1-255_nounit",
 		"label": "Dimming Rate",
 		"unit": "seconds",
 		"defaultValue": 3
@@ -1849,7 +1849,7 @@
 		]
 	},
 	"dimming_principle": {
-		"$import": "../../templates/master_template.json#base_0-1_nounit",
+		"$import": "~/templates/master_template.json#base_0-1_nounit",
 		"label": "Dimming Principle",
 		"defaultValue": 1,
 		"options": [
@@ -1892,12 +1892,12 @@
 		]
 	},
 	"min_brightness": {
-		"$import": "../../templates/master_template.json#base_0-99_nounit",
+		"$import": "~/templates/master_template.json#base_0-99_nounit",
 		"label": "Minimum Brightness Level",
 		"defaultValue": 0
 	},
 	"max_brightness": {
-		"$import": "../../templates/master_template.json#base_0-99_nounit",
+		"$import": "~/templates/master_template.json#base_0-99_nounit",
 		"label": "Maximum Brightness Level",
 		"defaultValue": 99
 	},
@@ -2248,7 +2248,7 @@
 		"defaultValue": 0
 	},
 	"base_led_duration": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"valueSize": 4,
 		"unit": "ms"
 	},
@@ -2584,7 +2584,7 @@
 		"label": "Button 3: Software Version"
 	},
 	"stop_action_button": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Stop Playing Tone on Action Button"
 	},
 	// Recover limits
@@ -2655,7 +2655,7 @@
 		"defaultValue": 0
 	},
 	"enable_appointment_one": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Auto-On Schedule One",
 		"valueSize": 4
 	},
@@ -2673,12 +2673,12 @@
 		"label": "Auto-On Schedule One: Minute"
 	},
 	"appointment_one_brightness": {
-		"$import": "../../templates/master_template.json#base_0-99_nounit",
+		"$import": "~/templates/master_template.json#base_0-99_nounit",
 		"label": "Auto-On Schedule One: Brightness",
 		"valueSize": 4
 	},
 	"enable_appointment_two": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Auto-On Schedule Two",
 		"valueSize": 4
 	},
@@ -2695,7 +2695,7 @@
 		"label": "Auto-On Schedule Two: Minute"
 	},
 	"appointment_two_brightness": {
-		"$import": "../../templates/master_template.json#base_0-99_nounit",
+		"$import": "~/templates/master_template.json#base_0-99_nounit",
 		"label": "Auto-On Schedule Two: Brightness",
 		"valueSize": 4
 	},
@@ -2717,15 +2717,15 @@
 	},
 	// WallMote Settings
 	"enable_touch_sound": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Touch Sound"
 	},
 	"enable_touch_vibration": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Touch Vibration"
 	},
 	"enable_button_slide": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Button Slide Function"
 	},
 	"wallmote_report_type": {
@@ -2748,7 +2748,7 @@
 		]
 	},
 	"wallmote_command_type": {
-		"$import": "../../templates/master_template.json#base_0-1_nounit",
+		"$import": "~/templates/master_template.json#base_0-1_nounit",
 		"label": "Command Type to Send Association Groups",
 		"options": [
 			{
@@ -2762,38 +2762,38 @@
 		]
 	},
 	"wakeup_led": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Wake Up Notification LED",
 		"description": "Blink the orange LED when wallmote sends out wake up notification",
 		"defaultValue": 0
 	},
 	"message_failure_led": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Blink LED on Message Send Failure"
 	},
 	"charging_led": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Charging Status LED"
 	},
 	"button_press_led": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Button Press LED"
 	},
 	// WallSwipe Options
 	"scene_control": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Scene Control (All Waves)",
 		"valueSize": 4,
 		"defaultValue": 1
 	},
 	"scene_control_left_right_wave": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Scene Control (Left/Right Wave)",
 		"valueSize": 4,
 		"defaultValue": 1
 	},
 	"wave_option": {
-		"$import": "../../templates/master_template.json#base_0-1_nounit",
+		"$import": "~/templates/master_template.json#base_0-1_nounit",
 		"label": "Wave Option",
 		"valueSize": 4,
 		"defaultValue": 1,
@@ -2809,160 +2809,160 @@
 		]
 	},
 	"enable_disable_ir_sensor": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "WallSwipe IR sensor",
 		"valueSize": 4
 	},
 	"button_color_brightness": {
-		"$import": "../../templates/master_template.json#base_0-99_nounit",
+		"$import": "~/templates/master_template.json#base_0-99_nounit",
 		"label": "WallSwipe Button Brightness",
 		"valueSize": 4,
 		"defaultValue": 87
 	},
 	"button_color_red": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "WallSwipe Button Color: Red",
 		"valueSize": 4,
 		"defaultValue": 255
 	},
 	"button_color_green": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "WallSwipe Button Color: Green",
 		"valueSize": 4,
 		"defaultValue": 255
 	},
 	"button_color_blue": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "WallSwipe Button Color: Blue",
 		"valueSize": 4,
 		"defaultValue": 255
 	},
 	"button_color_up_brightness": {
-		"$import": "../../templates/master_template.json#base_0-99_nounit",
+		"$import": "~/templates/master_template.json#base_0-99_nounit",
 		"label": "LED Indicator on Up Gesture: Brightness",
 		"valueSize": 4,
 		"defaultValue": 23
 	},
 	"button_color_up_red": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "LED Indicator on Up Gesture: Brightness: Red",
 		"valueSize": 4,
 		"defaultValue": 255
 	},
 	"button_color_up_green": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "LED Indicator on Up Gesture: Brightness: Green",
 		"valueSize": 4,
 		"defaultValue": 255
 	},
 	"button_color_up_blue": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "LED Indicator on Up Gesture: Brightness: Blue",
 		"valueSize": 4,
 		"defaultValue": 255
 	},
 	"button_color_down_brightness": {
-		"$import": "../../templates/master_template.json#base_0-99_nounit",
+		"$import": "~/templates/master_template.json#base_0-99_nounit",
 		"label": "LED Indicator on Down Gesture: Brightness",
 		"valueSize": 4,
 		"defaultValue": 23
 	},
 	"button_color_down_red": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "LED Indicator on Down Gesture: Brightness: Red",
 		"valueSize": 4,
 		"defaultValue": 255
 	},
 	"button_color_down_green": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "LED Indicator on Down Gesture: Brightness: Green",
 		"valueSize": 4,
 		"defaultValue": 255
 	},
 	"button_color_down_blue": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "LED Indicator on Down Gesture: Brightness: Blue",
 		"valueSize": 4,
 		"defaultValue": 255
 	},
 	"button_color_left_brightness": {
-		"$import": "../../templates/master_template.json#base_0-99_nounit",
+		"$import": "~/templates/master_template.json#base_0-99_nounit",
 		"label": "LED Indicator on Left Gesture: Brightness",
 		"valueSize": 4,
 		"defaultValue": 23
 	},
 	"button_color_left_red": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "LED Indicator on Left Gesture: Brightness: Red",
 		"valueSize": 4,
 		"defaultValue": 255
 	},
 	"button_color_left_green": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "LED Indicator on Left Gesture: Brightness: Green",
 		"valueSize": 4,
 		"defaultValue": 255
 	},
 	"button_color_left_blue": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "LED Indicator on Left Gesture: Brightness: Blue",
 		"valueSize": 4,
 		"defaultValue": 255
 	},
 	"button_color_right_brightness": {
-		"$import": "../../templates/master_template.json#base_0-99_nounit",
+		"$import": "~/templates/master_template.json#base_0-99_nounit",
 		"label": "LED Indicator on Right Gesture: Brightness",
 		"valueSize": 4,
 		"defaultValue": 23
 	},
 	"button_color_right_red": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "LED Indicator on Right Gesture: Brightness: Red",
 		"valueSize": 4,
 		"defaultValue": 255
 	},
 	"button_color_right_green": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "LED Indicator on Right Gesture: Brightness: Green",
 		"valueSize": 4,
 		"defaultValue": 255
 	},
 	"button_color_right_blue": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "LED Indicator on Right Gesture: Brightness: Blue",
 		"valueSize": 4,
 		"defaultValue": 255
 	},
 	"button_color_night_brightness": {
-		"$import": "../../templates/master_template.json#base_0-99_nounit",
+		"$import": "~/templates/master_template.json#base_0-99_nounit",
 		"label": "LED Indicator (Night): Brightness",
 		"valueSize": 4,
 		"defaultValue": 23
 	},
 	"button_color_night_red": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "LED Indicator (Night): Brightness: Red",
 		"valueSize": 4,
 		"defaultValue": 255
 	},
 	"button_color_night_green": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "LED Indicator (Night): Brightness: Green",
 		"valueSize": 4,
 		"defaultValue": 255
 	},
 	"button_color_night_blue": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "LED Indicator (Night): Brightness: Blue",
 		"valueSize": 4,
 		"defaultValue": 255
 	},
 	"wallswipe_recalibrate": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "WallSwipe Sensitivity"
 	},
 	"wallswipe_status": {
-		"$import": "../../templates/master_template.json#base_0-1_nounit",
+		"$import": "~/templates/master_template.json#base_0-1_nounit",
 		"label": "WallSwipe Status",
 		"options": [
 			{
@@ -2976,7 +2976,7 @@
 		]
 	},
 	"wallswipe_reset": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "WallSwipe Reset Function",
 		"defaultValue": 1
 	}

--- a/packages/config/config/devices/0x0086/zw056.json
+++ b/packages/config/config/devices/0x0086/zw056.json
@@ -57,16 +57,16 @@
 	},
 	"paramInformation": {
 		"2": {
-			"$import": "../templates/master_template.json#base_1-100_nounit",
+			"$import": "~/templates/master_template.json#base_1-100_nounit",
 			"label": "Set The Repetitions For Playing Doorbell Ringtone",
 			"defaultValue": 2
 		},
 		"5": {
-			"$import": "../templates/master_template.json#base_1-100_nounit",
+			"$import": "~/templates/master_template.json#base_1-100_nounit",
 			"label": "Default Doorbell Ringtone"
 		},
 		"6": {
-			"$import": "../templates/master_template.json#base_0-100_nounit",
+			"$import": "~/templates/master_template.json#base_0-100_nounit",
 			"label": "Play Ringtone",
 			"options": [
 				{
@@ -108,12 +108,12 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#base_0-10_nounit",
+			"$import": "~/templates/master_template.json#base_0-10_nounit",
 			"label": "Volume",
 			"defaultValue": 10
 		},
 		"10": {
-			"$import": "../templates/master_template.json#base_0-1_nounit",
+			"$import": "~/templates/master_template.json#base_0-1_nounit",
 			"label": "Define The Function of Button- and Button+",
 			"options": [
 				{
@@ -127,7 +127,7 @@
 			]
 		},
 		"11": {
-			"$import": "../templates/master_template.json#base_0-1_nounit",
+			"$import": "~/templates/master_template.json#base_0-1_nounit",
 			"label": "Short/Long Press Function of Button- And Button+",
 			"options": [
 				{
@@ -141,7 +141,7 @@
 			]
 		},
 		"42": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Wireless Button Battery Status",
 			"description": "Set Normal Battery Level to reset low battery alarm",
 			"defaultValue": 0,

--- a/packages/config/config/devices/0x0086/zw062.json
+++ b/packages/config/config/devices/0x0086/zw062.json
@@ -37,7 +37,7 @@
 	},
 	"paramInformation": {
 		"32": {
-			"$import": "../templates/master_template.json#base_0-100_nounit",
+			"$import": "~/templates/master_template.json#base_0-100_nounit",
 			"label": "Default Startup Sound",
 			"options": [
 				{
@@ -47,7 +47,7 @@
 			]
 		},
 		"34": {
-			"$import": "../templates/master_template.json#base_0-1_nounit",
+			"$import": "~/templates/master_template.json#base_0-1_nounit",
 			"label": "Sensor Calibration",
 			"description": "To calibrate, close door fully. Initiate calibration. Open door fully, then close door fully.",
 			"options": [
@@ -62,25 +62,25 @@
 			]
 		},
 		"35": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Sensor Calibration Timeout",
 			"valueSize": 2,
 			"unit": "seconds",
 			"defaultValue": 60
 		},
 		"36": {
-			"$import": "../templates/master_template.json#base_0-100_nounit",
+			"$import": "~/templates/master_template.json#base_0-100_nounit",
 			"label": "Get Current Alarm Music Number",
 			"readOnly": true,
 			"allowManualEntry": false
 		},
 		"37[0xff]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Opening Alarm",
 			"valueSize": 4
 		},
 		"37[0xff00]": {
-			"$import": "../templates/master_template.json#base_1-10_nounit",
+			"$import": "~/templates/master_template.json#base_1-10_nounit",
 			"label": "Opening Alarm: Volume",
 			"valueSize": 4,
 			"defaultValue": 8
@@ -93,19 +93,19 @@
 			"defaultValue": 1
 		},
 		"37[0xff000000]": {
-			"$import": "../templates/master_template.json#base_1-10_nounit",
+			"$import": "~/templates/master_template.json#base_1-10_nounit",
 			"label": "Opening Alarm: LED Blinking Frequency",
 			"valueSize": 4,
 			"defaultValue": 10
 		},
 		"38[0xff]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Closing Alarm",
 			"valueSize": 4,
 			"defaultValue": 1
 		},
 		"38[0xff00]": {
-			"$import": "../templates/master_template.json#base_1-10_nounit",
+			"$import": "~/templates/master_template.json#base_1-10_nounit",
 			"label": "Closing Alarm: Volume",
 			"valueSize": 4,
 			"defaultValue": 8
@@ -118,18 +118,18 @@
 			"defaultValue": 2
 		},
 		"38[0xff000000]": {
-			"$import": "../templates/master_template.json#base_1-10_nounit",
+			"$import": "~/templates/master_template.json#base_1-10_nounit",
 			"label": "Closing Alarm: LED Blinking Frequency",
 			"valueSize": 4,
 			"defaultValue": 6
 		},
 		"39[0xff]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Unknown State Alarm",
 			"valueSize": 4
 		},
 		"39[0xff00]": {
-			"$import": "../templates/master_template.json#base_1-10_nounit",
+			"$import": "~/templates/master_template.json#base_1-10_nounit",
 			"label": "Unknown State Alarm: Volume",
 			"valueSize": 4,
 			"defaultValue": 8
@@ -142,18 +142,18 @@
 			"defaultValue": 3
 		},
 		"39[0xff000000]": {
-			"$import": "../templates/master_template.json#base_1-10_nounit",
+			"$import": "~/templates/master_template.json#base_1-10_nounit",
 			"label": "Unknown State Alarm: LED Blinking Frequency",
 			"valueSize": 4,
 			"defaultValue": 4
 		},
 		"40[0xff]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Closed Position Alarm",
 			"valueSize": 4
 		},
 		"40[0xff00]": {
-			"$import": "../templates/master_template.json#base_1-10_nounit",
+			"$import": "~/templates/master_template.json#base_1-10_nounit",
 			"label": "Closed Position Alarm: Volume",
 			"valueSize": 4,
 			"defaultValue": 8
@@ -166,7 +166,7 @@
 			"defaultValue": 3
 		},
 		"40[0xff000000]": {
-			"$import": "../templates/master_template.json#base_1-10_nounit",
+			"$import": "~/templates/master_template.json#base_1-10_nounit",
 			"label": "Closed Position Alarm: LED Blinking Frequency",
 			"valueSize": 4,
 			"defaultValue": 4
@@ -210,7 +210,7 @@
 			]
 		},
 		"43": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Demo Sound Selection",
 			"description": "Allowable range: 0-100",
 			"options": [
@@ -221,7 +221,7 @@
 			]
 		},
 		"44": {
-			"$import": "../templates/master_template.json#base_1-10_nounit",
+			"$import": "~/templates/master_template.json#base_1-10_nounit",
 			"label": "Test Volume Level"
 		},
 		"45": {
@@ -235,7 +235,7 @@
 			"readOnly": true
 		},
 		"47": {
-			"$import": "../templates/master_template.json#base_0-1_nounit",
+			"$import": "~/templates/master_template.json#base_0-1_nounit",
 			"label": "Short/Long Press Function of Button- And Button+",
 			"options": [
 				{

--- a/packages/config/config/devices/0x0086/zw075.json
+++ b/packages/config/config/devices/0x0086/zw075.json
@@ -52,7 +52,7 @@
 		},
 		"20": {
 			"$if": "firmwareVersion >= 4.0",
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"80": {
 			"$import": "templates/aeotec_template.json#enable_notifications"

--- a/packages/config/config/devices/0x0086/zw078.json
+++ b/packages/config/config/devices/0x0086/zw078.json
@@ -44,7 +44,7 @@
 			"$import": "templates/aeotec_template.json#current_overload"
 		},
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"80": {
 			"$import": "/templates/aeotec_template.json#enable_notifications"

--- a/packages/config/config/devices/0x0086/zw088.json
+++ b/packages/config/config/devices/0x0086/zw088.json
@@ -33,7 +33,7 @@
 	},
 	"paramInformation": {
 		"250": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Scene Mode"
 		},
 		"255": {

--- a/packages/config/config/devices/0x0086/zw090.json
+++ b/packages/config/config/devices/0x0086/zw090.json
@@ -32,15 +32,15 @@
 	},
 	"paramInformation": {
 		"81": {
-			"$import": "../templates/master_template.json#enable_led_indicator"
+			"$import": "~/templates/master_template.json#enable_led_indicator"
 		},
 		"220": {
-			"$import": "../templates/master_template.json#base_0-10_nounit",
+			"$import": "~/templates/master_template.json#base_0-10_nounit",
 			"label": "Rf Power Level",
 			"defaultValue": 10
 		},
 		"242": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Security Network"
 		},
 		"252": {

--- a/packages/config/config/devices/0x0086/zw095.json
+++ b/packages/config/config/devices/0x0086/zw095.json
@@ -90,7 +90,7 @@
 			"defaultValue": 10
 		},
 		"13": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "CRC-16 Encapsulation"
 		},
 		"101[0x01]": {

--- a/packages/config/config/devices/0x0086/zw096.json
+++ b/packages/config/config/devices/0x0086/zw096.json
@@ -49,7 +49,7 @@
 			"$import": "templates/aeotec_template.json#current_overload"
 		},
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"80": {
 			"$import": "templates/aeotec_template.json#enable_notifications"

--- a/packages/config/config/devices/0x0086/zw098.json
+++ b/packages/config/config/devices/0x0086/zw098.json
@@ -62,7 +62,7 @@
 			"unsigned": true
 		},
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"32": {
 			"label": "Color Change Report Type",
@@ -88,32 +88,32 @@
 			]
 		},
 		"33[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Blue Color Value",
 			"valueSize": 4,
 			"readOnly": true,
 			"allowManualEntry": false
 		},
 		"33[0xff00]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Green Color Value",
 			"valueSize": 4,
 			"readOnly": true,
 			"allowManualEntry": false
 		},
 		"33[0xff0000]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Red Color Value",
 			"valueSize": 4,
 			"readOnly": true,
 			"allowManualEntry": false
 		},
 		"34": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "External Switch (On/Off)"
 		},
 		"35": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "External Switch (Color)"
 		},
 		"36": {
@@ -185,7 +185,7 @@
 			]
 		},
 		"37[0xff00]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Cycle Count",
 			"description": "Allowable range: 1-254",
 			"valueSize": 4,
@@ -202,7 +202,7 @@
 			]
 		},
 		"37[0xff0000]": {
-			"$import": "../templates/master_template.json#base_1-255_nounit",
+			"$import": "~/templates/master_template.json#base_1-255_nounit",
 			"label": "Brightness",
 			"description": "Allowable range: 1-99",
 			"valueSize": 4,
@@ -276,20 +276,20 @@
 			]
 		},
 		"38[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Pause Time of Off",
 			"description": "Active only in Fade Out/Fade In Transition Style",
 			"valueSize": 4,
 			"defaultValue": 0
 		},
 		"38[0xff00]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Pause Time of On",
 			"valueSize": 4,
 			"defaultValue": 6
 		},
 		"38[0xff0000]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Transition Speed (On to Off)",
 			"description": "Active only in Fade Out/Fade In Transition Style",
 			"valueSize": 4,
@@ -297,24 +297,24 @@
 			"defaultValue": 0
 		},
 		"38[0xff000000]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Transition Speed (Off to On)",
 			"valueSize": 4,
 			"maxValue": 125,
 			"defaultValue": 24
 		},
 		"39[0xff00]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Single Color/Fade Out: Blue Value",
 			"valueSize": 4
 		},
 		"39[0xff0000]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Single Color/Fade Out: Green Value",
 			"valueSize": 4
 		},
 		"39[0xff000000]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Single Color/Fade Out: Red Value",
 			"valueSize": 4
 		},

--- a/packages/config/config/devices/0x0086/zw099.json
+++ b/packages/config/config/devices/0x0086/zw099.json
@@ -38,7 +38,7 @@
 			"$import": "templates/aeotec_template.json#current_overload"
 		},
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"80": {
 			"$import": "templates/aeotec_template.json#enable_notifications_0-3"

--- a/packages/config/config/devices/0x0086/zw100.json
+++ b/packages/config/config/devices/0x0086/zw100.json
@@ -127,7 +127,7 @@
 			"defaultValue": 20
 		},
 		"42": {
-			"$import": "../templates/master_template.json#base_1-100_nounit",
+			"$import": "~/templates/master_template.json#base_1-100_nounit",
 			"label": "Humidity Change Threshold",
 			"unit": "%",
 			"defaultValue": 10
@@ -141,7 +141,7 @@
 			"defaultValue": 100
 		},
 		"44": {
-			"$import": "../templates/master_template.json#base_1-100_nounit",
+			"$import": "~/templates/master_template.json#base_1-100_nounit",
 			"label": "Battery Level Threshold",
 			"unit": "%",
 			"defaultValue": 10
@@ -241,13 +241,13 @@
 			"defaultValue": 0
 		},
 		"51": {
-			"$import": "../templates/master_template.json#base_0-100_nounit",
+			"$import": "~/templates/master_template.json#base_0-100_nounit",
 			"label": "Upper Humidity Limit",
 			"unit": "%",
 			"defaultValue": 60
 		},
 		"52": {
-			"$import": "../templates/master_template.json#base_0-100_nounit",
+			"$import": "~/templates/master_template.json#base_0-100_nounit",
 			"label": "Lower Humidity Limit",
 			"unit": "%",
 			"defaultValue": 50
@@ -302,48 +302,48 @@
 			"$import": "templates/aeotec_template.json#recover_limit_ultraviolet"
 		},
 		"61[0x01]": {
-			"$import": "../templates/master_template.json#base_true_false",
+			"$import": "~/templates/master_template.json#base_true_false",
 			"label": "Temperature: Below Lower Limit",
 			"readOnly": true
 		},
 		"61[0x10]": {
-			"$import": "../templates/master_template.json#base_true_false",
+			"$import": "~/templates/master_template.json#base_true_false",
 			"label": "Temperature: Above Lower Limit",
 			"readOnly": true
 		},
 		"61[0x02]": {
-			"$import": "../templates/master_template.json#base_true_false",
+			"$import": "~/templates/master_template.json#base_true_false",
 			"label": "Humidity: Below Lower Limit",
 			"readOnly": true
 		},
 		"61[0x20]": {
-			"$import": "../templates/master_template.json#base_true_false",
+			"$import": "~/templates/master_template.json#base_true_false",
 			"label": "Humidity: Above Lower Limit",
 			"readOnly": true
 		},
 		"61[0x04]": {
-			"$import": "../templates/master_template.json#base_true_false",
+			"$import": "~/templates/master_template.json#base_true_false",
 			"label": "Luminance: Below Lower Limit",
 			"readOnly": true
 		},
 		"61[0x40]": {
-			"$import": "../templates/master_template.json#base_true_false",
+			"$import": "~/templates/master_template.json#base_true_false",
 			"label": "Luminance: Above Lower Limit",
 			"readOnly": true
 		},
 		"61[0x08]": {
-			"$import": "../templates/master_template.json#base_true_false",
+			"$import": "~/templates/master_template.json#base_true_false",
 			"label": "Ultraviolet: Below Lower Limit",
 			"readOnly": true
 		},
 		"61[0x80]": {
-			"$import": "../templates/master_template.json#base_true_false",
+			"$import": "~/templates/master_template.json#base_true_false",
 			"label": "Ultraviolet: Above Lower Limit",
 			"readOnly": true
 		},
 		"81": {
 			"$if": "firmwareVersion >= 1.8",
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "LED Blinking"
 		},
 		"101[0x01]": {

--- a/packages/config/config/devices/0x0086/zw111.json
+++ b/packages/config/config/devices/0x0086/zw111.json
@@ -64,7 +64,7 @@
 			"$import": "templates/aeotec_template.json#overheat_protection"
 		},
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"80": {
 			"$import": "templates/aeotec_template.json#enable_notifications_0-4"
@@ -377,22 +377,22 @@
 		// End of WallSwipe Settings
 		"248[0x80]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Advanced Parameter Settings"
 		},
 		"248[0x01]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Advanced: Send NIFs"
 		},
 		"248[0x02]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Advanced: RF Power Level Test Mode"
 		},
 		"248[0x04]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Advanced: Factory Reset Function"
 		},
 		"252": {

--- a/packages/config/config/devices/0x0086/zw112.json
+++ b/packages/config/config/devices/0x0086/zw112.json
@@ -63,7 +63,7 @@
 			"defaultValue": 20
 		},
 		"101": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Enable/Disable The Function of Parameter 111"
 		},
 		"111": {

--- a/packages/config/config/devices/0x0086/zw116.json
+++ b/packages/config/config/devices/0x0086/zw116.json
@@ -60,7 +60,7 @@
 			"$import": "templates/aeotec_template.json#overheat_protection"
 		},
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"80": {
 			"$import": "templates/aeotec_template.json#enable_notifications_0-3"
@@ -331,22 +331,22 @@
 		// End of WallSwipe Settings
 		"248[0x80]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Advanced Parameter Settings"
 		},
 		"248[0x01]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Advanced: Send NIFs"
 		},
 		"248[0x02]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Advanced: RF Power Level Test Mode"
 		},
 		"248[0x04]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Advanced: Factory Reset Function"
 		},
 		"252": {

--- a/packages/config/config/devices/0x0086/zw117.json
+++ b/packages/config/config/devices/0x0086/zw117.json
@@ -43,7 +43,7 @@
 	},
 	"paramInformation": {
 		"82": {
-			"$import": "../templates/master_template.json#led_indicator_two_options",
+			"$import": "~/templates/master_template.json#led_indicator_two_options",
 			"options": [
 				{
 					"label": "On for 2 seconds",

--- a/packages/config/config/devices/0x0086/zw121.json
+++ b/packages/config/config/devices/0x0086/zw121.json
@@ -31,7 +31,7 @@
 	},
 	"paramInformation": {
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"32": {
 			"label": "Report Type",
@@ -53,26 +53,26 @@
 			]
 		},
 		"33[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Strip Color: Blue",
 			"valueSize": 4
 		},
 		"33[0xff00]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Strip Color: Green",
 			"valueSize": 4
 		},
 		"33[0xff0000]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Strip Color: Red",
 			"valueSize": 4
 		},
 		"34": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Use Last Brightness on Color Switch Set CC"
 		},
 		"35": {
-			"$import": "../templates/master_template.json#base_0-1_nounit",
+			"$import": "~/templates/master_template.json#base_0-1_nounit",
 			"label": "Cold/Warm White Display Mode",
 			"defaultValue": 1,
 			"options": [
@@ -155,7 +155,7 @@
 			]
 		},
 		"37[0xff00]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Cycle Count",
 			"description": "Allowable range: 1-254",
 			"valueSize": 4,
@@ -172,7 +172,7 @@
 			]
 		},
 		"37[0xff0000]": {
-			"$import": "../templates/master_template.json#base_1-255_nounit",
+			"$import": "~/templates/master_template.json#base_1-255_nounit",
 			"label": "Brightness",
 			"description": "Allowable range: 1-99",
 			"valueSize": 4,
@@ -246,20 +246,20 @@
 			]
 		},
 		"38[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Pause Time of Off",
 			"description": "Active only in Fade Out/Fade In Transition Style",
 			"valueSize": 4,
 			"defaultValue": 0
 		},
 		"38[0xff00]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Pause Time of On",
 			"valueSize": 4,
 			"defaultValue": 6
 		},
 		"38[0xff0000]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Transition Speed (On to Off)",
 			"description": "Active only in Fade Out/Fade In Transition Style",
 			"valueSize": 4,
@@ -267,24 +267,24 @@
 			"defaultValue": 0
 		},
 		"38[0xff000000]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Transition Speed (Off to On)",
 			"valueSize": 4,
 			"maxValue": 125,
 			"defaultValue": 24
 		},
 		"39[0xff00]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Single Color/Fade Out: Blue Value",
 			"valueSize": 4
 		},
 		"39[0xff0000]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Single Color/Fade Out: Green Value",
 			"valueSize": 4
 		},
 		"39[0xff000000]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Single Color/Fade Out: Red Value",
 			"valueSize": 4
 		},

--- a/packages/config/config/devices/0x0086/zw122.json
+++ b/packages/config/config/devices/0x0086/zw122.json
@@ -103,7 +103,7 @@
 			"defaultValue": 20
 		},
 		"48": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Sensor Reports"
 		},
 		"49[0xffff0000]": {
@@ -155,32 +155,32 @@
 			]
 		},
 		"86": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Buzzer",
 			"defaultValue": 1
 		},
 		"87[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Buzzer: Water Leak",
 			"valueSize": 4
 		},
 		"87[0x02]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Buzzer: Vibration",
 			"valueSize": 4
 		},
 		"87[0x04]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Buzzer: Tilt Sensor",
 			"valueSize": 4
 		},
 		"87[0x10]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Buzzer: Underheat",
 			"valueSize": 4
 		},
 		"87[0x20]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Buzzer: Overheat",
 			"valueSize": 4
 		},
@@ -233,7 +233,7 @@
 			]
 		},
 		"94": {
-			"$import": "../templates/master_template.json#base_0-1_nounit",
+			"$import": "~/templates/master_template.json#base_0-1_nounit",
 			"label": "Battery Source to Report",
 			"options": [
 				{

--- a/packages/config/config/devices/0x0086/zw132.json
+++ b/packages/config/config/devices/0x0086/zw132.json
@@ -58,7 +58,7 @@
 			"$import": "templates/aeotec_template.json#overheat_protection"
 		},
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"80": {
 			"$import": "templates/aeotec_template.json#enable_notifications_0-3"

--- a/packages/config/config/devices/0x0086/zw139.json
+++ b/packages/config/config/devices/0x0086/zw139.json
@@ -55,7 +55,7 @@
 			"$import": "templates/aeotec_template.json#overheat_protection"
 		},
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"80": {
 			"$import": "templates/aeotec_template.json#enable_notifications_0-3"

--- a/packages/config/config/devices/0x0086/zw140.json
+++ b/packages/config/config/devices/0x0086/zw140.json
@@ -55,7 +55,7 @@
 			"$import": "templates/aeotec_template.json#overheat_protection"
 		},
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"80": {
 			"$import": "templates/aeotec_template.json#enable_notifications_0-3"

--- a/packages/config/config/devices/0x0086/zw141.json
+++ b/packages/config/config/devices/0x0086/zw141.json
@@ -71,22 +71,22 @@
 		},
 		"248[0x80]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Advanced Parameter Settings"
 		},
 		"248[0x01]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Advanced: Send NIFs"
 		},
 		"248[0x02]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Advanced: RF Power Level Test Mode"
 		},
 		"248[0x04]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Advanced: Factory Reset Function"
 		},
 		"252": {

--- a/packages/config/config/devices/0x0107/fibefgs-213.json
+++ b/packages/config/config/devices/0x0107/fibefgs-213.json
@@ -16,7 +16,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"9": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"10": {
 			"label": "First channel operating mode",

--- a/packages/config/config/devices/0x0109/yrd210.json
+++ b/packages/config/config/devices/0x0109/yrd210.json
@@ -34,58 +34,58 @@
 	},
 	"paramInformation": {
 		"1": {
-			"$import": "../0x0129/templates/yale_template.json#volume_inverted"
+			"$import": "~/0x0129/templates/yale_template.json#volume_inverted"
 		},
 		"2": {
-			"$import": "../0x0129/templates/yale_template.json#auto_relock"
+			"$import": "~/0x0129/templates/yale_template.json#auto_relock"
 		},
 		"3": {
-			"$import": "../0x0129/templates/yale_template.json#auto_relock_time_180"
+			"$import": "~/0x0129/templates/yale_template.json#auto_relock_time_180"
 		},
 		"4": {
-			"$import": "../0x0129/templates/yale_template.json#wrong_code_limit_10"
+			"$import": "~/0x0129/templates/yale_template.json#wrong_code_limit_10"
 		},
 		"5": {
-			"$import": "../0x0129/templates/yale_template.json#language"
+			"$import": "~/0x0129/templates/yale_template.json#language"
 		},
 		"7": {
-			"$import": "../0x0129/templates/yale_template.json#wrong_code_lockout_10_to_127"
+			"$import": "~/0x0129/templates/yale_template.json#wrong_code_lockout_10_to_127"
 		},
 		"8": {
-			"$import": "../0x0129/templates/yale_template.json#operating_mode"
+			"$import": "~/0x0129/templates/yale_template.json#operating_mode"
 		}
 	},
 	"compat": {
 		"alarmMapping": [
 			{
-				"$import": "../0x0129/templates/yale_template.json#alarm_map_keypad_limit"
+				"$import": "~/0x0129/templates/yale_template.json#alarm_map_keypad_limit"
 			},
 			{
-				"$import": "../0x0129/templates/yale_template.json#alarm_map_manual_unlock"
+				"$import": "~/0x0129/templates/yale_template.json#alarm_map_manual_unlock"
 			},
 			{
-				"$import": "../0x0129/templates/yale_template.json#alarm_map_rf_unlock"
+				"$import": "~/0x0129/templates/yale_template.json#alarm_map_rf_unlock"
 			},
 			{
-				"$import": "../0x0129/templates/yale_template.json#alarm_map_keypad_unlock"
+				"$import": "~/0x0129/templates/yale_template.json#alarm_map_keypad_unlock"
 			},
 			{
-				"$import": "../0x0129/templates/yale_template.json#alarm_map_manual_lock"
+				"$import": "~/0x0129/templates/yale_template.json#alarm_map_manual_lock"
 			},
 			{
-				"$import": "../0x0129/templates/yale_template.json#alarm_map_rf_lock"
+				"$import": "~/0x0129/templates/yale_template.json#alarm_map_rf_lock"
 			},
 			{
-				"$import": "../0x0129/templates/yale_template.json#alarm_map_keypad_lock"
+				"$import": "~/0x0129/templates/yale_template.json#alarm_map_keypad_lock"
 			},
 			{
-				"$import": "../0x0129/templates/yale_template.json#alarm_map_deadbolt_jammed"
+				"$import": "~/0x0129/templates/yale_template.json#alarm_map_deadbolt_jammed"
 			},
 			{
-				"$import": "../0x0129/templates/yale_template.json#alarm_map_low_battery"
+				"$import": "~/0x0129/templates/yale_template.json#alarm_map_low_battery"
 			},
 			{
-				"$import": "../0x0129/templates/yale_template.json#alarm_map_auto_relock"
+				"$import": "~/0x0129/templates/yale_template.json#alarm_map_auto_relock"
 			}
 		]
 	}

--- a/packages/config/config/devices/0x010f/fgd211_0.0-1.8.json
+++ b/packages/config/config/devices/0x010f/fgd211_0.0-1.8.json
@@ -211,7 +211,7 @@
 			]
 		},
 		"16": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"17": {
 			"label": "3-way switch",

--- a/packages/config/config/devices/0x010f/fgd211_1.9-1.11.json
+++ b/packages/config/config/devices/0x010f/fgd211_1.9-1.11.json
@@ -211,7 +211,7 @@
 			]
 		},
 		"16": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"17": {
 			"label": "3-way switch",

--- a/packages/config/config/devices/0x010f/fgd211_2.1.json
+++ b/packages/config/config/devices/0x010f/fgd211_2.1.json
@@ -217,7 +217,7 @@
 			]
 		},
 		"16": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"17": {
 			"label": "3-way switch function",

--- a/packages/config/config/devices/0x010f/fgd212_0.0-3.4.json
+++ b/packages/config/config/devices/0x010f/fgd212_0.0-3.4.json
@@ -111,7 +111,7 @@
 			"defaultValue": 5
 		},
 		"9": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"10": {
 			"label": "Timer functionality (auto - off).",

--- a/packages/config/config/devices/0x010f/fgd212_3.5.json
+++ b/packages/config/config/devices/0x010f/fgd212_3.5.json
@@ -95,7 +95,7 @@
 			"defaultValue": 5
 		},
 		"9": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"10": {
 			"label": "Timer Functionality (Auto - Off)",
@@ -286,86 +286,86 @@
 			]
 		},
 		"23": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Double Click Sets Brightness to 100%",
 			"defaultValue": 1
 		},
 		"24[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable_inverted",
+			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
 			"label": "Send Command Frames in 2nd and 3rd Association Groups when Switching ON (Single Click)",
 			"defaultValue": 0
 		},
 		"24[0x02]": {
-			"$import": "../templates/master_template.json#base_enable_disable_inverted",
+			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
 			"label": "Send Command Frames in 2nd and 3rd Association Groups when Switching OFF (Single Click)",
 			"defaultValue": 0
 		},
 		"24[0x04]": {
-			"$import": "../templates/master_template.json#base_enable_disable_inverted",
+			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
 			"label": "Send Command Frames in 2nd and 3rd Association Groups when Changing Dimming Level",
 			"defaultValue": 0
 		},
 		"24[0x08]": {
-			"$import": "../templates/master_template.json#base_enable_disable_inverted",
+			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
 			"label": "Send Command Frames in 2nd and 3rd Association Groups on Double Click",
 			"defaultValue": 0
 		},
 		"24[0x10]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Command Frames in 2nd and 3rd Association Groups with 0xFF Value on Double Click"
 		},
 		"25[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable_inverted",
+			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
 			"label": "Send Command Frames in 4th and 5th Association Groups when Switching ON (Single Click)",
 			"defaultValue": 0
 		},
 		"25[0x02]": {
-			"$import": "../templates/master_template.json#base_enable_disable_inverted",
+			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
 			"label": "Send Command Frames in 4th and 5th Association Groups when Switching OFF (Single Click)",
 			"defaultValue": 0
 		},
 		"25[0x04]": {
-			"$import": "../templates/master_template.json#base_enable_disable_inverted",
+			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
 			"label": "Send Command Frames in 4th and 5th Association Groups when Changing Dimming Level",
 			"defaultValue": 0
 		},
 		"25[0x08]": {
-			"$import": "../templates/master_template.json#base_enable_disable_inverted",
+			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
 			"label": "Send Command Frames in 4th and 5th Association Groups on Double Click",
 			"defaultValue": 0
 		},
 		"25[0x10]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Command Frames in 4th and 5th Association Groups with 0xFF Value on Double Click"
 		},
 		"26": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "3-way Switch Function",
 			"description": "Key S2 also controls the dimmer"
 		},
 		"27[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Secure Z-wave Commands to 2nd Association Group"
 		},
 		"27[0x02]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Secure Z-wave Commands to 3rd Association Group"
 		},
 		"27[0x04]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Secure Z-wave Commands to 4th Association Group"
 		},
 		"27[0x08]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Secure Z-wave Commands to 5th Association Group"
 		},
 		"28": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Scene Activation Functionality",
 			"description": "See manual for SCENE ID specification details"
 		},
 		"29": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Swap Functionality of Key S1 and Key S2",
 			"description": "Causes S1 to operate as S2 and S2 to operate as S1"
 		},
@@ -815,7 +815,7 @@
 			]
 		},
 		"54": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Self-measurement",
 			"description": "Reports include power and energy used by device"
 		},

--- a/packages/config/config/devices/0x010f/fgrgbw-442.json
+++ b/packages/config/config/devices/0x010f/fgrgbw-442.json
@@ -28,7 +28,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"1": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"20": {
 			"label": "Input 1 - operating mode",

--- a/packages/config/config/devices/0x010f/fgrgbw.json
+++ b/packages/config/config/devices/0x010f/fgrgbw.json
@@ -181,7 +181,7 @@
 			"unsigned": true
 		},
 		"16": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"30": {
 			"label": "Alarm response",

--- a/packages/config/config/devices/0x010f/fgs211_0.0-2.0.json
+++ b/packages/config/config/devices/0x010f/fgs211_0.0-2.0.json
@@ -206,7 +206,7 @@
 			]
 		},
 		"16": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"30": {
 			"label": "Relay 1: Response to General Alarm",

--- a/packages/config/config/devices/0x010f/fgs211_2.1.json
+++ b/packages/config/config/devices/0x010f/fgs211_2.1.json
@@ -206,7 +206,7 @@
 			]
 		},
 		"16": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"30": {
 			"label": "Relay 1: Response to General Alarm",

--- a/packages/config/config/devices/0x010f/fgs212.json
+++ b/packages/config/config/devices/0x010f/fgs212.json
@@ -173,7 +173,7 @@
 			]
 		},
 		"16": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"30": {
 			"label": "Relay 1: Response to General Alarm",

--- a/packages/config/config/devices/0x010f/fgs213.json
+++ b/packages/config/config/devices/0x010f/fgs213.json
@@ -28,7 +28,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"9": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"10": {
 			"label": "First channel operating mode",

--- a/packages/config/config/devices/0x010f/fgs221_1.4-1.8.json
+++ b/packages/config/config/devices/0x010f/fgs221_1.4-1.8.json
@@ -248,7 +248,7 @@
 			]
 		},
 		"16": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"30": {
 			"label": "Relay 1: Response to General Alarm",

--- a/packages/config/config/devices/0x010f/fgs221_1.9-1.11.json
+++ b/packages/config/config/devices/0x010f/fgs221_1.9-1.11.json
@@ -234,7 +234,7 @@
 			]
 		},
 		"16": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"30": {
 			"label": "Relay 1: Response to General Alarm",

--- a/packages/config/config/devices/0x010f/fgs221_2.1-2.3.json
+++ b/packages/config/config/devices/0x010f/fgs221_2.1-2.3.json
@@ -242,7 +242,7 @@
 			]
 		},
 		"16": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"30": {
 			"label": "Relay 1: Response to General Alarm",

--- a/packages/config/config/devices/0x010f/fgs222.json
+++ b/packages/config/config/devices/0x010f/fgs222.json
@@ -222,7 +222,7 @@
 			]
 		},
 		"16": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"30": {
 			"label": "Relay 1: Response to General Alarm",

--- a/packages/config/config/devices/0x010f/fgs223.json
+++ b/packages/config/config/devices/0x010f/fgs223.json
@@ -59,7 +59,7 @@
 	},
 	"paramInformation": {
 		"9": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"10": {
 			"label": "First channel - operating mode",

--- a/packages/config/config/devices/0x010f/fgt001.json
+++ b/packages/config/config/devices/0x010f/fgt001.json
@@ -28,82 +28,82 @@
 			"defaultValue": 240
 		},
 		"2[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Open Window Detector (Normal)",
 			"defaultValue": 1, // Enable
 			"valueSize": 4
 		},
 		"2[0x02]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Open Window Detector (Rapid)",
 			"valueSize": 4
 		},
 		"2[0x04]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Increase Receiver Sensitivity",
 			"description": "Increase receiver sensitivity, but shortens battery life",
 			"valueSize": 4
 		},
 		"2[0x08]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Remote LED",
 			"description": "Enable LED indications when controlling remotely",
 			"valueSize": 4
 		},
 		"2[0x10]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Protect Setting Full ON/OFF",
 			"description": "Protect from setting Full ON and Full OFF mode by turning the knob manually",
 			"valueSize": 4
 		},
 		"2[0x20]": {
 			"$if": "firmwareVersion >= 4.7",
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Vertical Mount",
 			"description": "Device mounted in vertical position",
 			"valueSize": 4
 		},
 		"2[0x40]": {
 			"$if": "firmwareVersion >= 4.7",
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Moderate Regulator Behaviour",
 			"description": "Set moderate regulator behaviour instead of rapid",
 			"valueSize": 4
 		},
 		"2[0x80]": {
 			"$if": "firmwareVersion >= 4.7",
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Inverted Knob Operation",
 			"valueSize": 4
 		},
 		"2[0x100]": {
 			"$if": "firmwareVersion >= 4.7",
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Heating Medium Demand Reports",
 			"valueSize": 4
 		},
 		"2[0x200]": {
 			"$if": "firmwareVersion >= 4.7",
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Detecting Heating System Failures",
 			"valueSize": 4
 		},
 		"3[0x01]": {
-			"$import": "../templates/master_template.json#base_true_false",
+			"$import": "~/templates/master_template.json#base_true_false",
 			"label": "Temperature Sensor",
 			"description": "Optional temperature sensor connected and operational",
 			"valueSize": 4,
 			"readOnly": true
 		},
 		"3[0x02]": {
-			"$import": "../templates/master_template.json#base_true_false",
+			"$import": "~/templates/master_template.json#base_true_false",
 			"label": "Open Window Detected",
 			"valueSize": 4,
 			"readOnly": true
 		},
 		"3[0x04]": {
 			"$if": "firmwareVersion >= 4.7",
-			"$import": "../templates/master_template.json#base_true_false",
+			"$import": "~/templates/master_template.json#base_true_false",
 			"label": "Provide Heat",
 			"description": "Provide heat in order to maintain set temperature",
 			"valueSize": 4,
@@ -111,7 +111,7 @@
 		},
 		"3[0x08]": {
 			"$if": "firmwareVersion >= 4.7",
-			"$import": "../templates/master_template.json#base_true_false",
+			"$import": "~/templates/master_template.json#base_true_false",
 			"label": "Malfunctioning Heating System",
 			"description": "Malfunctioning heating system - cannot reach set temperature",
 			"valueSize": 4,

--- a/packages/config/config/devices/0x010f/fgwp101.json
+++ b/packages/config/config/devices/0x010f/fgwp101.json
@@ -55,7 +55,7 @@
 			]
 		},
 		"16": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"34": {
 			"label": "Reaction to alarms",

--- a/packages/config/config/devices/0x010f/fgwp102_2.1-2.5.json
+++ b/packages/config/config/devices/0x010f/fgwp102_2.1-2.5.json
@@ -40,7 +40,7 @@
 			]
 		},
 		"16": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"34": {
 			"label": "Reaction to alarms",

--- a/packages/config/config/devices/0x010f/fgwp102_3.2.json
+++ b/packages/config/config/devices/0x010f/fgwp102_3.2.json
@@ -43,7 +43,7 @@
 			]
 		},
 		"2": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "Overload safety switch",

--- a/packages/config/config/devices/0x010f/fgwpb-121.json
+++ b/packages/config/config/devices/0x010f/fgwpb-121.json
@@ -19,7 +19,7 @@
 	},
 	"paramInformation": {
 		"2": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "Overload",

--- a/packages/config/config/devices/0x010f/fgwpg-121.json
+++ b/packages/config/config/devices/0x010f/fgwpg-121.json
@@ -15,7 +15,7 @@
 	},
 	"paramInformation": {
 		"2": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "Overload",

--- a/packages/config/config/devices/0x0118/tze96.json
+++ b/packages/config/config/devices/0x0118/tze96.json
@@ -16,7 +16,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"4": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		}
 	}
 }

--- a/packages/config/config/devices/0x0129/sr-bx-zw.json
+++ b/packages/config/config/devices/0x0129/sr-bx-zw.json
@@ -25,7 +25,7 @@
 			"unsigned": true
 		},
 		"2": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Alarm LED Flash"
 		},
 		"3": {
@@ -45,7 +45,7 @@
 			]
 		},
 		"4": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Tamper Alarm"
 		}
 	},

--- a/packages/config/config/devices/0x0129/templates/yale_template.json
+++ b/packages/config/config/devices/0x0129/templates/yale_template.json
@@ -44,17 +44,17 @@
 		]
 	},
 	"auto_relock": {
-		"$import": "../../templates/master_template.json#base_enable_disable_255",
+		"$import": "~/templates/master_template.json#base_enable_disable_255",
 		"label": "Auto Relock"
 	},
 	"auto_relock_time_180": {
-		"$import": "../../templates/master_template.json#base_0-180_nounit",
+		"$import": "~/templates/master_template.json#base_0-180_nounit",
 		"label": "Auto Relock Time",
 		"unit": "seconds",
 		"defaultValue": 30
 	},
 	"auto_relock_time_127": {
-		"$import": "../../templates/master_template.json#base_0-127_nounit",
+		"$import": "~/templates/master_template.json#base_0-127_nounit",
 		"label": "Auto Relock Time",
 		"unit": "seconds",
 		"minValue": 10,
@@ -89,13 +89,13 @@
 		"unsigned": true
 	},
 	"wrong_code_lockout": {
-		"$import": "../../templates/master_template.json#base_0-180_nounit",
+		"$import": "~/templates/master_template.json#base_0-180_nounit",
 		"label": "Wrong Code Lockout Time",
 		"unit": "seconds",
 		"defaultValue": 60
 	},
 	"wrong_code_lockout_10_to_127": {
-		"$import": "../../templates/master_template.json#base_0-127_nounit",
+		"$import": "~/templates/master_template.json#base_0-127_nounit",
 		"label": "Wrong Code Lockout Time",
 		"unit": "seconds",
 		"minValue": 10,
@@ -194,15 +194,15 @@
 		]
 	},
 	"one_touch": {
-		"$import": "../../templates/master_template.json#base_enable_disable_255",
+		"$import": "~/templates/master_template.json#base_enable_disable_255",
 		"label": "One Touch Locking"
 	},
 	"privacy_button": {
-		"$import": "../../templates/master_template.json#base_enable_disable_255",
+		"$import": "~/templates/master_template.json#base_enable_disable_255",
 		"label": "Privacy Button"
 	},
 	"lock_status_led": {
-		"$import": "../../templates/master_template.json#base_enable_disable_255",
+		"$import": "~/templates/master_template.json#base_enable_disable_255",
 		"label": "Lock Status LED"
 	},
 	"reset_factory": {
@@ -225,23 +225,23 @@
 		]
 	},
 	"door_propped_timer": {
-		"$import": "../../templates/master_template.json#base_0-127_nounit",
+		"$import": "~/templates/master_template.json#base_0-127_nounit",
 		"label": "Door Propped Time Limit",
 		"unit": "10 seconds",
 		"minValue": 10,
 		"defaultValue": 0
 	},
 	"dps_alarm": {
-		"$import": "../../templates/master_template.json#base_enable_disable_255",
+		"$import": "~/templates/master_template.json#base_enable_disable_255",
 		"label": "Door Propped Alarm"
 	},
 	"enable_dps_alarm": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Door Propped Alarm",
 		"defaultValue": 1
 	},
 	"deadbolt_installed_state": {
-		"$import": "../../templates/master_template.json#base_enable_disable_255",
+		"$import": "~/templates/master_template.json#base_enable_disable_255",
 		"label": "Deadbolt Status",
 		"options": [
 			{
@@ -255,26 +255,26 @@
 		]
 	},
 	"eco_mode": {
-		"$import": "../../templates/master_template.json#base_enable_disable_255",
+		"$import": "~/templates/master_template.json#base_enable_disable_255",
 		"label": "Eco Mode"
 	},
 	"privacy_mode": {
-		"$import": "../../templates/master_template.json#base_enable_disable_255",
+		"$import": "~/templates/master_template.json#base_enable_disable_255",
 		"label": "Privacy Mode With Deadbolt",
 		"description": "If enabled then extending the deadbolt will put the lock into privacy mode"
 	},
 	"enable_deadbolt_alarm": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Deadbolt Alarm",
 		"defaultValue": 1
 	},
 	"enable_rotated_alarm": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Rotated Alarm",
 		"defaultValue": 1
 	},
 	"enable_escape_mode": {
-		"$import": "../../templates/master_template.json#base_enable_disable_255",
+		"$import": "~/templates/master_template.json#base_enable_disable_255",
 		"label": "Escape Return Mode"
 	},
 	"manual_relock_time": {

--- a/packages/config/config/devices/0x0129/yrd256.json
+++ b/packages/config/config/devices/0x0129/yrd256.json
@@ -35,7 +35,7 @@
 			"$import": "templates/yale_template.json#language"
 		},
 		"6": {
-			"$import": "../templates/master_template.json#base_enable_disable_255",
+			"$import": "~/templates/master_template.json#base_enable_disable_255",
 			"label": "Radio Event Reporting"
 		},
 		"7": {

--- a/packages/config/config/devices/0x0154/700793.json
+++ b/packages/config/config/devices/0x0154/700793.json
@@ -23,7 +23,7 @@
 	},
 	"paramInformation": {
 		"1": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev",
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev",
 			"defaultValue": 0
 		}
 	}

--- a/packages/config/config/devices/0x0154/pope700397.json
+++ b/packages/config/config/devices/0x0154/pope700397.json
@@ -90,7 +90,7 @@
 			]
 		},
 		"5": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"21": {
 			"label": "LED Color on OFF state",

--- a/packages/config/config/devices/0x0159/smart_plug_16a.json
+++ b/packages/config/config/devices/0x0159/smart_plug_16a.json
@@ -90,7 +90,7 @@
 			]
 		},
 		"30": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power Consumption (Watt) Reporting Threshold",

--- a/packages/config/config/devices/0x0159/zmnhaa.json
+++ b/packages/config/config/devices/0x0159/zmnhaa.json
@@ -129,7 +129,7 @@
 			"unsigned": true
 		},
 		"30": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power reporting in Watts on percentage change",

--- a/packages/config/config/devices/0x0159/zmnhad.json
+++ b/packages/config/config/devices/0x0159/zmnhad.json
@@ -137,7 +137,7 @@
 			]
 		},
 		"30": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power reporting in Watts on power change",

--- a/packages/config/config/devices/0x0159/zmnhba.json
+++ b/packages/config/config/devices/0x0159/zmnhba.json
@@ -111,7 +111,7 @@
 			"unsigned": true
 		},
 		"30": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power reporting in Watts on power change for Q1",

--- a/packages/config/config/devices/0x0159/zmnhbd.json
+++ b/packages/config/config/devices/0x0159/zmnhbd.json
@@ -156,7 +156,7 @@
 			"unsigned": true
 		},
 		"30": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power reporting in Watts for Q1",

--- a/packages/config/config/devices/0x0159/zmnhda.json
+++ b/packages/config/config/devices/0x0159/zmnhda.json
@@ -119,7 +119,7 @@
 			]
 		},
 		"30": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power reporting in Watts on power change",

--- a/packages/config/config/devices/0x0159/zmnhdd.json
+++ b/packages/config/config/devices/0x0159/zmnhdd.json
@@ -238,7 +238,7 @@
 			]
 		},
 		"30": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power reporting in watts on power change",

--- a/packages/config/config/devices/0x0159/zmnhhd.json
+++ b/packages/config/config/devices/0x0159/zmnhhd.json
@@ -85,7 +85,7 @@
 			]
 		},
 		"30": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power Consumption Threshold",

--- a/packages/config/config/devices/0x0159/zmnhia.json
+++ b/packages/config/config/devices/0x0159/zmnhia.json
@@ -181,7 +181,7 @@
 			"unsigned": true
 		},
 		"30": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power reporting in Watts on power change for Q1",

--- a/packages/config/config/devices/0x0159/zmnhja.json
+++ b/packages/config/config/devices/0x0159/zmnhja.json
@@ -265,7 +265,7 @@
 			]
 		},
 		"30": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off"
 		}
 	}
 }

--- a/packages/config/config/devices/0x0159/zmnhjd.json
+++ b/packages/config/config/devices/0x0159/zmnhjd.json
@@ -265,7 +265,7 @@
 			]
 		},
 		"30": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off"
 		}
 	}
 }

--- a/packages/config/config/devices/0x0159/zmnhmd.json
+++ b/packages/config/config/devices/0x0159/zmnhmd.json
@@ -69,7 +69,7 @@
 			]
 		},
 		"30": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"48": {
 			"label": "Total Water Consumption",

--- a/packages/config/config/devices/0x0159/zmnhnd.json
+++ b/packages/config/config/devices/0x0159/zmnhnd.json
@@ -128,7 +128,7 @@
 			]
 		},
 		"30": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"63": {
 			"label": "Output Switch selection",

--- a/packages/config/config/devices/0x0159/zmnhqd.json
+++ b/packages/config/config/devices/0x0159/zmnhqd.json
@@ -88,7 +88,7 @@
 			"defaultValue": 0
 		},
 		"30": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"50": {
 			"label": "Enable/disable beeper",

--- a/packages/config/config/devices/0x0159/zmnhsd.json
+++ b/packages/config/config/devices/0x0159/zmnhsd.json
@@ -152,7 +152,7 @@
 			]
 		},
 		"30": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power reporting in watts on power change",

--- a/packages/config/config/devices/0x0159/zmnhud.json
+++ b/packages/config/config/devices/0x0159/zmnhud.json
@@ -265,7 +265,7 @@
 			]
 		},
 		"30": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off"
 		}
 	}
 }

--- a/packages/config/config/devices/0x0159/zmnhvd.json
+++ b/packages/config/config/devices/0x0159/zmnhvd.json
@@ -72,7 +72,7 @@
 			"defaultValue": 0
 		},
 		"30": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"52": {
 			"label": "Auto or manual selection",

--- a/packages/config/config/devices/0x015d/zen20.json
+++ b/packages/config/config/devices/0x015d/zen20.json
@@ -28,7 +28,7 @@
 	},
 	"paramInformation": {
 		"1": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"2": {
 			"label": "Power Wattage Report Value Threshold",

--- a/packages/config/config/devices/0x015f/mh-dt311_411.json
+++ b/packages/config/config/devices/0x015f/mh-dt311_411.json
@@ -42,7 +42,7 @@
 	},
 	"paramInformation": {
 		"1": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"2": {
 			"label": "Dimming Mode",

--- a/packages/config/config/devices/0x015f/mh-p220.json
+++ b/packages/config/config/devices/0x015f/mh-p220.json
@@ -23,7 +23,7 @@
 	},
 	"paramInformation": {
 		"1": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"2": {
 			"label": "External Switch Type",

--- a/packages/config/config/devices/0x015f/mh-s212.json
+++ b/packages/config/config/devices/0x015f/mh-s212.json
@@ -26,7 +26,7 @@
 	},
 	"paramInformation": {
 		"1": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"2": {
 			"label": "External Switch Type",

--- a/packages/config/config/devices/0x015f/mh-s311h.json
+++ b/packages/config/config/devices/0x015f/mh-s311h.json
@@ -20,7 +20,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"2": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "ALL ON/ALL OFF",

--- a/packages/config/config/devices/0x015f/mh-s312.json
+++ b/packages/config/config/devices/0x015f/mh-s312.json
@@ -42,7 +42,7 @@
 	},
 	"paramInformation": {
 		"2": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "ALL ON/ALL OFF",

--- a/packages/config/config/devices/0x015f/mh-s314-1502.json
+++ b/packages/config/config/devices/0x015f/mh-s314-1502.json
@@ -39,7 +39,7 @@
 	},
 	"paramInformation": {
 		"2": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "All On/All Off",

--- a/packages/config/config/devices/0x015f/mh-s314.json
+++ b/packages/config/config/devices/0x015f/mh-s314.json
@@ -42,7 +42,7 @@
 	},
 	"paramInformation": {
 		"2": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "All On/All Off",

--- a/packages/config/config/devices/0x015f/mh-s411-1302.json
+++ b/packages/config/config/devices/0x015f/mh-s411-1302.json
@@ -26,7 +26,7 @@
 	},
 	"paramInformation": {
 		"1": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		}
 	}
 }

--- a/packages/config/config/devices/0x015f/mh-s411-1502.json
+++ b/packages/config/config/devices/0x015f/mh-s411-1502.json
@@ -26,7 +26,7 @@
 	},
 	"paramInformation": {
 		"2": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "All On/All Off",

--- a/packages/config/config/devices/0x015f/mh-s412-1302.json
+++ b/packages/config/config/devices/0x015f/mh-s412-1302.json
@@ -30,7 +30,7 @@
 	},
 	"paramInformation": {
 		"1": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		}
 	}
 }

--- a/packages/config/config/devices/0x015f/mh-s412-1502.json
+++ b/packages/config/config/devices/0x015f/mh-s412-1502.json
@@ -30,7 +30,7 @@
 	},
 	"paramInformation": {
 		"2": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "All On/All Off",

--- a/packages/config/config/devices/0x015f/mh-s511.json
+++ b/packages/config/config/devices/0x015f/mh-s511.json
@@ -15,7 +15,7 @@
 	},
 	"paramInformation": {
 		"2": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "All On / All Off",

--- a/packages/config/config/devices/0x015f/mh-s512.json
+++ b/packages/config/config/devices/0x015f/mh-s512.json
@@ -15,7 +15,7 @@
 	},
 	"paramInformation": {
 		"2": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "All On / All Off",

--- a/packages/config/config/devices/0x015f/mh-s513.json
+++ b/packages/config/config/devices/0x015f/mh-s513.json
@@ -15,7 +15,7 @@
 	},
 	"paramInformation": {
 		"2": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "All On / All Off",

--- a/packages/config/config/devices/0x015f/mh-s521.json
+++ b/packages/config/config/devices/0x015f/mh-s521.json
@@ -20,7 +20,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"2": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"3": {
 			"label": "ALL ON/ALL OFF",

--- a/packages/config/config/devices/0x0165/asp-3-1.json
+++ b/packages/config/config/devices/0x0165/asp-3-1.json
@@ -16,7 +16,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"1": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"2": {
 			"label": "Power Failure",

--- a/packages/config/config/devices/0x016a/ft100.json
+++ b/packages/config/config/devices/0x016a/ft100.json
@@ -35,7 +35,7 @@
 	//Fantem is an OEM for Aeotec
 	"paramInformation": {
 		"2": {
-			"$import": "../0x0086/templates/aeotec_template.json#wake_up_10_minutes"
+			"$import": "~/0x0086/templates/aeotec_template.json#wake_up_10_minutes"
 		},
 		"3": {
 			"label": "PIR Sensor Timeout",
@@ -53,24 +53,24 @@
 			"unsigned": true
 		},
 		"5": {
-			"$import": "../0x0086/templates/aeotec_template.json#motion_report_type"
+			"$import": "~/0x0086/templates/aeotec_template.json#motion_report_type"
 		},
 		"8": {
 			"$if": "firmwareVersion >= 1.8",
-			"$import": "../0x0086/templates/aeotec_template.json#wake_up_timeout"
+			"$import": "~/0x0086/templates/aeotec_template.json#wake_up_timeout"
 		},
 		"9[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#sleep_state"
+			"$import": "~/0x0086/templates/aeotec_template.json#sleep_state"
 		},
 		"9[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#current_power_mode"
+			"$import": "~/0x0086/templates/aeotec_template.json#current_power_mode"
 		},
 		"39": {
-			"$import": "../0x0086/templates/aeotec_template.json#low_battery_threshold",
+			"$import": "~/0x0086/templates/aeotec_template.json#low_battery_threshold",
 			"defaultValue": 20
 		},
 		"40": {
-			"$import": "../0x0086/templates/aeotec_template.json#selective_reporting"
+			"$import": "~/0x0086/templates/aeotec_template.json#selective_reporting"
 		},
 		"41[0xffff]": {
 			"$if": "firmwareVersion <= 1.6",
@@ -83,13 +83,13 @@
 		"41[0x0f]": [
 			{
 				"$if": "firmwareVersion > 1.6 && firmwareVersion <= 1.9",
-				"$import": "../0x0086/templates/aeotec_template.json#celsius_fahrenheit",
+				"$import": "~/0x0086/templates/aeotec_template.json#celsius_fahrenheit",
 				"label": "Temperature Threshold Unit",
 				"valueSize": 3
 			},
 			{
 				"$if": "firmwareVersion >= 1.10",
-				"$import": "../0x0086/templates/aeotec_template.json#celsius_fahrenheit",
+				"$import": "~/0x0086/templates/aeotec_template.json#celsius_fahrenheit",
 				"label": "Temperature Threshold Unit",
 				"valueSize": 4
 			}
@@ -115,7 +115,7 @@
 			}
 		],
 		"42": {
-			"$import": "../templates/master_template.json#base_1-100_nounit",
+			"$import": "~/templates/master_template.json#base_1-100_nounit",
 			"label": "Humidity Change Threshold",
 			"unit": "%",
 			"defaultValue": 10
@@ -129,7 +129,7 @@
 			"defaultValue": 100
 		},
 		"44": {
-			"$import": "../templates/master_template.json#base_1-100_nounit",
+			"$import": "~/templates/master_template.json#base_1-100_nounit",
 			"label": "Battery Level Threshold",
 			"unit": "%",
 			"defaultValue": 10
@@ -142,42 +142,42 @@
 			"defaultValue": 2
 		},
 		"46": {
-			"$import": "../0x0086/templates/aeotec_template.json#low_temp_alarm"
+			"$import": "~/0x0086/templates/aeotec_template.json#low_temp_alarm"
 		},
 		"48[0x01]": {
-			"$import": "../0x0086/templates/aeotec_template.json#below_temp_report"
+			"$import": "~/0x0086/templates/aeotec_template.json#below_temp_report"
 		},
 		"48[0x02]": {
-			"$import": "../0x0086/templates/aeotec_template.json#below_humidity_report"
+			"$import": "~/0x0086/templates/aeotec_template.json#below_humidity_report"
 		},
 		"48[0x04]": {
-			"$import": "../0x0086/templates/aeotec_template.json#below_luminance_report"
+			"$import": "~/0x0086/templates/aeotec_template.json#below_luminance_report"
 		},
 		"48[0x08]": {
-			"$import": "../0x0086/templates/aeotec_template.json#below_ultraviolet_report"
+			"$import": "~/0x0086/templates/aeotec_template.json#below_ultraviolet_report"
 		},
 		"48[0x10]": {
-			"$import": "../0x0086/templates/aeotec_template.json#above_temp_report"
+			"$import": "~/0x0086/templates/aeotec_template.json#above_temp_report"
 		},
 		"48[0x20]": {
-			"$import": "../0x0086/templates/aeotec_template.json#above_humidity_report"
+			"$import": "~/0x0086/templates/aeotec_template.json#above_humidity_report"
 		},
 		"48[0x40]": {
-			"$import": "../0x0086/templates/aeotec_template.json#above_luminance_report"
+			"$import": "~/0x0086/templates/aeotec_template.json#above_luminance_report"
 		},
 		"48[0x80]": {
-			"$import": "../0x0086/templates/aeotec_template.json#above_ultraviolet_report"
+			"$import": "~/0x0086/templates/aeotec_template.json#above_ultraviolet_report"
 		},
 		"49[0xff]": [
 			{
 				"$if": "firmwareVersion < 1.10",
-				"$import": "../0x0086/templates/aeotec_template.json#celsius_fahrenheit",
+				"$import": "~/0x0086/templates/aeotec_template.json#celsius_fahrenheit",
 				"label": "Upper Temperature Limit Unit",
 				"valueSize": 3
 			},
 			{
 				"$if": "firmwareVersion >= 1.10",
-				"$import": "../0x0086/templates/aeotec_template.json#celsius_fahrenheit",
+				"$import": "~/0x0086/templates/aeotec_template.json#celsius_fahrenheit",
 				"label": "Upper Temperature Limit Unit",
 				"valueSize": 4
 			}
@@ -205,13 +205,13 @@
 		"50[0xff]": [
 			{
 				"$if": "firmwareVersion < 1.10",
-				"$import": "../0x0086/templates/aeotec_template.json#celsius_fahrenheit",
+				"$import": "~/0x0086/templates/aeotec_template.json#celsius_fahrenheit",
 				"label": "Lower Temperature Limit Unit",
 				"valueSize": 3
 			},
 			{
 				"$if": "firmwareVersion >= 1.10",
-				"$import": "../0x0086/templates/aeotec_template.json#celsius_fahrenheit",
+				"$import": "~/0x0086/templates/aeotec_template.json#celsius_fahrenheit",
 				"label": "Lower Temperature Limit Unit",
 				"valueSize": 3
 			}
@@ -237,13 +237,13 @@
 			}
 		],
 		"51": {
-			"$import": "../templates/master_template.json#base_0-100_nounit",
+			"$import": "~/templates/master_template.json#base_0-100_nounit",
 			"label": "Upper Humidity Limit",
 			"unit": "%",
 			"defaultValue": 60
 		},
 		"52": {
-			"$import": "../templates/master_template.json#base_0-100_nounit",
+			"$import": "~/templates/master_template.json#base_0-100_nounit",
 			"label": "Lower Humidity Limit",
 			"unit": "%",
 			"defaultValue": 50
@@ -283,138 +283,138 @@
 			"unsigned": true
 		},
 		"57[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#recover_limit_temp"
+			"$import": "~/0x0086/templates/aeotec_template.json#recover_limit_temp"
 		},
 		"57[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#recover_limit_temp_unit"
+			"$import": "~/0x0086/templates/aeotec_template.json#recover_limit_temp_unit"
 		},
 		"58": {
-			"$import": "../0x0086/templates/aeotec_template.json#recover_limit_humidity"
+			"$import": "~/0x0086/templates/aeotec_template.json#recover_limit_humidity"
 		},
 		"59": {
-			"$import": "../0x0086/templates/aeotec_template.json#recover_limit_lighting"
+			"$import": "~/0x0086/templates/aeotec_template.json#recover_limit_lighting"
 		},
 		"60": {
-			"$import": "../0x0086/templates/aeotec_template.json#recover_limit_ultraviolet"
+			"$import": "~/0x0086/templates/aeotec_template.json#recover_limit_ultraviolet"
 		},
 		"61[0x01]": {
-			"$import": "../templates/master_template.json#base_true_false",
+			"$import": "~/templates/master_template.json#base_true_false",
 			"label": "Temperature: Below Lower Limit",
 			"readOnly": true
 		},
 		"61[0x10]": {
-			"$import": "../templates/master_template.json#base_true_false",
+			"$import": "~/templates/master_template.json#base_true_false",
 			"label": "Temperature: Above Lower Limit",
 			"readOnly": true
 		},
 		"61[0x02]": {
-			"$import": "../templates/master_template.json#base_true_false",
+			"$import": "~/templates/master_template.json#base_true_false",
 			"label": "Humidity: Below Lower Limit",
 			"readOnly": true
 		},
 		"61[0x20]": {
-			"$import": "../templates/master_template.json#base_true_false",
+			"$import": "~/templates/master_template.json#base_true_false",
 			"label": "Humidity: Above Lower Limit",
 			"readOnly": true
 		},
 		"61[0x04]": {
-			"$import": "../templates/master_template.json#base_true_false",
+			"$import": "~/templates/master_template.json#base_true_false",
 			"label": "Luminance: Below Lower Limit",
 			"readOnly": true
 		},
 		"61[0x40]": {
-			"$import": "../templates/master_template.json#base_true_false",
+			"$import": "~/templates/master_template.json#base_true_false",
 			"label": "Luminance: Above Lower Limit",
 			"readOnly": true
 		},
 		"61[0x08]": {
-			"$import": "../templates/master_template.json#base_true_false",
+			"$import": "~/templates/master_template.json#base_true_false",
 			"label": "Ultraviolet: Below Lower Limit",
 			"readOnly": true
 		},
 		"61[0x80]": {
-			"$import": "../templates/master_template.json#base_true_false",
+			"$import": "~/templates/master_template.json#base_true_false",
 			"label": "Ultraviolet: Above Lower Limit",
 			"readOnly": true
 		},
 		"81": {
 			"$if": "firmwareVersion >= 1.8",
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "LED Blinking"
 		},
 		"101[0x01]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group1_battery"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group1_battery"
 		},
 		"101[0x10]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group1_ultraviolet"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group1_ultraviolet"
 		},
 		"101[0x20]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group1_temp"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group1_temp"
 		},
 		"101[0x40]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group1_humidity"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group1_humidity"
 		},
 		"101[0x80]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group1_luminance"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group1_luminance"
 		},
 		"102[0x01]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group2_battery"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group2_battery"
 		},
 		"102[0x10]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group2_ultraviolet"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group2_ultraviolet"
 		},
 		"102[0x20]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group2_temp"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group2_temp"
 		},
 		"102[0x40]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group2_humidity"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group2_humidity"
 		},
 		"102[0x80]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group2_luminance"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group2_luminance"
 		},
 		"103[0x01]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group3_battery"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group3_battery"
 		},
 		"103[0x10]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group3_ultraviolet"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group3_ultraviolet"
 		},
 		"103[0x20]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group3_temp"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group3_temp"
 		},
 		"103[0x40]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group3_humidity"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group3_humidity"
 		},
 		"103[0x80]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group3_luminance"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group3_luminance"
 		},
 		"64": {
-			"$import": "../0x0086/templates/aeotec_template.json#celsius_fahrenheit",
+			"$import": "~/0x0086/templates/aeotec_template.json#celsius_fahrenheit",
 			"label": "Automatic Temperature Reporting Unit",
 			"valueSize": 1
 		},
 		"100": {
-			"$import": "../0x0086/templates/aeotec_template.json#reset_parameters",
+			"$import": "~/0x0086/templates/aeotec_template.json#reset_parameters",
 			"label": "Reset Parameters 101-103 to Default Values"
 		},
 		"111": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_interval_group1",
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_interval_group1",
 			"maxValue": 2678400
 		},
 		"112": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_interval_group2",
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_interval_group2",
 			"maxValue": 2678400
 		},
 		"113": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_interval_group3",
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_interval_group3",
 			"maxValue": 2678400
 		},
 		"110": {
-			"$import": "../0x0086/templates/aeotec_template.json#reset_parameters",
+			"$import": "~/0x0086/templates/aeotec_template.json#reset_parameters",
 			"label": "Reset Parameters 111-113 to Default Values"
 		},
 		"201[0xff]": {
 			"$if": "firmwareVersion >= 1.6",
-			"$import": "../0x0086/templates/aeotec_template.json#celsius_fahrenheit",
+			"$import": "~/0x0086/templates/aeotec_template.json#celsius_fahrenheit",
 			"label": "Temperature Calibration Unit",
 			"valueSize": 2
 		},
@@ -454,10 +454,10 @@
 			"defaultValue": 0
 		},
 		"252": {
-			"$import": "../0x0086/templates/aeotec_template.json#lock_configuration"
+			"$import": "~/0x0086/templates/aeotec_template.json#lock_configuration"
 		},
 		"255": {
-			"$import": "../0x0086/templates/aeotec_template.json#factory_reset_exclude"
+			"$import": "~/0x0086/templates/aeotec_template.json#factory_reset_exclude"
 		}
 	},
 	"compat": {

--- a/packages/config/config/devices/0x016a/ft111.json
+++ b/packages/config/config/devices/0x016a/ft111.json
@@ -44,293 +44,293 @@
 	//Fantem is an OEM for aeotec
 	"paramInformation": {
 		"3": {
-			"$import": "../0x0086/templates/aeotec_template.json#current_overload"
+			"$import": "~/0x0086/templates/aeotec_template.json#current_overload"
 		},
 		"4": {
-			"$import": "../0x0086/templates/aeotec_template.json#overheat_protection"
+			"$import": "~/0x0086/templates/aeotec_template.json#overheat_protection"
 		},
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"80": {
-			"$import": "../0x0086/templates/aeotec_template.json#enable_notifications_0-4"
+			"$import": "~/0x0086/templates/aeotec_template.json#enable_notifications_0-4"
 		},
 		"81": {
-			"$import": "../0x0086/templates/aeotec_template.json#notification_report_type",
+			"$import": "~/0x0086/templates/aeotec_template.json#notification_report_type",
 			"label": "Send Notifications to Associated Devices (Group 3)"
 		},
 		"82": {
-			"$import": "../0x0086/templates/aeotec_template.json#notification_report_type",
+			"$import": "~/0x0086/templates/aeotec_template.json#notification_report_type",
 			"label": "Send Notifications to Associated Devices (Group 4)"
 		},
 		"83": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#led_indicator_three_options"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_three_options"
 		},
 		"84[0xff000000]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#night_light_hour_on"
+			"$import": "~/0x0086/templates/aeotec_template.json#night_light_hour_on"
 		},
 		"84[0xff0000]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#night_light_minute_on"
+			"$import": "~/0x0086/templates/aeotec_template.json#night_light_minute_on"
 		},
 		"84[0xff00]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#night_light_hour_off"
+			"$import": "~/0x0086/templates/aeotec_template.json#night_light_hour_off"
 		},
 		"84[0xff]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#night_light_minute_off"
+			"$import": "~/0x0086/templates/aeotec_template.json#night_light_minute_off"
 		},
 		"85[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#appointment_one_day"
+			"$import": "~/0x0086/templates/aeotec_template.json#appointment_one_day"
 		},
 		"85[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#appointment_one_hour"
+			"$import": "~/0x0086/templates/aeotec_template.json#appointment_one_hour"
 		},
 		"85[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#appointment_one_minute"
+			"$import": "~/0x0086/templates/aeotec_template.json#appointment_one_minute"
 		},
 		"85[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#appointment_one_brightness"
+			"$import": "~/0x0086/templates/aeotec_template.json#appointment_one_brightness"
 		},
 		"86[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#appointment_two_day"
+			"$import": "~/0x0086/templates/aeotec_template.json#appointment_two_day"
 		},
 		"86[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#appointment_two_hour"
+			"$import": "~/0x0086/templates/aeotec_template.json#appointment_two_hour"
 		},
 		"86[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#appointment_two_minute"
+			"$import": "~/0x0086/templates/aeotec_template.json#appointment_two_minute"
 		},
 		"86[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#appointment_two_brightness"
+			"$import": "~/0x0086/templates/aeotec_template.json#appointment_two_brightness"
 		},
 		"90": {
-			"$import": "../0x0086/templates/aeotec_template.json#send_automatic_reports"
+			"$import": "~/0x0086/templates/aeotec_template.json#send_automatic_reports"
 		},
 		"91": {
-			"$import": "../0x0086/templates/aeotec_template.json#wattage_trigger",
+			"$import": "~/0x0086/templates/aeotec_template.json#wattage_trigger",
 			"defaultValue": 25
 		},
 		"92": {
-			"$import": "../0x0086/templates/aeotec_template.json#wattage_percent_trigger",
+			"$import": "~/0x0086/templates/aeotec_template.json#wattage_percent_trigger",
 			"defaultValue": 5
 		},
 		"100": {
-			"$import": "../0x0086/templates/aeotec_template.json#reset_parameters",
+			"$import": "~/0x0086/templates/aeotec_template.json#reset_parameters",
 			"label": "Reset Parameters 101-103 to Default Values"
 		},
 		"101[0x01]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group1_v"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group1_v"
 		},
 		"101[0x02]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group1_amp"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group1_amp"
 		},
 		"101[0x04]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group1_watt"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group1_watt"
 		},
 		"101[0x08]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group1_kwh"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group1_kwh"
 		},
 		"102[0x01]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group2_v"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group2_v"
 		},
 		"102[0x02]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group2_amp"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group2_amp"
 		},
 		"102[0x04]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group2_watt"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group2_watt"
 		},
 		"102[0x08]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group2_kwh"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group2_kwh"
 		},
 		"103[0x01]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group3_v"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group3_v"
 		},
 		"103[0x02]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group3_amp"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group3_amp"
 		},
 		"103[0x04]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group3_watt"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group3_watt"
 		},
 		"103[0x08]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_group3_kwh"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_group3_kwh"
 		},
 		"110": {
-			"$import": "../0x0086/templates/aeotec_template.json#reset_parameters",
+			"$import": "~/0x0086/templates/aeotec_template.json#reset_parameters",
 			"label": "Reset Parameters 111-113 to Default Values"
 		},
 		"111": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_interval_group1",
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_interval_group1",
 			"maxValue": 2147483647
 		},
 		"112": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_interval_group2",
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_interval_group2",
 			"maxValue": 2147483647
 		},
 		"113": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_interval_group3",
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_interval_group3",
 			"maxValue": 2147483647
 		},
 		"120": {
-			"$import": "../0x0086/templates/aeotec_template.json#external_switch_3way_auto",
+			"$import": "~/0x0086/templates/aeotec_template.json#external_switch_3way_auto",
 			"label": "External Switch Type: S1"
 		},
 		"247[0x01]": {
-			"$import": "../0x0086/templates/aeotec_template.json#switch_mode_state_s1"
+			"$import": "~/0x0086/templates/aeotec_template.json#switch_mode_state_s1"
 		},
 		"121": {
-			"$import": "../0x0086/templates/aeotec_template.json#external_switch_3way_auto",
+			"$import": "~/0x0086/templates/aeotec_template.json#external_switch_3way_auto",
 			"label": "External Switch Type: S2"
 		},
 		"247[0x02]": {
-			"$import": "../0x0086/templates/aeotec_template.json#switch_mode_state_s2"
+			"$import": "~/0x0086/templates/aeotec_template.json#switch_mode_state_s2"
 		},
 		"123": {
-			"$import": "../0x0086/templates/aeotec_template.json#switch_destination_s1"
+			"$import": "~/0x0086/templates/aeotec_template.json#switch_destination_s1"
 		},
 		"124": {
-			"$import": "../0x0086/templates/aeotec_template.json#switch_destination_s2"
+			"$import": "~/0x0086/templates/aeotec_template.json#switch_destination_s2"
 		},
 		"125": {
-			"$import": "../0x0086/templates/aeotec_template.json#dimming_rate_255"
+			"$import": "~/0x0086/templates/aeotec_template.json#dimming_rate_255"
 		},
 		"128": {
-			"$import": "../0x0086/templates/aeotec_template.json#current_working_mode"
+			"$import": "~/0x0086/templates/aeotec_template.json#current_working_mode"
 		},
 		"129": {
-			"$import": "../0x0086/templates/aeotec_template.json#dimming_principle"
+			"$import": "~/0x0086/templates/aeotec_template.json#dimming_principle"
 		},
 		"130": {
-			"$import": "../0x0086/templates/aeotec_template.json#load_type"
+			"$import": "~/0x0086/templates/aeotec_template.json#load_type"
 		},
 		"131": {
-			"$import": "../0x0086/templates/aeotec_template.json#min_brightness"
+			"$import": "~/0x0086/templates/aeotec_template.json#min_brightness"
 		},
 		"132": {
-			"$import": "../0x0086/templates/aeotec_template.json#max_brightness"
+			"$import": "~/0x0086/templates/aeotec_template.json#max_brightness"
 		},
 		"249": {
-			"$import": "../0x0086/templates/aeotec_template.json#load_recognition_method"
+			"$import": "~/0x0086/templates/aeotec_template.json#load_recognition_method"
 		},
 		// WallSwipe Settings
 		"144": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#wallswipe_status"
+			"$import": "~/0x0086/templates/aeotec_template.json#wallswipe_status"
 		},
 		"21[0xff]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#scene_control"
+			"$import": "~/0x0086/templates/aeotec_template.json#scene_control"
 		},
 		"21[0xff00]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#scene_control_left_right_wave"
+			"$import": "~/0x0086/templates/aeotec_template.json#scene_control_left_right_wave"
 		},
 		"21[0xff0000]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#wave_option"
+			"$import": "~/0x0086/templates/aeotec_template.json#wave_option"
 		},
 		"21[0xff000000]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#enable_disable_ir_sensor"
+			"$import": "~/0x0086/templates/aeotec_template.json#enable_disable_ir_sensor"
 		},
 		"64[0xff]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_brightness"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_brightness"
 		},
 		"64[0xff00]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_red"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_red"
 		},
 		"64[0xff0000]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_green"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_green"
 		},
 		"64[0xff000000]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_blue"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_blue"
 		},
 		"65[0xff]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_up_brightness"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_up_brightness"
 		},
 		"65[0xff00]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_up_red"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_up_red"
 		},
 		"65[0xff0000]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_up_green"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_up_green"
 		},
 		"65[0xff000000]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_up_blue"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_up_blue"
 		},
 		"66[0xff]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_down_brightness"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_down_brightness"
 		},
 		"66[0xff00]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_down_red"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_down_red"
 		},
 		"66[0xff0000]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_down_green"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_down_green"
 		},
 		"66[0xff000000]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_down_blue"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_down_blue"
 		},
 		"67[0xff]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_left_brightness"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_left_brightness"
 		},
 		"67[0xff00]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_left_red"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_left_red"
 		},
 		"67[0xff0000]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_left_green"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_left_green"
 		},
 		"67[0xff000000]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_left_blue"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_left_blue"
 		},
 		"68[0xff]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_right_brightness"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_right_brightness"
 		},
 		"68[0xff00]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_right_red"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_right_red"
 		},
 		"68[0xff0000]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_right_green"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_right_green"
 		},
 		"68[0xff000000]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_right_blue"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_right_blue"
 		},
 		"69[0xff]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_night_brightness"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_night_brightness"
 		},
 		"69[0xff00]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_night_red"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_night_red"
 		},
 		"69[0xff0000]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_night_green"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_night_green"
 		},
 		"69[0xff000000]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#button_color_night_blue"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_color_night_blue"
 		},
 		"70": {
 			"$if": "firmwareVersion >= 2.0",
@@ -354,38 +354,38 @@
 		},
 		"71": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#wallswipe_recalibrate"
+			"$import": "~/0x0086/templates/aeotec_template.json#wallswipe_recalibrate"
 		},
 		"251": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../0x0086/templates/aeotec_template.json#wallswipe_reset"
+			"$import": "~/0x0086/templates/aeotec_template.json#wallswipe_reset"
 		},
 		// End of WallSwipe Settings
 		"248[0x80]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Advanced Parameter Settings"
 		},
 		"248[0x01]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Advanced: Send NIFs"
 		},
 		"248[0x02]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Advanced: RF Power Level Test Mode"
 		},
 		"248[0x04]": {
 			"$if": "firmwareVersion >= 2.0",
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Advanced: Factory Reset Function"
 		},
 		"252": {
-			"$import": "../0x0086/templates/aeotec_template.json#lock_configuration"
+			"$import": "~/0x0086/templates/aeotec_template.json#lock_configuration"
 		},
 		"255": {
-			"$import": "../0x0086/templates/aeotec_template.json#factory_reset_exclude"
+			"$import": "~/0x0086/templates/aeotec_template.json#factory_reset_exclude"
 		}
 	},
 	"compat": {

--- a/packages/config/config/devices/0x016a/ft112.json
+++ b/packages/config/config/devices/0x016a/ft112.json
@@ -37,27 +37,27 @@
 	// Fantem is an OEM for Aeotec
 	"paramInformation": {
 		"1": {
-			"$import": "../0x0086/templates/aeotec_template.json#invert_state_report"
+			"$import": "~/0x0086/templates/aeotec_template.json#invert_state_report"
 		},
 		"39": {
-			"$import": "../0x0086/templates/aeotec_template.json#low_battery_threshold",
+			"$import": "~/0x0086/templates/aeotec_template.json#low_battery_threshold",
 			"defaultValue": 20
 		},
 		"101": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Enable/Disable The Function of Parameter 111"
 		},
 		"111": {
-			"$import": "../0x0086/templates/aeotec_template.json#low_battery_interval"
+			"$import": "~/0x0086/templates/aeotec_template.json#low_battery_interval"
 		},
 		"121": {
-			"$import": "../0x0086/templates/aeotec_template.json#binary_report_type"
+			"$import": "~/0x0086/templates/aeotec_template.json#binary_report_type"
 		},
 		"252": {
-			"$import": "../0x0086/templates/aeotec_template.json#lock_configuration"
+			"$import": "~/0x0086/templates/aeotec_template.json#lock_configuration"
 		},
 		"255": {
-			"$import": "../0x0086/templates/aeotec_template.json#factory_reset_exclude"
+			"$import": "~/0x0086/templates/aeotec_template.json#factory_reset_exclude"
 		}
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x0175/mt2759.json
+++ b/packages/config/config/devices/0x0175/mt2759.json
@@ -146,7 +146,7 @@
 			]
 		},
 		"30": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power reporting (W) on power change",

--- a/packages/config/config/devices/0x0175/mt2760.json
+++ b/packages/config/config/devices/0x0175/mt2760.json
@@ -238,7 +238,7 @@
 			]
 		},
 		"30": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off"
 		},
 		"40": {
 			"label": "Power reporting in watts on power change",

--- a/packages/config/config/devices/0x0176/tzwp-100.json
+++ b/packages/config/config/devices/0x0176/tzwp-100.json
@@ -29,7 +29,7 @@
 			"unsigned": true
 		},
 		"2": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev_on"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev_on"
 		},
 		"3": {
 			"label": "LED indicator",

--- a/packages/config/config/devices/0x0176/tzwp-102.json
+++ b/packages/config/config/devices/0x0176/tzwp-102.json
@@ -35,7 +35,7 @@
 			]
 		},
 		"2": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"3": {
 			"label": "Send Status When Load Changes",

--- a/packages/config/config/devices/0x0208/hkzw-so01.json
+++ b/packages/config/config/devices/0x0208/hkzw-so01.json
@@ -24,7 +24,7 @@
 			"defaultValue": 1
 		},
 		"21": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"24": {
 			"label": "Notification on Load Change",

--- a/packages/config/config/devices/0x0208/hkzw-so05.json
+++ b/packages/config/config/devices/0x0208/hkzw-so05.json
@@ -36,7 +36,7 @@
 			]
 		},
 		"21": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"24": {
 			"label": "Load Status Change Notification",

--- a/packages/config/config/devices/0x0208/hkzw_so03.json
+++ b/packages/config/config/devices/0x0208/hkzw_so03.json
@@ -35,7 +35,7 @@
 			]
 		},
 		"21": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"24": {
 			"label": "On/Off Status Change Notifications",

--- a/packages/config/config/devices/0x0234/templates/logic_group_template.json
+++ b/packages/config/config/devices/0x0234/templates/logic_group_template.json
@@ -1,28 +1,28 @@
 {
 	"enable_central_scene": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Central Scene",
 		"defaultValue": 1
 	},
 	"multilevel_enable": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"valueSize": 4,
 		"defaultValue": 1
 	},
 	"multilevel_upper_function": {
-		"$import": "../../templates/master_template.json#base_0-99_nounit",
+		"$import": "~/templates/master_template.json#base_0-99_nounit",
 		"label": "Upper Switch Value",
 		"valueSize": 4,
 		"defaultValue": 255
 	},
 	"multilevel_lower_function": {
-		"$import": "../../templates/master_template.json#base_0-99_nounit",
+		"$import": "~/templates/master_template.json#base_0-99_nounit",
 		"label": "Lower Switch Value",
 		"valueSize": 4,
 		"defaultValue": 0
 	},
 	"multilevel_duration_function": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "Duration",
 		"description": "Values 1-127 = seconds; 128-255 = minutes (minus 127)",
 		"valueSize": 4
@@ -94,7 +94,7 @@
 		]
 	},
 	"global_brightness": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "LED Indicator Brightness",
 		"valueSize": 4,
 		"defaultValue": 255
@@ -123,13 +123,13 @@
 		]
 	},
 	"dimming_duration": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "Duration of Dimming",
 		"unit": "seconds",
 		"defaultValue": 5
 	},
 	"duration_on_off": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "Duration of On/Off",
 		"defaultValue": 0
 	},
@@ -157,29 +157,29 @@
 		]
 	},
 	"dimmer_min": {
-		"$import": "../../templates/master_template.json#base_0-99_nounit",
+		"$import": "~/templates/master_template.json#base_0-99_nounit",
 		"label": "Dimmer: Minimum Level",
 		"defaultValue": 0
 	},
 	"dimmer_max": {
-		"$import": "../../templates/master_template.json#base_0-99_nounit",
+		"$import": "~/templates/master_template.json#base_0-99_nounit",
 		"label": "Dimmer: Maximum Level",
 		"defaultValue": 99
 	},
 	"dimmer_metering": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "Meter Report Time",
 		"defaultValue": 60
 	},
 	"led_indicator": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "Button LED Indicator",
 		"unsigned": true,
 		"valueSize": 4,
 		"defaultValue": 0
 	},
 	"button_led_indicator": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "Button LED Indicator",
 		"maxValue": 7,
 		"defaultValue": 7,
@@ -265,7 +265,7 @@
 		]
 	},
 	"input_funtion_relay": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "Input - Function",
 		"maxValue": 3,
 		"defaultValue": 3,
@@ -290,7 +290,7 @@
 		]
 	},
 	"output_function_relay": {
-		"$import": "../../templates/master_template.json#base_enable_disable",
+		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Output - Function",
 		"options": [
 			{
@@ -304,7 +304,7 @@
 		]
 	},
 	"status_led": {
-		"$import": "../../templates/master_template.json#led_indicator_four_options",
+		"$import": "~/templates/master_template.json#led_indicator_four_options",
 		"label": "Status of LED",
 		"defaultValue": 1,
 		"options": [
@@ -419,12 +419,12 @@
 		"unsigned": true
 	},
 	"led_brightness": {
-		"$import": "../../templates/master_template.json#base_0-99_nounit",
+		"$import": "~/templates/master_template.json#base_0-99_nounit",
 		"label": "Brightness of Status LED",
 		"defaultValue": 50
 	},
 	"input_calibration": {
-		"$import": "../../templates/master_template.json#base_0-99_nounit",
+		"$import": "~/templates/master_template.json#base_0-99_nounit",
 		"label": "Input: Calibration",
 		"unit": "0.1 °C",
 		"minValue": -40,
@@ -476,14 +476,14 @@
 		]
 	},
 	"button_debounce": {
-		"$import": "../../templates/master_template.json#base_1-255_nounit",
+		"$import": "~/templates/master_template.json#base_1-255_nounit",
 		"label": "Button Debounce Timer",
 		"unit": "10 ms",
 		"valueSize": 1,
 		"defaultValue": 5
 	},
 	"input_timer": {
-		"$import": "../../templates/master_template.json#base_0-255_nounit",
+		"$import": "~/templates/master_template.json#base_0-255_nounit",
 		"label": "Input: Timer",
 		"defaultValue": 0
 	},

--- a/packages/config/config/devices/0x0234/zba7140.json
+++ b/packages/config/config/devices/0x0234/zba7140.json
@@ -66,55 +66,55 @@
 			"$import": "templates/logic_group_template.json#led_indicator_zba7140"
 		},
 		"5[0xff000000]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Indicator: Red Value",
 			"valueSize": 4,
 			"defaultValue": 127
 		},
 		"5[0xff0000]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Indicator: Green Value",
 			"valueSize": 4,
 			"defaultValue": 85
 		},
 		"5[0xff00]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Indicator: Blue Value",
 			"valueSize": 4,
 			"defaultValue": 85
 		},
 		"6[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 2 Messages Securely",
 			"valueSize": 2
 		},
 		"6[0x02]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 3 Messages Securely",
 			"valueSize": 2
 		},
 		"6[0x04]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 4 Messages Securely",
 			"valueSize": 2
 		},
 		"6[0x08]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 5 Messages Securely",
 			"valueSize": 2
 		},
 		"6[0x10]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 6 Messages Securely",
 			"valueSize": 2
 		},
 		"6[0x20]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 7 Messages Securely",
 			"valueSize": 2
 		},
 		"6[0x40]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 8 Messages Securely",
 			"valueSize": 2
 		},

--- a/packages/config/config/devices/0x0234/zdb5100.json
+++ b/packages/config/config/devices/0x0234/zdb5100.json
@@ -163,19 +163,19 @@
 	},
 	"paramInformation": {
 		"1[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Button 1"
 		},
 		"1[0x02]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Button 2"
 		},
 		"1[0x04]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Button 3"
 		},
 		"1[0x08]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Button 4"
 		},
 		"2": {
@@ -197,12 +197,12 @@
 			"$import": "templates/logic_group_template.json#enable_central_scene"
 		},
 		"8": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Double Press",
 			"defaultValue": 1
 		},
 		"10": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Enhanced LED Control"
 		},
 		"11": {
@@ -211,13 +211,13 @@
 			"defaultValue": 5
 		},
 		"12": {
-			"$import": "../templates/master_template.json#base_1-255_nounit",
+			"$import": "~/templates/master_template.json#base_1-255_nounit",
 			"label": "Button Press Threshold Time",
 			"unit": "10 ms",
 			"defaultValue": 20
 		},
 		"13": {
-			"$import": "../templates/master_template.json#base_1-255_nounit",
+			"$import": "~/templates/master_template.json#base_1-255_nounit",
 			"label": "Button Held Threshold Time",
 			"unit": "10 ms",
 			"defaultValue": 50
@@ -235,67 +235,67 @@
 			"label": "LED Indicator Brightness: Blue"
 		},
 		"15[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 2 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x02]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 3 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x04]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 4 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x08]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 5 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x10]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 6 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x20]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 7 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x40]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 8 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x80]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 9 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x100]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 10 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x0200]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 11 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x0400]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 12 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x0800]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 13 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x1000]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 14 Messages Securely",
 			"valueSize": 2
 		},
@@ -304,7 +304,7 @@
 			"label": "Button 1 Functionality"
 		},
 		"17": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Button 1 - Timer",
 			"unit": "seconds",
 			"valueSize": 2,
@@ -349,7 +349,7 @@
 			"defaultValue": 127
 		},
 		"22[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 1 (On): Blinking",
 			"unit": "100 ms",
 			"valueSize": 4,
@@ -371,7 +371,7 @@
 			"defaultValue": 47
 		},
 		"23[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 1 (Off): Blinking",
 			"unit": "100 ms",
 			"valueSize": 4,
@@ -382,7 +382,7 @@
 			"label": "Button 2 Functionality"
 		},
 		"25": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Button 2 - Timer",
 			"unit": "seconds",
 			"valueSize": 2,
@@ -427,7 +427,7 @@
 			"defaultValue": 127
 		},
 		"30[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 2 (On): Blinking",
 			"unit": "100 ms",
 			"valueSize": 4,
@@ -449,7 +449,7 @@
 			"defaultValue": 47
 		},
 		"31[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 2 (Off) Blinking",
 			"unit": "100 ms",
 			"valueSize": 4,
@@ -460,7 +460,7 @@
 			"label": "Button 3 Functionality"
 		},
 		"33": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Button 3 - Timer",
 			"unit": "seconds",
 			"valueSize": 2,
@@ -505,7 +505,7 @@
 			"defaultValue": 127
 		},
 		"38[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 3 (On): Blinking",
 			"valueSize": 4,
 			"unit": "100 ms",
@@ -527,7 +527,7 @@
 			"defaultValue": 47
 		},
 		"39[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 3 (Off): Blinking",
 			"valueSize": 4,
 			"unit": "100 ms",
@@ -538,7 +538,7 @@
 			"label": "Button 4 Functionality"
 		},
 		"41": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Button 4 - Timer",
 			"valueSize": 2,
 			"unit": "seconds",
@@ -583,7 +583,7 @@
 			"defaultValue": 127
 		},
 		"46[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 4 (On): Blinking",
 			"unit": "100 ms",
 			"valueSize": 4
@@ -604,7 +604,7 @@
 			"defaultValue": 47
 		},
 		"47[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 4 (Off): Blinking",
 			"unit": "100 ms",
 			"valueSize": 4,

--- a/packages/config/config/devices/0x0234/zdb5400.json
+++ b/packages/config/config/devices/0x0234/zdb5400.json
@@ -75,19 +75,19 @@
 	},
 	"paramInformation": {
 		"1[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Button 1"
 		},
 		"1[0x02]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Button 2"
 		},
 		"1[0x04]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Button 3"
 		},
 		"1[0x08]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Button 4"
 		},
 		"2": {
@@ -109,12 +109,12 @@
 			"$import": "templates/logic_group_template.json#enable_central_scene"
 		},
 		"8": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Double Press",
 			"defaultValue": 1
 		},
 		"10": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Enhanced LED Control"
 		},
 		"11": {
@@ -123,13 +123,13 @@
 			"defaultValue": 5
 		},
 		"12": {
-			"$import": "../templates/master_template.json#base_1-255_nounit",
+			"$import": "~/templates/master_template.json#base_1-255_nounit",
 			"label": "Button Press Threshold Time",
 			"unit": "10 ms",
 			"defaultValue": 20
 		},
 		"13": {
-			"$import": "../templates/master_template.json#base_1-255_nounit",
+			"$import": "~/templates/master_template.json#base_1-255_nounit",
 			"label": "Button Held Threshold Time",
 			"unit": "10 ms",
 			"defaultValue": 50
@@ -147,67 +147,67 @@
 			"label": "LED Indicator Brightness: Blue"
 		},
 		"15[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 2 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x02]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 3 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x04]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 4 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x08]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 5 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x10]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 6 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x20]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 7 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x40]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 8 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x80]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 9 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x100]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 10 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x0200]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 11 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x0400]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 12 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x0800]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 13 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x1000]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 14 Messages Securely",
 			"valueSize": 2
 		},
@@ -216,7 +216,7 @@
 			"label": "Button 1 Functionality"
 		},
 		"17": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Button 1 - Timer",
 			"valueSize": 2,
 			"unit": "seconds",
@@ -261,7 +261,7 @@
 			"defaultValue": 127
 		},
 		"22[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 1 (On): Blinking",
 			"unit": "100 ms",
 			"valueSize": 4,
@@ -283,7 +283,7 @@
 			"defaultValue": 47
 		},
 		"23[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 1 (Off): Blinking",
 			"unit": "100 ms",
 			"valueSize": 4,
@@ -294,7 +294,7 @@
 			"label": "Button 2 Functionality"
 		},
 		"25": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Button 2 - Timer",
 			"unit": "seconds",
 			"valueSize": 2,
@@ -339,7 +339,7 @@
 			"defaultValue": 127
 		},
 		"30[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 2 (On): Blinking",
 			"unit": "100 ms",
 			"valueSize": 4,
@@ -361,7 +361,7 @@
 			"defaultValue": 47
 		},
 		"31[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 2 (Off) Blinking",
 			"unit": "100 ms",
 			"valueSize": 4,
@@ -372,7 +372,7 @@
 			"label": "Button 3 Functionality"
 		},
 		"33": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Button 3 - Timer",
 			"unit": "seconds",
 			"valueSize": 2,
@@ -417,7 +417,7 @@
 			"defaultValue": 127
 		},
 		"38[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 3 (On): Blinking",
 			"unit": "100 ms",
 			"valueSize": 4,
@@ -439,7 +439,7 @@
 			"defaultValue": 47
 		},
 		"39[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 3 (Off): Blinking",
 			"unit": "100 ms",
 			"valueSize": 4,
@@ -450,7 +450,7 @@
 			"label": "Button 4 Functionality"
 		},
 		"41": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Button 4 - Timer",
 			"unit": "seconds",
 			"valueSize": 2,
@@ -495,7 +495,7 @@
 			"defaultValue": 127
 		},
 		"46[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 4 (On): Blinking",
 			"unit": "100 ms",
 			"valueSize": 4
@@ -516,7 +516,7 @@
 			"defaultValue": 47
 		},
 		"47[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 4 (Off): Blinking",
 			"unit": "100 ms",
 			"valueSize": 4,

--- a/packages/config/config/devices/0x0234/zdi5200.json
+++ b/packages/config/config/devices/0x0234/zdi5200.json
@@ -38,7 +38,7 @@
 			"$import": "templates/logic_group_template.json#dimmer_max"
 		},
 		"5": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Meter Report Time",
 			"description": "Values 1-127 = seconds; 128-255 = minutes (minus 127)",
 			"defaultValue": 60

--- a/packages/config/config/devices/0x0234/zif5020_2.0.json
+++ b/packages/config/config/devices/0x0234/zif5020_2.0.json
@@ -108,85 +108,85 @@
 			"label": "Timer For Input 4"
 		},
 		"11": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Input Snubber-filter Time Constant.",
 			"unit": "50 ms",
 			"defaultValue": 5
 		},
 		"12": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Threshold Value For Activation Of Inputs.",
 			"unit": "200 ms",
 			"defaultValue": 20
 		},
 		"13": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Threshold For Input In Latched Mode.",
 			"unit": "50 ms",
 			"defaultValue": 50
 		},
 		"14": {
-			"$import": "../templates/master_template.json#base_enable_disable_inverted",
+			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
 			"label": "Central Scene",
 			"defaultValue": 0
 		},
 		"15[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Association Group 2 Secure Message",
 			"valueSize": 2
 		},
 		"15[0x02]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Association Group 3 Secure Message",
 			"valueSize": 2
 		},
 		"15[0x04]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Association Group 4 Secure Message",
 			"valueSize": 2
 		},
 		"15[0x08]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Association Group 5 Secure Message",
 			"valueSize": 2
 		},
 		"15[0x10]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Association Group 6 Secure Message",
 			"valueSize": 2
 		},
 		"15[0x20]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Association Group 7 Secure Message",
 			"valueSize": 2
 		},
 		"15[0x40]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Association Group 8 Secure Message",
 			"valueSize": 2
 		},
 		"15[0x80]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Association Group 9 Secure Message",
 			"valueSize": 2
 		},
 		"15[0x100]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Association Group 10 Secure Message",
 			"valueSize": 2
 		},
 		"15[0x0200]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Association Group 11 Secure Message",
 			"valueSize": 2
 		},
 		"15[0x0400]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Association Group 12 Secure Message",
 			"valueSize": 2
 		},
 		"15[0x0800]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Association Group 13 Secure Message",
 			"valueSize": 2
 		}

--- a/packages/config/config/devices/0x0234/zif5028.json
+++ b/packages/config/config/devices/0x0234/zif5028.json
@@ -144,30 +144,30 @@
 			"label": "Input 6 - Function"
 		},
 		"14": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Input 6 - Timer",
 			"defaultValue": 0
 		},
 		"15": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Input Snubber-filter Time Constant.",
 			"unit": "10 ms",
 			"defaultValue": 5
 		},
 		"16": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Threshold Value For Activation Of Inputs.",
 			"unit": "10 ms",
 			"defaultValue": 200
 		},
 		"17": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Threshold For Input In Latched Mode.",
 			"unit": "10 ms",
 			"defaultValue": 50
 		},
 		"18": {
-			"$import": "../templates/master_template.json#base_enable_disable_inverted",
+			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
 			"label": "Central Scene",
 			"defaultValue": 0
 		},

--- a/packages/config/config/devices/0x0234/zif5031_0.62.json
+++ b/packages/config/config/devices/0x0234/zif5031_0.62.json
@@ -44,19 +44,19 @@
 			"$import": "templates/logic_group_template.json#led_brightness"
 		},
 		"3": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Input 1 - Thermistor"
 		},
 		"4": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Input 2 - Thermistor"
 		},
 		"5": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Input 3 - Thermistor"
 		},
 		"6": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Input 4 - Thermistor"
 		},
 		"7": {

--- a/packages/config/config/devices/0x0234/zrb5120.json
+++ b/packages/config/config/devices/0x0234/zrb5120.json
@@ -78,47 +78,47 @@
 	},
 	"paramInformation": {
 		"1[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Button 1 Controls Relay 1"
 		},
 		"1[0x02]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Button 2 Controls Relay 1"
 		},
 		"1[0x04]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Button 3 Controls Relay 1"
 		},
 		"1[0x08]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Button 4 Controls Relay 1"
 		},
 		"2[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Button 1 Controls Relay 2"
 		},
 		"2[0x02]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Button 2 Controls Relay 2"
 		},
 		"2[0x04]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Button 3 Controls Relay 2"
 		},
 		"2[0x08]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Button 4 Controls Relay 2"
 		},
 		"7": {
 			"$import": "templates/logic_group_template.json#enable_central_scene"
 		},
 		"8": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Double Press",
 			"defaultValue": 1
 		},
 		"10": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Enhanced LED Control"
 		},
 		"11": {
@@ -127,13 +127,13 @@
 			"defaultValue": 5
 		},
 		"12": {
-			"$import": "../templates/master_template.json#base_1-255_nounit",
+			"$import": "~/templates/master_template.json#base_1-255_nounit",
 			"label": "Button Press Threshold Time",
 			"unit": "10 ms",
 			"defaultValue": 20
 		},
 		"13": {
-			"$import": "../templates/master_template.json#base_1-255_nounit",
+			"$import": "~/templates/master_template.json#base_1-255_nounit",
 			"label": "Button Held Threshold Time",
 			"unit": "10 ms",
 			"defaultValue": 50
@@ -151,67 +151,67 @@
 			"label": "LED Indicator Brightness: Blue"
 		},
 		"15[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 2 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x02]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 3 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x04]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 4 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x08]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 5 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x10]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 6 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x20]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 7 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x40]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 8 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x80]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 9 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x100]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 10 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x0200]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 11 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x0400]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 12 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x0800]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 13 Messages Securely",
 			"valueSize": 2
 		},
 		"15[0x1000]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 14 Messages Securely",
 			"valueSize": 2
 		},
@@ -220,7 +220,7 @@
 			"label": "Button 1 Functionality"
 		},
 		"17": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Button 1 - Timer",
 			"unit": "seconds",
 			"valueSize": 2,
@@ -265,7 +265,7 @@
 			"defaultValue": 127
 		},
 		"22[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 1 (On): Blinking",
 			"unit": "100 ms",
 			"valueSize": 4,
@@ -287,7 +287,7 @@
 			"defaultValue": 47
 		},
 		"23[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 1 (Off): Blinking",
 			"unit": "100 ms",
 			"valueSize": 4,
@@ -298,7 +298,7 @@
 			"label": "Button 2 Functionality"
 		},
 		"25": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Button 2 - Timer",
 			"unit": "seconds",
 			"valueSize": 2,
@@ -343,7 +343,7 @@
 			"defaultValue": 127
 		},
 		"30[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 2 (On): Blinking",
 			"unit": "100 ms",
 			"valueSize": 4,
@@ -365,7 +365,7 @@
 			"defaultValue": 47
 		},
 		"31[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 2 (Off) Blinking",
 			"unit": "100 ms",
 			"valueSize": 4,
@@ -376,7 +376,7 @@
 			"label": "Button 3 Functionality"
 		},
 		"33": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Button 3 - Timer",
 			"unit": "seconds",
 			"valueSize": 2,
@@ -421,7 +421,7 @@
 			"defaultValue": 127
 		},
 		"38[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 3 (On): Blinking",
 			"unit": "100 ms",
 			"valueSize": 4,
@@ -443,7 +443,7 @@
 			"defaultValue": 47
 		},
 		"39[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 3 (Off): Blinking",
 			"unit": "100 ms",
 			"valueSize": 4,
@@ -454,7 +454,7 @@
 			"label": "Button 4 Functionality"
 		},
 		"41": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Button 4 - Timer",
 			"unit": "seconds",
 			"valueSize": 2,
@@ -499,7 +499,7 @@
 			"defaultValue": 127
 		},
 		"46[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 4 (On): Blinking",
 			"unit": "100 ms",
 			"valueSize": 4
@@ -520,7 +520,7 @@
 			"defaultValue": 47
 		},
 		"47[0xff]": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "LED Time For Button 4 (Off): Blinking",
 			"unit": "100 ms",
 			"valueSize": 4,

--- a/packages/config/config/devices/0x0234/zso7300.json
+++ b/packages/config/config/devices/0x0234/zso7300.json
@@ -30,13 +30,13 @@
 	},
 	"paramInformation": {
 		"1": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Meter Report Time",
 			"description": "Values 1-127 = seconds; 128-255 = minutes (minus 127)",
 			"defaultValue": 60
 		},
 		"2": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Button 2 Controls Relay 1"
 		},
 		"3": {
@@ -85,18 +85,18 @@
 			"defaultValue": 255
 		},
 		"8": {
-			"$import": "../templates/master_template.json#base_0-100_nounit",
+			"$import": "~/templates/master_template.json#base_0-100_nounit",
 			"label": "LED Brightness",
 			"unit": "%",
 			"defaultValue": 10
 		},
 		"9[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 2 Messages Securely",
 			"valueSize": 2
 		},
 		"9[0x02]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Association Group 3 Messages Securely",
 			"valueSize": 2
 		}

--- a/packages/config/config/devices/0x024e/WIN-GDC-02.json
+++ b/packages/config/config/devices/0x024e/WIN-GDC-02.json
@@ -95,7 +95,7 @@
 			"description": "Relay 1 will be switched Off with predefined delay."
 		},
 		"7": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_off",
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off",
 			"label": "Relay 1 Restore After Power Loss",
 			"description": "Restore to the last known state for relay 1 after power was interrupted."
 		},
@@ -125,7 +125,7 @@
 			]
 		},
 		"9": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Hide Relay",
 			"description": "Hide relay 2 in controller interface"
 		},
@@ -149,17 +149,17 @@
 			"description": "Relay 2 will be switched Off with predefined delay."
 		},
 		"14": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_off",
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off",
 			"label": "Relay 2 Restore After Power Loss",
 			"description": "Restore to the last known state for relay 2 after power was interrupted."
 		},
 		"15": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Control Relay 1 & 2 together",
 			"description": "When enabled, Relay 2 will be switched On when Relay 1 is switched."
 		},
 		"16": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Control Relay 1 with S1"
 		},
 		"20": {
@@ -210,7 +210,7 @@
 			"description": "Values of sensor 3 options for processing. Devices included in association group 4 will be using this parameter for controlling sensor 3."
 		},
 		"35": {
-			"$import": "../templates/master_template.json#base_1-100_nounit",
+			"$import": "~/templates/master_template.json#base_1-100_nounit",
 			// I suspect the documentation is incorrect regarding this parameter
 			// as it doesn't make sense as documented. (same as 36).
 			// I think this is about sensor value change.
@@ -242,7 +242,7 @@
 			"description": "Values of sensor 4 options for processing. Devices included in association group 5 will be using this parameter for controlling sensor 4."
 		},
 		"40": {
-			"$import": "../templates/master_template.json#base_1-100_nounit",
+			"$import": "~/templates/master_template.json#base_1-100_nounit",
 			// I suspect the documentation is incorrect regarding this parameter
 			// as it doesn't make sense as documented. (same as 41).
 			// I think this is about sensor value change.
@@ -257,31 +257,31 @@
 			"defaultValue": 300
 		},
 		"50": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Require Secure Commands",
 			"description": "React only to secure commands when device is in secure mode.",
 			"defaultValue": 0
 		},
 		"51": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Secure Send Group 2",
 			"description": "Send secure command signals for association group 2.",
 			"defaultValue": 0
 		},
 		"52": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Secure Send Group 3",
 			"description": "Send secure command signals for association group 3.",
 			"defaultValue": 0
 		},
 		"53": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Secure Send Group 4",
 			"description": "Send secure command signals for association group 4.",
 			"defaultValue": 0
 		},
 		"54": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Secure Send Group 5",
 			"description": "Send secure command signals for association group 5.",
 			"defaultValue": 0

--- a/packages/config/config/devices/0x0258/nas-wr01z.json
+++ b/packages/config/config/devices/0x0258/nas-wr01z.json
@@ -100,7 +100,7 @@
 			"defaultValue": 5
 		},
 		"7": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"8": {
 			"label": "Timed auto-off",

--- a/packages/config/config/devices/0x0258/nas-wr01ze.json
+++ b/packages/config/config/devices/0x0258/nas-wr01ze.json
@@ -20,7 +20,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"1": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"2": {
 			"label": "Top button function",

--- a/packages/config/config/devices/0x027a/zen06.json
+++ b/packages/config/config/devices/0x027a/zen06.json
@@ -41,7 +41,7 @@
 			]
 		},
 		"21": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"24": {
 			"label": "On/Off Status Change Notifications",

--- a/packages/config/config/devices/0x027a/zen07.json
+++ b/packages/config/config/devices/0x027a/zen07.json
@@ -90,7 +90,7 @@
 			"defaultValue": 5
 		},
 		"7": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"8": {
 			"label": "Auto Turn-Off Timer Enable",

--- a/packages/config/config/devices/0x027a/zen15.json
+++ b/packages/config/config/devices/0x027a/zen15.json
@@ -34,7 +34,7 @@
 			]
 		},
 		"21": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"24": {
 			"label": "On/Off Status Change Notifications",

--- a/packages/config/config/devices/0x027a/zen20.json
+++ b/packages/config/config/devices/0x027a/zen20.json
@@ -16,7 +16,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"1": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"2": {
 			"label": "Power Wattage Report Value Threshold",

--- a/packages/config/config/devices/0x027a/zen21_3.0-3.3.json
+++ b/packages/config/config/devices/0x027a/zen21_3.0-3.3.json
@@ -121,7 +121,7 @@
 			"defaultValue": 60
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"$if": "firmwareVersion >= 3.1",

--- a/packages/config/config/devices/0x027a/zen21_3.4.json
+++ b/packages/config/config/devices/0x027a/zen21_3.4.json
@@ -201,7 +201,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Enable/Disable Scene Control",

--- a/packages/config/config/devices/0x027a/zen22_1.7-1.7.json
+++ b/packages/config/config/devices/0x027a/zen22_1.7-1.7.json
@@ -79,7 +79,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		}
 	}
 }

--- a/packages/config/config/devices/0x027a/zen22_3.0-3.0.json
+++ b/packages/config/config/devices/0x027a/zen22_3.0-3.0.json
@@ -196,7 +196,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Dimmer Ramp Rate",

--- a/packages/config/config/devices/0x027a/zen22_3.1-3.2.json
+++ b/packages/config/config/devices/0x027a/zen22_3.1-3.2.json
@@ -196,7 +196,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Dimmer Ramp Rate",

--- a/packages/config/config/devices/0x027a/zen22_3.3-3.3.json
+++ b/packages/config/config/devices/0x027a/zen22_3.3-3.3.json
@@ -196,7 +196,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Dimmer Ramp Rate",

--- a/packages/config/config/devices/0x027a/zen22_3.4-3.4.json
+++ b/packages/config/config/devices/0x027a/zen22_3.4-3.4.json
@@ -196,7 +196,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Dimmer Ramp Rate",

--- a/packages/config/config/devices/0x027a/zen22_3.5-3.6.json
+++ b/packages/config/config/devices/0x027a/zen22_3.5-3.6.json
@@ -196,7 +196,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Dimmer Ramp Rate",

--- a/packages/config/config/devices/0x027a/zen22_3.7-19.0.json
+++ b/packages/config/config/devices/0x027a/zen22_3.7-19.0.json
@@ -196,7 +196,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Dimmer Ramp Rate",

--- a/packages/config/config/devices/0x027a/zen23_3.0.json
+++ b/packages/config/config/devices/0x027a/zen23_3.0.json
@@ -105,7 +105,7 @@
 			"defaultValue": 60
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Enable/Disable Scene Control",

--- a/packages/config/config/devices/0x027a/zen23_4.0.json
+++ b/packages/config/config/devices/0x027a/zen23_4.0.json
@@ -105,7 +105,7 @@
 			"defaultValue": 60
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Enable/Disable Scene Control",

--- a/packages/config/config/devices/0x027a/zen24_3.0-3.255.json
+++ b/packages/config/config/devices/0x027a/zen24_3.0-3.255.json
@@ -101,7 +101,7 @@
 			"defaultValue": 60
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Ramp Rate Control",

--- a/packages/config/config/devices/0x027a/zen24_4.0.json
+++ b/packages/config/config/devices/0x027a/zen24_4.0.json
@@ -105,7 +105,7 @@
 			"defaultValue": 60
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Ramp Rate Control",

--- a/packages/config/config/devices/0x027a/zen26_1.0-1.0.json
+++ b/packages/config/config/devices/0x027a/zen26_1.0-1.0.json
@@ -79,7 +79,7 @@
 			"defaultValue": 60
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		}
 	}
 }

--- a/packages/config/config/devices/0x027a/zen26_2.0-2.1.json
+++ b/packages/config/config/devices/0x027a/zen26_2.0-2.1.json
@@ -194,7 +194,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"10": {
 			"label": "Scene Control",

--- a/packages/config/config/devices/0x027a/zen26_2.2-2.2.json
+++ b/packages/config/config/devices/0x027a/zen26_2.2-2.2.json
@@ -194,7 +194,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"10": {
 			"label": "Scene Control",

--- a/packages/config/config/devices/0x027a/zen26_2.3.json
+++ b/packages/config/config/devices/0x027a/zen26_2.3.json
@@ -206,7 +206,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"10": {
 			"label": "Enable/Disable Scene Control",

--- a/packages/config/config/devices/0x027a/zen27_1.0-1.0.json
+++ b/packages/config/config/devices/0x027a/zen27_1.0-1.0.json
@@ -122,7 +122,7 @@
 			"defaultValue": 30
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Ramp Rate Control",

--- a/packages/config/config/devices/0x027a/zen27_2.0-2.0.json
+++ b/packages/config/config/devices/0x027a/zen27_2.0-2.0.json
@@ -194,7 +194,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Ramp Rate Control",

--- a/packages/config/config/devices/0x027a/zen27_2.1-2.6.json
+++ b/packages/config/config/devices/0x027a/zen27_2.1-2.6.json
@@ -194,7 +194,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Ramp Rate Control",

--- a/packages/config/config/devices/0x027a/zen27_2.7-2.7.json
+++ b/packages/config/config/devices/0x027a/zen27_2.7-2.7.json
@@ -194,7 +194,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Ramp Rate Control",

--- a/packages/config/config/devices/0x027a/zen27_2.8.json
+++ b/packages/config/config/devices/0x027a/zen27_2.8.json
@@ -210,7 +210,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Ramp Rate Control",

--- a/packages/config/config/devices/0x027a/zen32.json
+++ b/packages/config/config/devices/0x027a/zen32.json
@@ -465,7 +465,7 @@
 			"unsigned": true
 		},
 		"18": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_off_on"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off_on"
 		},
 		"19": {
 			"label": "Relay Control",

--- a/packages/config/config/devices/0x027a/zen71.json
+++ b/packages/config/config/devices/0x027a/zen71.json
@@ -93,7 +93,7 @@
 			"defaultValue": 0
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Enable/Disable Scene Control",

--- a/packages/config/config/devices/0x027a/zen72.json
+++ b/packages/config/config/devices/0x027a/zen72.json
@@ -144,7 +144,7 @@
 			"defaultValue": 0
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Ramp Rate Control",

--- a/packages/config/config/devices/0x027a/zen73.json
+++ b/packages/config/config/devices/0x027a/zen73.json
@@ -107,7 +107,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"10": {
 			"label": "Scene Control",

--- a/packages/config/config/devices/0x027a/zen74.json
+++ b/packages/config/config/devices/0x027a/zen74.json
@@ -84,7 +84,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Ramp Rate Control (Manual)",

--- a/packages/config/config/devices/0x027a/zen76.json
+++ b/packages/config/config/devices/0x027a/zen76.json
@@ -212,7 +212,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"10": {
 			"label": "Scene Control",

--- a/packages/config/config/devices/0x027a/zen77.json
+++ b/packages/config/config/devices/0x027a/zen77.json
@@ -216,7 +216,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Ramp Rate Control",

--- a/packages/config/config/devices/0x0312/mp20z.json
+++ b/packages/config/config/devices/0x0312/mp20z.json
@@ -99,7 +99,7 @@
 			]
 		},
 		"6": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		}
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x0312/mp22z.json
+++ b/packages/config/config/devices/0x0312/mp22z.json
@@ -69,7 +69,7 @@
 			]
 		},
 		"6": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev",
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev",
 			"defaultValue": 0
 		}
 	},

--- a/packages/config/config/devices/0x0312/ms10z.json
+++ b/packages/config/config/devices/0x0312/ms10z.json
@@ -212,7 +212,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Enable/Disable Local Control",

--- a/packages/config/config/devices/0x0312/ms12z.json
+++ b/packages/config/config/devices/0x0312/ms12z.json
@@ -212,7 +212,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Enable/Disable Local Control",

--- a/packages/config/config/devices/0x0312/ms13z.json
+++ b/packages/config/config/devices/0x0312/ms13z.json
@@ -212,7 +212,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Dimmer Speed (Manual)",

--- a/packages/config/config/devices/0x0312/z97.json
+++ b/packages/config/config/devices/0x0312/z97.json
@@ -89,7 +89,7 @@
 			"unsigned": true
 		},
 		"6": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		}
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x0312/zw30.json
+++ b/packages/config/config/devices/0x0312/zw30.json
@@ -207,7 +207,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Enable/Disable Local Control",

--- a/packages/config/config/devices/0x0312/zw31.json
+++ b/packages/config/config/devices/0x0312/zw31.json
@@ -222,7 +222,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
 			"label": "Dimmer Speed (Manual)",

--- a/packages/config/config/devices/0x031e/lzw45.json
+++ b/packages/config/config/devices/0x031e/lzw45.json
@@ -140,7 +140,7 @@
 			"unsigned": true
 		},
 		"10": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev",
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev",
 			"options": [
 				{
 					"label": "Off",

--- a/packages/config/config/devices/0x0330/zv2400tac-sl-a.json
+++ b/packages/config/config/devices/0x0330/zv2400tac-sl-a.json
@@ -16,7 +16,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"2": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"3": {
 			"label": "Send Basic report",

--- a/packages/config/config/devices/0x0330/zv2835rac-nf.json
+++ b/packages/config/config/devices/0x0330/zv2835rac-nf.json
@@ -16,7 +16,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"2": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"3": {
 			"label": "Send Basic Report",

--- a/packages/config/config/devices/0x0330/zv9102fa-cct.json
+++ b/packages/config/config/devices/0x0330/zv9102fa-cct.json
@@ -16,7 +16,7 @@
 	"supportsZWavePlus": true,
 	"paramInformation": {
 		"2": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev",
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev",
 			"defaultValue": 0
 		},
 		"3": {

--- a/packages/config/config/devices/0x0370/zd2102-5.json
+++ b/packages/config/config/devices/0x0370/zd2102-5.json
@@ -16,7 +16,7 @@
 	},
 	"paramInformation": {
 		"1": {
-			"$import": "../templates/master_template.json#base_enable_disable_255",
+			"$import": "~/templates/master_template.json#base_enable_disable_255",
 			"label": "External Switch"
 		}
 	},

--- a/packages/config/config/devices/0x0371/zw141.json
+++ b/packages/config/config/devices/0x0371/zw141.json
@@ -16,7 +16,7 @@
 	},
 	"paramInformation": {
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off",
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off",
 			"options": [
 				{
 					"label": "Current position",
@@ -230,7 +230,7 @@
 			]
 		},
 		"80": {
-			"$import": "../0x0086/templates/aeotec_template.json#notification_report_type",
+			"$import": "~/0x0086/templates/aeotec_template.json#notification_report_type",
 			"label": "Command Report Type",
 			"options": [
 				{
@@ -365,7 +365,7 @@
 			]
 		},
 		"255": {
-			"$import": "../0x0086/templates/aeotec_template.json#factory_reset_exclude"
+			"$import": "~/0x0086/templates/aeotec_template.json#factory_reset_exclude"
 		}
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x0371/zw162.json
+++ b/packages/config/config/devices/0x0371/zw162.json
@@ -26,244 +26,244 @@
 	},
 	"paramInformation": {
 		"1[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#light_index_browse"
+			"$import": "~/0x0086/templates/aeotec_template.json#light_index_browse"
 		},
 		"1[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_play_mode_browse"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_play_mode_browse"
 		},
 		"2[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#light_index_tamper"
+			"$import": "~/0x0086/templates/aeotec_template.json#light_index_tamper"
 		},
 		"2[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_duration_tamper"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_duration_tamper"
 		},
 		"2[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_interval_tamper"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_interval_tamper"
 		},
 		"2[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_play_count_tamper"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_play_count_tamper"
 		},
 		"3[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#light_index_doorbell_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#light_index_doorbell_1"
 		},
 		"3[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_duration_doorbell_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_duration_doorbell_1"
 		},
 		"3[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_interval_doorbell_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_interval_doorbell_1"
 		},
 		"3[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_play_count_doorbell_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_play_count_doorbell_1"
 		},
 		"4[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#light_index_doorbell_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#light_index_doorbell_2"
 		},
 		"4[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_duration_doorbell_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_duration_doorbell_2"
 		},
 		"4[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_interval_doorbell_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_interval_doorbell_2"
 		},
 		"4[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_play_count_doorbell_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_play_count_doorbell_2"
 		},
 		"5[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#light_index_doorbell_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#light_index_doorbell_3"
 		},
 		"5[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_duration_doorbell_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_duration_doorbell_3"
 		},
 		"5[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_interval_doorbell_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_interval_doorbell_3"
 		},
 		"5[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_play_count_doorbell_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_play_count_doorbell_3"
 		},
 		"6[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#light_index_environment"
+			"$import": "~/0x0086/templates/aeotec_template.json#light_index_environment"
 		},
 		"6[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_duration_environment"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_duration_environment"
 		},
 		"6[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_interval_environment"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_interval_environment"
 		},
 		"6[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_play_count_environment"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_play_count_environment"
 		},
 		"7[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#light_index_security"
+			"$import": "~/0x0086/templates/aeotec_template.json#light_index_security"
 		},
 		"7[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_duration_security"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_duration_security"
 		},
 		"7[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_interval_security"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_interval_security"
 		},
 		"7[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_play_count_security"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_play_count_security"
 		},
 		"8[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#light_index_emergency"
+			"$import": "~/0x0086/templates/aeotec_template.json#light_index_emergency"
 		},
 		"8[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_duration_emergency"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_duration_emergency"
 		},
 		"8[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_interval_emergency"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_interval_emergency"
 		},
 		"8[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_play_count_emergency"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_play_count_emergency"
 		},
 		"16[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_on_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_on_1"
 		},
 		"16[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_off_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_off_1"
 		},
 		"16[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_on_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_on_1"
 		},
 		"16[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_off_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_off_1"
 		},
 		"17[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_on_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_on_2"
 		},
 		"17[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_off_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_off_2"
 		},
 		"17[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_on_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_on_2"
 		},
 		"17[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_off_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_off_2"
 		},
 		"18[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_on_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_on_3"
 		},
 		"18[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_off_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_off_3"
 		},
 		"18[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_on_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_on_3"
 		},
 		"18[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_off_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_off_3"
 		},
 		"19[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_on_4"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_on_4"
 		},
 		"19[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_off_4"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_off_4"
 		},
 		"19[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_on_4"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_on_4"
 		},
 		"19[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_off_4"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_off_4"
 		},
 		"20[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_on_5"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_on_5"
 		},
 		"20[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_off_5"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_off_5"
 		},
 		"20[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_on_5"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_on_5"
 		},
 		"20[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_off_5"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_off_5"
 		},
 		"21[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_on_6"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_on_6"
 		},
 		"21[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_off_6"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_off_6"
 		},
 		"21[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_on_6"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_on_6"
 		},
 		"21[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_off_6"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_off_6"
 		},
 		"22[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_on_7"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_on_7"
 		},
 		"22[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_off_7"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_off_7"
 		},
 		"22[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_on_7"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_on_7"
 		},
 		"22[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_off_7"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_off_7"
 		},
 		"32": {
-			"$import": "../0x0086/templates/aeotec_template.json#basic_set_command_browse"
+			"$import": "~/0x0086/templates/aeotec_template.json#basic_set_command_browse"
 		},
 		"33": {
-			"$import": "../0x0086/templates/aeotec_template.json#basic_set_command_tamper"
+			"$import": "~/0x0086/templates/aeotec_template.json#basic_set_command_tamper"
 		},
 		"34": {
-			"$import": "../0x0086/templates/aeotec_template.json#basic_set_command_doorbell_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#basic_set_command_doorbell_1"
 		},
 		"35": {
-			"$import": "../0x0086/templates/aeotec_template.json#basic_set_command_doorbell_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#basic_set_command_doorbell_2"
 		},
 		"36": {
-			"$import": "../0x0086/templates/aeotec_template.json#basic_set_command_doorbell_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#basic_set_command_doorbell_3"
 		},
 		"37": {
-			"$import": "../0x0086/templates/aeotec_template.json#basic_set_command_environment"
+			"$import": "~/0x0086/templates/aeotec_template.json#basic_set_command_environment"
 		},
 		"38": {
-			"$import": "../0x0086/templates/aeotec_template.json#basic_set_command_security"
+			"$import": "~/0x0086/templates/aeotec_template.json#basic_set_command_security"
 		},
 		"39": {
-			"$import": "../0x0086/templates/aeotec_template.json#basic_set_command_emergency"
+			"$import": "~/0x0086/templates/aeotec_template.json#basic_set_command_emergency"
 		},
 		"48": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_unpair"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_unpair"
 		},
 		"49": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_pair"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_pair"
 		},
 		"50": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_pairing_status"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_pairing_status"
 		},
 		"51[0x01]": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_status_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_status_1"
 		},
 		"51[0x02]": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_status_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_status_2"
 		},
 		"51[0x04]": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_status_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_status_3"
 		},
 		"52[0xffff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_battery_voltage_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_battery_voltage_1"
 		},
 		"52[0xffff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_version_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_version_1"
 		},
 		"53[0xffff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_battery_voltage_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_battery_voltage_2"
 		},
 		"53[0xffff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_version_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_version_2"
 		},
 		"54[0xffff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_battery_voltage_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_battery_voltage_3"
 		},
 		"54[0xffff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_version_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_version_3"
 		},
 		"96": {
-			"$import": "../0x0086/templates/aeotec_template.json#stop_action_button"
+			"$import": "~/0x0086/templates/aeotec_template.json#stop_action_button"
 		},
 		"255": {
-			"$import": "../0x0086/templates/aeotec_template.json#factory_reset_exclude"
+			"$import": "~/0x0086/templates/aeotec_template.json#factory_reset_exclude"
 		}
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x0371/zw164.json
+++ b/packages/config/config/devices/0x0371/zw164.json
@@ -26,244 +26,244 @@
 	},
 	"paramInformation": {
 		"1[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#light_index_browse"
+			"$import": "~/0x0086/templates/aeotec_template.json#light_index_browse"
 		},
 		"1[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_play_mode_browse"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_play_mode_browse"
 		},
 		"2[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#light_index_tamper"
+			"$import": "~/0x0086/templates/aeotec_template.json#light_index_tamper"
 		},
 		"2[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_duration_tamper"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_duration_tamper"
 		},
 		"2[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_interval_tamper"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_interval_tamper"
 		},
 		"2[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_play_count_tamper"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_play_count_tamper"
 		},
 		"3[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#light_index_doorbell_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#light_index_doorbell_1"
 		},
 		"3[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_duration_doorbell_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_duration_doorbell_1"
 		},
 		"3[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_interval_doorbell_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_interval_doorbell_1"
 		},
 		"3[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_play_count_doorbell_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_play_count_doorbell_1"
 		},
 		"4[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#light_index_doorbell_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#light_index_doorbell_2"
 		},
 		"4[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_duration_doorbell_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_duration_doorbell_2"
 		},
 		"4[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_interval_doorbell_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_interval_doorbell_2"
 		},
 		"4[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_play_count_doorbell_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_play_count_doorbell_2"
 		},
 		"5[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#light_index_doorbell_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#light_index_doorbell_3"
 		},
 		"5[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_duration_doorbell_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_duration_doorbell_3"
 		},
 		"5[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_interval_doorbell_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_interval_doorbell_3"
 		},
 		"5[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_play_count_doorbell_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_play_count_doorbell_3"
 		},
 		"6[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#light_index_environment"
+			"$import": "~/0x0086/templates/aeotec_template.json#light_index_environment"
 		},
 		"6[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_duration_environment"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_duration_environment"
 		},
 		"6[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_interval_environment"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_interval_environment"
 		},
 		"6[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_play_count_environment"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_play_count_environment"
 		},
 		"7[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#light_index_security"
+			"$import": "~/0x0086/templates/aeotec_template.json#light_index_security"
 		},
 		"7[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_duration_security"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_duration_security"
 		},
 		"7[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_interval_security"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_interval_security"
 		},
 		"7[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_play_count_security"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_play_count_security"
 		},
 		"8[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#light_index_emergency"
+			"$import": "~/0x0086/templates/aeotec_template.json#light_index_emergency"
 		},
 		"8[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_duration_emergency"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_duration_emergency"
 		},
 		"8[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_interval_emergency"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_interval_emergency"
 		},
 		"8[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#tone_play_count_emergency"
+			"$import": "~/0x0086/templates/aeotec_template.json#tone_play_count_emergency"
 		},
 		"16[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_on_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_on_1"
 		},
 		"16[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_off_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_off_1"
 		},
 		"16[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_on_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_on_1"
 		},
 		"16[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_off_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_off_1"
 		},
 		"17[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_on_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_on_2"
 		},
 		"17[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_off_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_off_2"
 		},
 		"17[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_on_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_on_2"
 		},
 		"17[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_off_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_off_2"
 		},
 		"18[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_on_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_on_3"
 		},
 		"18[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_off_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_off_3"
 		},
 		"18[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_on_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_on_3"
 		},
 		"18[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_off_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_off_3"
 		},
 		"19[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_on_4"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_on_4"
 		},
 		"19[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_off_4"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_off_4"
 		},
 		"19[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_on_4"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_on_4"
 		},
 		"19[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_off_4"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_off_4"
 		},
 		"20[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_on_5"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_on_5"
 		},
 		"20[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_off_5"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_off_5"
 		},
 		"20[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_on_5"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_on_5"
 		},
 		"20[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_off_5"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_off_5"
 		},
 		"21[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_on_6"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_on_6"
 		},
 		"21[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_off_6"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_off_6"
 		},
 		"21[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_on_6"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_on_6"
 		},
 		"21[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_off_6"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_off_6"
 		},
 		"22[0xff000000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_on_7"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_on_7"
 		},
 		"22[0xff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#dim_duration_off_7"
+			"$import": "~/0x0086/templates/aeotec_template.json#dim_duration_off_7"
 		},
 		"22[0xff00]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_on_7"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_on_7"
 		},
 		"22[0xff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_duration_off_7"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_duration_off_7"
 		},
 		"32": {
-			"$import": "../0x0086/templates/aeotec_template.json#basic_set_command_browse"
+			"$import": "~/0x0086/templates/aeotec_template.json#basic_set_command_browse"
 		},
 		"33": {
-			"$import": "../0x0086/templates/aeotec_template.json#basic_set_command_tamper"
+			"$import": "~/0x0086/templates/aeotec_template.json#basic_set_command_tamper"
 		},
 		"34": {
-			"$import": "../0x0086/templates/aeotec_template.json#basic_set_command_doorbell_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#basic_set_command_doorbell_1"
 		},
 		"35": {
-			"$import": "../0x0086/templates/aeotec_template.json#basic_set_command_doorbell_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#basic_set_command_doorbell_2"
 		},
 		"36": {
-			"$import": "../0x0086/templates/aeotec_template.json#basic_set_command_doorbell_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#basic_set_command_doorbell_3"
 		},
 		"37": {
-			"$import": "../0x0086/templates/aeotec_template.json#basic_set_command_environment"
+			"$import": "~/0x0086/templates/aeotec_template.json#basic_set_command_environment"
 		},
 		"38": {
-			"$import": "../0x0086/templates/aeotec_template.json#basic_set_command_security"
+			"$import": "~/0x0086/templates/aeotec_template.json#basic_set_command_security"
 		},
 		"39": {
-			"$import": "../0x0086/templates/aeotec_template.json#basic_set_command_emergency"
+			"$import": "~/0x0086/templates/aeotec_template.json#basic_set_command_emergency"
 		},
 		"48": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_unpair"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_unpair"
 		},
 		"49": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_pair"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_pair"
 		},
 		"50": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_pairing_status"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_pairing_status"
 		},
 		"51[0x01]": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_status_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_status_1"
 		},
 		"51[0x02]": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_status_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_status_2"
 		},
 		"51[0x04]": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_status_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_status_3"
 		},
 		"52[0xffff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_battery_voltage_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_battery_voltage_1"
 		},
 		"52[0xffff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_version_1"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_version_1"
 		},
 		"53[0xffff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_battery_voltage_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_battery_voltage_2"
 		},
 		"53[0xffff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_version_2"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_version_2"
 		},
 		"54[0xffff0000]": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_battery_voltage_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_battery_voltage_3"
 		},
 		"54[0xffff]": {
-			"$import": "../0x0086/templates/aeotec_template.json#button_version_3"
+			"$import": "~/0x0086/templates/aeotec_template.json#button_version_3"
 		},
 		"96": {
-			"$import": "../0x0086/templates/aeotec_template.json#stop_action_button"
+			"$import": "~/0x0086/templates/aeotec_template.json#stop_action_button"
 		},
 		"255": {
-			"$import": "../0x0086/templates/aeotec_template.json#factory_reset_exclude"
+			"$import": "~/0x0086/templates/aeotec_template.json#factory_reset_exclude"
 		}
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x0371/zw175.json
+++ b/packages/config/config/devices/0x0371/zw175.json
@@ -27,12 +27,12 @@
 	},
 	"paramInformation": {
 		"4": {
-			"$import": "../0x0086/templates/aeotec_template.json#current_overload_threshold",
+			"$import": "~/0x0086/templates/aeotec_template.json#current_overload_threshold",
 			"maxValue": 2415,
 			"defaultValue": 2415
 		},
 		"9[0x01]": {
-			"$import": "../templates/master_template.json#base_0-1_nounit",
+			"$import": "~/templates/master_template.json#base_0-1_nounit",
 			"label": "Alarm Trigger State",
 			"valueSize": 2,
 			"options": [
@@ -47,38 +47,38 @@
 			]
 		},
 		"9[0x0100]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "React to Alarm Type: Smoke Alarms",
 			"valueSize": 2
 		},
 		"9[0x0200]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "React to Alarm Type: CO Alarms",
 			"valueSize": 2
 		},
 		"9[0x0400]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "React to Alarm Type: CO2 Alarms",
 			"description": "React to CO2 Alarms from other Z-Wave devices.",
 			"valueSize": 2
 		},
 		"9[0x0800]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "React to Alarm Type: Heart Alarms",
 			"valueSize": 2
 		},
 		"9[0x1000]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "React to Alarm Type: Water Alarms",
 			"valueSize": 2
 		},
 		"9[0x2000]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "React to Alarm Type: Access Control Alarms",
 			"valueSize": 2
 		},
 		"9[0x4000]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "React to Alarm Type: Home Security Alarms",
 			"valueSize": 2
 		},
@@ -139,16 +139,16 @@
 			"unsigned": true
 		},
 		"19": {
-			"$import": "../0x0086/templates/aeotec_template.json#blink_duration"
+			"$import": "~/0x0086/templates/aeotec_template.json#blink_duration"
 		},
 		"20": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"80": {
-			"$import": "../0x0086/templates/aeotec_template.json#binary_report_type"
+			"$import": "~/0x0086/templates/aeotec_template.json#binary_report_type"
 		},
 		"81": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_indicator_three_options_alt"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_three_options_alt"
 		},
 		"82[0xff000000]": {
 			"label": "Night Light (Enable): Hour",
@@ -183,32 +183,32 @@
 			"defaultValue": 0
 		},
 		"91": {
-			"$import": "../0x0086/templates/aeotec_template.json#power_threshold",
+			"$import": "~/0x0086/templates/aeotec_template.json#power_threshold",
 			"maxValue": 2300,
 			"defaultValue": 0
 		},
 		"92": {
-			"$import": "../0x0086/templates/aeotec_template.json#kwh_threshold",
+			"$import": "~/0x0086/templates/aeotec_template.json#kwh_threshold",
 			"defaultValue": 0
 		},
 		"93": {
-			"$import": "../0x0086/templates/aeotec_template.json#current_threshold",
+			"$import": "~/0x0086/templates/aeotec_template.json#current_threshold",
 			"maxValue": 100
 		},
 		"101[0x01]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_kwh",
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_kwh",
 			"defaultValue": 1
 		},
 		"101[0x02]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_watt",
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_watt",
 			"defaultValue": 1
 		},
 		"101[0x04]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_v",
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_v",
 			"defaultValue": 1
 		},
 		"101[0x08]": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_amp",
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_amp",
 			"defaultValue": 1
 		},
 		"111": {
@@ -227,7 +227,7 @@
 			]
 		},
 		"255": {
-			"$import": "../0x0086/templates/aeotec_template.json#factory_reset_exclude"
+			"$import": "~/0x0086/templates/aeotec_template.json#factory_reset_exclude"
 		}
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x0371/zw187.json
+++ b/packages/config/config/devices/0x0371/zw187.json
@@ -37,11 +37,11 @@
 	},
 	"paramInformation": {
 		"1": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Binary Sensor Report"
 		},
 		"2": {
-			"$import": "../0x0086/templates/aeotec_template.json#invert_state_report"
+			"$import": "~/0x0086/templates/aeotec_template.json#invert_state_report"
 		},
 		"3": {
 			"label": "Association Group 2: Basic Set Value",
@@ -137,11 +137,11 @@
 			]
 		},
 		"90": {
-			"$import": "../0x0086/templates/aeotec_template.json#low_battery_threshold",
+			"$import": "~/0x0086/templates/aeotec_template.json#low_battery_threshold",
 			"defaultValue": 30
 		},
 		"101": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_battery"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_battery"
 		}
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x0371/zwa003.json
+++ b/packages/config/config/devices/0x0371/zwa003.json
@@ -31,22 +31,22 @@
 	},
 	"paramInformation": {
 		"32": {
-			"$import": "../0x0086/templates/aeotec_template.json#low_battery_threshold",
+			"$import": "~/0x0086/templates/aeotec_template.json#low_battery_threshold",
 			"label": "Level of Low Battery",
 			"defaultValue": 20
 		},
 		"41": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Central Scene Notifications",
 			"defaultValue": 1
 		},
 		"42": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Multilevel Command Duration",
 			"defaultValue": 255
 		},
 		"43": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Low Battery Buzzer"
 		}
 	},

--- a/packages/config/config/devices/0x0371/zwa004.json
+++ b/packages/config/config/devices/0x0371/zwa004.json
@@ -21,22 +21,22 @@
 	},
 	"paramInformation": {
 		"32": {
-			"$import": "../0x0086/templates/aeotec_template.json#low_battery_threshold",
+			"$import": "~/0x0086/templates/aeotec_template.json#low_battery_threshold",
 			"label": "Level of Low Battery",
 			"defaultValue": 20
 		},
 		"41": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Central Scene Notifications",
 			"defaultValue": 1
 		},
 		"42": {
-			"$import": "../templates/master_template.json#base_0-255_nounit",
+			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Multilevel Command Duration",
 			"defaultValue": 255
 		},
 		"43": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Low Battery Buzzer"
 		}
 	},

--- a/packages/config/config/devices/0x0371/zwa005.json
+++ b/packages/config/config/devices/0x0371/zwa005.json
@@ -46,7 +46,7 @@
 	},
 	"paramInformation": {
 		"1": {
-			"$import": "../0x0086/templates/aeotec_template.json#motion_timeout",
+			"$import": "~/0x0086/templates/aeotec_template.json#motion_timeout",
 			"minValue": 0,
 			"maxValue": 32767,
 			"defaultValue": 30
@@ -76,7 +76,7 @@
 			]
 		},
 		"4": {
-			"$import": "../0x0086/templates/aeotec_template.json#enable_binary_report"
+			"$import": "~/0x0086/templates/aeotec_template.json#enable_binary_report"
 		},
 		"5": {
 			"label": "Send Basic Set to Associated Nodes",
@@ -149,35 +149,35 @@
 			"defaultValue": 239
 		},
 		"10": {
-			"$import": "../0x0086/templates/aeotec_template.json#enable_led_indicator"
+			"$import": "~/0x0086/templates/aeotec_template.json#enable_led_indicator"
 		},
 		"11": {
-			"$import": "../0x0086/templates/aeotec_template.json#base_color_options",
+			"$import": "~/0x0086/templates/aeotec_template.json#base_color_options",
 			"label": "LED Color: Motion Event Report",
 			"defaultValue": 2
 		},
 		"12": {
-			"$import": "../0x0086/templates/aeotec_template.json#base_color_options",
+			"$import": "~/0x0086/templates/aeotec_template.json#base_color_options",
 			"label": "LED Color: Temperature Sensor Report",
 			"defaultValue": 0
 		},
 		"13": {
-			"$import": "../0x0086/templates/aeotec_template.json#base_color_options",
+			"$import": "~/0x0086/templates/aeotec_template.json#base_color_options",
 			"label": "LED Color: Light Sensor Report",
 			"defaultValue": 0
 		},
 		"14": {
-			"$import": "../0x0086/templates/aeotec_template.json#base_color_options",
+			"$import": "~/0x0086/templates/aeotec_template.json#base_color_options",
 			"label": "LED Color: Battery Report",
 			"defaultValue": 0
 		},
 		"15": {
-			"$import": "../0x0086/templates/aeotec_template.json#base_color_options",
+			"$import": "~/0x0086/templates/aeotec_template.json#base_color_options",
 			"label": "LED Color: Wakeup Notification Report",
 			"defaultValue": 0
 		},
 		"20": {
-			"$import": "../0x0086/templates/aeotec_template.json#celsius_fahrenheit_0",
+			"$import": "~/0x0086/templates/aeotec_template.json#celsius_fahrenheit_0",
 			"valueSize": 1
 		},
 		"21": {
@@ -208,7 +208,7 @@
 			"unsigned": true
 		},
 		"24": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_interval_light"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_interval_light"
 		},
 		"30": {
 			"label": "Temperature Offset Value",

--- a/packages/config/config/devices/0x0371/zwa006.json
+++ b/packages/config/config/devices/0x0371/zwa006.json
@@ -26,10 +26,10 @@
 	},
 	"paramInformation": {
 		"1": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off_schedule"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off_schedule"
 		},
 		"2": {
-			"$import": "../templates/master_template.json#led_indicator_three_options",
+			"$import": "~/templates/master_template.json#led_indicator_three_options",
 			"options": [
 				{
 					"label": "Always off",
@@ -46,10 +46,10 @@
 			]
 		},
 		"3": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_off_timer"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_off_timer"
 		},
 		"4": {
-			"$import": "../0x0086/templates/aeotec_template.json#current_overload"
+			"$import": "~/0x0086/templates/aeotec_template.json#current_overload"
 		},
 		"5": {
 			"label": "Boost Time",
@@ -76,29 +76,29 @@
 			]
 		},
 		"20": {
-			"$import": "../0x0086/templates/aeotec_template.json#kwh_threshold"
+			"$import": "~/0x0086/templates/aeotec_template.json#kwh_threshold"
 		},
 		"21": {
-			"$import": "../0x0086/templates/aeotec_template.json#power_threshold",
+			"$import": "~/0x0086/templates/aeotec_template.json#power_threshold",
 			"maxValue": 2500,
 			"defaultValue": 100
 		},
 		"22": {
-			"$import": "../0x0086/templates/aeotec_template.json#current_threshold",
+			"$import": "~/0x0086/templates/aeotec_template.json#current_threshold",
 			"valueSize": 2,
 			"maxValue": 130
 		},
 		"23": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_interval_watt"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_interval_watt"
 		},
 		"24": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_interval_kwh"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_interval_kwh"
 		},
 		"25": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_interval_v"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_interval_v"
 		},
 		"26": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_interval_amp"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_interval_amp"
 		}
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x0371/zwa008.json
+++ b/packages/config/config/devices/0x0371/zwa008.json
@@ -49,55 +49,55 @@
 	},
 	"paramInformation": {
 		"1": {
-			"$import": "../0x0086/templates/aeotec_template.json#sensor_operation_mode"
+			"$import": "~/0x0086/templates/aeotec_template.json#sensor_operation_mode"
 		},
 		"2": {
-			"$import": "../0x0086/templates/aeotec_template.json#invert_state_report"
+			"$import": "~/0x0086/templates/aeotec_template.json#invert_state_report"
 		},
 		"3[0x02]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_indicator_open"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_open"
 		},
 		"3[0x04]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_indicator_wake"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_wake"
 		},
 		"3[0x10]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_indicator_tamper"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_tamper"
 		},
 		"4": {
-			"$import": "../0x0086/templates/aeotec_template.json#range_test_double_click"
+			"$import": "~/0x0086/templates/aeotec_template.json#range_test_double_click"
 		},
 		"5": {
-			"$import": "../0x0086/templates/aeotec_template.json#association_group_2_trigger"
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_trigger"
 		},
 		"6": {
-			"$import": "../0x0086/templates/aeotec_template.json#association_group_2_command_type"
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_command_type"
 		},
 		"7": {
-			"$import": "../0x0086/templates/aeotec_template.json#association_group_2_basic_set_on"
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_basic_set_on"
 		},
 		"8": {
-			"$import": "../0x0086/templates/aeotec_template.json#association_group_2_basic_set_off"
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_basic_set_off"
 		},
 		"9": {
-			"$import": "../0x0086/templates/aeotec_template.json#time_delay_on"
+			"$import": "~/0x0086/templates/aeotec_template.json#time_delay_on"
 		},
 		"10": {
-			"$import": "../0x0086/templates/aeotec_template.json#time_delay_off"
+			"$import": "~/0x0086/templates/aeotec_template.json#time_delay_off"
 		},
 		"11": {
-			"$import": "../0x0086/templates/aeotec_template.json#time_delay_tamper"
+			"$import": "~/0x0086/templates/aeotec_template.json#time_delay_tamper"
 		},
 		"12": {
-			"$import": "../0x0086/templates/aeotec_template.json#report_on_tamper_cancel"
+			"$import": "~/0x0086/templates/aeotec_template.json#report_on_tamper_cancel"
 		},
 		"13": {
-			"$import": "../0x0086/templates/aeotec_template.json#central_scene_functionality"
+			"$import": "~/0x0086/templates/aeotec_template.json#central_scene_functionality"
 		},
 		"14": {
-			"$import": "../0x0086/templates/aeotec_template.json#tilt_sensor"
+			"$import": "~/0x0086/templates/aeotec_template.json#tilt_sensor"
 		},
 		"15": {
-			"$import": "../0x0086/templates/aeotec_template.json#tilt_sensor_sensitivity"
+			"$import": "~/0x0086/templates/aeotec_template.json#tilt_sensor_sensitivity"
 		}
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x0371/zwa009.json
+++ b/packages/config/config/devices/0x0371/zwa009.json
@@ -198,11 +198,11 @@
 			"defaultValue": 0
 		},
 		"64": {
-			"$import": "../0x0086/templates/aeotec_template.json#celsius_fahrenheit",
+			"$import": "~/0x0086/templates/aeotec_template.json#celsius_fahrenheit",
 			"valueSize": 1
 		},
 		"255": {
-			"$import": "../0x0086/templates/aeotec_template.json#factory_reset_complete"
+			"$import": "~/0x0086/templates/aeotec_template.json#factory_reset_complete"
 		}
 	}
 }

--- a/packages/config/config/devices/0x0371/zwa012.json
+++ b/packages/config/config/devices/0x0371/zwa012.json
@@ -44,55 +44,55 @@
 	},
 	"paramInformation": {
 		"1": {
-			"$import": "../0x0086/templates/aeotec_template.json#sensor_operation_mode"
+			"$import": "~/0x0086/templates/aeotec_template.json#sensor_operation_mode"
 		},
 		"2": {
-			"$import": "../0x0086/templates/aeotec_template.json#invert_state_report"
+			"$import": "~/0x0086/templates/aeotec_template.json#invert_state_report"
 		},
 		"3[0x02]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_indicator_open"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_open"
 		},
 		"3[0x04]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_indicator_wake"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_wake"
 		},
 		"3[0x10]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_indicator_tamper"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_tamper"
 		},
 		"4": {
-			"$import": "../0x0086/templates/aeotec_template.json#range_test_double_click"
+			"$import": "~/0x0086/templates/aeotec_template.json#range_test_double_click"
 		},
 		"5": {
-			"$import": "../0x0086/templates/aeotec_template.json#association_group_2_trigger"
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_trigger"
 		},
 		"6": {
-			"$import": "../0x0086/templates/aeotec_template.json#association_group_2_command_type"
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_command_type"
 		},
 		"7": {
-			"$import": "../0x0086/templates/aeotec_template.json#association_group_2_basic_set_on"
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_basic_set_on"
 		},
 		"8": {
-			"$import": "../0x0086/templates/aeotec_template.json#association_group_2_basic_set_off"
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_basic_set_off"
 		},
 		"9": {
-			"$import": "../0x0086/templates/aeotec_template.json#time_delay_on"
+			"$import": "~/0x0086/templates/aeotec_template.json#time_delay_on"
 		},
 		"10": {
-			"$import": "../0x0086/templates/aeotec_template.json#time_delay_off"
+			"$import": "~/0x0086/templates/aeotec_template.json#time_delay_off"
 		},
 		"11": {
-			"$import": "../0x0086/templates/aeotec_template.json#time_delay_tamper"
+			"$import": "~/0x0086/templates/aeotec_template.json#time_delay_tamper"
 		},
 		"12": {
-			"$import": "../0x0086/templates/aeotec_template.json#report_on_tamper_cancel"
+			"$import": "~/0x0086/templates/aeotec_template.json#report_on_tamper_cancel"
 		},
 		"13": {
-			"$import": "../0x0086/templates/aeotec_template.json#central_scene_functionality"
+			"$import": "~/0x0086/templates/aeotec_template.json#central_scene_functionality"
 		},
 		"14": {
-			"$import": "../0x0086/templates/aeotec_template.json#tilt_sensor"
+			"$import": "~/0x0086/templates/aeotec_template.json#tilt_sensor"
 		},
 		"15": {
-			"$import": "../0x0086/templates/aeotec_template.json#tilt_sensor_sensitivity"
+			"$import": "~/0x0086/templates/aeotec_template.json#tilt_sensor_sensitivity"
 		}
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x0371/zwa018.json
+++ b/packages/config/config/devices/0x0371/zwa018.json
@@ -34,40 +34,40 @@
 	},
 	"paramInformation": {
 		"3[0x04]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_indicator_wake"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_wake"
 		},
 		"3[0x10]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_indicator_tamper"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_tamper"
 		},
 		"4": {
-			"$import": "../0x0086/templates/aeotec_template.json#range_test_double_click"
+			"$import": "~/0x0086/templates/aeotec_template.json#range_test_double_click"
 		},
 		"5": {
-			"$import": "../0x0086/templates/aeotec_template.json#association_group_2_trigger"
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_trigger"
 		},
 		"6": {
-			"$import": "../0x0086/templates/aeotec_template.json#association_group_2_command_type"
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_command_type"
 		},
 		"7": {
-			"$import": "../0x0086/templates/aeotec_template.json#association_group_2_basic_set_on"
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_basic_set_on"
 		},
 		"8": {
-			"$import": "../0x0086/templates/aeotec_template.json#association_group_2_basic_set_off"
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_basic_set_off"
 		},
 		"9": {
-			"$import": "../0x0086/templates/aeotec_template.json#time_delay_on"
+			"$import": "~/0x0086/templates/aeotec_template.json#time_delay_on"
 		},
 		"10": {
-			"$import": "../0x0086/templates/aeotec_template.json#time_delay_off"
+			"$import": "~/0x0086/templates/aeotec_template.json#time_delay_off"
 		},
 		"11": {
-			"$import": "../0x0086/templates/aeotec_template.json#time_delay_tamper"
+			"$import": "~/0x0086/templates/aeotec_template.json#time_delay_tamper"
 		},
 		"12": {
-			"$import": "../0x0086/templates/aeotec_template.json#report_on_tamper_cancel"
+			"$import": "~/0x0086/templates/aeotec_template.json#report_on_tamper_cancel"
 		},
 		"255": {
-			"$import": "../0x0086/templates/aeotec_template.json#factory_reset_exclude"
+			"$import": "~/0x0086/templates/aeotec_template.json#factory_reset_exclude"
 		}
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x0371/zwa019.json
+++ b/packages/config/config/devices/0x0371/zwa019.json
@@ -40,37 +40,37 @@
 	},
 	"paramInformation": {
 		"3[0x04]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_indicator_wake"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_wake"
 		},
 		"3[0x10]": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_indicator_tamper"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_tamper"
 		},
 		"4": {
-			"$import": "../0x0086/templates/aeotec_template.json#range_test_double_click"
+			"$import": "~/0x0086/templates/aeotec_template.json#range_test_double_click"
 		},
 		"5": {
-			"$import": "../0x0086/templates/aeotec_template.json#association_group_2_trigger"
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_trigger"
 		},
 		"6": {
-			"$import": "../0x0086/templates/aeotec_template.json#association_group_2_command_type"
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_command_type"
 		},
 		"7": {
-			"$import": "../0x0086/templates/aeotec_template.json#association_group_2_basic_set_on"
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_basic_set_on"
 		},
 		"8": {
-			"$import": "../0x0086/templates/aeotec_template.json#association_group_2_basic_set_off"
+			"$import": "~/0x0086/templates/aeotec_template.json#association_group_2_basic_set_off"
 		},
 		"9": {
-			"$import": "../0x0086/templates/aeotec_template.json#time_delay_on"
+			"$import": "~/0x0086/templates/aeotec_template.json#time_delay_on"
 		},
 		"10": {
-			"$import": "../0x0086/templates/aeotec_template.json#time_delay_off"
+			"$import": "~/0x0086/templates/aeotec_template.json#time_delay_off"
 		},
 		"11": {
-			"$import": "../0x0086/templates/aeotec_template.json#time_delay_tamper"
+			"$import": "~/0x0086/templates/aeotec_template.json#time_delay_tamper"
 		},
 		"12": {
-			"$import": "../0x0086/templates/aeotec_template.json#report_on_tamper_cancel"
+			"$import": "~/0x0086/templates/aeotec_template.json#report_on_tamper_cancel"
 		},
 		"16": {
 			"label": "Temperature Change Report Trigger",
@@ -118,11 +118,11 @@
 			]
 		},
 		"64": {
-			"$import": "../0x0086/templates/aeotec_template.json#celsius_fahrenheit",
+			"$import": "~/0x0086/templates/aeotec_template.json#celsius_fahrenheit",
 			"valueSize": 1
 		},
 		"255": {
-			"$import": "../0x0086/templates/aeotec_template.json#factory_reset_exclude"
+			"$import": "~/0x0086/templates/aeotec_template.json#factory_reset_exclude"
 		}
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x0371/zwa023.json
+++ b/packages/config/config/devices/0x0371/zwa023.json
@@ -31,7 +31,7 @@
 	},
 	"paramInformation": {
 		"1": {
-			"$import": "../0x0086/templates/aeotec_template.json#led_indicator_three_options_alt"
+			"$import": "~/0x0086/templates/aeotec_template.json#led_indicator_three_options_alt"
 		},
 		"2": {
 			"label": "Night Light: On Time",
@@ -52,7 +52,7 @@
 			"unsigned": true
 		},
 		"4": {
-			"$import": "../0x0086/templates/aeotec_template.json#blink_duration"
+			"$import": "~/0x0086/templates/aeotec_template.json#blink_duration"
 		},
 		"5": {
 			"label": "LED Blink Speed",
@@ -102,7 +102,7 @@
 			]
 		},
 		"8": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"9": {
 			"label": "Scene Id (Group 3)",
@@ -114,7 +114,7 @@
 			"unsigned": true
 		},
 		"10": {
-			"$import": "../0x0086/templates/aeotec_template.json#current_overload_threshold",
+			"$import": "~/0x0086/templates/aeotec_template.json#current_overload_threshold",
 			"maxValue": 1800,
 			"defaultValue": 1800
 		},
@@ -135,7 +135,7 @@
 			]
 		},
 		"19": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_interval",
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_interval",
 			"valueSize": 1,
 			"unit": "seconds",
 			"minValue": 0,
@@ -149,62 +149,62 @@
 			]
 		},
 		"20": {
-			"$import": "../0x0086/templates/aeotec_template.json#kwh_threshold"
+			"$import": "~/0x0086/templates/aeotec_template.json#kwh_threshold"
 		},
 		"21": {
-			"$import": "../0x0086/templates/aeotec_template.json#power_threshold",
+			"$import": "~/0x0086/templates/aeotec_template.json#power_threshold",
 			"maxValue": 2500,
 			"defaultValue": 0
 		},
 		"22": {
-			"$import": "../0x0086/templates/aeotec_template.json#current_threshold"
+			"$import": "~/0x0086/templates/aeotec_template.json#current_threshold"
 		},
 		"23": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_interval_watt",
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_interval_watt",
 			"valueSize": 2
 		},
 		"24": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_interval_kwh",
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_interval_kwh",
 			"valueSize": 2
 		},
 		"25": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_interval_v",
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_interval_v",
 			"valueSize": 2
 		},
 		"26": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_report_interval_amp",
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_interval_amp",
 			"valueSize": 2
 		},
 		"30[0x01]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "React to Alarm Type: Smoke"
 		},
 		"30[0x02]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "React to Alarm Type: CO"
 		},
 		"30[0x04]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "React to Alarm Type: CO2"
 		},
 		"30[0x08]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "React to Alarm Type: Heat"
 		},
 		"30[0x10]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "React to Alarm Type: Water"
 		},
 		"30[0x20]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "React to Alarm Type: Access Control"
 		},
 		"30[0x40]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "React to Alarm Type: Home Security (Intrusion)"
 		},
 		"30[0x80]": {
-			"$import": "../templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "React to Alarm Type: Home Security (Motion)"
 		},
 		"31": {
@@ -258,13 +258,13 @@
 			]
 		},
 		"40": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_off_timer"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_off_timer"
 		},
 		"41": {
-			"$import": "../0x0086/templates/aeotec_template.json#auto_on_timer"
+			"$import": "~/0x0086/templates/aeotec_template.json#auto_on_timer"
 		},
 		"42": {
-			"$import": "../0x0086/templates/aeotec_template.json#binary_report_type"
+			"$import": "~/0x0086/templates/aeotec_template.json#binary_report_type"
 		}
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x0403/shha10000.json
+++ b/packages/config/config/devices/0x0403/shha10000.json
@@ -34,7 +34,7 @@
 			]
 		},
 		"2": {
-			"$import": "../templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
 		"3": {
 			"label": "Notification Load Status Change",

--- a/packages/config/config/devices/0x0431/ecodim.json
+++ b/packages/config/config/devices/0x0431/ecodim.json
@@ -39,7 +39,7 @@
 	},
 	"paramInformation": {
 		"1": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev",
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev",
 			"defaultValue": 0
 		},
 		"2": {

--- a/packages/config/config/devices/0x0433/q-light_puck.json
+++ b/packages/config/config/devices/0x0433/q-light_puck.json
@@ -96,7 +96,7 @@
 			"unsigned": true
 		},
 		"7": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"8": {
 			"label": "Switch type",

--- a/packages/config/config/devices/0x0433/q-light_zerodim.json
+++ b/packages/config/config/devices/0x0433/q-light_zerodim.json
@@ -87,7 +87,7 @@
 			"unsigned": true
 		},
 		"7": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"8": {
 			"label": "Scene ID set",

--- a/packages/config/config/devices/0x0433/q-light_zerodim_2pol.json
+++ b/packages/config/config/devices/0x0433/q-light_zerodim_2pol.json
@@ -87,7 +87,7 @@
 			"unsigned": true
 		},
 		"7": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"8": {
 			"label": "Scene ID set",

--- a/packages/config/config/devices/0x0438/dimmer2-400w.json
+++ b/packages/config/config/devices/0x0438/dimmer2-400w.json
@@ -15,7 +15,7 @@
 	},
 	"paramInformation": {
 		"2": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_on_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"3": {
 			"label": "Send Basic Report",

--- a/packages/config/config/devices/0x5254/zdm-80.json
+++ b/packages/config/config/devices/0x5254/zdm-80.json
@@ -54,7 +54,7 @@
 			]
 		},
 		"5": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"13": {
 			"label": "Double click option",

--- a/packages/config/config/devices/0x5254/zds-210na.json
+++ b/packages/config/config/devices/0x5254/zds-210na.json
@@ -26,7 +26,7 @@
 	},
 	"paramInformation": {
 		"5": {
-			"$import": "../templates/master_template.json#state_after_power_failure_off_prev"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"13": {
 			"label": "Double click option",

--- a/packages/config/src/Devices.ts
+++ b/packages/config/src/Devices.ts
@@ -363,7 +363,7 @@ export class ConditionalDeviceConfig {
 		const relativePath = relativeTo
 			? path.relative(relativeTo, filename).replace(/\\/g, "/")
 			: filename;
-		const json = await readJsonWithTemplate(filename);
+		const json = await readJsonWithTemplate(filename, relativeTo);
 		return new ConditionalDeviceConfig(relativePath, json);
 	}
 

--- a/packages/config/src/Devices.ts
+++ b/packages/config/src/Devices.ts
@@ -66,7 +66,7 @@ export type ParamInfoMap = ReadonlyObjectKeyMap<
 	ParamInformation
 >;
 
-const embeddedDevicesDir = path.join(configDir, "devices");
+export const embeddedDevicesDir = path.join(configDir, "devices");
 const fulltextIndexPath = path.join(embeddedDevicesDir, "fulltext_index.json");
 
 function getDevicesPaths(configDir: string): {
@@ -363,7 +363,10 @@ export class ConditionalDeviceConfig {
 		const relativePath = relativeTo
 			? path.relative(relativeTo, filename).replace(/\\/g, "/")
 			: filename;
-		const json = await readJsonWithTemplate(filename, relativeTo);
+		const json = await readJsonWithTemplate(
+			filename,
+			relativeTo ?? embeddedDevicesDir,
+		);
 		return new ConditionalDeviceConfig(relativePath, json);
 	}
 


### PR DESCRIPTION
With this PR, we simplified navigating to other directories in config file `$import`s. By prefixing a path with `~/`, it is resolved from the config root directory, avoiding broken links when moving files around or refactoring parameters into templates.

/cc @blhoward2 

fixes: #2980