### PR TITLE
fix(cc): don't retrieve startValue for multicast start/stopLevelChange

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -415,11 +415,15 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 				// Try to retrieve the current value to use as the start level,
 				// even if the target node is going to ignore it. There might
 				// be some bugged devices that ignore the ignore start level flag.
-				const startLevel = this.endpoint
-					.getNodeUnsafe()
-					?.getValue<number>(
-						getCurrentValueValueId(this.endpoint.index),
-					);
+				const startLevel =
+					// except for multicast, where we can't access the current value
+					this.endpoint instanceof VirtualEndpoint
+						? undefined
+						: this.endpoint
+								.getNodeUnsafe()
+								?.getValue<number>(
+									getCurrentValueValueId(this.endpoint.index),
+								);
 				// And perform the level change
 				const duration = Duration.from(options?.transitionDuration);
 				await this.startLevelChange({


### PR DESCRIPTION
Fixes the issue reported in https://github.com/zwave-js/node-zwave-js/discussions/3060