### PR TITLE
feat(config): disable strict entry control validation for ring keypad v2

### DIFF
--- a/packages/config/config/devices/0x0346/keypad_v2.json
+++ b/packages/config/config/devices/0x0346/keypad_v2.json
@@ -278,6 +278,8 @@
 		}
 	},
 	"compat": {
+		// The device doesn't respect some spec requirements, 
+		// for example that ASCII-encoded codes must be padded to 16 bytes
 		"disableStrictEntryControlDataValidation": true
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x0346/keypad_v2.json
+++ b/packages/config/config/devices/0x0346/keypad_v2.json
@@ -278,7 +278,7 @@
 		}
 	},
 	"compat": {
-		// The device doesn't respect some spec requirements, 
+		// The device doesn't respect some spec requirements,
 		// for example that ASCII-encoded codes must be padded to 16 bytes
 		"disableStrictEntryControlDataValidation": true
 	},

--- a/packages/config/config/devices/0x0346/keypad_v2.json
+++ b/packages/config/config/devices/0x0346/keypad_v2.json
@@ -277,6 +277,9 @@
 			]
 		}
 	},
+	"compat": {
+		"disableStrictEntryControlDataValidation": true
+	},
 	"metadata": {
 		"inclusion": "After powering on the device, press and hold the #1 button for ~3 seconds. Release the button and the device will enter Classic inclusion mode which implements both classic inclusion with a Node Information Frame, and Network Wide Inclusion. During Classic Inclusion mode, the green Connection LED will blink three times followed by a brief pause, repeatedly. When Classic inclusion times-out, the device will blink alternating red and green a few times",
 		"exclusion": "Exclusion Instructions: \n1. Initiate remove “Ring Alarm Keypad” flow in the Ring Alarm mobile application – Select the settings icon from device details page and choose “Remove Device” to remove the device. This will place the controller into Remove or “Z-Wave Exclusion” mode. \n2. Locate the pinhole reset button on the back of the device. \n3. With the controller in Remove (Z-Wave Exclusion) mode, use a paper clip or similar object and tap the pinhole button. The device’s Connection LED turns on solid red to indicate the device was removed from the network.",


### PR DESCRIPTION
Discovered in #3240, turns out v2 of the Ring Keypad also needs to have strict entry control validation disabled for the key entries to be recognised.