### PR TITLE
feat(config): add fingerprint for Fibaro FGFS

### DIFF
--- a/packages/config/config/devices/0x010f/fgfs101_3.2-23.0.json
+++ b/packages/config/config/devices/0x010f/fgfs101_3.2-23.0.json
@@ -27,6 +27,10 @@
 		{
 			"productType": "0x0b01",
 			"productId": "0x3002"
+		},
+		{
+			"productType": "0x0b01",
+			"productId": "0x3003"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
[](url)Updates the Product ID to include 0x3003

I recently purchased a couple of Fibaro Flood Sensors (Australia) but only one was identified as a flood sensor. On further investigation, one had a Product ID of 0x3002 (which was identified and has firmware 3.2, zwave protocol version 4.5) and another 0x3003 (which was not identified and has firmware 3.4, zwave protocol version 4.24).

Creating the Product ID to the configuration file has enabled the device settings in zwave2jsmqtt.

Product link in the z-wave alliance database

https://products.z-wavealliance.org/products/3503?selectedFrequencyId=4

[ZC10-19076581.zip](https://github.com/zwave-js/node-zwave-js/files/7043945/ZC10-19076581.zip)

