### PR TITLE
fix(config): add device identifier for MCOHome MH10-PM2.5

### DIFF
--- a/packages/config/config/devices/0x015f/mh10-pm2_5-wa_wd.json
+++ b/packages/config/config/devices/0x015f/mh10-pm2_5-wa_wd.json
@@ -7,6 +7,10 @@
 		{
 			"productType": "0x0a01",
 			"productId": "0x5102"
+		},
+		{
+			"productType": "0x0a02",
+			"productId": "0x5102"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
Need for adding device identifier . My MCOHome MH10-PM2.5-WA/WD reports following in zwave js: 'Device ID 351-20738-2562 (0x015f-0x0a02-0x5102'
see: ![image](https://user-images.githubusercontent.com/1336329/133341725-9ec63936-cd49-491e-883a-69200c784dc5.png)
