### PR TITLE
fix(config): add option 11 to ZEN17 parameters 2 & 3

### DIFF
--- a/packages/config/config/devices/0x027a/zen17.json
+++ b/packages/config/config/devices/0x027a/zen17.json
@@ -363,94 +363,46 @@
 			"defaultValue": 0,
 			"unsigned": true
 		},
-		"10": [
-			{
-				"$if": "firmwareVersion >= 1.4",
-				"label": "Control Relay 1 with S1 Input",
-				"description": "If disabled and Parameter 2 is values 4-11, a Z-Wave report will be sent but R1 will not be triggered",
-				"valueSize": 1,
-				"minValue": 0,
-				"maxValue": 1,
-				"defaultValue": 1,
-				"unsigned": true,
-				"allowManualEntry": false,
-				"options": [
-					{
-						"label": "Disable",
-						"value": 0
-					},
-					{
-						"label": "Enable",
-						"value": 1
-					}
-				]
-			},
-			{
-				"$if": "firmwareVersion < 1.4",
-				"label": "Control Relay 1 with S1 Input",
-				"description": "If disabled and Parameter 2 is values 4-10, a Z-Wave report will be sent but R1 will not be triggered",
-				"valueSize": 1,
-				"minValue": 0,
-				"maxValue": 1,
-				"defaultValue": 1,
-				"unsigned": true,
-				"allowManualEntry": false,
-				"options": [
-					{
-						"label": "Disable",
-						"value": 0
-					},
-					{
-						"label": "Enable",
-						"value": 1
-					}
-				]
-			}
-		],
-		"11": [
-			{
-				"$if": "firmwareVersion >= 1.4",
-				"label": "Control Relay 2 with S2 Input",
-				"description": "If disabled and Parameter 3 is values 4-11, a Z-Wave report will be sent but R2 will not be triggered",
-				"valueSize": 1,
-				"minValue": 0,
-				"maxValue": 1,
-				"defaultValue": 1,
-				"unsigned": true,
-				"allowManualEntry": false,
-				"options": [
-					{
-						"label": "Disable",
-						"value": 0
-					},
-					{
-						"label": "Enable",
-						"value": 1
-					}
-				]
-			},
-			{
-				"$if": "firmwareVersion < 1.4",
-				"label": "Control Relay 2 with S2 Input",
-				"description": "If disabled and Parameter 3 is values 4-10, a Z-Wave report will be sent but R2 will not be triggered",
-				"valueSize": 1,
-				"minValue": 0,
-				"maxValue": 1,
-				"defaultValue": 1,
-				"unsigned": true,
-				"allowManualEntry": false,
-				"options": [
-					{
-						"label": "Disable",
-						"value": 0
-					},
-					{
-						"label": "Enable",
-						"value": 1
-					}
-				]
-			}
-		],
+		"10": {
+			"label": "Control Relay 1 with S1 Input",
+			"description": "If disabled and Parameter 2 is >= 4, a Z-Wave report will be sent but R1 will not be triggered",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		"11": {
+			"label": "Control Relay 2 with S2 Input",
+			"description": "If disabled and Parameter 3 is >= 4, a Z-Wave report will be sent but R2 will not be triggered",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
 		"15": {
 			"label": "Auto Turn-Off Timer Unit (Relay 1)",
 			"valueSize": 1,

--- a/packages/config/config/devices/0x027a/zen17.json
+++ b/packages/config/config/devices/0x027a/zen17.json
@@ -60,118 +60,246 @@
 				}
 			]
 		},
