### PR TITLE
fix(config): updates to FGS223 and FGD212

### DIFF
--- a/packages/config/config/devices/0x010f/fgd212_3.5.json
+++ b/packages/config/config/devices/0x010f/fgd212_3.5.json
@@ -29,6 +29,34 @@
 		"min": "3.5",
 		"max": "255.255"
 	},
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"description": "Reports the device status and allows for assigning single device only (main controller by default).",
+			"maxNodes": 1,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "Key S1 - On/Off",
+			"description": "Assigned to Key S1 (uses basic command class)",
+			"maxNodes": 5
+		},
+		"3": {
+			"label": "Key S1 - Dimmer",
+			"description": "Assigned to Key S1 (uses multilevel switch command class)",
+			"maxNodes": 5
+		},
+		"4": {
+			"label": "Key S2 - On/Off",
+			"description": "Assigned to Key S2 (uses Basic command class)",
+			"maxNodes": 5
+		},
+		"5": {
+			"label": "Key S2 - Dimmer",
+			"description": "Assigned to Key S2 (uses multilevel switch command class)",
+			"maxNodes": 5
+		}
+	},
 	"paramInformation": {
 		"1": {
 			"label": "Minimum Brightness Level",
@@ -172,11 +200,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "No calibration or manual settings",
+					"label": "No calibration or manual override",
 					"value": 0
 				},
 				{
-					"label": "Dimmer operates on auto-calibration",
+					"label": "Using auto-calibration",
 					"value": 1
 				}
 			]
@@ -234,7 +262,7 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Mono-stable input (button)",
+					"label": "Mono-stable input (momentary button)",
 					"value": 0
 				},
 				{
@@ -242,7 +270,7 @@
 					"value": 1
 				},
 				{
-					"label": "Roller blind switch (UP / DOWN)",
+					"label": "Roller blind switch (up / down)",
 					"value": 2
 				}
 			]
@@ -280,7 +308,7 @@
 					"value": 0
 				},
 				{
-					"label": "Output synced with input switch position",
+					"label": "Output syncs with input switch position",
 					"value": 1
 				}
 			]
@@ -291,48 +319,32 @@
 			"defaultValue": 1
 		},
 		"24[0x01]": {
-			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
-			"label": "Send Command Frames in 2nd and 3rd Association Groups when Switching ON (Single Click)",
-			"defaultValue": 0
+			"$import": "templates/fibaro_template.json#send_s1_associations_on"
 		},
 		"24[0x02]": {
-			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
-			"label": "Send Command Frames in 2nd and 3rd Association Groups when Switching OFF (Single Click)",
-			"defaultValue": 0
+			"$import": "templates/fibaro_template.json#send_s1_associations_off"
 		},
 		"24[0x04]": {
-			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
-			"label": "Send Command Frames in 2nd and 3rd Association Groups when Changing Dimming Level",
-			"defaultValue": 0
+			"$import": "templates/fibaro_template.json#send_s1_associations_hold_release"
 		},
 		"24[0x08]": {
-			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
-			"label": "Send Command Frames in 2nd and 3rd Association Groups on Double Click",
-			"defaultValue": 0
+			"$import": "templates/fibaro_template.json#send_s1_associations_double_click"
 		},
 		"24[0x10]": {
 			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Send Command Frames in 2nd and 3rd Association Groups with 0xFF Value on Double Click"
 		},
 		"25[0x01]": {
-			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
-			"label": "Send Command Frames in 4th and 5th Association Groups when Switching ON (Single Click)",
-			"defaultValue": 0
+			"$import": "templates/fibaro_template.json#send_s2_associations_on"
 		},
 		"25[0x02]": {
-			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
-			"label": "Send Command Frames in 4th and 5th Association Groups when Switching OFF (Single Click)",
-			"defaultValue": 0
+			"$import": "templates/fibaro_template.json#send_s2_associations_off"
 		},
 		"25[0x04]": {
-			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
-			"label": "Send Command Frames in 4th and 5th Association Groups when Changing Dimming Level",
-			"defaultValue": 0
+			"$import": "templates/fibaro_template.json#send_s2_associations_hold_release"
 		},
 		"25[0x08]": {
-			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
-			"label": "Send Command Frames in 4th and 5th Association Groups on Double Click",
-			"defaultValue": 0
+			"$import": "templates/fibaro_template.json#send_s2_associations_double_click"
 		},
 		"25[0x10]": {
 			"$import": "~/templates/master_template.json#base_enable_disable",
@@ -344,20 +356,20 @@
 			"description": "Key S2 also controls the dimmer"
 		},
 		"27[0x01]": {
-			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Send Secure Z-wave Commands to 2nd Association Group"
+			"$import": "templates/fibaro_template.json#send_secure_commands_group2",
+			"defaultValue": 1
 		},
 		"27[0x02]": {
-			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Send Secure Z-wave Commands to 3rd Association Group"
+			"$import": "templates/fibaro_template.json#send_secure_commands_group3",
+			"defaultValue": 1
 		},
 		"27[0x04]": {
-			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Send Secure Z-wave Commands to 4th Association Group"
+			"$import": "templates/fibaro_template.json#send_secure_commands_group4",
+			"defaultValue": 1
 		},
 		"27[0x08]": {
-			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Send Secure Z-wave Commands to 5th Association Group"
+			"$import": "templates/fibaro_template.json#send_secure_commands_group5",
+			"defaultValue": 1
 		},
 		"28": {
 			"$import": "~/templates/master_template.json#base_enable_disable",
@@ -387,7 +399,7 @@
 					"value": 1
 				},
 				{
-					"label": "Select from auto-calibration",
+					"label": "As recognized during auto-calibration",
 					"value": 2
 				}
 			]
@@ -413,7 +425,7 @@
 		},
 		"32": {
 			"label": "On/Off Mode",
-			"description": "Mode for connecting non-dimmable light sources.",
+			"description": "Useful when connecting non-dimmable loads.",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 2,
@@ -422,21 +434,21 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Disable (dimming is possible)",
+					"label": "Disable (dimming possible)",
 					"value": 0
 				},
 				{
-					"label": "Enable (dimming is not possible)",
+					"label": "Enable (dimming not possible)",
 					"value": 1
 				},
 				{
-					"label": "Select from auto-calibration",
+					"label": "As recognized during auto-calibration",
 					"value": 2
 				}
 			]
 		},
 		"33": {
-			"label": "Dimmability of the Load Recognized During Auto-Calibration",
+			"label": "Dimmability Recognized During Auto-Calibration",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
@@ -445,11 +457,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Dimming possible",
+					"label": "Enable (dimming possible",
 					"value": 0
 				},
 				{
-					"label": "Dimming not possible",
+					"label": "Disable (dimming not possible)",
 					"value": 1
 				}
 			]
