### PR TITLE
fix(config): correct parameter 81 for Aeotec ZW100

### DIFF
--- a/packages/config/config/devices/0x0086/zw100.json
+++ b/packages/config/config/devices/0x0086/zw100.json
@@ -341,10 +341,11 @@
 			"label": "Ultraviolet: Above Lower Limit",
 			"readOnly": true
 		},
-		"81": {
+		"81[0x51]": {
 			"$if": "firmwareVersion >= 1.8",
-			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "LED Blinking"
+			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
+			"label": "LED Blinking",
+			"defaultValue": 0
 		},
 		"101[0x01]": {
 			"$import": "templates/aeotec_template.json#auto_report_group1_battery"

--- a/packages/config/config/devices/0x0086/zw100.json
+++ b/packages/config/config/devices/0x0086/zw100.json
@@ -341,7 +341,7 @@
 			"label": "Ultraviolet: Above Lower Limit",
 			"readOnly": true
 		},
-		"81[0x51]": {
+		"81": {
 			"$if": "firmwareVersion >= 1.8",
 			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
 			"label": "LED Blinking",


### PR DESCRIPTION
The template `base_enable_disable_inverted` matches the documentation and the functionality of my devices.