### PR TITLE
feat: add new ConfigManager properties to cover more config maps

### DIFF
--- a/docs/api/config-manager.md
+++ b/docs/api/config-manager.md
@@ -376,6 +376,150 @@ Returns the defined label for a given notification type
 
 ## ConfigManager properties
 
+### `basicDeviceClasses`
+
+```ts
+readonly basicDeviceClasses: BasicDeviceClassMap;
+```
+
+A map of the defined named basic device classes.
+
+<!-- #import BasicDeviceClassMap from "@zwave-js/config" -->
+
+```ts
+type BasicDeviceClassMap = ReadonlyMap<number, string>;
+```
+
+### `genericDeviceClasses`
+
+```ts
+readonly genericDeviceClasses: GenericDeviceClassMap;
+```
+
+A map of the defined named generic device classes.
+
+<!-- #import GenericDeviceClassMap from "@zwave-js/config" -->
+
+```ts
+type GenericDeviceClassMap = ReadonlyMap<number, GenericDeviceClass>;
+```
+
+<!-- #import GenericDeviceClass from "@zwave-js/config" -->
+
+```ts
+interface GenericDeviceClass {
+	readonly key: number;
+	readonly label: string;
+	readonly zwavePlusDeviceType?: string;
+	readonly requiresSecurity?: boolean;
+	readonly supportedCCs: readonly CommandClasses[];
+	readonly controlledCCs: readonly CommandClasses[];
+	readonly specific: ReadonlyMap<number, SpecificDeviceClass>;
+}
+```
+
+<!-- #import SpecificDeviceClass from "@zwave-js/config" -->
+
+```ts
+interface SpecificDeviceClass {
+	readonly key: number;
+	readonly label: string;
+	readonly zwavePlusDeviceType?: string;
+	readonly requiresSecurity?: boolean;
+	readonly supportedCCs: readonly CommandClasses[];
+	readonly controlledCCs: readonly CommandClasses[];
+}
+```
+
+### `indicators`
+
+```ts
+readonly indicators: IndicatorMap;
+```
+
+A map of the defined named indicators.
+
+<!-- #import IndicatorMap from "@zwave-js/config" -->
+
+```ts
+type IndicatorMap = ReadonlyMap<number, string>;
+```
+
+### `indicatorProperties`
+
+```ts
+readonly indicatorProperties: IndicatorPropertiesMap;
+```
+
+A map (numeric indicator type -> indicator properties definition) of the defined named indicators and their properties.
+
+<!-- #import IndicatorPropertiesMap from "@zwave-js/config" -->
+
+```ts
+type IndicatorPropertiesMap = ReadonlyMap<number, IndicatorProperty>;
+```
+
+<!-- #import IndicatorProperty from "@zwave-js/config" -->
+
+```ts
+interface IndicatorProperty {
+	readonly id: number;
+	readonly label: string;
+	readonly description: string | undefined;
+	readonly min: number | undefined;
+	readonly max: number | undefined;
+	readonly readonly: boolean | undefined;
+	readonly type: ValueType | undefined;
+}
+```
+
+### `manufacturers`
+
+```ts
+readonly manufacturers: ManufacturersMap;
+```
+
+A map of known manufacturer IDs and the manufacturer's name.
+
+<!-- #import ManufacturersMap from "@zwave-js/config" -->
+
+```ts
+type ManufacturersMap = ManufacturersMap = Map<number, string>;
+```
+
+### `meters`
+
+```ts
+readonly meters: MeterMap;
+```
+
+A map (numeric meter type -> meter type definition) of the known meter types and their scales.
+
+<!-- #import MeterMap from "@zwave-js/config" -->
+
+```ts
+type MeterMap = ReadonlyMap<number, Meter>;
+```
+
+<!-- #import Meter from "@zwave-js/config" -->
+
+```ts
+interface Meter {
+	readonly id: number;
+	readonly name: string;
+	readonly scales: ReadonlyMap<number, MeterScale>;
+}
+```
+
+<!-- #import MeterScale from "@zwave-js/config" -->
+
+```ts
+interface MeterScale {
+	readonly key: number;
+	readonly label: string;
+}
+```
+
 ### `namedScales`
 
 ```ts
@@ -399,6 +543,53 @@ type ScaleGroup = ReadonlyMap<number, Scale> & {
 };
 ```
 