@@ -556,120 +568,20 @@
 			"defaultValue": 250
 		},
 		"40": {
-			"label": "General Purpose Alarm Response",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 3,
-			"defaultValue": 3,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "No reaction",
-					"value": 0
-				},
-				{
-					"label": "Turn on the load",
-					"value": 1
-				},
-				{
-					"label": "Turn off the load",
-					"value": 2
-				},
-				{
-					"label": "Load blinking",
-					"value": 3
-				}
-			]
+			"$import": "templates/fibaro_template.json#general_purpose_alarm_response"
 		},
 		"41": {
-			"label": "Water Flooding Alarm Response",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 3,
-			"defaultValue": 2,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "No reaction",
-					"value": 0
-				},
-				{
-					"label": "Turn on the load",
-					"value": 1
-				},
-				{
-					"label": "Turn off the load",
-					"value": 2
-				},
-				{
-					"label": "Load blinking",
-					"value": 3
-				}
-			]
+			"$import": "templates/fibaro_template.json#water_flood_alarm_response"
 		},
 		"42": {
-			"label": "Smoke, CO or CO2 Alarm Response",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 3,
-			"defaultValue": 3,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "No reaction",
-					"value": 0
-				},
-				{
-					"label": "Turn on the load",
-					"value": 1
-				},
-				{
-					"label": "Turn off the load",
-					"value": 2
-				},
-				{
-					"label": "Load blinking",
-					"value": 3
-				}
-			]
+			"$import": "templates/fibaro_template.json#smoke_alarm_response"
 		},
 		"43": {
-			"label": "Temperature Alarm Response",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "No reaction",
-					"value": 0
-				},
-				{
-					"label": "Turn on the load",
-					"value": 1
-				},
-				{
-					"label": "Turn off the load",
-					"value": 2
-				},
-				{
-					"label": "Load blinking",
-					"value": 3
-				}
-			]
+			"$import": "templates/fibaro_template.json#temperature_alarm_response"
 		},
 		"44": {
-			"label": "Time of Alarm State",
-			"valueSize": 2,
-			"unit:": "seconds",
-			"minValue": 1,
-			"maxValue": 32767,
-			"defaultValue": 600
+			"$import": "templates/fibaro_template.json#alarm_state_time",
+			"maxValue": 32767
 		},
 		"45": {
 			"label": "Power Limit Alarm Report",
@@ -772,52 +684,21 @@
 			]
 		},
 		"50": {
-			"label": "Active Power Report: Threshold",
-			"description": "Relative change since previous report sent",
-			"valueSize": 1,
-			"unit": "%",
-			"minValue": 0,
-			"maxValue": 100,
-			"defaultValue": 10,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				}
-			]
+			"$import": "templates/fibaro_template.json#active_power_report_threshold",
+			"defaultValue": 10
 		},
 		"52": {
+			"$import": "templates/fibaro_template.json#reports_periodic",
 			"label": "Periodic Active Power and Energy Reports",
-			"valueSize": 2,
-			"unit": "seconds",
-			"minValue": 0,
-			"maxValue": 32767,
-			"defaultValue": 3600,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				}
-			]
+			"maxValue": 32767
 		},
 		"53": {
-			"label": "Energy Report: Threshold",
-			"valueSize": 2,
-			"unit": "0.01 kWh",
-			"minValue": 0,
+			"$import": "templates/fibaro_template.json#energy_report_threshold",
 			"maxValue": 255,
-			"defaultValue": 10,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				}
-			]
+			"defaultValue": 10
 		},
 		"54": {
-			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Self-measurement",
-			"description": "Reports include power and energy used by device"
+			"$import": "templates/fibaro_template.json#reports_include_self"
 		},
 		"58": {
 			"label": "Active Power Calculation Method",
@@ -852,8 +733,8 @@
 		}
 	},
 	"metadata": {
-		"inclusion": "Turn the primary controller of Z-Wave network into inclusion mode, quickly press key S1 or B-button product's housing three times",
-		"exclusion": "Turn the primary controller of Z-Wave network into exclusion mode, quickly press key S1 or B-button product's housing three times",
+		"inclusion": "Turn the primary controller of Z-Wave network into inclusion mode, quickly press key S1 or B-button on product's housing three times",
+		"exclusion": "Turn the primary controller of Z-Wave network into exclusion mode, quickly press key S1 or B-button on product's housing three times",
 		"reset": "1. Power-cycle the device\n2. Press and hold the B-button to enter the menu\n3. Wait for the LED to turn yellow\n4. Quickly release and click B-button again\n5. Device will restart and LED will turn red",
 		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/2836/FGD-212-EN-T-v1.3.pdf"
 	}

--- a/packages/config/config/devices/0x010f/fgd212_3.5.json
+++ b/packages/config/config/devices/0x010f/fgd212_3.5.json
@@ -705,9 +705,7 @@
 		}
 	},
 	"metadata": {
-		"inclusion": "Turn the primary controller of Z-Wave network into inclusion mode, quickly press key S1 or B-button on product's housing three times",
-		"exclusion": "Turn the primary controller of Z-Wave network into exclusion mode, quickly press key S1 or B-button on product's housing three times",
-		"reset": "1. Power-cycle the device\n2. Press and hold the B-button to enter the menu\n3. Wait for the LED to turn yellow\n4. Quickly release and click B-button again\n5. Device will restart and LED will turn red",
+		"$import": "templates/fibaro_template.json#default_metadata_for_fibaro",
 		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/2836/FGD-212-EN-T-v1.3.pdf"
 	}
 }

--- a/packages/config/config/devices/0x010f/fgd212_3.5.json
+++ b/packages/config/config/devices/0x010f/fgd212_3.5.json
@@ -29,34 +29,6 @@
 		"min": "3.5",
 		"max": "255.255"
 	},