-		"2": {
-			"label": "Input Type for S1 Terminal",
-			"description": "Note: The device must be excluded (without resetting it) and re-included after changing to/from values 4-10",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 10,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Momentary switch",
-					"value": 0
-				},
-				{
-					"label": "Toggle switch (follow switch)",
-					"value": 1
-				},
-				{
-					"label": "Toggle switch (change on toggle)",
-					"value": 2
-				},
-				{
-					"label": "Garage door (momentary mode)",
-					"value": 3
-				},
-				{
-					"label": "Water sensor",
-					"value": 4
-				},
-				{
-					"label": "Heat alarm",
-					"value": 5
-				},
-				{
-					"label": "Motion alert",
-					"value": 6
-				},
-				{
-					"label": "Door sensor (open/close)",
-					"value": 7
-				},
-				{
-					"label": "CO alarm",
-					"value": 8
-				},
-				{
-					"label": "CO2 alarm",
-					"value": 9
-				},
-				{
-					"label": "On/off report (dry contact switch/sensor)",
-					"value": 10
-				}
-			]
-		},
-		"3": {
-			"label": "Input Type for S2 Terminal",
-			"description": "Note: The device must be excluded (without resetting it) and re-included after changing to/from values 4-10",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 10,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Momentary switch",
-					"value": 0
-				},
-				{
-					"label": "Toggle switch (follow switch)",
-					"value": 1
-				},
-				{
-					"label": "Toggle switch (change on toggle)",
-					"value": 2
-				},
-				{
-					"label": "Garage door (momentary mode)",
-					"value": 3
-				},
-				{
-					"label": "Water sensor",
-					"value": 4
-				},
-				{
-					"label": "Heat alarm",
-					"value": 5
-				},
-				{
-					"label": "Motion alert",
-					"value": 6
-				},
-				{
-					"label": "Door sensor (open/close)",
-					"value": 7
-				},
-				{
-					"label": "CO alarm",
-					"value": 8
-				},
-				{
-					"label": "CO2 alarm",
-					"value": 9
-				},
-				{
-					"label": "On/off report (dry contact switch/sensor)",
-					"value": 10
-				}
-			]
-		},
+		"2": [
+			{
+				"$if": "firmwareVersion >= 1.4",
+				"label": "Input Type for S1 Terminal",
+				"description": "Note: The device must be excluded (without resetting it) and re-included after changing to/from values 4-11",
+				"valueSize": 1,
+				"minValue": 0,
+				"maxValue": 11,
+				"defaultValue": 1,
+				"unsigned": true,
+				"allowManualEntry": false,
+				"options": [
+					{
+						"label": "Momentary switch",
+						"value": 0
+					},
+					{
+						"label": "Toggle switch (follow switch)",
+						"value": 1
+					},
+					{
+						"label": "Toggle switch (change on toggle)",
+						"value": 2
+					},
+					{
+						"label": "Garage door (momentary mode)",
+						"value": 3
+					},
+					{
+						"label": "Water sensor",
+						"value": 4
+					},
+					{
+						"label": "Heat alarm",
+						"value": 5
+					},
+					{
+						"label": "Motion alert",
+						"value": 6
+					},
+					{
+						"label": "Door sensor (open/close)",
+						"value": 7
+					},
+					{
+						"label": "CO alarm",
+						"value": 8
+					},
+					{
+						"label": "CO2 alarm",
+						"value": 9
+					},
+					{
+						"label": "On/off report (dry contact switch/sensor)",
+						"value": 10
+					},
+					{
+						"label": "Garage door mode (momentary mode) for relay and door sensor (open/close) for input",
+						"value": 11
+					}
+				]
+			},
+			{
+				"$if": "firmwareVersion < 1.4",
+				"label": "Input Type for S1 Terminal",
+				"description": "Note: The device must be excluded (without resetting it) and re-included after changing to/from values 4-10",
+				"valueSize": 1,
+				"minValue": 0,
+				"maxValue": 10,
+				"defaultValue": 1,
+				"unsigned": true,
+				"allowManualEntry": false,
+				"options": [
+					{
+						"label": "Momentary switch",
+						"value": 0
+					},
+					{
+						"label": "Toggle switch (follow switch)",
+						"value": 1
+					},
+					{
+						"label": "Toggle switch (change on toggle)",
+						"value": 2
+					},
+					{
+						"label": "Garage door (momentary mode)",
+						"value": 3
+					},
+					{
+						"label": "Water sensor",
+						"value": 4
+					},
+					{
+						"label": "Heat alarm",
+						"value": 5
+					},
+					{
+						"label": "Motion alert",
+						"value": 6
+					},
+					{
+						"label": "Door sensor (open/close)",
+						"value": 7
+					},
+					{
+						"label": "CO alarm",
+						"value": 8
+					},
+					{
+						"label": "CO2 alarm",
+						"value": 9
+					},
+					{
+						"label": "On/off report (dry contact switch/sensor)",
+						"value": 10
+					}
+				]
+			}
+		],
+		"3": [
+			{
+				"$if": "firmwareVersion >= 1.4",
+				"label": "Input Type for S2 Terminal",
+				"description": "Note: The device must be excluded (without resetting it) and re-included after changing to/from values 4-11",
+				"valueSize": 1,
+				"minValue": 0,
+				"maxValue": 11,
+				"defaultValue": 1,
+				"unsigned": true,
+				"allowManualEntry": false,
+				"options": [
+					{
+						"label": "Momentary switch",
+						"value": 0
+					},
+					{
+						"label": "Toggle switch (follow switch)",
+						"value": 1
+					},
+					{
+						"label": "Toggle switch (change on toggle)",
+						"value": 2
+					},
+					{
+						"label": "Garage door (momentary mode)",
+						"value": 3
+					},
+					{
+						"label": "Water sensor",
+						"value": 4
+					},
+					{
+						"label": "Heat alarm",
+						"value": 5
+					},
+					{
+						"label": "Motion alert",
+						"value": 6
+					},
+					{
+						"label": "Door sensor (open/close)",
+						"value": 7
+					},
+					{
+						"label": "CO alarm",
+						"value": 8
+					},
+					{
+						"label": "CO2 alarm",
+						"value": 9
+					},
+					{
+						"label": "On/off report (dry contact switch/sensor)",
+						"value": 10
+					},
+					{
+						"label": "Garage door mode (momentary mode) for relay and door sensor (open/close) for input",
+						"value": 11
+					}
+				]
+			},
+			{
+				"$if": "firmwareVersion < 1.4",
+				"label": "Input Type for S2 Terminal",
+				"description": "Note: The device must be excluded (without resetting it) and re-included after changing to/from values 4-10",
+				"valueSize": 1,
+				"minValue": 0,
+				"maxValue": 10,
+				"defaultValue": 1,
+				"unsigned": true,
+				"allowManualEntry": false,
+				"options": [
+					{
+						"label": "Momentary switch",
+						"value": 0
+					},
+					{
+						"label": "Toggle switch (follow switch)",
+						"value": 1
+					},
+					{
+						"label": "Toggle switch (change on toggle)",
+						"value": 2
+					},
+					{
+						"label": "Garage door (momentary mode)",
+						"value": 3
+					},
+					{
+						"label": "Water sensor",
+						"value": 4
+					},
+					{
+						"label": "Heat alarm",
+						"value": 5
+					},
+					{
+						"label": "Motion alert",
+						"value": 6
+					},
+					{
+						"label": "Door sensor (open/close)",
+						"value": 7
+					},
+					{
+						"label": "CO alarm",
+						"value": 8
+					},
+					{
+						"label": "CO2 alarm",
+						"value": 9
+					},
+					{
+						"label": "On/off report (dry contact switch/sensor)",
+						"value": 10
+					}
+				]
+			}
+		],
 		"5": {
 			"label": "LED Indicator",
 			"valueSize": 1,
@@ -235,46 +363,94 @@
 			"defaultValue": 0,
 			"unsigned": true
 		},
