### PR TITLE
fix: rename consumed/produced in meter label to consumption/production

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/MeterCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MeterCC.ts
@@ -148,7 +148,7 @@ function getValueLabel(
 	suffix?: string,
 ): string {
 	let ret = getMeterTypeName(configManager, meterType);
-	if (rateType !== RateType.Unspecified && rateType !== RateType.Consumed) {
+	if (rateType === RateType.Produced) {
 		ret += ` ${getEnumMemberName(RateType, rateType)}`;
 	}
 	ret += ` [${scale.label}]`;

--- a/packages/zwave-js/src/lib/commandclass/MeterCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MeterCC.ts
@@ -148,7 +148,7 @@ function getValueLabel(
 	suffix?: string,
 ): string {
 	let ret = getMeterTypeName(configManager, meterType);
-	if (rateType !== RateType.Unspecified) {
+	if (rateType !== RateType.Unspecified && rateType !== RateType.Consumed) {
 		ret += ` ${getEnumMemberName(RateType, rateType)}`;
 	}
 	ret += ` [${scale.label}]`;

--- a/packages/zwave-js/src/lib/commandclass/MeterCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MeterCC.ts
@@ -148,7 +148,7 @@ function getValueLabel(
 	suffix?: string,
 ): string {
 	let ret = getMeterTypeName(configManager, meterType);
-	if (rateType === RateType.Produced) {
+	if (rateType !== RateType.Unspecified && rateType !== RateType.Consumed) {
 		ret += ` ${getEnumMemberName(RateType, rateType)}`;
 	}
 	ret += ` [${scale.label}]`;

--- a/packages/zwave-js/src/lib/commandclass/MeterCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MeterCC.ts
@@ -148,10 +148,16 @@ function getValueLabel(
 	suffix?: string,
 ): string {
 	let ret = getMeterTypeName(configManager, meterType);
-	if (rateType !== RateType.Unspecified && rateType !== RateType.Consumed) {
-		ret += ` ${getEnumMemberName(RateType, rateType)}`;
+	switch (rateType) {
+		case RateType.Consumed:
+			ret += ` Consumption [${scale.label}]`;
+			break;
+		case RateType.Produced:
+			ret += ` Production [${scale.label}]`;
+			break;
+		default:
+			ret += ` [${scale.label}]`;
 	}
-	ret += ` [${scale.label}]`;
 	if (suffix) {
 		ret += ` (${suffix})`;
 	}


### PR DESCRIPTION
As proposed in Slack discussion