### PR TITLE
feat(cc): support Wake Up On Demand

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/SupervisionCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SupervisionCC.ts
@@ -187,7 +187,7 @@ export class SupervisionCC extends CommandClass {
 
 export type SupervisionCCReportOptions = {
 	moreUpdatesFollow: boolean;
-	requestWakeUp?: boolean;
+	requestWakeUpOnDemand?: boolean;
 	sessionId: number;
 } & (
 	| {
@@ -224,7 +224,7 @@ export class SupervisionCCReport extends SupervisionCC {
 			this.duration = Duration.parseReport(this.payload[2]);
 		} else {
 			this.moreUpdatesFollow = options.moreUpdatesFollow;
-			this.requestWakeUp = options.requestWakeUp ?? false;
+			this.requestWakeUp = options.requestWakeUpOnDemand ?? false;
 			this.sessionId = options.sessionId;
 			this.status = options.status;
 			if (options.status === SupervisionStatus.Working) {

--- a/packages/zwave-js/src/lib/commandclass/SupervisionCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SupervisionCC.ts
@@ -88,10 +88,17 @@ export class SupervisionCCAPI extends PhysicalCCAPI {
 	public async sendReport(
 		options: SupervisionCCReportOptions & { secure?: boolean },
 	): Promise<void> {
+		// Ask the node if it needs Wake Up On Demand,
+		// unless it's overriden in `options`
+		const requestWakeUpOnDemand =
+			options.requestWakeUpOnDemand ??
+			this.endpoint.getNodeUnsafe()?.shouldRequestWakeUpOnDemand;
+
 		const { secure = false, ...cmdOptions } = options;
 		const cc = new SupervisionCCReport(this.driver, {
 			nodeId: this.endpoint.nodeId,
 			...cmdOptions,
+			requestWakeUpOnDemand,
 		});
 
 		// The report should be sent back with security if the received command was secure
@@ -217,14 +224,13 @@ export class SupervisionCCReport extends SupervisionCC {
 		if (gotDeserializationOptions(options)) {
 			validatePayload(this.payload.length >= 3);
 			this.moreUpdatesFollow = !!(this.payload[0] & 0b1_0_000000);
-			// Ignore requestWakeUpOnDemand bit when receiving Report
-			this.requestWakeUpOnDemand = false;
+			this.requestWakeUpOnDemand = !!(this.payload[0] & 0b0_1_000000);
 			this.sessionId = this.payload[0] & 0b111111;
 			this.status = this.payload[1];
 			this.duration = Duration.parseReport(this.payload[2]);
 		} else {
 			this.moreUpdatesFollow = options.moreUpdatesFollow;
-			this.requestWakeUpOnDemand = options.requestWakeUpOnDemand ?? false;
+			this.requestWakeUpOnDemand = !!options.requestWakeUpOnDemand;
 			this.sessionId = options.sessionId;
 			this.status = options.status;
 			if (options.status === SupervisionStatus.Working) {

--- a/packages/zwave-js/src/lib/commandclass/SupervisionCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SupervisionCC.ts
@@ -217,14 +217,14 @@ export class SupervisionCCReport extends SupervisionCC {
 		if (gotDeserializationOptions(options)) {
 			validatePayload(this.payload.length >= 3);
 			this.moreUpdatesFollow = !!(this.payload[0] & 0b1_0_000000);
-			// Ignore requestWakeUp bit when receiving Report
-			this.requestWakeUp = false;
+			// Ignore requestWakeUpOnDemand bit when receiving Report
+			this.requestWakeUpOnDemand = false;
 			this.sessionId = this.payload[0] & 0b111111;
 			this.status = this.payload[1];
 			this.duration = Duration.parseReport(this.payload[2]);
 		} else {
 			this.moreUpdatesFollow = options.moreUpdatesFollow;
-			this.requestWakeUp = options.requestWakeUpOnDemand ?? false;
+			this.requestWakeUpOnDemand = options.requestWakeUpOnDemand ?? false;
 			this.sessionId = options.sessionId;
 			this.status = options.status;
 			if (options.status === SupervisionStatus.Working) {
@@ -236,7 +236,7 @@ export class SupervisionCCReport extends SupervisionCC {
 	}
 
 	public readonly moreUpdatesFollow: boolean;
-	public readonly requestWakeUp: boolean;
+	public readonly requestWakeUpOnDemand: boolean;
 	public readonly sessionId: number;
 	public readonly status: SupervisionStatus;
 	public readonly duration: Duration | undefined;
@@ -245,7 +245,7 @@ export class SupervisionCCReport extends SupervisionCC {
 		this.payload = Buffer.concat([
 			Buffer.from([
 				(this.moreUpdatesFollow ? 0b1_0_000000 : 0) |
-					(this.requestWakeUp ? 0b0_1_000000 : 0) |
+					(this.requestWakeUpOnDemand ? 0b0_1_000000 : 0) |
 					(this.sessionId & 0b111111),
 				this.status,
 			]),

--- a/packages/zwave-js/src/lib/commandclass/SupervisionCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SupervisionCC.ts
@@ -130,7 +130,7 @@ export class SupervisionCCAPI extends PhysicalCCAPI {
 }
 
 @commandClass(CommandClasses.Supervision)
-@implementedVersion(1)
+@implementedVersion(2)
 export class SupervisionCC extends CommandClass {
 	declare ccCommand: SupervisionCommand;
 	// Force singlecast for the supervision CC
@@ -187,6 +187,7 @@ export class SupervisionCC extends CommandClass {
 
 export type SupervisionCCReportOptions = {
 	moreUpdatesFollow: boolean;
+	requestWakeUp?: boolean;
 	sessionId: number;
 } & (
 	| {
@@ -216,11 +217,14 @@ export class SupervisionCCReport extends SupervisionCC {
 		if (gotDeserializationOptions(options)) {
 			validatePayload(this.payload.length >= 3);
 			this.moreUpdatesFollow = !!(this.payload[0] & 0b1_0_000000);
+			// Ignore requestWakeUp bit when receiving Report
+			this.requestWakeUp = false;
 			this.sessionId = this.payload[0] & 0b111111;
 			this.status = this.payload[1];
 			this.duration = Duration.parseReport(this.payload[2]);
 		} else {
 			this.moreUpdatesFollow = options.moreUpdatesFollow;
+			this.requestWakeUp = options.requestWakeUp ?? false;
 			this.sessionId = options.sessionId;
 			this.status = options.status;
 			if (options.status === SupervisionStatus.Working) {
@@ -232,6 +236,7 @@ export class SupervisionCCReport extends SupervisionCC {
 	}
 
 	public readonly moreUpdatesFollow: boolean;
+	public readonly requestWakeUp: boolean;
 	public readonly sessionId: number;
 	public readonly status: SupervisionStatus;
 	public readonly duration: Duration | undefined;
@@ -239,7 +244,8 @@ export class SupervisionCCReport extends SupervisionCC {
 	public serialize(): Buffer {
 		this.payload = Buffer.concat([
 			Buffer.from([
-				(this.moreUpdatesFollow ? 0b10_000000 : 0) |
+				(this.moreUpdatesFollow ? 0b1_0_000000 : 0) |
+					(this.requestWakeUp ? 0b0_1_000000 : 0) |
 					(this.sessionId & 0b111111),
 				this.status,
 			]),

--- a/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
@@ -246,7 +246,7 @@ default wakeup interval: ${wakeupCaps.defaultWakeUpInterval} seconds
 minimum wakeup interval: ${wakeupCaps.minWakeUpInterval} seconds
 maximum wakeup interval: ${wakeupCaps.maxWakeUpInterval} seconds
 wakeup interval steps:   ${wakeupCaps.wakeUpIntervalSteps} seconds
-wake up on demand supported: ${wakeupCaps.wakeUpOnDemandSupported}`;
+wakeup on demand supported: ${wakeupCaps.wakeUpOnDemandSupported}`;
 					this.driver.controllerLog.logNode(node.id, {
 						endpoint: this.endpointIndex,
 						message: logMessage,

--- a/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
@@ -301,10 +301,6 @@ controller node: ${wakeupResp.controllerNodeId}`;
 		// Remember that the interview is complete
 		if (!hadCriticalTimeout) this.interviewComplete = true;
 	}
-
-	public static supportsWakeUpOnDemand(node?: ZWaveNode): boolean {
-		return node?.getValue(getWakeUpOnDemandSupportedValueId()) ?? false;
-	}
 }
 
 interface WakeUpCCIntervalSetOptions extends CCCommandOptions {

--- a/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
@@ -41,6 +41,13 @@ export function getWakeUpIntervalValueId(): ValueID {
 	};
 }
 
+export function getWakeUpOnDemandSupportedValueId(): ValueID {
+	return {
+		commandClass: CommandClasses["Wake Up"],
+		property: "wakeUpOnDemandSupported",
+	};
+}
+
 export enum WakeUpCommand {
 	IntervalSet = 0x04,
 	IntervalGet = 0x05,
@@ -294,6 +301,10 @@ controller node: ${wakeupResp.controllerNodeId}`;
 		// Remember that the interview is complete
 		if (!hadCriticalTimeout) this.interviewComplete = true;
 	}
+
+	public static supportsWakeOnDemand(node?: ZWaveNode): boolean {
+		return node?.getValue(getWakeUpOnDemandSupportedValueId()) ?? false;
+	}
 }
 
 interface WakeUpCCIntervalSetOptions extends CCCommandOptions {
@@ -442,6 +453,9 @@ export class WakeUpCCIntervalCapabilitiesReport extends WakeUpCC {
 				default: this._defaultWakeUpInterval,
 			},
 		);
+
+		// Store wakeUpOnDemandSupported in valueDB
+		this.persistValues();
 	}
 
 	private _minWakeUpInterval: number;

--- a/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
@@ -302,7 +302,7 @@ controller node: ${wakeupResp.controllerNodeId}`;
 		if (!hadCriticalTimeout) this.interviewComplete = true;
 	}
 
-	public static supportsWakeOnDemand(node?: ZWaveNode): boolean {
+	public static supportsWakeUpOnDemand(node?: ZWaveNode): boolean {
 		return node?.getValue(getWakeUpOnDemandSupportedValueId()) ?? false;
 	}
 }

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -2764,9 +2764,6 @@ ${handlers.length} left`,
 				// Remember that this transaction was part of an interview
 				options.tag = "interview";
 			}
-			if (options.requestWakeUpOnDemand) {
-				options.tag = "requestWakeUpOnDemand";
-			}
 			options.priority = MessagePriority.WakeUp;
 		}
 
@@ -2783,6 +2780,7 @@ ${handlers.length} left`,
 			transaction.changeNodeStatusOnTimeout =
 				options.changeNodeStatusOnMissingACK;
 		}
+		transaction.requestWakeUpOnDemand = !!options.requestWakeUpOnDemand;
 		transaction.tag = options.tag;
 
 		// start sending now (maybe)

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1718,8 +1718,6 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> {
 								sessionId: supervisionSessionId,
 								moreUpdatesFollow: false,
 								status: SupervisionStatus.NoSupport,
-								requestWakeUpOnDemand:
-									node.shouldRequestWakeUpOnDemand,
 								secure: msg.command.secure,
 							});
 							return;
@@ -2510,8 +2508,6 @@ ${handlers.length} left`,
 								sessionId: supervisionSessionId,
 								moreUpdatesFollow: false,
 								status: SupervisionStatus.Success,
-								requestWakeUpOnDemand:
-									node.shouldRequestWakeUpOnDemand,
 								secure,
 							});
 						}
@@ -2529,8 +2525,6 @@ ${handlers.length} left`,
 							sessionId: supervisionSessionId,
 							moreUpdatesFollow: false,
 							status: SupervisionStatus.Success,
-							requestWakeUpOnDemand:
-								node.shouldRequestWakeUpOnDemand,
 							secure,
 						});
 					} catch (e) {
@@ -2538,8 +2532,6 @@ ${handlers.length} left`,
 							sessionId: supervisionSessionId,
 							moreUpdatesFollow: false,
 							status: SupervisionStatus.Fail,
-							requestWakeUpOnDemand:
-								node.shouldRequestWakeUpOnDemand,
 							secure,
 						});
 

--- a/packages/zwave-js/src/lib/driver/Transaction.ts
+++ b/packages/zwave-js/src/lib/driver/Transaction.ts
@@ -34,6 +34,9 @@ export class Transaction implements Comparable<Transaction> {
 	/** Whether the node status should be updated when this transaction times out */
 	public changeNodeStatusOnTimeout: boolean = true;
 
+	/** If a Wake Up On Demand should be requested for the target node. */
+	public requestWakeUpOnDemand: boolean = false;
+
 	/** Internal information used to identify or mark this transaction */
 	public tag?: any;
 

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -122,6 +122,7 @@ import {
 import { getFirmwareVersionsValueId } from "../commandclass/VersionCC";
 import {
 	getWakeUpIntervalValueId,
+	getWakeUpOnDemandSupportedValueId,
 	WakeUpCCWakeUpNotification,
 } from "../commandclass/WakeUpCC";
 import {
@@ -582,6 +583,21 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner {
 
 	public get zwavePlusRoleType(): ZWavePlusRoleType | undefined {
 		return this.getValue(getRoleTypeValueId());
+	}
+
+	public get supportsWakeUpOnDemand(): boolean | undefined {
+		return this.getValue(getWakeUpOnDemandSupportedValueId());
+	}
+
+	public get shouldRequestWakeUpOnDemand(): boolean {
+		return (
+			!!this.supportsWakeUpOnDemand &&
+			this.driver.hasPendingTransactions(
+				(t) =>
+					t.message.getNodeId() === this.id &&
+					t.tag === "requestWakeUpOnDemand",
+			)
+		);
 	}
 
 	/**

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -591,12 +591,12 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner {
 
 	public get shouldRequestWakeUpOnDemand(): boolean {
 		return (
-			this.status === NodeStatus.Asleep &&
 			!!this.supportsWakeUpOnDemand &&
+			this.status === NodeStatus.Asleep &&
 			this.driver.hasPendingTransactions(
 				(t) =>
-					t.message.getNodeId() === this.id &&
-					t.tag === "requestWakeUpOnDemand",
+					t.requestWakeUpOnDemand &&
+					t.message.getNodeId() === this.id,
 			)
 		);
 	}

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -591,6 +591,7 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner {
 
 	public get shouldRequestWakeUpOnDemand(): boolean {
 		return (
+			this.status === NodeStatus.Asleep &&
 			!!this.supportsWakeUpOnDemand &&
 			this.driver.hasPendingTransactions(
 				(t) =>


### PR DESCRIPTION
This PR is the first step in resolving #1158.

This adds support for Wake Up On Demand.

`SupervisionCC` support is upgraded to `V2`.
`WakeUpCC` support is upgraded to `V3`.
The `Driver` and `Node` classes are updated to set the Wake Up On Demand bit when sending `SupervisionCCReport` replies to sleeping nodes that have important messages pending in the queue.

A Wake Up On Demand for a node is requested by setting `options.requestWakeUpOnDemand = true` in the `SendCommandOptions` when calling `driver.sendCommand`.

The code is currently untested, because I'd like feedback that this is a good way to implement this functionality before spending too much time on it.

fixes: #1158