### PR TITLE
fix(config): add fingerprint to Logic Group ZSO7300

### DIFF
--- a/packages/config/config/devices/0x0234/zso7300.json
+++ b/packages/config/config/devices/0x0234/zso7300.json
@@ -7,6 +7,10 @@
 		{
 			"productType": "0x0003",
 			"productId": "0x012a"
+		},
+		{
+			"productType": "0x0004",
+			"productId": "0x002a"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
The ZSO7300 Switch devices delivered by Logic Group have a new ProductType and ProductID, these have been added to device file.