### PR TITLE
fix(config): reduce parameter 9's minValue to 0 for Zooz ZEN24 4.0

### DIFF
--- a/packages/config/config/devices/0x027a/zen24_4.0.json
+++ b/packages/config/config/devices/0x027a/zen24_4.0.json
@@ -108,8 +108,7 @@
 			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		"9": {
-			"label": "Ramp Rate Control",
-			"description": "Adjust the physical ramp rate for your dimmer (fade-in / fade-out effect for on / off operation).",
+			"label": "Dim Rate Speed",
 			"unit": "seconds",
 			"valueSize": 1,
 			"minValue": 0,

--- a/packages/config/config/devices/0x027a/zen24_4.0.json
+++ b/packages/config/config/devices/0x027a/zen24_4.0.json
@@ -112,9 +112,15 @@
 			"description": "Adjust the physical ramp rate for your dimmer (fade-in / fade-out effect for on / off operation).",
 			"unit": "seconds",
 			"valueSize": 1,
-			"minValue": 1,
+			"minValue": 0,
 			"maxValue": 99,
-			"defaultValue": 1
+			"defaultValue": 1,
+			"options": [
+				{
+					"label": "Instant on/off",
+					"value": 0
+				}
+			]
 		},
 		"10": {
 			"label": "Minimum Brightness",


### PR DESCRIPTION
Reduced parameter 9's minValue to 0 to allow disabling ramp on/off as described in documentation: https://www.support.getzooz.com/kb/article/318-zen24-toggle-dimmer-ver-4-01-advanced-settings/

Closes #3317