### PR TITLE
chore: update README.md modify terminology and mention hardware compability

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 Z-Wave is an amazing piece of technology, but it is difficult to get started with and develop for.  
 **It shouldn't be!** We've got you covered.
 
-Built on Node.js and compatible with all known Z-Wave 500 series + Z-Wave 700 series controller hardware adapters, **Z-Wave JS** runs on almost anything with a little bit of computing power and a serial port. Check out the [documentation](https://zwave-js.github.io/node-zwave-js) to get started!
+Built on Node.js and compatible with all known 500 and 700 series Z-Wave controller hardware adapters, **Z-Wave JS** runs on almost anything with a little bit of computing power and a serial port. Check out the [documentation](https://zwave-js.github.io/node-zwave-js) to get started!
 
 ## Quick Links
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 Z-Wave is an amazing piece of technology, but it is difficult to get started with and develop for.  
 **It shouldn't be!** We've got you covered.
 
-Built on Node.js and compatible with all known Z-Wave controller hardware adapters, **Z-Wave JS** runs on almost anything with a little bit of computing power and a serial port. Check out the [documentation](https://zwave-js.github.io/node-zwave-js) to get started!
+Built on Node.js and compatible with all known Z-Wave 500 series + Z-Wave 700 series controller hardware adapters, **Z-Wave JS** runs on almost anything with a little bit of computing power and a serial port. Check out the [documentation](https://zwave-js.github.io/node-zwave-js) to get started!
 
 ## Quick Links
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![node-zwave-js](docs/_images/logo.svg)
 
-<h2 align="center">Z-Wave driver written entirely in JavaScript/TypeScript</h2>
+<h2 align="center">Z-Wave device driver written entirely in JavaScript/TypeScript</h2>
 
 ![Test and Release](https://github.com/AlCalzone/node-zwave-js/workflows/Test%20and%20Release/badge.svg)
 [![Coverage Status](https://img.shields.io/coveralls/github/AlCalzone/node-zwave-js.svg)](https://coveralls.io/github/AlCalzone/node-zwave-js)
@@ -20,7 +20,7 @@
 Z-Wave is an amazing piece of technology, but it is difficult to get started with and develop for.  
 **It shouldn't be!** We've got you covered.
 
-Built on Node.js, **Z-Wave JS** runs on almost anything with a little bit of computing power and a serial port. Check out the [documentation](https://zwave-js.github.io/node-zwave-js) to get started!
+Built on Node.js and compatible with all known Z-Wave controller hardware adapters, **Z-Wave JS** runs on almost anything with a little bit of computing power and a serial port. Check out the [documentation](https://zwave-js.github.io/node-zwave-js) to get started!
 
 ## Quick Links
 
@@ -33,7 +33,7 @@ Built on Node.js, **Z-Wave JS** runs on almost anything with a little bit of com
 
 ## Supporting Z-Wave JS
 
-Started in 2018, **Z-Wave JS** has breathed new life into the Z-Wave ecosystem and is now powering thousands of smart homes all over the world. We strive to build the best open source Z-Wave driver out there and hold ourselves to the highest standards. This requires a lot of effort and is done entirely in our free time. We'd love to spend more time on **Z-Wave JS**, but need your support to do so.
+Started in 2018, **Z-Wave JS** has breathed new life into the Z-Wave ecosystem and is now powering thousands of smart homes all over the world. We strive to build the best open source Z-Wave device driver out there and hold ourselves to the highest standards. This requires a lot of effort and is done entirely in our free time. We'd love to spend more time on **Z-Wave JS**, but need your support to do so.
 
 If you'd like to help support the future of the project and make the Z-Wave world a better place, please consider:
 


### PR DESCRIPTION
Following confusion and reasoning in discussion at https://github.com/zwave-js/node-zwave-js/discussions/3087

Modifying terminology to read "device driver" which I understand as an industry-standard terminology instead of "driver" as per wikipedia explanation of the two https://en.wikipedia.org/wiki/Device_driver verses https://en.wikipedia.org/wiki/Driver_(software)

Also mention that zwave-js is compatible with all known Z-Wave controller hardware adapters in order to somewhat further clarify that it is a device driver for those..