### PR TITLE
fix(config): add missing product spec to MCOHome MH9-CO2-WD

### DIFF
--- a/packages/config/config/devices/0x015f/mh9-co2-wd.json
+++ b/packages/config/config/devices/0x015f/mh9-co2-wd.json
@@ -9,6 +9,10 @@
 			"productId": "0x3102"
 		},
 		{
+			"productType": "0x0902",
+			"productId": "0x5102"
+		},
+		{
 			"productType": "0x0905",
 			"productId": "0x0201"
 		}


### PR DESCRIPTION
According to the OpenSmartHouse Z-wave DB this product spec should be included as part of this product: https://opensmarthouse.org/zwavedatabase/455

I've just received this product and it is showing this ID+type as unrecognized currently. 