### PR TITLE
feat(cc): implement inclusion using Security S2

### DIFF
--- a/maintenance/schemas/deviceClasses.json
+++ b/maintenance/schemas/deviceClasses.json
@@ -19,6 +19,9 @@
 						"zwavePlusDeviceType": {
 							"type": "string"
 						},
+						"requiresSecurity": {
+							"const": true
+						},
 						"supportedCCs": {
 							"$ref": "#/definitions/CCs"
 						},
@@ -33,6 +36,9 @@
 										"label": { "type": "string" },
 										"zwavePlusDeviceType": {
 											"type": "string"
+										},
+										"requiresSecurity": {
+											"const": true
 										},
 										"supportedCCs": {
 											"$ref": "#/definitions/CCs"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@zwave-js/config": "workspace:*",
     "@zwave-js/core": "workspace:*",
     "@zwave-js/shared": "workspace:*",
+    "alcalzone-shared": "^4.0.0",
     "ansi-colors": "^4.1.1",
     "comment-json": "^4.1.0",
     "commitizen": "^4.2.4",

--- a/packages/config/config/deviceClasses.json
+++ b/packages/config/config/deviceClasses.json
@@ -698,11 +698,13 @@
 				"0x03": {
 					"label": "Secure Keypad Door Lock",
 					"zwavePlusDeviceType": "Door Lock - Keypad",
+					"requiresSecurity": true,
 					"supportedCCs": ["Basic", "Door Lock", "User Code", "Manufacturer Specific", "Security", "Version"]
 				},
 				"0x05": {
 					"label": "Secure Door",
 					"zwavePlusDeviceType": "Motorized Barrier - GDO",
+					"requiresSecurity": true,
 					"supportedCCs": [
 						"Application Status",
 						"Association", // V2+
@@ -724,6 +726,7 @@
 				"0x06": {
 					"label": "Secure Gate",
 					"zwavePlusDeviceType": "Motorized Barrier - Gate",
+					"requiresSecurity": true,
 					"supportedCCs": [
 						"Application Status",
 						"Association", // V2+
@@ -745,6 +748,7 @@
 				"0x07": {
 					"label": "Secure Barrier Add-on",
 					"zwavePlusDeviceType": "Motorized Barrier - Add-on",
+					"requiresSecurity": true,
 					"supportedCCs": [
 						"Application Status",
 						"Association", // V2+
@@ -766,6 +770,7 @@
 				"0x08": {
 					"label": "Secure Barrier Open only",
 					"zwavePlusDeviceType": "Motorized Barrier - Open only",
+					"requiresSecurity": true,
 					"supportedCCs": [
 						"Application Status",
 						"Association", // V2+
@@ -787,6 +792,7 @@
 				"0x09": {
 					"label": "Secure Barrier Close only",
 					"zwavePlusDeviceType": "Motorized Barrier - Close only",
+					"requiresSecurity": true,
 					"supportedCCs": [
 						"Application Status",
 						"Association", // V2+
@@ -808,6 +814,7 @@
 				"0x0a": {
 					"label": "Lockbox",
 					"zwavePlusDeviceType": "Lockbox",
+					"requiresSecurity": true,
 					"supportedCCs": [
 						// MUST NOT support Basic
 						"Notification",
@@ -821,6 +828,7 @@
 				"0x0b": {
 					"label": "Secure Keypad",
 					"zwavePlusDeviceType": "Entry Control Keypad",
+					"requiresSecurity": true,
 					"supportedCCs": [
 						// "Device Reset Locally", (we can't know if the device can be reset)
 						"Entry Control",

--- a/packages/config/src/DeviceClasses.ts
+++ b/packages/config/src/DeviceClasses.ts
@@ -159,6 +159,19 @@ export class GenericDeviceClass {
 			}
 		}
 
+		if (definition.requiresSecurity != undefined) {
+			if (typeof definition.requiresSecurity !== "boolean") {
+				throwInvalidConfig(
+					"device classes",
+					`The requiresSecurity property for generic device class ${num2hex(
+						key,
+					)} is not a boolean!`,
+				);
+			} else {
+				this.requiresSecurity = definition.requiresSecurity;
+			}
+		}
+
 		if (definition.supportedCCs != undefined) {
 			if (
 				!isArray(definition.supportedCCs) ||
@@ -253,6 +266,7 @@ export class GenericDeviceClass {
 	public readonly label: string;
 	/** @internal */
 	public readonly zwavePlusDeviceType?: string;
+	public readonly requiresSecurity?: boolean;
 	public readonly supportedCCs: readonly CommandClasses[];
 	public readonly controlledCCs: readonly CommandClasses[];
 	public readonly specific: ReadonlyMap<number, SpecificDeviceClass>;
@@ -289,6 +303,21 @@ export class SpecificDeviceClass {
 			}
 		} else if (generic.zwavePlusDeviceType != undefined) {
 			this.zwavePlusDeviceType = generic.zwavePlusDeviceType;
+		}
+
+		if (definition.requiresSecurity != undefined) {
+			if (typeof definition.requiresSecurity !== "boolean") {
+				throwInvalidConfig(
+					"device classes",
+					`The requiresSecurity property for device class ${
+						generic.label
+					} -> ${num2hex(key)} is not a string!`,
+				);
+			} else {
+				this.requiresSecurity = definition.requiresSecurity;
+			}
+		} else if (generic.requiresSecurity != undefined) {
+			this.requiresSecurity = generic.requiresSecurity;
 		}
 
 		if (definition.supportedCCs != undefined) {
@@ -365,6 +394,7 @@ export class SpecificDeviceClass {
 	public readonly key: number;
 	public readonly label: string;
 	public readonly zwavePlusDeviceType?: string;
+	public readonly requiresSecurity?: boolean;
 	public readonly supportedCCs: readonly CommandClasses[];
 	public readonly controlledCCs: readonly CommandClasses[];
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@ export * from "./consts";
 export * from "./error/ZWaveError";
 export * from "./log/shared";
 export * from "./security/crypto";
+export * from "./security/DSK";
 export * from "./security/Manager";
 export * from "./security/Manager2";
 export * from "./security/SecurityClass";

--- a/packages/core/src/security/DSK.ts
+++ b/packages/core/src/security/DSK.ts
@@ -1,0 +1,34 @@
+import { padStart } from "alcalzone-shared/strings";
+import { ZWaveError, ZWaveErrorCodes } from "../error/ZWaveError";
+
+export function dskToString(dsk: Buffer): string {
+	if (dsk.length !== 16) {
+		throw new ZWaveError(
+			`DSK length must be 16 bytes, got ${dsk.length}`,
+			ZWaveErrorCodes.Argument_Invalid,
+		);
+	}
+	let ret = "";
+	for (let i = 0; i < 16; i += 2) {
+		if (i > 0) ret += "-";
+		ret += padStart(dsk.readUInt16BE(i).toString(10), 5, "0");
+	}
+	return ret;
+}
+
+export function dskFromString(dsk: string): Buffer {
+	if (!/^(\d{5}-){7}\d{5}$/.test(dsk)) {
+		throw new ZWaveError(
+			`The DSK must be in the form "aaaaa-bbbbb-ccccc-ddddd-eeeee-fffff-11111-22222"`,
+			ZWaveErrorCodes.Argument_Invalid,
+		);
+	}
+
+	const ret = Buffer.allocUnsafe(16);
+	const parts = dsk.split("-");
+	for (let i = 0; i < 8; i++) {
+		const partAsNumber = parseInt(parts[i], 10);
+		ret.writeUInt16BE(partAsNumber, i * 2);
+	}
+	return ret;
+}

--- a/packages/core/src/security/SecurityClass.ts
+++ b/packages/core/src/security/SecurityClass.ts
@@ -1,6 +1,7 @@
 import type { Maybe } from "../values/Primitive";
 
 export enum SecurityClass {
+	Temporary = -2,
 	None = -1,
 	S2_Unauthenticated = 0,
 	S2_Authenticated = 1,

--- a/packages/core/src/values/Primitive.ts
+++ b/packages/core/src/values/Primitive.ts
@@ -199,7 +199,7 @@ export function parseBitMask(mask: Buffer, startValue: number = 1): number[] {
 
 /** Serializes a numeric array with a given maximum into a bit mask */
 export function encodeBitMask(
-	values: number[],
+	values: readonly number[],
 	maxValue: number,
 	startValue: number = 1,
 ): Buffer {

--- a/packages/zwave-js/src/lib/commandclass/Security2/shared.ts
+++ b/packages/zwave-js/src/lib/commandclass/Security2/shared.ts
@@ -17,3 +17,13 @@ export enum KEXFailType {
 	NoVerify = 0x09, // VERIFY
 	DifferentKey = 0x0a, // REPORT
 }
+
+export const inclusionTimeouts = Object.freeze({
+	TA1: 10000,
+	TA2: 10000,
+	TA3: 10000,
+	TA4: 10000,
+	TA5: 10000,
+	TAI1: 240000,
+	TAI2: 240000,
+} as const);

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -1,12 +1,18 @@
 import {
 	actuatorCCs,
 	CommandClasses,
+	computePRK,
+	decodeX25519KeyDER,
+	deriveTempKeys,
+	dskToString,
+	encodeX25519KeyDERSPKI,
 	indexDBsByNode,
 	isRecoverableZWaveError,
 	isTransmissionError,
 	isZWaveError,
 	NODE_ID_BROADCAST,
 	SecurityClass,
+	securityClassOrder,
 	ValueDB,
 	ZWaveError,
 	ZWaveErrorCodes,
@@ -23,12 +29,23 @@ import {
 	TypedEventEmitter,
 } from "@zwave-js/shared";
 import { distinct } from "alcalzone-shared/arrays";
+import { wait } from "alcalzone-shared/async";
 import {
 	createDeferredPromise,
 	DeferredPromise,
 } from "alcalzone-shared/deferred-promise";
 import { composeObject } from "alcalzone-shared/objects";
 import { isObject } from "alcalzone-shared/typeguards";
+import crypto from "crypto";
+import util from "util";
+import {
+	Security2CCKEXFail,
+	Security2CCKEXSet,
+	Security2CCNetworkKeyGet,
+	Security2CCNetworkKeyVerify,
+	Security2CCPublicKeyReport,
+	Security2CCTransferEnd,
+} from "../commandclass";
 import type { AssociationCC } from "../commandclass/AssociationCC";
 import type {
 	AssociationGroup,
@@ -47,6 +64,12 @@ import type {
 	EndpointAddress,
 	MultiChannelAssociationCC,
 } from "../commandclass/MultiChannelAssociationCC";
+import {
+	ECDHProfiles,
+	inclusionTimeouts,
+	KEXFailType,
+	KEXSchemes,
+} from "../commandclass/Security2/shared";
 import {
 	getFirmwareVersionsMetadata,
 	getFirmwareVersionsValueId,
@@ -194,12 +217,136 @@ export type ReadonlyThrowingMap<K, V> = ReadonlyMap<K, V> & {
 	getOrThrow(key: K): V;
 };
 
+export enum InclusionStrategy {
+	/**
+	 * Always uses Security S2 if supported, otherwise uses Security S0 for certain devices which don't work without encryption and uses no encryption otherwise.
+	 *
+	 * Issues a warning if Security S0 or S2 is supported, but the secure bootstrapping fails.
+	 *
+	 * **This is the recommended** strategy and should be used unless there is a good reason not to.
+	 */
+	Default = 0,
+	/**
+	 * Include using SmartStart (requires Security S2).
+	 * Issues a warning if Security S2 is not supported, or the secure bootstrapping fails.
+	 *
+	 * **Should be preferred** over **Default** if supported.
+	 */
+	SmartStart,
+
+	/**
+	 * Don't use encryption, even if supported.
+	 *
+	 * **Not recommended**, because S2 should be used where possible.
+	 */
+	Insecure,
+	/**
+	 * Use Security S0, even if a higher security mode is supported.
+	 *
+	 * Issues a warning if Security S0 is not supported or the secure bootstrapping fails.
+	 *
+	 * **Not recommended** because S0 should be used sparingly and S2 preferred whereever possible.
+	 */
+	Security_S0,
+	/**
+	 * Use Security S2 and issue a warning if it is not supported or the secure bootstrapping fails.
+	 *
+	 * **Not recommended** because the *Default* strategy is more versatile and user-friendly.
+	 */
+	Security_S2,
+}
+
+export interface InclusionGrant {
+	/**
+	 * An array of security classes that are requested or to be granted.
+	 * The granted security classes MUST be a subset of the requested ones.
+	 */
+	securityClasses: SecurityClass[];
+	/** Whether client side authentication is requested or to be granted */
+	clientSideAuth: boolean;
+}
+
+/** Defines the callbacks that are necessary to trigger user interaction during S2 inclusion */
+export interface InclusionUserCallbacks {
+	/**
+	 * Instruct the application to display the user which security classes the device has requested and whether client-side authentication (CSA) is desired.
+	 * The returned promise MUST resolve to the user selection - which of the requested security classes have been granted and whether CSA was allowed.
+	 * If the user did not accept the requested security classes, the promise MUST resolve to `true`.
+	 */
+	grantSecurityClasses(
+		requested: InclusionGrant,
+	): Promise<InclusionGrant | false>;
+
+	// /**
+	//  * Instruct the application to display the received DSK for the user to verify if it matches the one belonging to the device.
+	//  * The returned promise MUST resolve to `true` when the user has confirmed the DSK and `false` if the user declined.
+	//  *
+	//  * @param dsk The full DSK in the form `aaaaa-bbbbb-ccccc-ddddd-eeeee-fffff-11111-22222`
+	//  */
+	// validateDSK(dsk: string): Promise<boolean>;
+
+	/**
+	 * Instruct the application to display the received DSK for the user to verify if it matches the one belonging to the device and
+	 * additionally enter the PIN that's found on the device.
+	 * The returned promise MUST resolve to the 5-digit PIN (as a string) when the user has confirmed the DSK and entered the PIN and `false` otherwise.
+	 *
+	 * @param dsk The partial DSK in the form `-bbbbb-ccccc-ddddd-eeeee-fffff-11111-22222`. The first 5 characters are left out because they are the unknown PIN.
+	 */
+	validateDSKAndEnterPIN(dsk: string): Promise<string | false>;
+
+	/** Called by the driver when the user validation has timed out and needs to be aborted */
+	abort(): void;
+}
+
+/** Options for inclusion of a new node */
+export type InclusionOptions =
+	| {
+			strategy: InclusionStrategy.Default;
+			userCallbacks: InclusionUserCallbacks;
+			/**
+			 * Force secure communication (S0) even when S2 is not supported and S0 is not necessary.
+			 * This is not recommended due to the overhead caused by S0.
+			 */
+			forceSecurity?: boolean;
+	  }
+	| {
+			strategy: InclusionStrategy.Security_S2;
+			userCallbacks: InclusionUserCallbacks;
+	  }
+	| {
+			strategy: InclusionStrategy.SmartStart;
+			provisioningList: unknown;
+	  }
+	| {
+			strategy:
+				| InclusionStrategy.Insecure
+				| InclusionStrategy.Security_S0;
+			/** @internal Whether the promise should resolve to a boolean instead of an InclusionResult */
+			legacyReturnType?: true;
+	  };
+
+/** Options for replacing a node */
+export type ReplaceNodeOptions =
+	// We don't know which security CCs a node supports when it is a replacement
+	// we we need the user to specify how the node should be included
+	| {
+			strategy: InclusionStrategy.Security_S2;
+			userCallbacks: InclusionUserCallbacks;
+	  }
+	| {
+			strategy:
+				| InclusionStrategy.Insecure
+				| InclusionStrategy.Security_S0;
+			/** @internal Whether the promise should resolve to a boolean instead of an InclusionResult */
+			legacyReturnType?: true;
+	  };
+
 // Strongly type the event emitter events
 interface ControllerEventCallbacks
 	extends StatisticsEventCallbacks<ControllerStatistics> {
 	"inclusion failed": () => void;
 	"exclusion failed": () => void;
-	"inclusion started": (secure: boolean) => void;
+	"inclusion started": (secure: boolean, strategy: InclusionStrategy) => void;
 	"exclusion started": () => void;
 	"inclusion stopped": () => void;
 	"exclusion stopped": () => void;
@@ -808,8 +955,8 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 
 	private _exclusionActive: boolean = false;
 	private _inclusionActive: boolean = false;
-	private _includeNonSecure: boolean = false;
 	private _includeController: boolean = false;
+	private _inclusionOptions: InclusionOptions | undefined;
 	private _nodePendingInclusion: ZWaveNode | undefined;
 	private _nodePendingExclusion: ZWaveNode | undefined;
 	private _nodePendingReplace: ZWaveNode | undefined;
@@ -822,15 +969,43 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 	 * Starts the inclusion process of new nodes.
 	 * Resolves to true when the process was started, and false if the inclusion was already active.
 	 *
-	 * @param includeNonSecure Whether the node should be included non-securely, even if it supports Security. By default, all nodes will be included securely if possible
+	 * @param options Defines the inclusion strategy to use.
 	 */
+	public async beginInclusion(options: InclusionOptions): Promise<boolean>;
+
+	/**
+	 * Starts the inclusion process of new nodes.
+	 * Resolves to true when the process was started, and false if the inclusion was already active.
+	 *
+	 * @param includeNonSecure Whether the new node should be included non-securely, even if it supports Security S0. By default, S0 will be used.
+	 * @deprecated Use the overload with options instead
+	 */
+	public async beginInclusion(includeNonSecure: boolean): Promise<boolean>;
+
 	public async beginInclusion(
-		includeNonSecure: boolean = false,
+		options?: InclusionOptions | boolean,
 	): Promise<boolean> {
 		// don't start it twice
-		if (this._inclusionActive || this._exclusionActive) return false;
+		if (this._inclusionActive || this._exclusionActive) {
+			return false;
+		}
+
+		if (options == undefined) {
+			options = {
+				strategy: InclusionStrategy.Security_S0,
+				legacyReturnType: true,
+			};
+		} else if (typeof options === "boolean") {
+			options = {
+				strategy: options
+					? InclusionStrategy.Insecure
+					: InclusionStrategy.Security_S0,
+				legacyReturnType: true,
+			};
+		}
+
 		this._inclusionActive = true;
-		this._includeNonSecure = includeNonSecure;
+		this._inclusionOptions = options;
 
 		this.driver.controllerLog.print(`starting inclusion process...`);
 
@@ -948,75 +1123,470 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 
 	private async secureBootstrapS0(
 		node: ZWaveNode,
-		assumeSecure: boolean = false,
+		assumeSupported: boolean = false,
 	): Promise<void> {
-		// If security has been set up and we are allowed to include the node securely, try to do it
-		if (
-			this.driver.securityManager &&
-			(assumeSecure || node.supportsCC(CommandClasses.Security))
-		) {
-			// Only try once, otherwise the node stays unsecure
-			try {
-				// When replacing a node, we receive no NIF, so we cannot know that the Security CC is supported.
-				// Querying the node info however kicks some devices out of secure inclusion mode.
-				// Therefore we must assume that the node supports Security in order to support replacing a node securely
-				if (assumeSecure && !node.supportsCC(CommandClasses.Security)) {
-					node.addCC(CommandClasses.Security, {
-						secure: true,
-						isSupported: true,
-						version: 1,
-					});
-				}
-
-				// SDS13783 - impose a 10s timeout on each message
-				const api = node.commandClasses.Security.withOptions({
-					expire: 10000,
-				});
-				// Request security scheme, because it is required by the specs
-				await api.getSecurityScheme(); // ignore the result
-
-				// Request nonce separately, so we can impose a timeout
-				await api.getNonce({
-					standalone: true,
-					storeAsFreeNonce: true,
-				});
-
-				// send the network key
-				await api.setNetworkKey(this.driver.securityManager.networkKey);
-
-				if (this._includeController) {
-					// Tell the controller which security scheme to use
-					await api.inheritSecurityScheme();
-				}
-
-				// Remember that the node was granted the S0 security class
-				node.securityClasses.set(SecurityClass.S0_Legacy, true);
-			} catch (e: unknown) {
-				let errorMessage = `Security S0 bootstrapping failed, the node was not granted the S0 security class`;
-				if (!isZWaveError(e)) {
-					errorMessage += `: ${e as any}`;
-				} else if (
-					e.code === ZWaveErrorCodes.Controller_MessageExpired
-				) {
-					errorMessage += ": a secure inclusion timer has elapsed.";
-				} else if (
-					e.code !== ZWaveErrorCodes.Controller_MessageDropped &&
-					e.code !== ZWaveErrorCodes.Controller_NodeTimeout
-				) {
-					errorMessage += `: ${e.message}`;
-				}
-				this.driver.controllerLog.logNode(
-					node.id,
-					errorMessage,
-					"warn",
-				);
-				// Remember that the node was NOT granted the S0 security class
-				node.securityClasses.set(SecurityClass.S0_Legacy, false);
-				node.removeCC(CommandClasses.Security);
-			}
-		} else {
+		if (!this.driver.securityManager) {
 			// Remember that the node was NOT granted the S0 security class
 			node.securityClasses.set(SecurityClass.S0_Legacy, false);
+			return;
+		}
+
+		// If security has been set up and we are allowed to include the node securely, try to do it
+		try {
+			// When replacing a node, we receive no NIF, so we cannot know that the Security CC is supported.
+			// Querying the node info however kicks some devices out of secure inclusion mode.
+			// Therefore we must assume that the node supports Security in order to support replacing a node securely
+			if (assumeSupported && !node.supportsCC(CommandClasses.Security)) {
+				node.addCC(CommandClasses.Security, {
+					secure: true,
+					isSupported: true,
+					version: 1,
+				});
+			}
+
+			// SDS13783 - impose a 10s timeout on each message
+			const api = node.commandClasses.Security.withOptions({
+				expire: 10000,
+			});
+			// Request security scheme, because it is required by the specs
+			await api.getSecurityScheme(); // ignore the result
+
+			// Request nonce separately, so we can impose a timeout
+			await api.getNonce({
+				standalone: true,
+				storeAsFreeNonce: true,
+			});
+
+			// send the network key
+			await api.setNetworkKey(this.driver.securityManager.networkKey);
+
+			if (this._includeController) {
+				// Tell the controller which security scheme to use
+				await api.inheritSecurityScheme();
+			}
+
+			// Remember that the node was granted the S0 security class
+			node.securityClasses.set(SecurityClass.S0_Legacy, true);
+		} catch (e: unknown) {
+			let errorMessage = `Security S0 bootstrapping failed, the node was not granted the S0 security class`;
+			if (!isZWaveError(e)) {
+				errorMessage += `: ${e as any}`;
+			} else if (e.code === ZWaveErrorCodes.Controller_MessageExpired) {
+				errorMessage += ": a secure inclusion timer has elapsed.";
+			} else if (
+				e.code !== ZWaveErrorCodes.Controller_MessageDropped &&
+				e.code !== ZWaveErrorCodes.Controller_NodeTimeout
+			) {
+				errorMessage += `: ${e.message}`;
+			}
+			this.driver.controllerLog.logNode(node.id, errorMessage, "warn");
+			// Remember that the node was NOT granted the S0 security class
+			node.securityClasses.set(SecurityClass.S0_Legacy, false);
+			node.removeCC(CommandClasses.Security);
+		}
+	}
+
+	private async secureBootstrapS2(
+		node: ZWaveNode,
+		assumeSupported: boolean = false,
+	): Promise<void> {
+		const unGrantSecurityClasses = () => {
+			for (const secClass of securityClassOrder) {
+				node.securityClasses.set(secClass, false);
+			}
+		};
+
+		if (!this.driver.securityManager2) {
+			// Remember that the node was NOT granted any S2 security classes
+			unGrantSecurityClasses();
+			return;
+		}
+
+		// When replacing a node, we receive no NIF, so we cannot know that the Security CC is supported.
+		// Querying the node info however kicks some devices out of secure inclusion mode.
+		// Therefore we must assume that the node supports Security in order to support replacing a node securely
+		if (assumeSupported && !node.supportsCC(CommandClasses["Security 2"])) {
+			node.addCC(CommandClasses["Security 2"], {
+				secure: true,
+				isSupported: true,
+				version: 1,
+			});
+		}
+
+		const { userCallbacks } = this._inclusionOptions as InclusionOptions & {
+			strategy: InclusionStrategy.Security_S2;
+		};
+
+		try {
+			const api = node.commandClasses["Security 2"];
+			const abort = async (failType?: KEXFailType): Promise<void> => {
+				if (failType != undefined) {
+					try {
+						await api.abortKeyExchange(failType);
+					} catch {
+						// ignore
+					}
+				}
+				// Un-grant S2 security classes we might have granted
+				unGrantSecurityClasses();
+			};
+
+			const abortUser = () => {
+				setImmediate(() => {
+					try {
+						userCallbacks.abort();
+					} catch {
+						// ignore errors in application callbacks
+					}
+				});
+				return abort(KEXFailType.BootstrappingCanceled);
+			};
+
+			// Ask the node for its desired security classes and key exchange params
+			const kexParams = await api
+				.withOptions({ expire: inclusionTimeouts.TA1 })
+				.getKeyExchangeParameters();
+			if (!kexParams) {
+				this.driver.controllerLog.logNode(node.id, {
+					message: `Security S2 bootstrapping failed: did not receive the node's desired security classes.`,
+					level: "warn",
+				});
+				return abort();
+			}
+
+			// Validate the response
+			// At the time of implementation, only these are defined
+			if (
+				!kexParams.supportedKEXSchemes.includes(KEXSchemes.KEXScheme1)
+			) {
+				this.driver.controllerLog.logNode(node.id, {
+					message: `Security S2 bootstrapping failed: No supported key exchange scheme.`,
+					level: "warn",
+				});
+				return abort(KEXFailType.NoSupportedScheme);
+			} else if (
+				!kexParams.supportedECDHProfiles.includes(
+					ECDHProfiles.Curve25519,
+				)
+			) {
+				this.driver.controllerLog.logNode(node.id, {
+					message: `Security S2 bootstrapping failed: No supported ECDH profile.`,
+					level: "warn",
+				});
+				return abort(KEXFailType.NoSupportedCurve);
+			}
+			const supportedKeys = kexParams.requestedKeys.filter((k) =>
+				securityClassOrder.includes(k as any),
+			);
+			if (!supportedKeys.length) {
+				this.driver.controllerLog.logNode(node.id, {
+					message: `Security S2 bootstrapping failed: None of the requested security classes are supported.`,
+					level: "warn",
+				});
+				return abort(KEXFailType.NoKeyMatch);
+			}
+
+			// TODO: Validate client-side auth if requested
+			const grantResult = await Promise.race([
+				wait(inclusionTimeouts.TAI1).then(() => false as const),
+				userCallbacks.grantSecurityClasses({
+					securityClasses: supportedKeys,
+					clientSideAuth: false,
+				}),
+			]);
+			if (grantResult === false) {
+				// There was a timeout or the user did not confirm the request, abort
+				this.driver.controllerLog.logNode(node.id, {
+					message: `Security S2 bootstrapping failed: User rejected the requested security classes or interaction timed out.`,
+					level: "warn",
+				});
+				return abortUser();
+			}
+			const grantedKeys = supportedKeys.filter((k) =>
+				grantResult.securityClasses.includes(k),
+			);
+			if (!grantedKeys.length) {
+				// The user did not grant any of the requested keys
+				this.driver.controllerLog.logNode(node.id, {
+					message: `Security S2 bootstrapping failed: None of the requested keys were granted by the user.`,
+					level: "warn",
+				});
+				return abortUser();
+			}
+
+			// Tell the node how we want the inclusion to go and grant it the keys
+			// It will send its public key in response
+			await api.grantKeys({
+				grantedKeys,
+				permitCSA: false,
+				selectedECDHProfile: ECDHProfiles.Curve25519,
+				selectedKEXScheme: KEXSchemes.KEXScheme1,
+			});
+
+			const pubKeyResponse = await this.driver.waitForCommand<
+				Security2CCPublicKeyReport | Security2CCKEXFail
+			>(
+				(cc) =>
+					cc instanceof Security2CCPublicKeyReport ||
+					cc instanceof Security2CCKEXFail,
+				inclusionTimeouts.TA2,
+			);
+			if (
+				pubKeyResponse instanceof Security2CCKEXFail ||
+				pubKeyResponse.includingNode
+			) {
+				this.driver.controllerLog.logNode(node.id, {
+					message: `The joining node canceled the Security S2 bootstrapping.`,
+					direction: "inbound",
+					level: "warn",
+				});
+				return abort();
+			}
+
+			const nodePublicKey = pubKeyResponse.publicKey;
+			// This is the starting point of the timer TAI2. Depending on how long the user takes to confirm,
+			// the node has less time to send its KEXSet
+			const timerStartTAI2 = Date.now();
+			if (
+				grantedKeys.includes(SecurityClass.S2_AccessControl) ||
+				grantedKeys.includes(SecurityClass.S2_Authenticated)
+			) {
+				// For authenticated encryption, the DSK (first 16 bytes of the public key) is obfuscated (missing the first 2 bytes)
+				// Request the user to enter the missing part as a 5-digit PIN
+				const dsk = dskToString(nodePublicKey.slice(0, 16)).slice(5);
+
+				const pinResult = await Promise.race([
+					wait(inclusionTimeouts.TAI2).then(() => false as const),
+					userCallbacks.validateDSKAndEnterPIN(dsk),
+				]);
+				if (
+					typeof pinResult !== "string" ||
+					!/^\d{5}$/.test(pinResult)
+				) {
+					// There was a timeout, the user did not confirm the DSK or entered an invalid PIN
+					this.driver.controllerLog.logNode(node.id, {
+						message: `Security S2 bootstrapping failed: User rejected the DSK, entered an invalid PIN or the interaction timed out.`,
+						level: "warn",
+					});
+					return abortUser();
+				}
+
+				// Fill in the missing two bytes of the public key
+				nodePublicKey.writeUInt16BE(parseInt(pinResult, 10), 0);
+			}
+
+			// Generate ECDH key pair. Z-Wave works with the "raw" keys, so this is a tad complicated
+			const keyPair = await util.promisify(crypto.generateKeyPair)(
+				"x25519",
+			);
+			const publicKey = decodeX25519KeyDER(
+				keyPair.publicKey.export({
+					type: "spki",
+					format: "der",
+				}),
+			);
+			const sharedSecret = crypto.diffieHellman({
+				publicKey: crypto.createPublicKey({
+					key: encodeX25519KeyDERSPKI(nodePublicKey),
+					format: "der",
+					type: "spki",
+				}),
+				privateKey: keyPair.privateKey,
+			});
+
+			// Derive temporary key from ECDH key pair
+			const tempKeys = deriveTempKeys(
+				computePRK(sharedSecret, publicKey, nodePublicKey),
+			);
+			this.driver.securityManager2.tempKeys.set(node.id, {
+				keyCCM: tempKeys.tempKeyCCM,
+				personalizationString: tempKeys.tempPersonalizationString,
+			});
+
+			await api.sendPublicKey(publicKey);
+
+			// Wait until the encrypted KEXSet from the node was received
+			// (if there is even time left)
+			const tai2RemainingMs = Date.now() - timerStartTAI2;
+			if (tai2RemainingMs < 1) {
+				this.driver.controllerLog.logNode(node.id, {
+					message: `Security S2 bootstrapping failed: a secure inclusion timer has elapsed`,
+					level: "warn",
+				});
+				return abortUser();
+			}
+
+			const keySetEcho = await this.driver.waitForCommand<
+				Security2CCKEXSet | Security2CCKEXFail
+			>(
+				(cc) =>
+					cc instanceof Security2CCKEXSet ||
+					cc instanceof Security2CCKEXFail,
+				tai2RemainingMs,
+			);
+			// Validate that the received command contains the correct list of keys
+			if (keySetEcho instanceof Security2CCKEXFail || !keySetEcho.echo) {
+				this.driver.controllerLog.logNode(node.id, {
+					message: `The joining node canceled the Security S2 bootstrapping.`,
+					direction: "inbound",
+					level: "warn",
+				});
+				return abort();
+			} else if (
+				keySetEcho.grantedKeys.length !== grantedKeys.length ||
+				!keySetEcho.grantedKeys.every((k) => grantedKeys.includes(k))
+			) {
+				this.driver.controllerLog.logNode(node.id, {
+					message: `Security S2 bootstrapping failed: Granted key mismatch.`,
+					level: "warn",
+				});
+				return abort(KEXFailType.WrongSecurityLevel);
+			}
+			// Confirm the keys - the node will start requesting the granted keys in response
+			await api.confirmGrantedKeys({
+				requestCSA: kexParams.requestCSA,
+				requestedKeys: [...kexParams.requestedKeys],
+				supportedECDHProfiles: [...kexParams.supportedECDHProfiles],
+				supportedKEXSchemes: [...kexParams.supportedKEXSchemes],
+			});
+
+			for (let i = 0; i < grantedKeys.length; i++) {
+				// Wait for the key request
+				const keyRequest = await this.driver.waitForCommand<
+					Security2CCNetworkKeyGet | Security2CCKEXFail
+				>(
+					(cc) =>
+						cc instanceof Security2CCNetworkKeyGet ||
+						cc instanceof Security2CCKEXFail,
+					inclusionTimeouts.TA3,
+				);
+				if (keyRequest instanceof Security2CCKEXFail) {
+					this.driver.controllerLog.logNode(node.id, {
+						message: `The joining node canceled the Security S2 bootstrapping.`,
+						direction: "inbound",
+						level: "warn",
+					});
+					return abort();
+				}
+
+				const securityClass = keyRequest.requestedKey;
+				// Ensure it was received encrypted with the temporary key
+				if (
+					!this.driver.securityManager2.hasUsedSecurityClass(
+						node.id,
+						SecurityClass.Temporary,
+					)
+				) {
+					this.driver.controllerLog.logNode(node.id, {
+						message: `Security S2 bootstrapping failed: Node used wrong key to communicate.`,
+						level: "warn",
+					});
+					return abort(KEXFailType.WrongSecurityLevel);
+				} else if (!grantedKeys.includes(securityClass)) {
+					// and that the requested key is one of the granted keys
+					this.driver.controllerLog.logNode(node.id, {
+						message: `Security S2 bootstrapping failed: Node used key it was not granted.`,
+						level: "warn",
+					});
+					return abort(KEXFailType.KeyNotGranted);
+				}
+
+				// Send the node the requested key
+				await api.sendNetworkKey(
+					securityClass,
+					this.driver.securityManager2.getKeysForSecurityClass(
+						securityClass,
+					).pnk,
+				);
+				// We need to temporarily mark this security class as granted, so the following exchange will use this
+				// key for decryption
+				node.securityClasses.set(securityClass, true);
+
+				// And wait for verification
+				const verify = await this.driver.waitForCommand<
+					Security2CCNetworkKeyVerify | Security2CCKEXFail
+				>(
+					(cc) =>
+						cc instanceof Security2CCNetworkKeyVerify ||
+						cc instanceof Security2CCKEXFail,
+					inclusionTimeouts.TA4,
+				);
+				if (verify instanceof Security2CCKEXFail) {
+					this.driver.controllerLog.logNode(node.id, {
+						message: `The joining node canceled the Security S2 bootstrapping.`,
+						direction: "inbound",
+						level: "warn",
+					});
+					return abort();
+				}
+
+				if (
+					!this.driver.securityManager2.hasUsedSecurityClass(
+						node.id,
+						securityClass,
+					)
+				) {
+					this.driver.controllerLog.logNode(node.id, {
+						message: `Security S2 bootstrapping failed: Node used wrong key to communicate.`,
+						level: "warn",
+					});
+					return abort(KEXFailType.NoVerify);
+				}
+
+				// Tell the node that verification was successful. We need to reset the SPAN state
+				// so the temporary key will be used again. Also we don't know in which order the node requests the keys
+				// so our logic to use the highest security class for decryption might be problematic. Therefore delete the
+				// security class for now.
+				node.securityClasses.delete(securityClass);
+				this.driver.securityManager2.deleteNonce(node.id);
+				await api.confirmKeyVerification();
+			}
+
+			// After all keys were sent and verified, we need to wait for the node to confirm that it is done
+			const transferEnd =
+				await this.driver.waitForCommand<Security2CCTransferEnd>(
+					(cc) => cc instanceof Security2CCTransferEnd,
+					inclusionTimeouts.TA5,
+				);
+			if (!transferEnd.keyRequestComplete) {
+				// S2 bootstrapping failed
+				this.driver.controllerLog.logNode(node.id, {
+					message: `Security S2 bootstrapping failed: Node did not confirm completion of the key exchange`,
+					level: "warn",
+				});
+				return abort();
+			}
+
+			// Remember all security classes we have granted
+			for (const securityClass of grantedKeys) {
+				node.securityClasses.set(securityClass, true);
+			}
+			this.driver.controllerLog.logNode(node.id, {
+				message: `Security S2 bootstrapping successful with these security classes:${[
+					...node.securityClasses.entries(),
+				]
+					.filter(([, v]) => v)
+					.map(([k]) => `\n· ${getEnumMemberName(SecurityClass, k)}`)
+					.join("")}`,
+			});
+
+			// success 🎉
+		} catch (e: unknown) {
+			let errorMessage = `Security S2 bootstrapping failed, the node was not granted any S2 security class`;
+			if (!isZWaveError(e)) {
+				errorMessage += `: ${e as any}`;
+			} else if (e.code === ZWaveErrorCodes.Controller_MessageExpired) {
+				errorMessage += ": a secure inclusion timer has elapsed.";
+			} else if (
+				e.code !== ZWaveErrorCodes.Controller_MessageDropped &&
+				e.code !== ZWaveErrorCodes.Controller_NodeTimeout
+			) {
+				errorMessage += `: ${e.message}`;
+			}
+			this.driver.controllerLog.logNode(node.id, errorMessage, "warn");
+			// Remember that the node was NOT granted any S2 security classes
+			unGrantSecurityClasses();
+			node.removeCC(CommandClasses["Security 2"]);
 		}
 	}
 
@@ -1132,7 +1702,11 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 				AddNodeStatus[msg.status!]
 			})`,
 		);
-		if (!this._inclusionActive && msg.status !== AddNodeStatus.Done) {
+
+		if (
+			(!this._inclusionActive && msg.status !== AddNodeStatus.Done) ||
+			this._inclusionOptions == undefined
+		) {
 			this.driver.controllerLog.print(
 				`  inclusion is NOT active, ignoring it...`,
 			);
@@ -1147,7 +1721,13 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 				);
 				if (this._beginInclusionPromise != null) {
 					this._beginInclusionPromise.resolve(true);
-					this.emit("inclusion started", !this._includeNonSecure);
+					this.emit(
+						"inclusion started",
+						// TODO: Remove first parameter in next major version
+						this._inclusionOptions.strategy !==
+							InclusionStrategy.Insecure,
+						this._inclusionOptions.strategy,
+					);
 				}
 				break;
 			case AddNodeStatus.Failed:
@@ -1268,8 +1848,27 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 						newNode.id,
 					);
 
-					if (!this._includeNonSecure) {
+					const opts = this._inclusionOptions;
+					// The default inclusion strategy is: Use S2 if possible, only use S0 if necessary, use no encryption otherwise
+					if (
+						newNode.supportsCC(CommandClasses["Security 2"]) &&
+						(opts.strategy === InclusionStrategy.Default ||
+							opts.strategy === InclusionStrategy.Security_S2)
+					) {
+						await this.secureBootstrapS2(newNode);
+						// TODO: Warn if failed
+					} else if (
+						newNode.supportsCC(CommandClasses.Security) &&
+						(opts.strategy === InclusionStrategy.Security_S0 ||
+							(opts.strategy === InclusionStrategy.Default &&
+								(opts.forceSecurity ||
+									(
+										newNode.deviceClass?.specific ??
+										newNode.deviceClass?.generic
+									)?.requiresSecurity)))
+					) {
 						await this.secureBootstrapS0(newNode);
+						// TODO: Warn if failed
 					}
 					this._includeController = false;
 
@@ -1301,6 +1900,13 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 			})`,
 		);
 
+		if (this._inclusionOptions == undefined) {
+			this.driver.controllerLog.print(
+				`  currently NOT replacing a node, ignoring it...`,
+			);
+			return true; // Don't invoke any more handlers
+		}
+
 		switch (msg.replaceStatus) {
 			case ReplaceFailedNodeStatus.NodeOK:
 				this._replaceFailedPromise?.reject(
@@ -1324,7 +1930,13 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 				this.driver.controllerLog.print(
 					`The failed node is ready to be replaced, inclusion started...`,
 				);
-				this.emit("inclusion started", !this._includeNonSecure);
+				this.emit(
+					"inclusion started",
+					// TODO: Remove first parameter in next major version
+					this._inclusionOptions.strategy !==
+						InclusionStrategy.Insecure,
+					this._inclusionOptions.strategy,
+				);
 				this._inclusionActive = true;
 				this._replaceFailedPromise?.resolve(true);
 
@@ -1365,8 +1977,19 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 					);
 
 					// Try perform the security bootstrap process
-					if (!this._includeNonSecure) {
+					const strategy = this._inclusionOptions.strategy;
+					if (
+						newNode.supportsCC(CommandClasses["Security 2"]) &&
+						strategy === InclusionStrategy.Security_S2
+					) {
+						await this.secureBootstrapS2(newNode, true);
+						// TODO: Warn if failed
+					} else if (
+						newNode.supportsCC(CommandClasses.Security) &&
+						strategy === InclusionStrategy.Security_S0
+					) {
 						await this.secureBootstrapS0(newNode, true);
+						// TODO: Warn if failed
 					}
 
 					// Bootstrap the node's lifelines, so it knows where the controller is
@@ -2736,15 +3359,44 @@ ${associatedNodes.join(", ")}`,
 	/**
 	 * Replace a failed node from the controller's memory. If the process fails, this will throw an exception with the details why.
 	 * @param nodeId The id of the node to replace
-	 * @param includeNonSecure Whether the new node should be included non-securely, even if it supports Security. By default, all nodes will be included securely if possible
-	 *
+	 * @param options Defines the inclusion strategy to use for the replacement node
 	 */
 	public async replaceFailedNode(
 		nodeId: number,
-		includeNonSecure: boolean = false,
+		options: ReplaceNodeOptions,
+	): Promise<boolean>;
+
+	/**
+	 * Replace a failed node from the controller's memory. If the process fails, this will throw an exception with the details why.
+	 * @param nodeId The id of the node to replace
+	 * @param includeNonSecure Whether the new node should be included non-securely, even if it supports Security S0. By default, S0 will be used.
+	 * @deprecated Use the overload with options instead
+	 */
+	public async replaceFailedNode(
+		nodeId: number,
+		includeNonSecure: boolean,
+	): Promise<boolean>;
+
+	public async replaceFailedNode(
+		nodeId: number,
+		options?: ReplaceNodeOptions | boolean,
 	): Promise<boolean> {
 		// don't start it twice
 		if (this._inclusionActive || this._exclusionActive) return false;
+
+		if (options == undefined) {
+			options = {
+				strategy: InclusionStrategy.Security_S0,
+				legacyReturnType: true,
+			};
+		} else if (typeof options === "boolean") {
+			options = {
+				strategy: options
+					? InclusionStrategy.Insecure
+					: InclusionStrategy.Security_S0,
+				legacyReturnType: true,
+			};
+		}
 
 		this.driver.controllerLog.print(
 			`starting replace failed node process...`,
@@ -2758,7 +3410,7 @@ ${associatedNodes.join(", ")}`,
 			);
 		}
 
-		this._includeNonSecure = includeNonSecure;
+		this._inclusionOptions = options;
 
 		const result = await this.driver.sendMessage<ReplaceFailedNodeResponse>(
 			new ReplaceFailedNodeRequest(this.driver, {

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -302,7 +302,7 @@ export type InclusionOptions =
 			strategy: InclusionStrategy.Default;
 			userCallbacks: InclusionUserCallbacks;
 			/**
-			 * Force secure communication (S0) even when S2 is not supported and S0 is not necessary.
+			 * Force secure communication (S0) even when S2 is not supported and S0 is supported but not necessary.
 			 * This is not recommended due to the overhead caused by S0.
 			 */
 			forceSecurity?: boolean;

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -2505,8 +2505,9 @@ ${handlers.length} left`,
 		if (node?.supportsCC(CommandClasses["Security 2"])) {
 			const securityClass = node.getHighestSecurityClass();
 			if (
-				securityClass != undefined &&
-				securityClass !== SecurityClass.S0_Legacy &&
+				((securityClass != undefined &&
+					securityClass !== SecurityClass.S0_Legacy) ||
+					this.securityManager2?.tempKeys.has(node.id)) &&
 				Security2CC.requiresEncapsulation(msg.command)
 			) {
 				msg.command = Security2CC.encapsulate(this, msg.command);

--- a/test/run.ts
+++ b/test/run.ts
@@ -2,7 +2,6 @@
 // import { Driver } from "../packages/zwave-js";
 
 // To test without Sentry reporting
-import { SecurityClass } from "@zwave-js/core";
 import path from "path";
 import "reflect-metadata";
 import { Driver } from "../packages/zwave-js/src/lib/driver/Driver";
@@ -33,11 +32,6 @@ const driver = new Driver("COM5", {
 })
 	.on("error", console.error)
 	.once("driver ready", async () => {
-		// TODO: find a more elegant way to do this
-		driver.securityManager2?.assignSecurityClassSinglecast(31, [
-			SecurityClass.S2_Authenticated,
-			SecurityClass.S2_Unauthenticated,
-		]);
 		// driver.controller.on("statistics updated", (s) => {
 		// 	console.debug(s);
 		// });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3761,6 +3761,7 @@ __metadata:
     "@zwave-js/config": "workspace:*"
     "@zwave-js/core": "workspace:*"
     "@zwave-js/shared": "workspace:*"
+    alcalzone-shared: ^4.0.0
     ansi-colors: ^4.1.1
     comment-json: ^4.1.0
     commitizen: ^4.2.4


### PR DESCRIPTION
This PR implements inclusion of new nodes using `Security S2`. To realize this, new inclusion strategies have been added, marking the old S0-by-default strategy as deprecated:

> **Default:**  
> Prefer Security S2 if supported, use Security S0 if absolutely necessary (e.g. for legacy locks), don't use encryption otherwise.
> Issues a warning if Security S2/S0 is attempted to be used but secure bootstrapping fails.
> 👍🏻 **This is the recommended** strategy and should be used unless there is a good reason not to.
> 
> ---
> 
> **SmartStart:**  
> Include using SmartStart (requires Security S2).
> Can't include a device that does not support Smart Start.
> Issues a warning if secure bootstrapping fails.
> 👍🏻👍🏻 **Should be preferred** over **Default** if supported.
>
> ---
> 
> **Insecure:**  
> Don't use encryption, even if supported.
> 👎🏻 **Not recommended**, because S2 should be used where possible.
> 
> ---
> 
> **Security_S0:**  
> Use Security S0, even if a higher security mode is supported.
> Issues a warning if Security S0 is not supported or the secure bootstrapping fails.
> 👎🏻👎🏻 **Not recommended** because S0 should be used sparingly and S2 preferred whereever possible.
> 
> ---
> 
> **Security_S2:**  
> Use Security S2 and issue a warning if it is not supported or the secure bootstrapping fails.
> 🤷🏻‍♂️ Not really an advantage over **Default**. Less versatile, more complicated for the user.

---

The method signatures for `beginInclusion` and `replaceFailedNode` have been changed as follows
```ts
public async beginInclusion(options: InclusionOptions): Promise<boolean>;
public async replaceFailedNode(nodeId: number, options: ReplaceNodeOptions): Promise<boolean>;
```
to accomodate for S2 inclusion (the old variants will keep working until v9.x).

The shape of these options depend on the inclusion strategy:
```ts
export type InclusionOptions =
	| {
			strategy: InclusionStrategy.Default;
			userCallbacks: InclusionUserCallbacks;
			/**
			 * Force secure communication (S0) even when S2 is not supported and S0 is supported but not necessary.
			 * This is not recommended due to the overhead caused by S0.
			 */
			forceSecurity?: boolean;
	  }
	| {
			strategy: InclusionStrategy.Security_S2;
			userCallbacks: InclusionUserCallbacks;
	  }
	| {
			strategy: InclusionStrategy.SmartStart;
			provisioningList: unknown;
	  }
	| {
			strategy: InclusionStrategy.Insecure | InclusionStrategy.Security_S0;
	  };
```

Default, and Security_S2 will accept user callbacks that allow interactively validating the DSK and choosing security classes. Although it is not guaranteed that they will be called, the application MUST provide them:
```ts
export interface InclusionUserCallbacks {
	/**
	 * Instruct the application to display the user which security classes the device has requested and whether client-side authentication (CSA) is desired.
	 * The returned promise MUST resolve to the user selection - which of the requested security classes have been granted and whether CSA was allowed.
	 * If the user did not accept the requested security classes, the promise MUST resolve to `true`.
	 */
	grantSecurityClasses(
		requested: InclusionGrant,
	): Promise<InclusionGrant | false>;

	/**
	 * Instruct the application to display the received DSK for the user to verify if it matches the one belonging to the device and
	 * additionally enter the PIN that's found on the device.
	 * The returned promise MUST resolve to the 5-digit PIN (as a string) when the user has confirmed the DSK and entered the PIN and `false` otherwise.
	 *
	 * @param dsk The partial DSK in the form `-bbbbb-ccccc-ddddd-eeeee-fffff-11111-22222`. The first 5 characters are left out because they are the unknown PIN.
	 */
	validateDSKAndEnterPIN(dsk: string): Promise<string | false>;

	/** Called by the driver when the user validation has timed out and needs to be aborted */
	abort(): void;
}

export interface InclusionGrant {
	/**
	 * An array of security classes that are requested or to be granted.
	 * The granted security classes MUST be a subset of the requested ones.
	 */
	securityClasses: SecurityClass[];
	/** Whether client side authentication is requested or to be granted */
	clientSideAuth: boolean;
}
```
For the Default strategy, the application can also decide to prefer S0 over no encryption (`forceSecurity: true`), even if it is not necessary.

SmartStart is just a stub at this point and likely to change. Insecure and Security_S0 won't need any arguments.

---

`replaceFailedNode` only supports a subset of the inclusion strategies. Because that command does not provide the node info of the new node, reacting to the supported CCs or device classes is not possible. For that reason, the application MUST tell `zwave-js` before the inclusion whether S2, S0 or no encryption should be used:
```ts
export type ReplaceNodeOptions =
	| {
			strategy: InclusionStrategy.Security_S2;
			userCallbacks: InclusionUserCallbacks;
	  }
	| {
			strategy: InclusionStrategy.Insecure | InclusionStrategy.Security_S0;
	  };
```

---

Last but not least this PR adds a second parameter to the `"node added"` event to indicate whether a node was included with lower than intended security:
```ts
// node added event handler:
(node: ZWaveNode, result: InclusionResult) => void;

export interface InclusionResult {
	/** This flag warns that a node was included with a lower than intended security, e.g. unencrypted instead of Security S2 */
	lowSecurity?: boolean;
}
```