+<!-- #import Scale from "@zwave-js/config" -->
+
+```ts
+interface Scale {
+	readonly key: number;
+	readonly unit: string | undefined;
+	readonly label: string;
+	readonly description: string | undefined;
+}
+```
+
+### `notifications`
+
+```ts
+readonly notifications: NotificationMap;
+```
+
+A map of the defined named notification types.
+
+<!-- #import NotificationMap from "@zwave-js/config" -->
+
+```ts
+type NotificationMap = ReadonlyMap<number, Notification>;
+```
+
+<!-- #import Notification from "@zwave-js/config" with comments -->
+
+```ts
+interface Notification {
+	readonly id: number;
+	readonly name: string;
+	readonly variables: readonly NotificationVariable[];
+	readonly events: ReadonlyMap<number, NotificationEvent>;
+}
+```
+
+<!-- #import NotificationEvent from "@zwave-js/config" with comments -->
+
+```ts
+interface NotificationEvent {
+	readonly id: number;
+	readonly label: string;
+	readonly description?: string;
+	readonly parameter?: NotificationParameter;
+}
+```
+
 ### `sensorTypes`
 
 ```ts
@@ -420,5 +611,25 @@ interface SensorType {
 	readonly key: number;
 	readonly label: string;
 	readonly scales: ScaleGroup;
+}
+```
+
+<!-- #import ScaleGroup from "@zwave-js/config" -->
+
+```ts
+type ScaleGroup = ReadonlyMap<number, Scale> & {
+	/** The name of the scale group if it is named */
+	readonly name?: string;
+};
+```
+
+<!-- #import Scale from "@zwave-js/config" -->
+
+```ts
+interface Scale {
+	readonly key: number;
+	readonly unit: string | undefined;
+	readonly label: string;
+	readonly description: string | undefined;
 }
 ```