-	"associations": {
-		"1": {
-			"label": "Lifeline",
-			"description": "Reports the device status and allows for assigning single device only (main controller by default).",
-			"maxNodes": 1,
-			"isLifeline": true
-		},
-		"2": {
-			"label": "Key S1 - On/Off",
-			"description": "Assigned to Key S1 (uses basic command class)",
-			"maxNodes": 5
-		},
-		"3": {
-			"label": "Key S1 - Dimmer",
-			"description": "Assigned to Key S1 (uses multilevel switch command class)",
-			"maxNodes": 5
-		},
-		"4": {
-			"label": "Key S2 - On/Off",
-			"description": "Assigned to Key S2 (uses Basic command class)",
-			"maxNodes": 5
-		},
-		"5": {
-			"label": "Key S2 - Dimmer",
-			"description": "Assigned to Key S2 (uses multilevel switch command class)",
-			"maxNodes": 5
-		}
-	},
 	"paramInformation": {
 		"1": {
 			"label": "Minimum Brightness Level",

--- a/packages/config/config/devices/0x010f/fgd212_3.5.json
+++ b/packages/config/config/devices/0x010f/fgd212_3.5.json
@@ -705,7 +705,7 @@
 		}
 	},
 	"metadata": {
-		"$import": "templates/fibaro_template.json#default_metadata_for_fibaro",
+		"$import": "templates/fibaro_template.json#default_metadata",
 		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/2836/FGD-212-EN-T-v1.3.pdf"
 	}
 }

--- a/packages/config/config/devices/0x010f/fgd212_3.5.json
+++ b/packages/config/config/devices/0x010f/fgd212_3.5.json
@@ -429,11 +429,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Enable (dimming possible",
+					"label": "Dimming possible",
 					"value": 0
 				},
 				{
-					"label": "Disable (dimming not possible)",
+					"label": "Dimming not possible",
 					"value": 1
 				}
 			]

--- a/packages/config/config/devices/0x010f/fgs223.json
+++ b/packages/config/config/devices/0x010f/fgs223.json
@@ -319,11 +319,11 @@
 		},
 		"35[0x04]": {
 			"$import": "templates/fibaro_template.json#send_s2_associations_hold_release",
-			"description": "Reuqires Key S2 to be configured as momentary"
+			"description": "Requires Key S2 to be configured as momentary"
 		},
 		"35[0x08]": {
 			"$import": "templates/fibaro_template.json#send_s2_associations_double_click",
-			"description": "Reuqires Key S2 to be configured as momentary or to change each time input changes"
+			"description": "Requires Key S2 to be configured as momentary or to change each time input changes"
 		},
 		"36": {
 			"label": "Key S2 Associations: Switch ON Value Sent",

--- a/packages/config/config/devices/0x010f/fgs223.json
+++ b/packages/config/config/devices/0x010f/fgs223.json
@@ -37,23 +37,23 @@
 			"isLifeline": true
 		},
 		"2": {
-			"label": "On/Off (S1)",
-			"description": "On/Off (S1) is assigned to switch connected to the S1 terminal (uses Basic command class)",
+			"label": "Key S1 - On/Off",
+			"description": "Assigned to Key S1 (uses basic command class)",
 			"maxNodes": 5
 		},
 		"3": {
-			"label": "Dimmer (S1)",
-			"description": "Dimmer (S1) is assigned to switch connected to the S1 terminal (uses Switch Multilevel command class)",
+			"label": "Key S1 - Dimmer",
+			"description": "Assigned to Key S1 (uses multilevel switch command class)",
 			"maxNodes": 5
 		},
 		"4": {
-			"label": "On/Off (S2)",
-			"description": "On/Off (S2) is assigned to switch connected to the S2 terminal (uses Basic command class)",
+			"label": "Key S2 - On/Off",
+			"description": "Assigned to Key S2 (uses basic command class)",
 			"maxNodes": 5
 		},
 		"5": {
-			"label": "Dimmer (S2)",
-			"description": "Dimmer (S2) is assigned to switch connected to the S2 terminal (uses Switch Multilevel command class)",
+			"label": "Key S2 - Dimmer",
+			"description": "Assigned to Key S2 (uses multilevel switch command class)",
 			"maxNodes": 5
 		}
 	},
