### PR TITLE
fix: endpoint interview for Security S2

### DIFF
--- a/packages/core/src/security/SecurityClass.ts
+++ b/packages/core/src/security/SecurityClass.ts
@@ -16,13 +16,15 @@ export enum SecurityClass {
 	S0_Legacy = 7,
 }
 
+export type S2SecurityClass =
+	| SecurityClass.S2_Unauthenticated
+	| SecurityClass.S2_Authenticated
+	| SecurityClass.S2_AccessControl;
+
 /** Tests if the given security class is S2 */
 export function securityClassIsS2(
 	secClass: SecurityClass | undefined,
-): secClass is
-	| SecurityClass.S2_Unauthenticated
-	| SecurityClass.S2_Authenticated
-	| SecurityClass.S2_AccessControl {
+): secClass is S2SecurityClass {
 	return (
 		secClass != undefined &&
 		secClass >= SecurityClass.S2_Unauthenticated &&

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -339,6 +339,8 @@ export interface SendMessageOptions {
 export interface SendCommandOptions extends SendMessageOptions {
 	/** How many times the driver should try to send the message. Defaults to the configured Driver option */
 	maxSendAttempts?: number;
+	/** Whether the driver should automatically handle the encapsulation. Default: true */
+	autoEncapsulate?: boolean;
 }
 
 export type SupervisionUpdateHandler = (
@@ -2822,7 +2824,7 @@ ${handlers.length} left`,
 		}
 
 		// Automatically encapsulate commands before sending
-		this.encapsulateCommands(msg);
+		if (options.autoEncapsulate !== false) this.encapsulateCommands(msg);
 
 		try {
 			const resp = await this.sendMessage(msg, options);


### PR DESCRIPTION
With this PR, endpoint interviews for the S2 CC correctly use multi channel encapsulation and only use the highest security class the node has been granted.

fixes: #3295