### PR TITLE
fix(config): add fingerprint `0x0202:0x0009` to Aeotec ZWA009

### DIFF
--- a/packages/config/config/devices/0x0371/zwa009.json
+++ b/packages/config/config/devices/0x0371/zwa009.json
@@ -11,6 +11,10 @@
 		{
 			"productType": "0x0102",
 			"productId": "0x0009"
+		},
+		{
+			"productType": "0x0202",
+			"productId": "0x0009"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
fixes: #3095