### PR TITLE
feat(cc): add setting `dimmingDuration` for `Scene Controller Configuration CC` with `setValue` API

### DIFF
--- a/packages/core/src/values/Duration.ts
+++ b/packages/core/src/values/Duration.ts
@@ -95,26 +95,6 @@ export class Duration {
 		}
 	}
 
-	/**
-	 * Guards that an arbitrary object is a valid Duration
-	 */
-	public static isDuration(input: any): input is Duration {
-		if (typeof input.value !== "number" || typeof input.unit !== "string") {
-			return false;
-		}
-		switch (input.unit) {
-			case "minutes":
-				return input.value >= 1 && input.value <= 127;
-			case "seconds":
-				return input.value <= 127;
-			case "unknown":
-			case "default":
-				return input.value === 0;
-			default:
-				return false;
-		}
-	}
-
 	/** Serializes a duration for a Set command */
 	public serializeSet(): number {
 		if (this.unit === "default") return 0xff;

--- a/packages/core/src/values/Duration.ts
+++ b/packages/core/src/values/Duration.ts
@@ -95,6 +95,26 @@ export class Duration {
 		}
 	}
 
+	/**
+	 * Guards that an arbitrary object is a valid Duration
+	 */
+	public static isDuration(input: any): input is Duration {
+		if (typeof input.value !== "number" || typeof input.unit !== "string") {
+			return false;
+		}
+		switch (input.unit) {
+			case "minutes":
+				return input.value >= 1 && input.value <= 127;
+			case "seconds":
+				return input.value <= 127;
+			case "unknown":
+			case "default":
+				return input.value === 0;
+			default:
+				return false;
+		}
+	}
+
 	/** Serializes a duration for a Set command */
 	public serializeSet(): number {
 		if (this.unit === "default") return 0xff;

--- a/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.test.ts
@@ -88,6 +88,24 @@ describe("lib/commandclass/SceneControllerConfigurationCC => ", () => {
 		expect(cc.serialize()).toEqual(expected);
 	});
 
+	it("the Set command should serialize correctly with undefined duration", () => {
+		const cc = new SceneControllerConfigurationCCSet(fakeDriver, {
+			nodeId: 2,
+			groupId: 3,
+			sceneId: 240,
+			dimmingDuration: undefined,
+		});
+		const expected = buildCCBuffer(
+			Buffer.from([
+				SceneControllerConfigurationCommand.Set, // CC Command
+				3, // groupId
+				240, // sceneId
+				0x00, // dimming duration
+			]),
+		);
+		expect(cc.serialize()).toEqual(expected);
+	});
+
 	it("the Set command should throw if GroupId > groupCount", () => {
 		expect(
 			() =>

--- a/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.test.ts
@@ -100,7 +100,7 @@ describe("lib/commandclass/SceneControllerConfigurationCC => ", () => {
 				SceneControllerConfigurationCommand.Set, // CC Command
 				3, // groupId
 				240, // sceneId
-				0x00, // dimming duration
+				0xff, // dimming duration
 			]),
 		);
 		expect(cc.serialize()).toEqual(expected);

--- a/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
@@ -1,6 +1,7 @@
 import {
 	CommandClasses,
 	Duration,
+	getCCName,
 	Maybe,
 	MessageOrCCLogEntry,
 	validatePayload,
@@ -149,7 +150,7 @@ export class SceneControllerConfigurationCCAPI extends CCAPI {
 				await this.set(propertyKey, value, dimmingDuration);
 			}
 		} else if (property === "dimmingDuration") {
-			if (typeof value !== "string" && !Duration.isDuration(value)) {
+			if (typeof value !== "string" && !(value instanceof Duration)) {
 				throwWrongValueType(
 					this.ccId,
 					property,
@@ -161,7 +162,11 @@ export class SceneControllerConfigurationCCAPI extends CCAPI {
 			const dimmingDuration = Duration.from(value);
 			if (dimmingDuration == undefined) {
 				throw new ZWaveError(
-					`${CommandClasses["Scene Controller Configuration"]}: "${property}" could not be set. Value is not a valid duration.`,
+					`${getCCName(
+						this.ccId,
+					)}: "${property}" could not be set. ${JSON.stringify(
+						value,
+					)} is not a valid duration.`,
 					ZWaveErrorCodes.Argument_Invalid,
 				);
 			}
@@ -419,7 +424,7 @@ export class SceneControllerConfigurationCCSet extends SceneControllerConfigurat
 			const groupCount = this.getGroupCountCached();
 			this.groupId = options.groupId;
 			this.sceneId = options.sceneId;
-			// if dimmingDuration was missing, default to 0xff
+			// if dimmingDuration was missing, use default duration.
 			this.dimmingDuration =
 				options.dimmingDuration ?? new Duration(0, "default");
 

--- a/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
@@ -178,14 +178,6 @@ export class SceneControllerConfigurationCCAPI extends CCAPI {
 					propertyKey,
 				);
 				const valueDB = node.valueDB;
-
-				if (!valueDB.hasMetadata(dimmingDurationValueId)) {
-					valueDB.setMetadata(dimmingDurationValueId, {
-						...ValueMetadata.Duration,
-						label: `Dimming duration (${propertyKey})`,
-					});
-				}
-
 				valueDB.setValue(dimmingDurationValueId, dimmingDuration);
 				return;
 			}

--- a/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
@@ -149,7 +149,7 @@ export class SceneControllerConfigurationCCAPI extends CCAPI {
 				await this.set(propertyKey, value, dimmingDuration);
 			}
 		} else if (property === "dimmingDuration") {
-			if (typeof value !== "number") {
+			if (typeof value !== "string" && !Duration.isDuration(value)) {
 				throwWrongValueType(
 					this.ccId,
 					property,
@@ -158,15 +158,38 @@ export class SceneControllerConfigurationCCAPI extends CCAPI {
 				);
 			}
 
-			const dimmingDuration = Duration.parseSet(value);
+			const dimmingDuration = Duration.from(value);
+			if (dimmingDuration == undefined) {
+				throw new ZWaveError(
+					`${CommandClasses["Scene Controller Configuration"]}: "${property}" could not be set. Value is not a valid duration.`,
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
 
 			const node = this.endpoint.getNodeUnsafe()!;
-			// If SceneId missing, we need to set a default to 0,
-			// which disables the scene configuration for the association group
-			const sceneId =
-				node.getValue<number>(
-					getSceneIdValueID(this.endpoint.index, propertyKey),
-				) ?? 0;
+			const sceneId = node.getValue<number>(
+				getSceneIdValueID(this.endpoint.index, propertyKey),
+			);
+			if (sceneId == undefined || sceneId === 0) {
+				// Can't actually send dimmingDuration without valid sceneId
+				// So we save it in the valueDB without sending it to the node
+				const dimmingDurationValueId = getDimmingDurationValueID(
+					this.endpoint.index,
+					propertyKey,
+				);
+				const valueDB = node.valueDB;
+
+				if (!valueDB.hasMetadata(dimmingDurationValueId)) {
+					valueDB.setMetadata(dimmingDurationValueId, {
+						...ValueMetadata.Duration,
+						label: `Dimming duration (${propertyKey})`,
+					});
+				}
+
+				valueDB.setValue(dimmingDurationValueId, dimmingDuration);
+				return;
+			}
+
 			await this.set(propertyKey, sceneId, dimmingDuration);
 		} else {
 			throwUnsupportedProperty(this.ccId, property);
@@ -404,9 +427,9 @@ export class SceneControllerConfigurationCCSet extends SceneControllerConfigurat
 			const groupCount = this.getGroupCountCached();
 			this.groupId = options.groupId;
 			this.sceneId = options.sceneId;
-			// if dimmingDuration was missing, default to 0 seconds
+			// if dimmingDuration was missing, default to 0xff
 			this.dimmingDuration =
-				options.dimmingDuration ?? new Duration(0, "seconds");
+				options.dimmingDuration ?? new Duration(0, "default");
 
 			// The client SHOULD NOT specify group 1 (the life-line group).
 			// We don't block it here, because the specs don't forbid it,


### PR DESCRIPTION
This pull request should fix #3309 by adding support for setting the `dimmingDuration` for a group's scene configuration with the `SET_VALUE` API.

One thing I'm not 100% certain on is if the client (like zwavejs2mqtt) will send the `value` with type `number` corresponding to the z-wave encoding of a `Duration`.

I'm not really able to test this code, because I don't have any devices that support the Scene Controller Configuration CC.

Once this pull request goes through, I can do the equivalent changes for Scene Actuator Configuration CC.