### PR TITLE
refactor: move more scale definitions into scales.json

### DIFF
--- a/packages/config/config/scales.json
+++ b/packages/config/config/scales.json
@@ -9,5 +9,67 @@
 			"label": "Fahrenheit",
 			"unit": "°F"
 		}
+	},
+	"mass": {
+		"0x00": {
+			"label": "Kilogram",
+			"unit": "kg"
+		}
+	},
+	"acceleration": {
+		"0x00": {
+			"label": "Meter per square second",
+			"unit": "m/s2"
+		}
+	},
+	"percentage": {
+		"0x00": {
+			"label": "Percentage value",
+			"unit": "%"
+		}
+	},
+	"acidity": {
+		"0x00": {
+			"label": "Acidity",
+			"unit": "pH"
+		}
+	},
+	"direction": {
+		"0x00": {
+			"label": "Degrees",
+			"unit": "°",
+			"description": "0° = no motion detected, 90° = east, 180° = south, 270° = west, 360° = north"
+		}
+	},
+	"pressure": {
+		"0x00": {
+			"label": "Kilopascal",
+			"unit": "kPa"
+		},
+		"0x01": {
+			"label": "Pound per square inch",
+			"unit": "psi"
+		}
+	},
+	"air_pressure": {
+		"0x00": {
+			"label": "Kilopascal",
+			"unit": "kPa"
+		},
+		"0x01": {
+			"label": "Inches of Mercury",
+			"unit": "inHg"
+		}
+	},
+	"density": {
+		"0x00": {
+			"label": "Density",
+			"unit": "µg/m³"
+		}
+	},
+	"unitless": {
+		"0x00": {
+			"label": "Unitless"
+		}
 	}
 }

