### PR TITLE
fix(config): enable basic set mapping for ZWN-BPC variants

### DIFF
--- a/packages/config/config/devices/0x011a/zwn-bpc_0.0-5.9.json
+++ b/packages/config/config/devices/0x011a/zwn-bpc_0.0-5.9.json
@@ -1,6 +1,6 @@
 {
-	"manufacturer": "Nortek Security & Control LLC",
-	"manufacturerId": "0x014f",
+	"manufacturer": "Enerwave / Wenzhou MTLC Electric Appliances Co., Ltd.",
+	"manufacturerId": "0x011a",
 	"label": "ZWN-BPC",
 	"description": "PIR Sensor",
 	"devices": [


### PR DESCRIPTION
fixes: #3197