-		"10": {
-			"label": "Control Relay 1 with S1 Input",
-			"description": "If disabled and Parameter 2 is values 4-10, a Z-Wave report will be sent but R1 will not be triggered",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
-		},
-		"11": {
-			"label": "Control Relay 2 with S2 Input",
-			"description": "If disabled and Parameter 3 is values 4-10, a Z-Wave report will be sent but R2 will not be triggered",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
-		},
+		"10": [
+			{
+				"$if": "firmwareVersion >= 1.4",
+				"label": "Control Relay 1 with S1 Input",
+				"description": "If disabled and Parameter 2 is values 4-11, a Z-Wave report will be sent but R1 will not be triggered",
+				"valueSize": 1,
+				"minValue": 0,
+				"maxValue": 1,
+				"defaultValue": 1,
+				"unsigned": true,
+				"allowManualEntry": false,
+				"options": [
+					{
+						"label": "Disable",
+						"value": 0
+					},
+					{
+						"label": "Enable",
+						"value": 1
+					}
+				]
+			},
+			{
+				"$if": "firmwareVersion < 1.4",
+				"label": "Control Relay 1 with S1 Input",
+				"description": "If disabled and Parameter 2 is values 4-10, a Z-Wave report will be sent but R1 will not be triggered",
+				"valueSize": 1,
+				"minValue": 0,
+				"maxValue": 1,
+				"defaultValue": 1,
+				"unsigned": true,
+				"allowManualEntry": false,
+				"options": [
+					{
+						"label": "Disable",
+						"value": 0
+					},
+					{
+						"label": "Enable",
+						"value": 1
+					}
+				]
+			}
+		],
+		"11": [
+			{
+				"$if": "firmwareVersion >= 1.4",
+				"label": "Control Relay 2 with S2 Input",
+				"description": "If disabled and Parameter 3 is values 4-11, a Z-Wave report will be sent but R2 will not be triggered",
+				"valueSize": 1,
+				"minValue": 0,
+				"maxValue": 1,
+				"defaultValue": 1,
+				"unsigned": true,
+				"allowManualEntry": false,
+				"options": [
+					{
+						"label": "Disable",
+						"value": 0
+					},
+					{
+						"label": "Enable",
+						"value": 1
+					}
+				]
+			},
+			{
+				"$if": "firmwareVersion < 1.4",
+				"label": "Control Relay 2 with S2 Input",
+				"description": "If disabled and Parameter 3 is values 4-10, a Z-Wave report will be sent but R2 will not be triggered",
+				"valueSize": 1,
+				"minValue": 0,
+				"maxValue": 1,
+				"defaultValue": 1,
+				"unsigned": true,
+				"allowManualEntry": false,
+				"options": [
+					{
+						"label": "Disable",
+						"value": 0
+					},
+					{
+						"label": "Enable",
+						"value": 1
+					}
+				]
+			}
+		],
 		"15": {
 			"label": "Auto Turn-Off Timer Unit (Relay 1)",
 			"valueSize": 1,


### PR DESCRIPTION
Adds value 11 to parameters 2 & 3 which was added in firmwareVersion 1.4.

Source:
https://www.support.getzooz.com/kb/article/698-zen17-universal-relay-advanced-settings/