@@ -62,8 +62,7 @@
 			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
 		},
 		"10": {
-			"label": "First channel - operating mode",
-			"description": "This parameter allows to choose operating for the 1st channel controlled by the S1 switch.",
+			"label": "First Channel - Operating Mode",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 5,
@@ -72,34 +71,33 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Standard operation",
+					"label": "Standard",
 					"value": 0
 				},
 				{
-					"label": "Delay ON",
+					"label": "Delay turn ON",
 					"value": 1
 				},
 				{
-					"label": "Delay OFF",
+					"label": "Delay turn OFF",
 					"value": 2
 				},
 				{
-					"label": "Auto ON",
+					"label": "Automatically turn ON",
 					"value": 3
 				},
 				{
-					"label": "Auto OFF",
+					"label": "Automatically turn OFF",
 					"value": 4
 				},
 				{
-					"label": "Flashing Mode",
+					"label": "Blink",
 					"value": 5
 				}
 			]
 		},
 		"11": {
-			"label": "First channel - reaction to switch for delay/auto ON/OFF modes",
-			"description": "This parameter determines how the device in timed mode reacts to pushing the switch connected to the S1 terminal.",
+			"label": "First Channel - Reaction to Key S1 for Delay/Auto ON/OFF Modes",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 2,
@@ -108,32 +106,36 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Cancel mode and set target state",
+					"label": "Cancel and set target state",
 					"value": 0
 				},
 				{
-					"label": "No reaction to switch - mode runs until it ends",
+					"label": "Ignore - mode runs until it ends",
 					"value": 1
 				},
 				{
-					"label": "Reset timer - start counting from the beginning",
+					"label": "Reset - start time from the beginning",
 					"value": 2
 				}
 			]
 		},
 		"12": {
-			"label": "First channel - time parameter for delay/auto ON/OFF modes",
-			"description": "This parameter allows to set time parameter used in timed modes.",
+			"label": "First Channel - Time Parameter for Delay/Auto ON/OFF Modes",
 			"valueSize": 2,
 			"unit": "seconds",
-			"minValue": 1,
+			"minValue": 0,
 			"maxValue": 32000,
 			"defaultValue": 50,
-			"unsigned": true
+			"unsigned": true,
+			"options": [
+				{
+					"label": "0.1 seconds",
+					"value": 0
+				}
+			]
 		},
 		"13": {
-			"label": "First channel - pulse time for flashing mode",
-			"description": "This parameter allows to set time of switching to opposite state in flashing mode.",
+			"label": "First Channel - Pulse Time for Blink Mode",
 			"valueSize": 2,
 			"unit": "0.1 seconds",
 			"minValue": 1,
@@ -142,8 +144,7 @@
 			"unsigned": true
 		},
 		"15": {
-			"label": "Second channel - operating mode",
-			"description": "This parameter allows to choose operating for the 2nd channel controlled by the S2 switch.",
+			"label": "Second Channel - Operating Mode",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 5,
@@ -152,34 +153,33 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Standard operation",
+					"label": "Standard",
 					"value": 0
 				},
 				{
-					"label": "Delay ON",
+					"label": "Delay turn ON",
 					"value": 1
 				},
 				{
-					"label": "Delay OFF",
+					"label": "Delay turn OFF",
 					"value": 2
 				},
 				{
-					"label": "Auto ON",
+					"label": "Automatically turn ON",
 					"value": 3
 				},
 				{
-					"label": "Auto OFF",
+					"label": "Automatically turn OFF",
 					"value": 4
 				},
 				{
-					"label": "Flashing Mode",
+					"label": "Blink",
 					"value": 5
 				}
 			]
 		},
 		"16": {
-			"label": "Second channel - reaction to switch for delay/auto ON/OFF modes",
-			"description": "This parameter determines how the device in timed mode reacts to pushing the switch connected to the S2 terminal.",
+			"label": "Second Channel - Reaction to Key S2 for Delay/Auto ON/OFF Modes",
 			"valueSize": 1,
 			"unit": "seconds",
 			"minValue": 0,
@@ -189,41 +189,45 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Cancel mode and set target state",
+					"label": "Cancel and set target state",
 					"value": 0
 				},
 				{
-					"label": "No reaction to switch - mode runs until it ends",
+					"label": "Ignore - mode runs until it ends",
 					"value": 1
 				},
 				{
-					"label": "Reset timer - start counting from the beginning",
+					"label": "Reset - start time from the beginning",
 					"value": 2
 				}
 			]
 		},
 		"17": {
-			"label": "Second channel - time parameter for delay/auto ON/OFF modes",
-			"description": "This parameter allows to set time parameter used in timed modes.",
+			"label": "Second Channel - Time Parameter for Delay/Auto ON/OFF Modes",
 			"valueSize": 2,
-			"unit": "0.1 seconds",
-			"minValue": 1,
+			"unit": "seconds",
+			"minValue": 0,
 			"maxValue": 32000,
 			"defaultValue": 50,
-			"unsigned": true
+			"unsigned": true,
+			"options": [
+				{
+					"label": "0.1 seconds",
+					"value": 0
+				}
+			]
 		},
 		"18": {
-			"label": "Second channel - pulse time for flashing mode",
-			"description": "This parameter allows to set time of switching to opposite state in flashing mode.",
+			"label": "Second Channel - Pulse Time for Blink Mode",
 			"valueSize": 2,
+			"unit": "0.1 seconds",
 			"minValue": 1,
 			"maxValue": 32000,
 			"defaultValue": 5,
 			"unsigned": true
 		},
 		"20": {
-			"label": "Switch type",
-			"description": "Inputs type configuration",
+			"label": "Input Button/Switch Configuration",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 2,
@@ -232,174 +236,87 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Momentary switch",
+					"label": "Momentary",
 					"value": 0
 				},
 				{
-					"label": "Toggle switch (contact closed - ON, contact opened - OFF)",
+					"label": "Switch (status syncs with switch position)",
 					"value": 1
 				},
 				{
-					"label": "Toggle switch (device changes status when switch changes status)",
+					"label": "Switch (status changes when switch change)",
 					"value": 2
 				}
 			]
 		},
 		"21": {
-			"label": "Flashing mode report",
-			"description": "Enabled / Disabled reports on Flashing mode",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disabled",
-					"value": 0
-				},
-				{
-					"label": "Enabled",
-					"value": 1
-				}
-			]
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Report During Blink Mode"
 		},
 		"27[0x01]": {
-			"label": "Associations: Send secure commands to 2nd group",
-			"description": "This is only active when the node is included securely",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"unsigned": true
+			"$import": "templates/fibaro_template.json#send_secure_commands_group2",
+			"defaultValue": 1
 		},
 		"27[0x02]": {
-			"label": "Associations: Send secure commands to 3rd group",
-			"description": "This is only active when the node is included securely",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"unsigned": true
+			"$import": "templates/fibaro_template.json#send_secure_commands_group3",
+			"defaultValue": 1
 		},
 		"27[0x04]": {
-			"label": "Associations: Send secure commands to 4th group",
-			"description": "This is only active when the node is included securely",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"unsigned": true
+			"$import": "templates/fibaro_template.json#send_secure_commands_group4",
+			"defaultValue": 1
 		},
 		"27[0x08]": {
-			"label": "Associations: Send secure commands to 5th group",
-			"description": "This is only active when the node is included securely",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"unsigned": true
+			"$import": "templates/fibaro_template.json#send_secure_commands_group5",
+			"defaultValue": 1
 		},
 		"28[0x01]": {
-			"label": "S1 switch - Send Scenes: Key pressed 1 time",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Key S1: Send Scenes When Pressed 1 Time"
 		},
 		"28[0x02]": {
-			"label": "S1 switch - Send Scenes: Key pressed 2 times",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Key S1: Send Scenes When Pressed 2 Times"
 		},
 		"28[0x04]": {
-			"label": "S1 switch - Send Scenes: Key pressed 3 times",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Key S1: Send Scenes When Pressed 3 Times"
 		},
 		"28[0x08]": {
-			"label": "S1 switch - Send Scenes: Key held down and Key released",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Key S1: Send Scenes When Held Down and Released"
 		},
 		"29[0x01]": {
-			"label": "S2 switch - Send Scenes: Key pressed 1 time",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Key S2: Send Scenes When Pressed 1 Time"
 		},
 		"29[0x02]": {
-			"label": "S2 switch - Send Scenes: Key pressed 2 times",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Key S2: Send Scenes When Pressed 2 Times"
 		},
 		"29[0x04]": {
-			"label": "S2 switch - Send Scenes: Key pressed 3 times",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Key S2: Send Scenes When Pressed 3 Times"
 		},
 		"29[0x08]": {
-			"label": "S2 switch - Send Scenes: Key held down and Key released",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Key S2: Send Scenes When Held Down and Released"
 		},
 		"30[0x01]": {
-			"label": "S1 switch associations - Ignore turning ON with 1 click",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "templates/fibaro_template.json#send_s1_associations_on"
 		},
 		"30[0x02]": {
-			"label": "S1 switch associations - Ignore turning OFF with 1 click",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "templates/fibaro_template.json#send_s1_associations_off"
 		},
 		"30[0x04]": {
-			"label": "S1 switch associations - Ignore holding and releasing",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "templates/fibaro_template.json#send_s1_associations_hold_release",
+			"description": "Reuqires Key S1 to be configured as momentary"
 		},
 		"30[0x08]": {
-			"label": "S1 switch associations - Ignore double click",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "templates/fibaro_template.json#send_s1_associations_double_click",
+			"description": "Reuqires Key S1 to be configured as momentary or to change each time input changes"
 		},
 		"31": {
-			"label": "S1 Switch ON value sent to 2nd and 3rd association groups",
-			"description": "This parameter determines value sent with Switch On command to devices associated in 2nd and 3rd association group.",
+			"label": "Key S1 Associations: Switch ON Value Sent",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 255,
@@ -407,8 +324,7 @@
 			"unsigned": true
 		},
 		"32": {
-			"label": "S1 Switch OFF value sent to 2nd and 3rd association groups",
-			"description": "This parameter determines value sent with Switch Off command to devices associated in 2nd and 3rd association group.",
+			"label": "Key S1 Associations: Switch OFF Value Sent",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 255,
@@ -416,8 +332,7 @@
 			"unsigned": true
 		},
 		"33": {
-			"label": "S1 Switch Double Click value sent to 2nd and 3rd association groups",
-			"description": "This parameter determines value sent with Double Click command to devices associated in 2nd and 3rd association group.",
+			"label": "Key S1 Associations: Double Click Value Sent",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 255,
@@ -425,40 +340,21 @@
 			"unsigned": true
 		},
 		"35[0x01]": {
-			"label": "S2 switch associations - Ignore turning ON with 1 click",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "templates/fibaro_template.json#send_s2_associations_on"
 		},
 		"35[0x02]": {
-			"label": "S2 switch associations - Ignore turning OFF with 1 click",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "templates/fibaro_template.json#send_s2_associations_off"
 		},
 		"35[0x04]": {
-			"label": "S2 switch associations - Ignore holding and releasing",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "templates/fibaro_template.json#send_s2_associations_hold_release",
+			"description": "Reuqires Key S2 to be configured as momentary"
 		},
 		"35[0x08]": {
-			"label": "S2 switch associations - Ignore double click",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "templates/fibaro_template.json#send_s2_associations_double_click",
+			"description": "Reuqires Key S2 to be configured as momentary or to change each time input changes"
 		},
 		"36": {
-			"label": "S2 Switch ON value sent to 4th and 5th association groups",
-			"description": "This parameter determines value sent with Switch On command to devices associated in 4th and 5th association group.",
+			"label": "Key S2 Associations: Switch ON Value Sent",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 255,
@@ -466,8 +362,7 @@
 			"unsigned": true
 		},
 		"37": {
-			"label": "S2 Switch OFF value sent to 4th and 5th association groups",
-			"description": "This parameter determines value sent with Switch Off command to devices associated in 4th and 5th association group.",
+			"label": "Key S2 Associations: Switch OFF Value Sent",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 255,
@@ -475,8 +370,7 @@
 			"unsigned": true
 		},
 		"38": {
-			"label": "S2 Switch Double Click value sent to 4th and 5th association groups",
-			"description": "This parameter determines value sent with Double Click command to devices associated in 4th and 5th association group.",
+			"label": "Key S2 Associations: Double Click Value Sent",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 255,
@@ -484,226 +378,92 @@
 			"unsigned": true
 		},
 		"40": {
-			"label": "Reaction to General Alarm",
-			"description": "This parameter determines how the device will react to General Alarm frame.",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 3,
-			"defaultValue": 3,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Ignored",
-					"value": 0
-				},
-				{
-					"label": "Turn On",
-					"value": 1
-				},
-				{
-					"label": "Turn OFF",
-					"value": 2
-				},
-				{
-					"label": "Flash",
-					"value": 3
-				}
-			]
+			"$import": "templates/fibaro_template.json#general_purpose_alarm_response"
 		},
 		"41": {
-			"label": "Reaction to Flood Alarm",
-			"description": "This parameter determines how the device will react to Flood Alarm frame.",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 3,
-			"defaultValue": 2,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Ignored",
-					"value": 0
-				},
-				{
-					"label": "Turn On",
-					"value": 1
-				},
-				{
-					"label": "Turn OFF",
-					"value": 2
-				},
-				{
-					"label": "Flash",
-					"value": 3
-				}
-			]
+			"$import": "templates/fibaro_template.json#water_flood_alarm_response"
 		},
 		"42": {
-			"label": "Reaction to CO/CO2/Smoke Alarm",
-			"description": "This parameter determines how the device will react to CO/CO2/Smoke Alarm frame.",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 3,
-			"defaultValue": 3,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Ignored",
-					"value": 0
-				},
-				{
-					"label": "Turn On",
-					"value": 1
-				},
-				{
-					"label": "Turn OFF",
-					"value": 2
-				},
-				{
-					"label": "Flash",
-					"value": 3
-				}
-			]
+			"$import": "templates/fibaro_template.json#smoke_alarm_response"
 		},
 		"43": {
-			"label": "Reaction to Heat Alarm",
-			"description": "This parameter determines how the device will react to Heat alarm frame.",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 3,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Ignored",
-					"value": 0
-				},
-				{
-					"label": "Turn On",
-					"value": 1
-				},
-				{
-					"label": "Turn OFF",
-					"value": 2
-				},
-				{
-					"label": "Flash",
-					"value": 3
-				}
-			]
+			"$import": "templates/fibaro_template.json#temperature_alarm_response"
 		},
 		"44": {
-			"label": "Flashing alarm duration",
-			"description": "This parameter allows to set duration of flashing alarm mode.",
-			"valueSize": 2,
-			"unit": "seconds",
-			"minValue": 1,
-			"maxValue": 32000,
-			"defaultValue": 600,
-			"unsigned": true
+			"$import": "templates/fibaro_template.json#alarm_state_time",
+			"maxValue": 32000
 		},
 		"50": {
-			"label": "First channel - power reports",
-			"description": "This parameter determines the minimum change in consumed power that will result in sending new power report to the main controller.",
-			"valueSize": 2,
-			"unit": "%",
-			"minValue": 1,
-			"maxValue": 100,
+			"$import": "templates/fibaro_template.json#active_power_report_threshold",
 			"defaultValue": 20,
-			"unsigned": true
+			"label": "First Channel - Active Power Report: Threshold"
 		},
 		"51": {
-			"label": "First channel - minimal time between power reports",
-			"description": "This parameter determines minimum time that has to elapse before sending new power report to the main controller.",
-			"valueSize": 2,
-			"unit": "seconds",
-			"minValue": 1,
-			"maxValue": 120,
-			"defaultValue": 10,
-			"unsigned": true
-		},
-		"53": {
-			"label": "First channel - energy reports",
-			"description": "This parameter determines the minimum change in consumed energy that will result in sending new energy report to the main controller.",
-			"valueSize": 2,
-			"unit": "0.01 kWh",
-			"minValue": 1,
-			"maxValue": 32000,
-			"defaultValue": 100,
-			"unsigned": true
-		},
-		"54": {
-			"label": "Second Channel - power reports",
-			"description": "This parameter determines the minimum change in consumed power that will result in sending new power report to the main controller.",
-			"valueSize": 2,
-			"unit": "%",
-			"minValue": 1,
-			"maxValue": 100,
-			"defaultValue": 20,
-			"unsigned": true
-		},
-		"55": {
-			"label": "Second channel - minimal time between power reports",
-			"description": "This parameter determines minimum time that has to elapse before sending new power report to the main controller.",
-			"valueSize": 2,
-			"unit": "seconds",
-			"minValue": 1,
-			"maxValue": 120,
-			"defaultValue": 10,
-			"unsigned": true
-		},
-		"57": {
-			"label": "Second channel - energy reports",
-			"description": "This parameter determines the minimum change in consumed energy that will result in sending new energy report to the main controller.",
-			"valueSize": 2,
-			"unit": "0.01 kWh",
-			"minValue": 1,
-			"maxValue": 32000,
-			"defaultValue": 100,
-			"unsigned": true
-		},
-		"58": {
-			"label": "Periodic power reports",
-			"description": "This parameter determines in what time interval the periodic power reports are sent to the main controller.",
-			"valueSize": 2,
-			"unit": "seconds",
-			"minValue": 1,
-			"maxValue": 32000,
-			"defaultValue": 3600,
-			"unsigned": true
-		},
-		"59": {
-			"label": "Periodic energy reports",
-			"description": "This parameter determines in what time interval the periodic power reports are sent to the main controller.",
-			"valueSize": 2,
-			"unit": "seconds",
-			"minValue": 1,
-			"maxValue": 32000,
-			"defaultValue": 3600,
-			"unsigned": true
-		},
-		"60": {
-			"label": "Measuring energy consumed by the device itself",
-			"description": "This parameter determines whether energy metering should include the amount of energy consumed by the device itself. Results are being added to energy reports for first endpoint.",
+			"label": "First Channel - Active Power Report: Minimum Time Between Reports",
 			"valueSize": 1,
+			"unit": "seconds",
 			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
+			"maxValue": 120,
+			"defaultValue": 10,
 			"unsigned": true,
-			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "function inactive",
+					"label": "Disable",
 					"value": 0
-				},
-				{
-					"label": "function active",
-					"value": 1
 				}
 			]
