### PR TITLE
fix(config): update Fibaro FGT001 for v8 changes, preserve root and endpoint 2

### DIFF
--- a/packages/config/config/devices/0x010f/fgt001.json
+++ b/packages/config/config/devices/0x010f/fgt001.json
@@ -119,13 +119,6 @@
 		}
 	},
 	"compat": {
-		"commandClasses": {
-			"remove": {
-				// Root endpoint duplicates endpoint 1, causing duplicated Battery CC values
-				"0x80": {
-					"endpoints": [0]
-				}
-			}
-		}
+		"preserveEndpoints": [2]
 	}
 }


### PR DESCRIPTION
Fibaro FGT001 may have additional external temperature sensor and we must preserve additional endpoints explicitely according to documentation.