### PR TITLE
feat(config): add Silabs UZB3 500 series controller device

### DIFF
--- a/packages/config/config/devices/0x0000/m417_9e.json
+++ b/packages/config/config/devices/0x0000/m417_9e.json
@@ -11,7 +11,7 @@
 	],
 	"firmwareVersion": {
 		"min": "0.0",
-		"max": "255.255"
+		"max": "5.255"
 	},
 	"supportsZWavePlus": true
 }

--- a/packages/config/config/devices/0x0000/uzb3_500_controller.json
+++ b/packages/config/config/devices/0x0000/uzb3_500_controller.json
@@ -1,5 +1,5 @@
 {
-	"manufacturer": "Silicon Labs (Sigma Designs)",
+	"manufacturer": "Silicon Labs",
 	"manufacturerId": "0x0000",
 	"label": "ACC-UZB3",
 	"description": "Z-Wave 500 Series Controller",

--- a/packages/config/config/devices/0x0000/uzb3_500_controller.json
+++ b/packages/config/config/devices/0x0000/uzb3_500_controller.json
@@ -1,0 +1,16 @@
+{
+	"manufacturer": "Silicon Labs (Sigma Designs)",
+	"manufacturerId": "0x0000",
+	"label": "ACC-UZB3",
+	"description": "Z-Wave 500 Series Controller",
+	"devices": [
+		{
+			"productType": "0x0003",
+			"productId": "0x0008"
+		}
+	],
+	"firmwareVersion": {
+		"min": "6.0",
+		"max": "255.255"
+	}
+}


### PR DESCRIPTION
Adding device config for Silabs (Sigma) UZB3 ZWave 500 Series Controller
https://www.silabs.com/development-tools/wireless/z-wave/uzb-908-mhz-static-controller-reference-design

Looks like firmware v6.x that's included in SDK 6.8x started reporting this ZWave 500 controller as 0x0000 - 0x0003 - 0x0008 which was originally used by M417_9E temp sensor. I used the firmware versions min/max to separate the two devices, so they will both be identified correctly. 

This will solve for issues reported before:
https://github.com/zwave-js/zwavejs2mqtt/issues/572
https://github.com/zwave-js/node-zwave-js/issues/2282

This will also solve for HUSBZB-1 controller with the SDK firmware upgrade from v4.x to v6.x as discussed here:
https://community.hubitat.com/t/guide-nortek-husbzb-1-nvm-backup-restore-and-updating-z-wave-firmware/48012
and here:
https://community.home-assistant.io/t/husbzb-1-z-wave-firmware-portion-update/259623

It will also reduce confusion for anyone moving from OpenZWave to ZWave-js, since it's already set in OpenZWave:
https://github.com/OpenZWave/open-zwave/blob/a8aa6341f4da161d0747c9cad205d821105ed09d/config/manufacturer_specific.xml#L1985
