### PR TITLE
feat(config): add fingerprint to Ring 1st Gen Range Extender config

### DIFF
--- a/packages/config/config/devices/0x0346/range_extender_gen1.json
+++ b/packages/config/config/devices/0x0346/range_extender_gen1.json
@@ -11,7 +11,11 @@
 		{
 			"productType": "0x0401",
 			"productId": "0x0102"
-		}
+		},
+		{
+			"productType": "0x0401",
+			"productId": "0x0202"
+		}	
 	],
 	"firmwareVersion": {
 		"min": "0.0",

--- a/packages/config/config/devices/0x0346/range_extender_gen1.json
+++ b/packages/config/config/devices/0x0346/range_extender_gen1.json
@@ -15,7 +15,7 @@
 		{
 			"productType": "0x0401",
 			"productId": "0x0202"
-		}	
+		}
 	],
 	"firmwareVersion": {
 		"min": "0.0",


### PR DESCRIPTION
Adding ProductId 0x0202 to the list of devices for Ring Range Extender 1st Gen