### PR TITLE
feat(cc): add `compat` for `Scene Controller Configuration CC`

### DIFF
--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -355,7 +355,7 @@ Version 8 of the `Notification CC` added the requirement that devices must issue
 
 ### `forceSceneControllerGroupCount`
 
-The specifications mandate that each `Scene Controller Configuration CC` Group ID corresponds to that actual `Association CC` group. Some devices ignore this rule, and the count of `Scene Controller Configuration CC` groups cannot be known from the count of `Association CC` groups. `forceSceneControllerGroupCount` directly specifies the number of `Scene Controller Configuration CC` groups to support.
+The specifications mandate that each `Scene Controller Configuration CC` Group ID corresponds to exactly one association group. Some devices ignore this rule, and as a result not all scenes can be configured. Using the `forceSceneControllerGroupCount` flag, the actual number of scenes of these devices can be configured.
 
 ### `manualValueRefreshDelayMs`
 

--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -353,6 +353,10 @@ The specifications mandate strict rules for the data and sequence numbers in `En
 
 Version 8 of the `Notification CC` added the requirement that devices must issue an idle notification after a notification variable is no longer active. Several legacy devices and some misbehaving V8 devices do not return their variables to idle automatically. By setting `forceNotificationIdleReset` to `true`, `zwave-js` auto-idles supporting notification variables after 5 minutes.
 
+### `forceSceneControllerGroupCount`
+
+The specifications mandate that each `Scene Controller Configuration CC` Group ID corresponds to that actual `Association CC` group. Some devices ignore this rule, and the count of `Scene Controller Configuration CC` groups cannot be known from the count of `Association CC` groups. `forceSceneControllerGroupCount` directly specifies the number of `Scene Controller Configuration CC` groups to support.
+
 ### `manualValueRefreshDelayMs`
 
 Some legacy devices emit an NIF when a local event occurs (e.g. a button press) to signal that the controller should request a status update. However, some of these devices require a delay before they are ready to respond to this request. `manualValueRefreshDelayMs` specifies that delay, expressed in milliseconds. If unset, there will be no delay.

--- a/maintenance/schemas/device-config.json
+++ b/maintenance/schemas/device-config.json
@@ -227,6 +227,11 @@
 				"forceNotificationIdleReset": {
 					"const": true
 				},
+				"forceSceneControllerGroupCount": {
+					"type": "number",
+					"minimum": 0,
+					"maximum": 255
+				},
 				"manualValueRefreshDelayMs": {
 					"type": "number",
 					"minimum": 0

--- a/packages/config/src/CompatConfig.ts
+++ b/packages/config/src/CompatConfig.ts
@@ -104,6 +104,30 @@ error in compat option forceNotificationIdleReset`,
 				definition.forceNotificationIdleReset;
 		}
 
+		if (definition.forceSceneControllerGroupCount != undefined) {
+			if (typeof definition.forceSceneControllerGroupCount !== "number") {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+compat option forceSceneControllerGroupCount must be a number!`,
+				);
+			}
+
+			if (
+				definition.forceSceneControllerGroupCount < 0 ||
+				definition.forceSceneControllerGroupCount > 255
+			) {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+compat option forceSceneControllerGroupCount must be between 0 and 255!`,
+				);
+			}
+
+			this.forceSceneControllerGroupCount =
+				definition.forceSceneControllerGroupCount;
+		}
+
 		if (definition.preserveRootApplicationCCValueIDs != undefined) {
 			if (definition.preserveRootApplicationCCValueIDs !== true) {
 				throwInvalidConfig(
@@ -424,6 +448,7 @@ compat option alarmMapping must be an array where all items are objects!`,
 	public readonly disableStrictEntryControlDataValidation?: boolean;
 	public readonly enableBasicSetMapping?: boolean;
 	public readonly forceNotificationIdleReset?: boolean;
+	public readonly forceSceneControllerGroupCount?: number;
 	public readonly manualValueRefreshDelayMs?: number;
 	public readonly mapRootReportsToEndpoint?: number;
 	public readonly overrideFloatEncoding?: {

--- a/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
@@ -381,13 +381,9 @@ export class SceneControllerConfigurationCC extends CommandClass {
 			return;
 		}
 
-		// Always query scene configuration for each association group
+		// Create metadata for each scene, but don't query their actual configuration
+		// since some devices only support setting scenes
 		for (let groupId = 1; groupId <= groupCount; groupId++) {
-			this.driver.controllerLog.logNode(node.id, {
-				endpoint: this.endpointIndex,
-				message: `setting metadata for scene configuration for association group #${groupId}...`,
-				direction: "outbound",
-			});
 			setSceneConfigurationMetadata.call(this, groupId);
 		}
 


### PR DESCRIPTION
Resolves #3350 
Should also resolve zwave-js/zwavejs2mqtt#1640

- `forceSceneControllerGroupCount` compat flag sets the `groupCount` for devices that don't adhere to the 1:1 corespondence between `Scene Controller Configuration CC` groups and `Association CC` groups. This is know to be needed by the "Leviton VRCZ4-M0Z".
- The `SceneControllerConfigurationCC.interview` no longer queries the node for the scene configuration of each group. Instead, it only presets the `ValueMetaData` for each group. This speeds up the interview and avoids problems with devices that break spec and don't support `SceneControllerConfigurationCCGet` (ex: "Enerwave ZWN-SC7"). No `compat` flag is required for this.