### PR TITLE
feat: support interviewing nodes with S2 security

### DIFF
--- a/packages/core/src/error/ZWaveError.ts
+++ b/packages/core/src/error/ZWaveError.ts
@@ -128,6 +128,8 @@ export enum ZWaveErrorCodes {
 	Security2CC_NotSecure,
 	/** Gets thrown when a Security S2 command is missing a required extension */
 	Security2CC_MissingExtension,
+	/** Gets thrown when a Security S2 encapsulated command cannot be decoded by the target node */
+	Security2CC_CannotDecode,
 
 	/** The firmware update process is already active */
 	FirmwareUpdateCC_Busy = 1500,

--- a/packages/core/src/security/Manager2.test.ts
+++ b/packages/core/src/security/Manager2.test.ts
@@ -49,6 +49,7 @@ describe("lib/security/Manager2", () => {
 		if (options.nodeId) {
 			man.initializeSPAN(
 				node,
+				options.secClass ?? SecurityClass.S2_Authenticated,
 				crypto.randomBytes(16),
 				crypto.randomBytes(16),
 			);
@@ -105,6 +106,7 @@ describe("lib/security/Manager2", () => {
 				() =>
 					man.initializeSPAN(
 						node,
+						SecurityClass.S2_Authenticated,
 						Buffer.alloc(15),
 						Buffer.alloc(16),
 					),
@@ -116,7 +118,12 @@ describe("lib/security/Manager2", () => {
 
 			assertZWaveError(
 				() =>
-					man.initializeSPAN(node, Buffer.alloc(16), Buffer.alloc(1)),
+					man.initializeSPAN(
+						node,
+						SecurityClass.S2_Authenticated,
+						Buffer.alloc(16),
+						Buffer.alloc(1),
+					),
 				{
 					errorCode: ZWaveErrorCodes.Argument_Invalid,
 					messageMatches: "16 bytes",
@@ -131,6 +138,7 @@ describe("lib/security/Manager2", () => {
 				() =>
 					man.initializeSPAN(
 						node,
+						SecurityClass.S2_Authenticated,
 						Buffer.alloc(16),
 						Buffer.alloc(16),
 					),
@@ -148,6 +156,7 @@ describe("lib/security/Manager2", () => {
 				() =>
 					man.initializeSPAN(
 						node,
+						SecurityClass.S2_Authenticated,
 						Buffer.alloc(16),
 						Buffer.alloc(16),
 					),
@@ -165,7 +174,12 @@ describe("lib/security/Manager2", () => {
 				secClass: SecurityClass.S2_Authenticated,
 			});
 			expect(() =>
-				man.initializeSPAN(node, Buffer.alloc(16), Buffer.alloc(16)),
+				man.initializeSPAN(
+					node,
+					SecurityClass.S2_Authenticated,
+					Buffer.alloc(16),
+					Buffer.alloc(16),
+				),
 			).not.toThrow();
 		});
 	});

--- a/packages/core/src/security/SecurityClass.ts
+++ b/packages/core/src/security/SecurityClass.ts
@@ -8,6 +8,19 @@ export enum SecurityClass {
 	S0_Legacy = 7,
 }
 
+/** Tests if the given security class is S2 */
+export function securityClassIsS2(
+	secClass: SecurityClass,
+): secClass is
+	| SecurityClass.S2_Unauthenticated
+	| SecurityClass.S2_Authenticated
+	| SecurityClass.S2_AccessControl {
+	return (
+		secClass >= SecurityClass.S2_Unauthenticated &&
+		secClass <= SecurityClass.S2_AccessControl
+	);
+}
+
 /** An array of security classes, ordered from high (index 0) to low (index > 0) */
 export const securityClassOrder = [
 	SecurityClass.S2_AccessControl,

--- a/packages/zwave-js/src/lib/commandclass/Security2CC.ts
+++ b/packages/zwave-js/src/lib/commandclass/Security2CC.ts
@@ -5,16 +5,18 @@ import {
 	encryptAES128CCM,
 	getCCName,
 	isTransmissionError,
+	isZWaveError,
 	Maybe,
 	MessageOrCCLogEntry,
 	MessageRecord,
 	parseBitMask,
 	parseCCList,
 	SecurityClass,
+	securityClassIsS2,
+	securityClassOrder,
 	SecurityManager2,
 	SECURITY_S2_AUTH_TAG_LENGTH,
 	SPANState,
-	unknownBoolean,
 	validatePayload,
 	ZWaveError,
 	ZWaveErrorCodes,
@@ -232,16 +234,27 @@ export class Security2CCAPI extends CCAPI {
 		});
 	}
 
-	public async getSupportedCommands(): Promise<CommandClasses[] | undefined> {
+	/**
+	 * Queries the securely supported commands for the current security class
+	 * @param securityClass Can be used to overwrite the security class to use. If this doesn't match the current one, new nonces will need to be exchanged.
+	 */
+	public async getSupportedCommands(
+		securityClass?:
+			| SecurityClass.S2_AccessControl
+			| SecurityClass.S2_Authenticated
+			| SecurityClass.S2_Unauthenticated,
+	): Promise<CommandClasses[] | undefined> {
 		this.assertSupportsCommand(
 			Security2Command,
 			Security2Command.CommandsSupportedGet,
 		);
 
-		const cc = new Security2CCCommandsSupportedGet(this.driver, {
+		let cc = new Security2CCCommandsSupportedGet(this.driver, {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 		});
+		cc = Security2CC.encapsulate(this.driver, cc, securityClass);
+
 		const response =
 			await this.driver.sendCommand<Security2CCCommandsSupportedReport>(
 				cc,
@@ -267,12 +280,13 @@ export class Security2CC extends CommandClass {
 		let hasReceivedSecureCommands = false;
 
 		for (const secClass of [
-			SecurityClass.S2_AccessControl,
-			SecurityClass.S2_Authenticated,
 			SecurityClass.S2_Unauthenticated,
+			SecurityClass.S2_Authenticated,
+			SecurityClass.S2_AccessControl,
 		] as const) {
-			// We might not know all assigned security classes yet, so we
-			// go down from the highest and try to request the supported commands.
+			// We might not know all assigned security classes yet, so we work our way up from low to high and try to request the supported commands.
+			// This way, each command is encrypted with the security class we're currently testing.
+
 			// If the node does not respond, it wasn't assigned the security class.
 			// If it responds with a non-empty list, we know this is the highest class it supports.
 			// If the list is empty, the security class is still supported.
@@ -288,27 +302,24 @@ export class Security2CC extends CommandClass {
 				direction: "outbound",
 			});
 
-			let assignedTemporarily = false;
-			if (node.hasSecurityClass(secClass) === unknownBoolean) {
-				// We need to temporarily assign the security class to send the encrypted command
-				node.securityClasses.set(secClass, true);
-				// It will be removed afterwards if the request fails
-				assignedTemporarily = true;
-			}
-
-			let supportedCCs: CommandClasses[] | undefined;
 			// Query the supported commands but avoid remembering the wrong security class in case of a failure
+			let supportedCCs: CommandClasses[] | undefined;
 			try {
-				supportedCCs = await api.getSupportedCommands();
+				supportedCCs = await api.getSupportedCommands(secClass);
 			} catch (e) {
-				if (assignedTemporarily) {
-					node.securityClasses.delete(secClass);
+				if (
+					isZWaveError(e) &&
+					e.code === ZWaveErrorCodes.Security2CC_CannotDecode
+				) {
+					// This has to be expected when we're using a non-granted security class
+					supportedCCs = undefined;
+				} else {
+					throw e;
 				}
-				throw e;
 			}
 
 			if (supportedCCs == undefined) {
-				// No supported commands found, mark the security class as not supported
+				// No supported commands found, mark the security class as not granted
 				node.securityClasses.set(secClass, false);
 
 				this.driver.controllerLog.logNode(node.id, {
@@ -321,7 +332,7 @@ export class Security2CC extends CommandClass {
 				continue;
 			}
 
-			// Mark the security class as supported
+			// Mark the security class as granted
 			node.securityClasses.set(secClass, true);
 
 			this.driver.controllerLog.logNode(node.id, {
@@ -385,15 +396,19 @@ export class Security2CC extends CommandClass {
 	public static encapsulate(
 		driver: Driver,
 		cc: CommandClass,
+		securityClass?: SecurityClass,
 	): Security2CCMessageEncapsulation {
 		return new Security2CCMessageEncapsulation(driver, {
 			nodeId: cc.nodeId,
 			encapsulated: cc,
+			securityClass,
 		});
 	}
 }
 
 interface Security2CCMessageEncapsulationOptions extends CCCommandOptions {
+	/** Can be used to override the default security class for the command */
+	securityClass?: SecurityClass;
 	extensions?: Security2Extension[];
 	encapsulated: CommandClass;
 }
@@ -445,8 +460,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 			const node = this.getNode()!;
 			const securityClass = node.getHighestSecurityClass();
 			validatePayload.withReason("No security class granted")(
-				securityClass != undefined &&
-					securityClass !== SecurityClass.None,
+				securityClass !== SecurityClass.None,
 			);
 
 			const hasExtensions = !!(this.payload[1] & 0b1);
@@ -474,39 +488,6 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 			};
 			if (hasExtensions) parseExtensions(this.payload);
 
-			const spanState =
-				this.driver.securityManager2.getSPANState(peerNodeID);
-			if (spanState.type !== SPANState.SPAN) {
-				// If no SPAN was established yet, we can't decode this further
-				// Figure out what to do
-
-				const failNoSPAN = () => {
-					return validatePayload.fail(
-						ZWaveErrorCodes.Security2CC_NoSPAN,
-					);
-				};
-
-				if (spanState.type === SPANState.None) {
-					return failNoSPAN();
-				} else if (spanState.type === SPANState.RemoteEI) {
-					// TODO: The specs are not clear how to handle this case
-					// For now, do the same as if we didn't have any EI
-					return failNoSPAN();
-				} else if (spanState.type === SPANState.LocalEI) {
-					// We've sent the other our receiver's EI and received its sender's EI,
-					// meaning we can now establish an SPAN
-					const senderEI = this.getSenderEI();
-					if (!senderEI) return failNoSPAN();
-					const receiverEI = spanState.receiverEI;
-					this.driver.securityManager2.initializeSPAN(
-						node,
-						senderEI,
-						receiverEI,
-					);
-				}
-			}
-
-			// Now we do have an SPAN
 			const unencryptedPayload = this.payload.slice(0, offset);
 			const ciphertext = this.payload.slice(
 				offset,
@@ -525,20 +506,96 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 			);
 
 			// Decrypt payload and verify integrity
-			const { keyCCM: key } = this.driver.securityManager2.getKeys({
-				node,
-			});
-			const iv = this.driver.securityManager2.nextNonce(peerNodeID);
-			const { plaintext, authOK } = decryptAES128CCM(
-				key,
-				iv,
-				ciphertext,
-				authData,
-				authTag,
-			);
+			const spanState =
+				this.driver.securityManager2.getSPANState(peerNodeID);
+			const failNoSPAN = () => {
+				return validatePayload.fail(ZWaveErrorCodes.Security2CC_NoSPAN);
+			};
+
+			// If we are not able to establish an SPAN yet, fail the decryption
+			if (spanState.type === SPANState.None) {
+				return failNoSPAN();
+			} else if (spanState.type === SPANState.RemoteEI) {
+				// TODO: The specs are not clear how to handle this case
+				// For now, do the same as if we didn't have any EI
+				return failNoSPAN();
+			}
+
+			const decrypt = (): { plaintext: Buffer; authOK: boolean } => {
+				const getNonceAndDecrypt = () => {
+					const iv = this.driver.securityManager2.nextNonce(node.id);
+					const { keyCCM: key } =
+						this.driver.securityManager2.getKeys({ node });
+					return decryptAES128CCM(
+						key,
+						iv,
+						ciphertext,
+						authData,
+						authTag,
+					);
+				};
+
+				if (spanState.type === SPANState.SPAN) {
+					// This can only happen if the security class is known
+					return getNonceAndDecrypt();
+				} else if (spanState.type === SPANState.LocalEI) {
+					// We've sent the other our receiver's EI and received its sender's EI,
+					// meaning we can now establish an SPAN
+					const senderEI = this.getSenderEI();
+					if (!senderEI) {
+						debugger;
+						return failNoSPAN();
+					}
+					const receiverEI = spanState.receiverEI;
+
+					// How we do this depends on whether we know the security class of the other node
+					if (securityClass != undefined) {
+						this.driver.securityManager2.initializeSPAN(
+							node,
+							securityClass,
+							senderEI,
+							receiverEI,
+						);
+
+						return getNonceAndDecrypt();
+					} else {
+						// Not knowing it can happen if we just took over an existing network
+						// Try multiple security classes
+						const possibleSecurityClasses = securityClassOrder
+							.filter((s) => securityClassIsS2(s))
+							.filter((s) => node.hasSecurityClass(s) !== false);
+						for (const secClass of possibleSecurityClasses) {
+							// Initialize an SPAN with that security class
+							this.driver.securityManager2.initializeSPAN(
+								node,
+								secClass,
+								senderEI,
+								receiverEI,
+							);
+							const ret = getNonceAndDecrypt();
+
+							// It worked, return the result and remember the security class
+							if (ret.authOK) {
+								node.securityClasses.set(secClass, true);
+								return ret;
+							}
+							// Reset the SPAN state and try with the next security class
+							this.driver.securityManager2.setSPANState(
+								node.id,
+								spanState,
+							);
+						}
+					}
+				}
+
+				// Nothing worked, fail the decryption
+				return { plaintext: Buffer.from([]), authOK: false };
+			};
+
+			const { plaintext, authOK } = decrypt();
 			validatePayload.withReason(
 				"Message authentication failed, won't accept security encapsulated command.",
-			)(authOK);
+			)(!!authOK && !!plaintext);
 
 			offset = 0;
 			if (hasEncryptedExtensions) parseExtensions(plaintext);
@@ -556,6 +613,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 				});
 			}
 		} else {
+			this._securityClass = options.securityClass;
 			this.encapsulated = options.encapsulated;
 			options.encapsulated.encapsulatingCC = this as any;
 
@@ -571,6 +629,8 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 			}
 		}
 	}
+
+	private _securityClass?: SecurityClass;
 
 	private _sequenceNumber: number | undefined;
 	/**
@@ -591,6 +651,23 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 
 	public encapsulated?: CommandClass;
 	public extensions: Security2Extension[];
+
+	private _wasRetriedAfterDecodeFailure: boolean = false;
+	/** Indicates whether sending this command was retried after the target node failed to decode it  */
+	public get wasRetriedAfterDecodeFailure(): boolean {
+		return this._wasRetriedAfterDecodeFailure;
+	}
+
+	public prepareRetryAfterDecodeFailure(): void {
+		if (this._wasRetriedAfterDecodeFailure) {
+			throw new ZWaveError(
+				`S2 encapsulated messages may only be retried once after the target failed to decode them!`,
+				ZWaveErrorCodes.Controller_MessageDropped,
+			);
+		}
+		this._wasRetriedAfterDecodeFailure = true;
+		this._sequenceNumber = undefined;
+	}
 
 	private getDestinationIDTX(): number {
 		const mgrpExtension = this.extensions.find(
@@ -659,8 +736,18 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 			const senderEI =
 				this.driver.securityManager2.generateNonce(undefined);
 			const receiverEI = spanState.receiverEI;
+			const securityClass =
+				this._securityClass ?? node.getHighestSecurityClass();
+
+			if (securityClass == undefined) {
+				throw new ZWaveError(
+					"No security class defined for this command!",
+					ZWaveErrorCodes.Security2CC_NoSPAN,
+				);
+			}
 			this.driver.securityManager2.initializeSPAN(
 				node,
+				securityClass,
 				senderEI,
 				receiverEI,
 			);
@@ -713,10 +800,14 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 			unencryptedPayload,
 		);
 
-		const { keyCCM: key } = this.driver.securityManager2.getKeys({
-			node,
-		});
 		const iv = this.driver.securityManager2.nextNonce(node.id);
+		const { keyCCM: key } = this.driver.securityManager2.getKeys(
+			// Prefer the overridden security class if it was given
+			this._securityClass != undefined
+				? { securityClass: this._securityClass }
+				: { node },
+		);
+
 		const { ciphertext: ciphertextPayload, authTag } = encryptAES128CCM(
 			key,
 			iv,

--- a/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
@@ -345,7 +345,7 @@ export class SecurityCC extends CommandClass {
 		}
 
 		const logLines: string[] = [
-			"received secure commands",
+			"received secure commands (S0)",
 			"supported CCs:",
 		];
 		for (const cc of resp.supportedCCs) {

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -2254,14 +2254,23 @@ ${handlers.length} left`,
 		// A controlling node MUST discard a received Report/Notification type command if it is
 		// not received using S0 encapsulation and the corresponding Command Class is supported securely only
 
-		if (cc.secure && cc.ccId !== CommandClasses.Security) {
+		if (
+			cc.secure &&
+			cc.ccId !== CommandClasses.Security &&
+			cc.ccId !== CommandClasses["Security 2"]
+		) {
 			const commandName = cc.constructor.name;
 			if (
 				commandName.endsWith("Report") ||
 				commandName.endsWith("Notification")
 			) {
-				// Check whether there was a S0 encapsulation
-				if (cc.isEncapsulatedWith(CommandClasses.Security)) return true;
+				// Check whether there was a security encapsulation
+				if (
+					cc.isEncapsulatedWith(CommandClasses.Security) ||
+					cc.isEncapsulatedWith(CommandClasses["Security 2"])
+				) {
+					return true;
+				}
 				// none found, don't accept the CC
 				this.controllerLog.logNode(
 					cc.nodeId as number,

--- a/packages/zwave-js/src/lib/driver/SendThreadMachine.ts
+++ b/packages/zwave-js/src/lib/driver/SendThreadMachine.ts
@@ -105,6 +105,8 @@ export type SendThreadEvent =
 	// and the current transaction and react accordingly. The reducer must not have
 	// side-effects because it may be executed multiple times for each transaction
 	| { type: "reduce"; reducer: TransactionReducer }
+	// Re-transmit the current transaction immediately
+	| { type: "resend" }
 	// These events are forwarded to the SerialAPICommand machine
 	| { type: "ACK" }
 	| { type: "CAN" }
@@ -995,6 +997,11 @@ export function createSendThreadMachine(
 								nodeUpdate: {
 									actions: resolveCurrentTransaction,
 									target: "done",
+								},
+								resend: {
+									// We were asked to resend the pending transaction immediately
+									// without increasing the retry counter
+									target: "execute",
 								},
 							},
 							after: {


### PR DESCRIPTION
With this PR, we interview the S2 CC to detect the securely supported commands. Also, we now try multiple decryption keys when it is ambiguous which one was used by the device.