+		},
+		"53": {
+			"$import": "templates/fibaro_template.json#energy_report_threshold",
+			"maxValue": 32000,
+			"defaultValue": 100,
+			"label": "First Channel - Energy Reports: Threshold"
+		},
+		"54": {
+			"$import": "templates/fibaro_template.json#active_power_report_threshold",
+			"defaultValue": 20,
+			"label": "Second Channel - Active Power Report: Threshold"
+		},
+		"55": {
+			"label": "Second Channel - Active Power Report: Minimum Time Between Reports",
+			"valueSize": 1,
+			"unit": "seconds",
+			"minValue": 0,
+			"maxValue": 120,
+			"defaultValue": 10,
+			"unsigned": true,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
+		},
+		"57": {
+			"$import": "templates/fibaro_template.json#energy_report_threshold",
+			"maxValue": 32000,
+			"defaultValue": 100,
+			"label": "Second Channel - Energy Reports: Threshold"
+		},
+		"58": {
+			"$import": "templates/fibaro_template.json#reports_periodic",
+			"label": "Periodic Active Power Reports",
+			"maxValue": 32000
+		},
+		"59": {
+			"$import": "templates/fibaro_template.json#reports_periodic",
+			"label": "Periodic Energy Reports",
+			"maxValue": 32000
+		},
+		"60": {
+			"$import": "templates/fibaro_template.json#reports_include_self",
+			"description": "If enabled, it will be included in the reports for the first channel"
 		}
