### PR TITLE
fix(config): correct units for Fibaro FGS-224 and FGS-214 params 154 and 155

### DIFF
--- a/packages/config/config/devices/0x010f/fgs214.json
+++ b/packages/config/config/devices/0x010f/fgs214.json
@@ -175,11 +175,11 @@
 		},
 		"154": {
 			"label": "First channel – time parameter for delayed/auto OFF and flashing modes",
-			"description": "This parameter allows to set time parameter used in timed modes. (s)",
+			"description": "This parameter allows to set time parameter used in timed modes. (deciseconds)",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 32000,
-			"unit": "s",
+			"unit": "ds",
 			"defaultValue": 5,
 			"unsigned": true
 		},

--- a/packages/config/config/devices/0x010f/fgs214.json
+++ b/packages/config/config/devices/0x010f/fgs214.json
@@ -175,11 +175,11 @@
 		},
 		"154": {
 			"label": "First channel – time parameter for delayed/auto OFF and flashing modes",
-			"description": "This parameter allows to set time parameter used in timed modes. (deciseconds)",
+			"description": "This parameter allows to set time parameter used in timed modes.",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 32000,
-			"unit": "ds",
+			"unit": "0.1 s",
 			"defaultValue": 5,
 			"unsigned": true
 		},

--- a/packages/config/config/devices/0x010f/fgs224.json
+++ b/packages/config/config/devices/0x010f/fgs224.json
@@ -251,11 +251,11 @@
 		},
 		"154": {
 			"label": "First channel – time parameter for delayed/auto OFF and flashing modes",
-			"description": "This parameter allows to set time parameter used in timed modes. (s)",
+			"description": "This parameter allows to set time parameter used in timed modes. (deciseconds)",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 32000,
-			"unit": "s",
+			"unit": "ds",
 			"defaultValue": 5,
 			"unsigned": true
 		},

--- a/packages/config/config/devices/0x010f/fgs224.json
+++ b/packages/config/config/devices/0x010f/fgs224.json
@@ -261,11 +261,11 @@
 		},
 		"155": {
 			"label": "Second channel – time parameter for delayed/auto OFF and flashing modes",
-			"description": "This parameter allows to set time parameter used in timed modes. (s)",
+			"description": "This parameter allows to set time parameter used in timed modes.",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 32000,
-			"unit": "s",
+			"unit": "0.1 s",
 			"defaultValue": 5,
 			"unsigned": true
 		},

--- a/packages/config/config/devices/0x010f/fgs224.json
+++ b/packages/config/config/devices/0x010f/fgs224.json
@@ -251,11 +251,11 @@
 		},
 		"154": {
 			"label": "First channel – time parameter for delayed/auto OFF and flashing modes",
-			"description": "This parameter allows to set time parameter used in timed modes. (deciseconds)",
+			"description": "This parameter allows to set time parameter used in timed modes.",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 32000,
-			"unit": "ds",
+			"unit": "0.1 s",
 			"defaultValue": 5,
 			"unsigned": true
 		},


### PR DESCRIPTION
As stated in the [documentation](https://manuals.fibaro.com/content/manuals/en/FGS-2x4/FGS-2x4-T-EN-1.0.pdf): Parameter 154 is an integer that represents increments of 0.1 seconds also known as deciseconds (ds) https://en.wikipedia.org/wiki/Second

Maybe is a better idea to remove unit and explain the step size in the description?