--- a/docs/api/config-manager.md
+++ b/docs/api/config-manager.md
@@ -568,7 +568,7 @@ A map of the defined named notification types.
 type NotificationMap = ReadonlyMap<number, Notification>;
 ```
 
-<!-- #import Notification from "@zwave-js/config" with comments -->
+<!-- #import Notification from "@zwave-js/config" -->
 
 ```ts
 interface Notification {
@@ -579,7 +579,7 @@ interface Notification {
 }
 ```
 
-<!-- #import NotificationEvent from "@zwave-js/config" with comments -->
+<!-- #import NotificationEvent from "@zwave-js/config" -->
 
 ```ts
 interface NotificationEvent {
@@ -614,7 +614,7 @@ interface SensorType {
 }
 ```
 
-<!-- #import ScaleGroup from "@zwave-js/config" -->
+<!-- #import ScaleGroup from "@zwave-js/config" with comments -->
 
 ```ts
 type ScaleGroup = ReadonlyMap<number, Scale> & {

--- a/docs/api/config-manager.md
+++ b/docs/api/config-manager.md
@@ -614,16 +614,12 @@ interface SensorType {
 }
 ```
 
-<!-- #import ScaleGroup from "@zwave-js/config" with comments -->
-
 ```ts
 type ScaleGroup = ReadonlyMap<number, Scale> & {
 	/** The name of the scale group if it is named */
 	readonly name?: string;
 };
 ```
-
-<!-- #import Scale from "@zwave-js/config" -->
 
 ```ts
 interface Scale {

--- a/packages/config/src/ConfigManager.ts
+++ b/packages/config/src/ConfigManager.ts
@@ -94,9 +94,38 @@ export class ConfigManager {
 
 	private logger: ConfigLogger;
 
-	private indicators: IndicatorMap | undefined;
-	private indicatorProperties: IndicatorPropertiesMap | undefined;
-	private manufacturers: ManufacturersMap | undefined;
+	private _indicators: IndicatorMap | undefined;
+	public get indicators(): IndicatorMap {
+		if (!this._indicators) {
+			throw new ZWaveError(
+				"The config has not been loaded yet!",
+				ZWaveErrorCodes.Driver_NotReady,
+			);
+		}
+		return this._indicators;
+	}
+
+	private _indicatorProperties: IndicatorPropertiesMap | undefined;
+	public get indicatorProperties(): IndicatorPropertiesMap {
+		if (!this._indicatorProperties) {
+			throw new ZWaveError(
+				"The config has not been loaded yet!",
+				ZWaveErrorCodes.Driver_NotReady,
+			);
+		}
+		return this._indicatorProperties;
+	}
+
+	private _manufacturers: ManufacturersMap | undefined;
+	public get manufacturers(): ManufacturersMap {
+		if (!this._manufacturers) {
+			throw new ZWaveError(
+				"The config has not been loaded yet!",
+				ZWaveErrorCodes.Driver_NotReady,
+			);
+		}
+		return this._manufacturers;
+	}
 
 	private _namedScales: NamedScalesGroupMap | undefined;
 	public get namedScales(): NamedScalesGroupMap {
@@ -120,14 +149,53 @@ export class ConfigManager {
 		return this._sensorTypes;
 	}
 
-	private meters: MeterMap | undefined;
-	private basicDeviceClasses: BasicDeviceClassMap | undefined;
-	private genericDeviceClasses: GenericDeviceClassMap | undefined;
+	private _meters: MeterMap | undefined;
+	public get meters(): MeterMap {
+		if (!this._meters) {
+			throw new ZWaveError(
+				"The config has not been loaded yet!",
+				ZWaveErrorCodes.Driver_NotReady,
+			);
+		}
+		return this._meters;
+	}
+
+	private _basicDeviceClasses: BasicDeviceClassMap | undefined;
+	public get basicDeviceClasses(): BasicDeviceClassMap {
+		if (!this._basicDeviceClasses) {
+			throw new ZWaveError(
+				"The config has not been loaded yet!",
+				ZWaveErrorCodes.Driver_NotReady,
+			);
+		}
+		return this._basicDeviceClasses;
+	}
+
+	private _genericDeviceClasses: GenericDeviceClassMap | undefined;
+	public get genericDeviceClasses(): GenericDeviceClassMap {
+		if (!this._genericDeviceClasses) {
+			throw new ZWaveError(
+				"The config has not been loaded yet!",
+				ZWaveErrorCodes.Driver_NotReady,
+			);
+		}
+		return this._genericDeviceClasses;
+	}
 
 	private deviceConfigPriorityDir: string | undefined;
 	private index: DeviceConfigIndex | undefined;
 	private fulltextIndex: FulltextDeviceConfigIndex | undefined;
-	private notifications: NotificationMap | undefined;
+
+	private _notifications: NotificationMap | undefined;
+	public get notifications(): NotificationMap {
+		if (!this._notifications) {
+			throw new ZWaveError(
+				"The config has not been loaded yet!",
+				ZWaveErrorCodes.Driver_NotReady,
+			);
+		}
+		return this._notifications;
+	}
 
 	private _useExternalConfig: boolean = false;
 	public get useExternalConfig(): boolean {
@@ -162,7 +230,7 @@ export class ConfigManager {
 
 	public async loadManufacturers(): Promise<void> {
 		try {
-			this.manufacturers = await loadManufacturersInternal(
+			this._manufacturers = await loadManufacturersInternal(
 				this._useExternalConfig,
 			);
 		} catch (e: unknown) {
@@ -174,7 +242,7 @@ export class ConfigManager {
 						"error",
 					);
 				}
-				if (!this.manufacturers) this.manufacturers = new Map();
+				if (!this._manufacturers) this._manufacturers = new Map();
 			} else {
 				// This is an unexpected error
 				throw e;
@@ -183,14 +251,14 @@ export class ConfigManager {
 	}
 
 	public async saveManufacturers(): Promise<void> {
-		if (!this.manufacturers) {
+		if (!this._manufacturers) {
 			throw new ZWaveError(
 				"The config has not been loaded yet!",
 				ZWaveErrorCodes.Driver_NotReady,
 			);
 		}
 
-		await saveManufacturersInternal(this.manufacturers);
+		await saveManufacturersInternal(this._manufacturers);
 	}
 
 	/**
@@ -198,14 +266,14 @@ export class ConfigManager {
 	 * @param manufacturerId The manufacturer id to look up
 	 */
 	public lookupManufacturer(manufacturerId: number): string | undefined {
-		if (!this.manufacturers) {
+		if (!this._manufacturers) {
 			throw new ZWaveError(
 				"The config has not been loaded yet!",
 				ZWaveErrorCodes.Driver_NotReady,
 			);
 		}
 
-		return this.manufacturers.get(manufacturerId);
+		return this._manufacturers.get(manufacturerId);
 	}
 
 	/**
@@ -217,14 +285,14 @@ export class ConfigManager {
 		manufacturerId: number,
 		manufacturerName: string,
 	): void {
-		if (!this.manufacturers) {
+		if (!this._manufacturers) {
 			throw new ZWaveError(
 				"The config has not been loaded yet!",
 				ZWaveErrorCodes.Driver_NotReady,
 			);
 		}
 
-		this.manufacturers.set(manufacturerId, manufacturerName);
+		this._manufacturers.set(manufacturerId, manufacturerName);
 	}
 
 	public async loadIndicators(): Promise<void> {
@@ -232,8 +300,8 @@ export class ConfigManager {
 			const config = await loadIndicatorsInternal(
 				this._useExternalConfig,
 			);
-			this.indicators = config.indicators;
-			this.indicatorProperties = config.properties;
+			this._indicators = config.indicators;
+			this._indicatorProperties = config.properties;
 		} catch (e: unknown) {
 			// If the config file is missing or invalid, don't try to find it again
 			if (isZWaveError(e) && e.code === ZWaveErrorCodes.Config_Invalid) {
@@ -243,9 +311,9 @@ export class ConfigManager {
 						"error",
 					);
 				}
-				if (!this.indicators) this.indicators = new Map();
-				if (!this.indicatorProperties)
-					this.indicatorProperties = new Map();
+				if (!this._indicators) this._indicators = new Map();
+				if (!this._indicatorProperties)
+					this._indicatorProperties = new Map();
 			} else {
 				// This is an unexpected error
 				throw e;
@@ -257,28 +325,28 @@ export class ConfigManager {
 	 * Looks up the label for a given indicator id
 	 */
 	public lookupIndicator(indicatorId: number): string | undefined {
-		if (!this.indicators) {
+		if (!this._indicators) {
 			throw new ZWaveError(
 				"The config has not been loaded yet!",
 				ZWaveErrorCodes.Driver_NotReady,
 			);
 		}
 
-		return this.indicators.get(indicatorId);
+		return this._indicators.get(indicatorId);
 	}
 
 	/**
 	 * Looks up the property definition for a given indicator property id
 	 */
 	public lookupProperty(propertyId: number): IndicatorProperty | undefined {
-		if (!this.indicatorProperties) {
+		if (!this._indicatorProperties) {
 			throw new ZWaveError(
 				"The config has not been loaded yet!",
 				ZWaveErrorCodes.Driver_NotReady,
 			);
 		}
 
-		return this.indicatorProperties.get(propertyId);
+		return this._indicatorProperties.get(propertyId);
 	}
 
 	public async loadNamedScales(): Promise<void> {
@@ -374,7 +442,7 @@ export class ConfigManager {
 
 	public async loadMeters(): Promise<void> {
 		try {
-			this.meters = await loadMetersInternal(this._useExternalConfig);
+			this._meters = await loadMetersInternal(this._useExternalConfig);
 		} catch (e: unknown) {
 			// If the config file is missing or invalid, don't try to find it again
 			if (isZWaveError(e) && e.code === ZWaveErrorCodes.Config_Invalid) {
@@ -384,7 +452,7 @@ export class ConfigManager {
 						"error",
 					);
 				}
-				if (!this.meters) this.meters = new Map();
+				if (!this._meters) this._meters = new Map();
 			} else {
 				// This is an unexpected error
 				throw e;
@@ -396,14 +464,14 @@ export class ConfigManager {
 	 * Looks up the notification configuration for a given notification type
 	 */
 	public lookupMeter(meterType: number): Meter | undefined {
-		if (!this.meters) {
+		if (!this._meters) {
 			throw new ZWaveError(
 				"The config has not been loaded yet!",
 				ZWaveErrorCodes.Driver_NotReady,
 			);
 		}
 
-		return this.meters.get(meterType);
+		return this._meters.get(meterType);
 	}
 
 	public getMeterName(meterType: number): string {
@@ -422,8 +490,8 @@ export class ConfigManager {
 			const config = await loadDeviceClassesInternal(
 				this._useExternalConfig,
 			);
-			this.basicDeviceClasses = config.basicDeviceClasses;
-			this.genericDeviceClasses = config.genericDeviceClasses;
+			this._basicDeviceClasses = config.basicDeviceClasses;
+			this._genericDeviceClasses = config.genericDeviceClasses;
 		} catch (e: unknown) {
 			// If the config file is missing or invalid, don't try to find it again
 			if (isZWaveError(e) && e.code === ZWaveErrorCodes.Config_Invalid) {
@@ -433,10 +501,10 @@ export class ConfigManager {
 						"error",
 					);
 				}
-				if (!this.basicDeviceClasses)
-					this.basicDeviceClasses = new Map();
-				if (!this.genericDeviceClasses)
-					this.genericDeviceClasses = new Map();
+				if (!this._basicDeviceClasses)
+					this._basicDeviceClasses = new Map();
+				if (!this._genericDeviceClasses)
+					this._genericDeviceClasses = new Map();
 			} else {
 				// This is an unexpected error
 				throw e;
@@ -445,7 +513,7 @@ export class ConfigManager {
 	}
 
 	public lookupBasicDeviceClass(basic: number): BasicDeviceClass {
-		if (!this.basicDeviceClasses) {
+		if (!this._basicDeviceClasses) {
 			throw new ZWaveError(
 				"The config has not been loaded yet!",
 				ZWaveErrorCodes.Driver_NotReady,
@@ -455,13 +523,13 @@ export class ConfigManager {
 		return {
 			key: basic,
 			label:
-				this.basicDeviceClasses.get(basic) ??
+				this._basicDeviceClasses.get(basic) ??
 				`UNKNOWN (${num2hex(basic)})`,
 		};
 	}
 
 	public lookupGenericDeviceClass(generic: number): GenericDeviceClass {
-		if (!this.genericDeviceClasses) {
+		if (!this._genericDeviceClasses) {
 			throw new ZWaveError(
 				"The config has not been loaded yet!",
 				ZWaveErrorCodes.Driver_NotReady,
@@ -469,7 +537,7 @@ export class ConfigManager {
 		}
 
 		return (
-			this.genericDeviceClasses.get(generic) ??
+			this._genericDeviceClasses.get(generic) ??
 			getDefaultGenericDeviceClass(generic)
 		);
 	}
@@ -637,7 +705,7 @@ export class ConfigManager {
 
 	public async loadNotifications(): Promise<void> {
 		try {
-			this.notifications = await loadNotificationsInternal(
+			this._notifications = await loadNotificationsInternal(
 				this._useExternalConfig,
 			);
 		} catch (e: unknown) {
@@ -649,7 +717,7 @@ export class ConfigManager {
 						"error",
 					);
 				}
-				this.notifications = new Map();
+				this._notifications = new Map();
 			} else {
 				// This is an unexpected error
 				throw e;
@@ -663,14 +731,14 @@ export class ConfigManager {
 	public lookupNotification(
 		notificationType: number,
 	): Notification | undefined {
-		if (!this.notifications) {
+		if (!this._notifications) {
 			throw new ZWaveError(
 				"The config has not been loaded yet!",
 				ZWaveErrorCodes.Driver_NotReady,
 			);
 		}
 
-		return this.notifications.get(notificationType);
+		return this._notifications.get(notificationType);
 	}
 
 	/**
@@ -680,7 +748,7 @@ export class ConfigManager {
 	private lookupNotificationUnsafe(
 		notificationType: number,
 	): Notification | undefined {
-		return this.notifications?.get(notificationType);
+		return this._notifications?.get(notificationType);
 	}
 
 	public getNotificationName(notificationType: number): string {


### PR DESCRIPTION
This is a follow up to the questions I was asking Al in Discord - basically taking any config data that is not already exposed as properties and exposing it as new properties