+	},
+	"metadata": {
+		"inclusion": "Turn the primary controller of Z-Wave network into inclusion mode, quickly press key S1 or B-button on product's housing three times",
+		"exclusion": "Turn the primary controller of Z-Wave network into exclusion mode, quickly press key S1 or B-button on product's housing three times",
+		"reset": "1. Power-cycle the device\n2. Press and hold the B-button to enter the menu\n3. Wait for the LED to turn yellow\n4. Quickly release and click B-button again\n5. Device will restart and LED will turn red",
+		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/1742/FGS-2x3-EN-T-v1.0%2006.06.2016.pdf"
 	}
 }

--- a/packages/config/config/devices/0x010f/fgs223.json
+++ b/packages/config/config/devices/0x010f/fgs223.json
@@ -367,8 +367,8 @@
 		},
 		"50": {
 			"$import": "templates/fibaro_template.json#active_power_report_threshold",
-			"defaultValue": 20,
-			"label": "First Channel - Active Power Report: Threshold"
+			"label": "First Channel - Active Power Report: Threshold",
+			"defaultValue": 20
 		},
 		"51": {
 			"label": "First Channel - Active Power Report: Minimum Time Between Reports",

--- a/packages/config/config/devices/0x010f/fgs223.json
+++ b/packages/config/config/devices/0x010f/fgs223.json
@@ -433,7 +433,7 @@
 		}
 	},
 	"metadata": {
-		"$import": "templates/fibaro_template.json#default_metadata_for_fibaro",
+		"$import": "templates/fibaro_template.json#default_metadata",
 		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/1742/FGS-2x3-EN-T-v1.0%2006.06.2016.pdf"
 	}
 }