--- a/packages/config/config/sensorTypes.json
+++ b/packages/config/config/sensorTypes.json
@@ -71,39 +71,15 @@
 	},
 	"0x07": {
 		"label": "Direction",
-		"scales": {
-			"0x00": {
-				"label": "Degrees",
-				"unit": "°",
-				"description": "0° = no wind, 90° = east, 180° = south, 270° = west, 360° = north"
-			}
-		}
+		"scales": "$SCALES:direction"
 	},
 	"0x08": {
 		"label": "Atmospheric pressure",
-		"scales": {
-			"0x00": {
-				"label": "Kilopascal",
-				"unit": "kPa"
-			},
-			"0x01": {
-				"label": "Inches of Mercury",
-				"unit": "inHg"
-			}
-		}
+		"scales": "$SCALES:air_pressure"
 	},
 	"0x09": {
 		"label": "Barometric pressure",
-		"scales": {
-			"0x00": {
-				"label": "Kilopascal",
-				"unit": "kPa"
-			},
-			"0x01": {
-				"label": "Inches of Mercury",
-				"unit": "inHg"
-			}
-		}
+		"scales": "$SCALES:air_pressure"
 	},
 	"0x0a": {
 		"label": "Solar radiation",
@@ -471,21 +447,11 @@
 	},
 	"0x29": {
 		"label": "Soil humidity",
-		"scales": {
-			"0x00": {
-				"label": "Percentage value",
-				"unit": "%"
-			}
-		}
+		"scales": "$SCALES:percentage"
 	},
 	"0x2a": {
 		"label": "Soil reactivity",
-		"scales": {
-			"0x00": {
-				"label": "Acidity",
-				"unit": "pH"
-			}
-		}
+		"scales": "SCALES:acidity"
 	},
 	"0x2b": {
 		"label": "Soil salinity",
@@ -520,39 +486,19 @@
 	},
 	"0x2e": {
 		"label": "Muscle mass",
-		"scales": {
-			"0x00": {
-				"label": "Kilogram",
-				"unit": "kg"
-			}
-		}
+		"scales": "$SCALES:mass"
 	},
 	"0x2f": {
 		"label": "Fat mass",
-		"scales": {
-			"0x00": {
-				"label": "Kilogram",
-				"unit": "kg"
-			}
-		}
+		"scales": "$SCALES:mass"
 	},
 	"0x30": {
 		"label": "Bone mass",
-		"scales": {
-			"0x00": {
-				"label": "Kilogram",
-				"unit": "kg"
-			}
-		}
+		"scales": "$SCALES:mass"
 	},
 	"0x31": {
 		"label": "Total body water (TBW)",
-		"scales": {
-			"0x00": {
-				"label": "Kilogram",
-				"unit": "kg"
-			}
-		}
+		"scales": "$SCALES:mass"
 	},
 	"0x32": {
 		"label": "Basis metabolic rate (BMR)",
@@ -573,39 +519,19 @@
 	},
 	"0x34": {
 		"label": "Acceleration X-axis",
-		"scales": {
-			"0x00": {
-				"label": "Meter per square second",
-				"unit": "m/s2"
-			}
-		}
+		"scales": "$SCALES:acceleration"
 	},
 	"0x35": {
 		"label": "Acceleration Y-axis",
-		"scales": {
-			"0x00": {
-				"label": "Meter per square second",
-				"unit": "m/s2"
-			}
-		}
+		"scales": "$SCALES:acceleration"
 	},
 	"0x36": {
 		"label": "Acceleration Z-axis",
-		"scales": {
-			"0x00": {
-				"label": "Meter per square second",
-				"unit": "m/s2"
-			}
-		}
+		"scales": "$SCALES:acceleration"
 	},
 	"0x37": {
 		"label": "Smoke density",
-		"scales": {
-			"0x00": {
-				"label": "Percentage value",
-				"unit": "%"
-			}
-		}
+		"scales": "$SCALES:percentage"
 	},
 	"0x38": {
 		"label": "Water flow",
@@ -662,12 +588,7 @@
 	},
 	"0x3d": {
 		"label": "Relative Modulation level",
-		"scales": {
-			"0x00": {
-				"label": "Percentage value",
-				"unit": "%"
-			}
-		}
+		"scales": "$SCALES:percentage"
 	},
 	"0x3e": {
 		"label": "Boiler water temperature",
@@ -696,12 +617,7 @@
 	},
 	"0x43": {
 		"label": "Water acidity",
-		"scales": {
-			"0x00": {
-				"label": "Acidity",
-				"unit": "pH"
-			}
-		}
+		"scales": "SCALES:acidity"
 	},
 	"0x44": {
 		"label": "Water Oxidation reduction potential",
@@ -714,21 +630,11 @@
 	},
 	"0x45": {
 		"label": "Heart Rate LF/HF ratio",
-		"scales": {
-			"0x00": {
-				"label": "Unitless"
-			}
-		}
+		"scales": "$SCALES:unitless"
 	},
 	"0x46": {
 		"label": "Motion Direction",
-		"scales": {
-			"0x00": {
-				"label": "Degrees",
-				"unit": "°",
-				"description": "0° = no motion detected, 90° = east, 180° = south, 270° = west, 360° = north"
-			}
-		}
+		"scales": "$SCALES:direction"
 	},
 	"0x47": {
 		"label": "Applied force on the sensor",
@@ -765,29 +671,11 @@
 	},
 	"0x4e": {
 		"label": "Suction Pressure",
-		"scales": {
-			"0x00": {
-				"label": "Kilopascal",
-				"unit": "kPa"
-			},
-			"0x01": {
-				"label": "Pound per square inch",
-				"unit": "psi"
-			}
-		}
+		"scales": "$SCALES:pressure"
 	},
 	"0x4f": {
 		"label": "Discharge Pressure",
-		"scales": {
-			"0x00": {
-				"label": "Kilopascal",
-				"unit": "kPa"
-			},
-			"0x01": {
-				"label": "Pound per square inch",
-				"unit": "psi"
-			}
-		}
+		"scales": "$SCALES:pressure"
 	},
 	"0x50": {
 		"label": "Defrost temperature",
@@ -795,72 +683,34 @@
 	},
 	"0x51": {
 		"label": "Ozone",
-		"scales": {
-			"0x00": {
-				"label": "Density",
-				"unit": "µg/m³"
-			}
-		}
+		"scales": "$SCALES:density"
 	},
 	"0x52": {
 		"label": "Sulfur dioxide",
-		"scales": {
-			"0x00": {
-				"label": "Density",
-				"unit": "µg/m³"
-			}
-		}
+		"scales": "$SCALES:density"
 	},
 	"0x53": {
 		"label": "Nitrogen dioxide",
-		"scales": {
-			"0x00": {
-				"label": "Density",
-				"unit": "µg/m³"
-			}
-		}
+		"scales": "$SCALES:density"
 	},
 	"0x54": {
 		"label": "Ammonia",
-		"scales": {
-			"0x00": {
-				"label": "Density",
-				"unit": "µg/m³"
-			}
-		}
+		"scales": "$SCALES:density"
 	},
 	"0x55": {
 		"label": "Lead",
-		"scales": {
-			"0x00": {
-				"label": "Density",
-				"unit": "µg/m³"
-			}
-		}
+		"scales": "$SCALES:density"
 	},
 	"0x56": {
 		"label": "Particulate Matter 1",
-		"scales": {
-			"0x00": {
-				"label": "Density",
-				"unit": "µg/m³"
-			}
-		}
+		"scales": "$SCALES:density"
 	},
 	"0x57": {
 		"label": "Person counter (entering)",
-		"scales": {
-			"0x00": {
-				"label": "Unitless"
-			}
-		}
+		"scales": "$SCALES:unitless"
 	},
 	"0x58": {
 		"label": "Person counter (exiting)",
-		"scales": {
-			"0x00": {
-				"label": "Unitless"
-			}
-		}
+		"scales": "$SCALES:unitless"
 	}
 }


### PR DESCRIPTION
As I mentioned in Discord, I found additional "common" scale types that I have moved over to `scales.json`.