### PR TITLE
fix: treat legacy cache files as no S2

### DIFF
--- a/packages/zwave-js/src/lib/node/Node.test.ts
+++ b/packages/zwave-js/src/lib/node/Node.test.ts
@@ -1100,8 +1100,11 @@ describe("lib/node/Node", () => {
 				...serializedTestNode,
 				isFrequentListening: "1000ms",
 				securityClasses: {
-					// S2 classes are not known when deserializing legacy caches
 					S0_Legacy: true,
+					// S2 classes are not granted when deserializing legacy caches
+					S2_AccessControl: false,
+					S2_Authenticated: false,
+					S2_Unauthenticated: false,
 				},
 			};
 			expect(node.serialize()).toEqual(expected);

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3591,8 +3591,12 @@ protocol version:      ${this._protocolVersion}`;
 				}
 			}
 		} else if (typeof obj.isSecure === "boolean") {
-			// Fallback to "isSecure" for legacy cache files
+			// Fallback to "isSecure" === S0 for legacy cache files
 			this.securityClasses.set(SecurityClass.S0_Legacy, obj.isSecure);
+
+			this.securityClasses.set(SecurityClass.S2_AccessControl, false);
+			this.securityClasses.set(SecurityClass.S2_Authenticated, false);
+			this.securityClasses.set(SecurityClass.S2_Unauthenticated, false);
 		}
 		tryParse("supportsSecurity", "boolean");
 		tryParse("supportsBeaming", "boolean");


### PR DESCRIPTION
This fixes the `isSecure` property to be "unknown" after a migration to 8.1.x