--- a/packages/config/config/devices/0x010f/fgs223.json
+++ b/packages/config/config/devices/0x010f/fgs223.json
@@ -433,9 +433,7 @@
 		}
 	},
 	"metadata": {
-		"inclusion": "Turn the primary controller of Z-Wave network into inclusion mode, quickly press key S1 or B-button on product's housing three times",
-		"exclusion": "Turn the primary controller of Z-Wave network into exclusion mode, quickly press key S1 or B-button on product's housing three times",
-		"reset": "1. Power-cycle the device\n2. Press and hold the B-button to enter the menu\n3. Wait for the LED to turn yellow\n4. Quickly release and click B-button again\n5. Device will restart and LED will turn red",
+		"$import": "templates/fibaro_template.json#default_metadata_for_fibaro",
 		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/1742/FGS-2x3-EN-T-v1.0%2006.06.2016.pdf"
 	}
 }

--- a/packages/config/config/devices/0x010f/fgs223.json
+++ b/packages/config/config/devices/0x010f/fgs223.json
@@ -29,34 +29,6 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
-	"associations": {
-		"1": {
-			"label": "Lifeline",
-			"description": "Reports the device status and allows for assigning single device only (main controller by default).",
-			"maxNodes": 1,
-			"isLifeline": true
-		},
-		"2": {
-			"label": "Key S1 - On/Off",
-			"description": "Assigned to Key S1 (uses basic command class)",
-			"maxNodes": 5
-		},
-		"3": {
-			"label": "Key S1 - Dimmer",
-			"description": "Assigned to Key S1 (uses multilevel switch command class)",
-			"maxNodes": 5
-		},
-		"4": {
-			"label": "Key S2 - On/Off",
-			"description": "Assigned to Key S2 (uses basic command class)",
-			"maxNodes": 5
-		},
-		"5": {
-			"label": "Key S2 - Dimmer",
-			"description": "Assigned to Key S2 (uses multilevel switch command class)",
-			"maxNodes": 5
-		}
-	},
 	"paramInformation": {
 		"9": {
 			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"

--- a/packages/config/config/devices/0x010f/templates/fibaro_template.json
+++ b/packages/config/config/devices/0x010f/templates/fibaro_template.json
@@ -1,0 +1,219 @@
+{
+	"send_secure_commands_group2": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Send Secure Z-wave Commands to 2nd Association Group",
+		"description": "Only active when the node is included securely"
+	},
+	"send_secure_commands_group3": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Send Secure Z-wave Commands to 3rd Association Group",
+		"description": "Only active when the node is included securely"
+	},
+	"send_secure_commands_group4": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Send Secure Z-wave Commands to 4tg Association Group",
+		"description": "Only active when the node is included securely"
+	},
+	"send_secure_commands_group5": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Send Secure Z-wave Commands to 5th Association Group",
+		"description": "Only active when the node is included securely"
+	},
+	"send_s1_associations_on": {
+		"$import": "~/templates/master_template.json#base_enable_disable_inverted",
+		"label": "Key S1 Associations: Send ON With Single Click",
+		"defaultValue": 0
+	},
+	"send_s1_associations_off": {
+		"$import": "~/templates/master_template.json#base_enable_disable_inverted",
+		"label": "Key S1 Associations: Send OFF With Single Click",
+		"defaultValue": 0
+	},
+	"send_s1_associations_hold_release": {
+		"$import": "~/templates/master_template.json#base_enable_disable_inverted",
+		"label": "Key S1 Associations: Send When Holding and Releasing",
+		"defaultValue": 0
+	},
+	"send_s1_associations_double_click": {
+		"$import": "~/templates/master_template.json#base_enable_disable_inverted",
+		"label": "Key S1 Associations: Send When Double Clicking",
+		"defaultValue": 0
+	},
+	"send_s2_associations_on": {
+		"$import": "~/templates/master_template.json#base_enable_disable_inverted",
+		"label": "Key S2 Associations: Send ON With Single Click",
+		"defaultValue": 0
+	},
+	"send_s2_associations_off": {
+		"$import": "~/templates/master_template.json#base_enable_disable_inverted",
+		"label": "Key S2 Associations: Send OFF With Single Click",
+		"defaultValue": 0
+	},
+	"send_s2_associations_hold_release": {
+		"$import": "~/templates/master_template.json#base_enable_disable_inverted",
+		"label": "Key S2 Associations: Send When Holding and Releasing",
+		"defaultValue": 0
+	},
+	"send_s2_associations_double_click": {
+		"$import": "~/templates/master_template.json#base_enable_disable_inverted",
+		"label": "Key S2 Associations: Send When Double Clicking",
+		"defaultValue": 0
+	},
+	"general_purpose_alarm_response": {
+		"label": "General Purpose Alarm Response",
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 3,
+		"defaultValue": 3,
+		"unsigned": true,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Ignore",
+				"value": 0
+			},
+			{
+				"label": "Turn on load",
+				"value": 1
+			},
+			{
+				"label": "Turn off load",
+				"value": 2
+			},
+			{
+				"label": "Blink load",
+				"value": 3
+			}
+		]
+	},
+	"water_flood_alarm_response": {
+		"label": "Water Flood Alarm Response",
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 3,
+		"defaultValue": 2,
+		"unsigned": true,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Ignore",
+				"value": 0
+			},
+			{
+				"label": "Turn on load",
+				"value": 1
+			},
+			{
+				"label": "Turn off load",
+				"value": 2
+			},
+			{
+				"label": "Blink load",
+				"value": 3
+			}
+		]
+	},
+	"smoke_alarm_response": {
+		"label": "Smoke, CO or CO2 Alarm Response",
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 3,
+		"defaultValue": 3,
+		"unsigned": true,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Ignore",
+				"value": 0
+			},
+			{
+				"label": "Turn on load",
+				"value": 1
+			},
+			{
+				"label": "Turn off load",
+				"value": 2
+			},
+			{
+				"label": "Blink load",
+				"value": 3
+			}
+		]
+	},
+	"temperature_alarm_response": {
+		"label": "Temperature Alarm Response",
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 3,
+		"defaultValue": 1,
+		"unsigned": true,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Ignore",
+				"value": 0
+			},
+			{
+				"label": "Turn on load",
+				"value": 1
+			},
+			{
+				"label": "Turn off load",
+				"value": 2
+			},
+			{
+				"label": "Blink load",
+				"value": 3
+			}
+		]
+	},
+	"alarm_state_time": {
+		"label": "Time of Alarm State",
+		"valueSize": 2,
+		"unit:": "seconds",
+		"minValue": 1,
+		"defaultValue": 600
+	},
+	"active_power_report_threshold": {
+		"label": "Active Power Report: Threshold",
+		"description": "Relative change since previous report sent",
+		"valueSize": 1,
+		"unit": "%",
+		"minValue": 0,
+		"maxValue": 100,
+		"options": [
+			{
+				"label": "Disable",
+				"value": 0
+			}
+		]
+	},
+	"energy_report_threshold": {
+		"label": "Energy Reports: Threshold",
+		"valueSize": 2,
+		"unit": "0.01 kWh",
+		"minValue": 0,
+		"options": [
+			{
+				"label": "Disable",
+				"value": 0
+			}
+		]
+	},
+	"reports_periodic": {
+		"valueSize": 2,
+		"unit": "seconds",
+		"minValue": 0,
+		"defaultValue": 3600,
+		"options": [
+			{
+				"label": "Disable",
+				"value": 0
+			}
+		]
+	},
+	"reports_include_self": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Include Consumption By Device Itself in Reports"
+	}
+}

