### PR TITLE
fix: determine if config file is embedded on the ConfigManager level

### DIFF
--- a/packages/config/maintenance/lintConfigFiles.ts
+++ b/packages/config/maintenance/lintConfigFiles.ts
@@ -183,9 +183,13 @@ async function lintDevices(): Promise<void> {
 		// Try parsing the file
 		let conditionalConfig: ConditionalDeviceConfig;
 		try {
-			conditionalConfig = await ConditionalDeviceConfig.from(filePath, {
-				rootDir,
-			});
+			conditionalConfig = await ConditionalDeviceConfig.from(
+				filePath,
+				true,
+				{
+					rootDir,
+				},
+			);
 		} catch (e) {
 			addError(file, e.message);
 			continue;

--- a/packages/config/src/ConfigManager.test.ts
+++ b/packages/config/src/ConfigManager.test.ts
@@ -122,9 +122,9 @@ describe("ConfigManager", () => {
 			await cm.loadAll();
 
 			// Load the Aeotec ZW100 Multisensor 6 - we know that it uses multiple imports that could fail validation
-			expect(
-				await cm.lookupDevice(0x0086, 0x0002, 0x0064),
-			).not.toBeUndefined();
+			const device = await cm.lookupDevice(0x0086, 0x0002, 0x0064);
+			expect(device).not.toBeUndefined();
+			expect(device?.isEmbedded).toBeTrue();
 		});
 
 		it("from the ZWAVEJS_EXTERNAL_CONFIG", async () => {
@@ -140,9 +140,9 @@ describe("ConfigManager", () => {
 			expect(await fs.pathExists(configDir)).toBeTrue();
 
 			// Load the Aeotec ZW100 Multisensor 6 - we know that it uses multiple imports that could fail validation
-			expect(
-				await cm.lookupDevice(0x0086, 0x0002, 0x0064),
-			).not.toBeUndefined();
+			const device = await cm.lookupDevice(0x0086, 0x0002, 0x0064);
+			expect(device).not.toBeUndefined();
+			expect(device?.isEmbedded).toBeTrue(); // ZWAVEJS_EXTERNAL_CONFIG is still considered as an embedded config
 		});
 
 		async function testDeviceConfigPriorityDir(
@@ -216,6 +216,7 @@ describe("ConfigManager", () => {
 			expect(device?.paramInformation?.get({ parameter: 1 })?.label).toBe(
 				"Test",
 			);
+			expect(device?.isEmbedded).toBeFalse(); // deviceConfigPriorityDir is considered a user-provided config
 		}
 
 		it("from the deviceConfigPriorityDir (without ZWAVEJS_EXTERNAL_CONFIG)", () =>

--- a/packages/config/src/ConfigManager.ts
+++ b/packages/config/src/ConfigManager.ts
@@ -576,11 +576,21 @@ export class ConfigManager {
 				: path.join(devicesDir, indexEntry.filename);
 			if (!(await pathExists(filePath))) return;
 
+			// A config file is treated as am embedded one when it is located under the devices root dir
+			// or the external config dir
+			const isEmbedded = !path
+				.relative(devicesDir, filePath)
+				.startsWith("..");
+
 			try {
-				return await ConditionalDeviceConfig.from(filePath, {
-					// When looking for device files, fall back to the embedded config dir
-					rootDir: indexEntry.rootDir ?? devicesDir,
-				});
+				return await ConditionalDeviceConfig.from(
+					filePath,
+					isEmbedded,
+					{
+						// When looking for device files, fall back to the embedded config dir
+						rootDir: indexEntry.rootDir ?? devicesDir,
+					},
+				);
 			} catch (e) {
 				if (process.env.NODE_ENV !== "test") {
 					this.logger.print(


### PR DESCRIPTION
With the recent fixes to config file loading, we noticed that all files from `ZWAVEJS_EXTERNAL_CONFIG` dir were considered external, although they are just a mirror of the embedded config (see https://github.com/zwave-js/node-zwave-js/issues/3067#issuecomment-884990168)

This PR fixes it.