### PR TITLE
fix(config): add product id 0x0103 to Aeotec ZW141

### DIFF
--- a/packages/config/config/devices/0x0371/zw141.json
+++ b/packages/config/config/devices/0x0371/zw141.json
@@ -8,6 +8,11 @@
 			"productType": "0x0003",
 			"productId": "0x008d",
 			"zwaveAllianceId": [3693, 3742]
+		},
+		{
+			"productType": "0x0103",
+			"productId": "0x008d",
+			"zwaveAllianceId": [3693, 3742]
 		}
 	],
 	"firmwareVersion": {

--- a/packages/config/config/devices/0x0371/zw141.json
+++ b/packages/config/config/devices/0x0371/zw141.json
@@ -11,8 +11,7 @@
 		},
 		{
 			"productType": "0x0103",
-			"productId": "0x008d",
-			"zwaveAllianceId": [3693, 3742]
+			"productId": "0x008d"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
I've updated my nanoshutter to the newest firmware. Using custom config files I've determined this config file works for the device (used to be mfg 0x0086) after getting the updated firmware.