--- a/packages/config/config/devices/0x010f/templates/fibaro_template.json
+++ b/packages/config/config/devices/0x010f/templates/fibaro_template.json
@@ -1,5 +1,5 @@
 {
-	"default_metadata_for_fibaro": {
+	"default_metadata": {
 		"inclusion": "Turn the primary controller of Z-Wave network into inclusion mode, quickly press key S1 or B-button on product's housing three times",
 		"exclusion": "Turn the primary controller of Z-Wave network into exclusion mode, quickly press key S1 or B-button on product's housing three times",
 		"reset": "1. Power-cycle the device\n2. Press and hold the B-button to enter the menu\n3. Wait for the LED to turn yellow\n4. Quickly release and click B-button again\n5. Device will restart and LED will turn red"

--- a/packages/config/config/devices/0x010f/templates/fibaro_template.json
+++ b/packages/config/config/devices/0x010f/templates/fibaro_template.json
@@ -16,7 +16,7 @@
 	},
 	"send_secure_commands_group4": {
 		"$import": "~/templates/master_template.json#base_enable_disable",
-		"label": "Send Secure Z-wave Commands to 4tg Association Group",
+		"label": "Send Secure Z-wave Commands to 4th Association Group",
 		"description": "Only active when the node is included securely"
 	},
 	"send_secure_commands_group5": {

--- a/packages/config/config/devices/0x010f/templates/fibaro_template.json
+++ b/packages/config/config/devices/0x010f/templates/fibaro_template.json
@@ -6,22 +6,22 @@
 	},
 	"send_secure_commands_group2": {
 		"$import": "~/templates/master_template.json#base_enable_disable",
-		"label": "Send Secure Z-wave Commands to 2nd Association Group",
+		"label": "Send Secure Commands to 2nd Association Group",
 		"description": "Only active when the node is included securely"
 	},
 	"send_secure_commands_group3": {
 		"$import": "~/templates/master_template.json#base_enable_disable",
-		"label": "Send Secure Z-wave Commands to 3rd Association Group",
+		"label": "Send Secure Commands to 3rd Association Group",
 		"description": "Only active when the node is included securely"
 	},
 	"send_secure_commands_group4": {
 		"$import": "~/templates/master_template.json#base_enable_disable",
-		"label": "Send Secure Z-wave Commands to 4th Association Group",
+		"label": "Send Secure Commands to 4th Association Group",
 		"description": "Only active when the node is included securely"
 	},
 	"send_secure_commands_group5": {
 		"$import": "~/templates/master_template.json#base_enable_disable",
-		"label": "Send Secure Z-wave Commands to 5th Association Group",
+		"label": "Send Secure Commands to 5th Association Group",
 		"description": "Only active when the node is included securely"
 	},
 	"send_s1_associations_on": {

--- a/packages/config/config/devices/0x010f/templates/fibaro_template.json
+++ b/packages/config/config/devices/0x010f/templates/fibaro_template.json
@@ -1,4 +1,9 @@
 {
+	"default_metadata_for_fibaro": {
+		"inclusion": "Turn the primary controller of Z-Wave network into inclusion mode, quickly press key S1 or B-button on product's housing three times",
+		"exclusion": "Turn the primary controller of Z-Wave network into exclusion mode, quickly press key S1 or B-button on product's housing three times",
+		"reset": "1. Power-cycle the device\n2. Press and hold the B-button to enter the menu\n3. Wait for the LED to turn yellow\n4. Quickly release and click B-button again\n5. Device will restart and LED will turn red"
+	},
 	"send_secure_commands_group2": {
 		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Send Secure Z-wave Commands to 2nd Association Group",


### PR DESCRIPTION
After updating the FGD212 file in https://github.com/zwave-js/node-zwave-js/pull/2854 I have now continued with the FGS223. I might to more Fibaro devices in the future, but I'm taking it step-by-step and hopefully improving a little bit each time.

I have extracted the things I found to be common into a new `fibaro_template.json` file.

As I went through the FGS223 I also did several text updates to the FGD212. E.g. consistently using "Blink" instead of "Flash", which is the term used in the Aeotec files.

I am a bit unsure of a few things:

* When to define association groups. The [guide ](https://zwave-js.github.io/node-zwave-js/#/config-files/file-format?id=associations) says to only do this when necessary, one of the devices had, the other didn't. The default names are not terrible, they are: `On/Off (S2)`, `Dimmer (S2)` and `Lifeline`. I guess that means I should leave them out in both files? Even since they were already present for one device previously and I have only tried with the latest FW?
* What to do with values in templates that differ between the 2 devices. E.g. `reports_periodic` and `energy_report_threshold`. They have different default and max values. Currently I left that out in the template and defined the differences in both device files. As I only have done 2 devices I don't know if one is more common than the other. Is this ok?
* Can templates be used for other things than parameters? E.g. the metadata explaining how to do inclusion etc. I found no examples of this when I checked the existing files.

Happy for any feedback.