### PR TITLE
fix(config): use unsigned (0-99, 255) instead of (-1) for config parameters setting Basic Set levels

### DIFF
--- a/packages/config/config/devices/0x000c/hs-hsm200.json
+++ b/packages/config/config/devices/0x000c/hs-hsm200.json
@@ -37,12 +37,12 @@
 		},
 		"2": {
 			"label": "Dim Level",
-			"description": "Sets the dim level; -1 for full on",
-			"unit": "%",
+			"description": "Allowable range: 0-99, 255",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 99,
-			"defaultValue": -1
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		"3": {
 			"label": "Light Level Report Interval",

--- a/packages/config/config/devices/0x001e/ezmultipli.json
+++ b/packages/config/config/devices/0x001e/ezmultipli.json
@@ -37,11 +37,12 @@
 		},
 		"2": {
 			"label": "OnLevel",
-			"unit": "Percent",
+			"description": "Allowable range: 0-99, 255",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 99,
-			"defaultValue": -1
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		"3": {
 			"label": "LiteMin",

--- a/packages/config/config/devices/0x002c/z-flexnet_dongl.json
+++ b/packages/config/config/devices/0x002c/z-flexnet_dongl.json
@@ -155,11 +155,16 @@
 		},
 		"15": {
 			"label": "Reset to Factory Default",
-			"description": "-1 (0xff) - reset the device",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 0,
-			"defaultValue": 0
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{ "label": "idle", "value": 0 },
+				{ "label": "Factory reset", "value": 255 }
+			]
 		}
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x003b/s-6500f.json
+++ b/packages/config/config/devices/0x003b/s-6500f.json
@@ -17,39 +17,39 @@
 	"paramInformation": {
 		"3": {
 			"label": "Beeper",
-			"description": "Read and write 0: disable beeper -1: enable beeper",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 0,
-			"defaultValue": -1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 255,
+			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Enable beeper",
-					"value": -1
+					"label": "Disable",
+					"value": 0
 				},
 				{
-					"label": "Disable beeper",
-					"value": 0
+					"label": "Enable",
+					"value": 255
 				}
 			]
 		},
 		"5": {
 			"label": "Auto Lock",
-			"description": "Read-only 0: disable auto lock -1: enable auto lock",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 0,
+			"minValue": 0,
+			"maxValue": 255,
 			"defaultValue": 0,
+			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Enable auto lock",
-					"value": -1
+					"label": "Disable ",
+					"value": 0
 				},
 				{
-					"label": "Disable auto lock",
-					"value": 0
+					"label": "Enable",
+					"value": 255
 				}
 			]
 		},

--- a/packages/config/config/devices/0x0118/tsm02.json
+++ b/packages/config/config/devices/0x0118/tsm02.json
@@ -28,10 +28,12 @@
 	"paramInformation": {
 		"2": {
 			"label": "Basic Set Level",
+			"description": "Allowable range: 0-99, 255",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 100,
-			"defaultValue": -1
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		"3": {
 			"label": "PIR Sensitivity",

--- a/packages/config/config/devices/0x013c/pst02b.json
+++ b/packages/config/config/devices/0x013c/pst02b.json
@@ -17,11 +17,12 @@
 	"paramInformation": {
 		"2": {
 			"label": "Basic Set Level",
-			"description": "BASIC command value sent when turning on lights",
+			"description": "BASIC command value sent when turning on lights. Allowable range: 0-99, 255",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 100,
-			"defaultValue": -1
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		"3": {
 			"label": "PIR Sensitivity",

--- a/packages/config/config/devices/0x0149/dry.json
+++ b/packages/config/config/devices/0x0149/dry.json
@@ -42,27 +42,30 @@
 		},
 		"4": {
 			"label": "Value used for devices belonging to Group 2",
-			"description": "Value sent when the external switch receives 1 Click",
+			"description": "Value sent when the external switch receives 1 click. Allowable range: 0-99, 255",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 100,
-			"defaultValue": 100
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		"5": {
 			"label": "Value used for devices belonging to Group 3",
-			"description": "Value sent wen the external switch receives 2 Clicks",
+			"description": "Value sent when the external switch receives 2 clicks. Allowable range: 0-99, 255",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 100,
-			"defaultValue": 100
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		"6": {
 			"label": "Value used for devices belonging to Group 4",
-			"description": "Value sent when external switch receives 3 Clicks",
+			"description": "Value sent when external switch receives 3 clicks. Allowable range: 0-99, 255",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 100,
-			"defaultValue": 100
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		"10": {
 			"label": "Timer to switch OFF the Relay",

--- a/packages/config/config/devices/0x0149/ums2.json
+++ b/packages/config/config/devices/0x0149/ums2.json
@@ -57,45 +57,57 @@
 		},
 		"4": {
 			"label": "Value for Group 2 with 1 click on UP button",
+			"description": "Allowable range: 0-99, 255",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 99,
-			"defaultValue": -1
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		"5": {
 			"label": "Value for Group 2 with 1 click on DOWN button",
+			"description": "Allowable range: 0-99, 255",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 99,
-			"defaultValue": 0
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"unsigned": true
 		},
 		"6": {
 			"label": "Value for Group 3 with 2 clicks on UP button",
+			"description": "Allowable range: 0-99, 255",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 99,
-			"defaultValue": -1
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		"7": {
 			"label": "Value for Group 3 with 2 clicks on DOWN button",
+			"description": "Allowable range: 0-99, 255",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 99,
-			"defaultValue": 0
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"unsigned": true
 		},
 		"8": {
 			"label": "Value for Group 4 with 3 clicks on UP button",
+			"description": "Allowable range: 0-99, 255",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 99,
-			"defaultValue": -1
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		"9": {
 			"label": "Value for Group 4 with 3 clicks on DOWN button",
+			"description": "Allowable range: 0-99, 255",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 99,
-			"defaultValue": 0
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"unsigned": true
 		},
 		"20": {
 			"label": "Calibration",

--- a/packages/config/config/devices/0x0149/wps104.json
+++ b/packages/config/config/devices/0x0149/wps104.json
@@ -193,11 +193,12 @@
 		},
 		"38": {
 			"label": "UP Power Associated",
-			"description": "Defines the status of Group 2 devices",
+			"description": "Defines the status of Group 2 devices. Allowable range: 0-99, 255",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 99,
-			"defaultValue": 0
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"unsigned": true
 		},
 		"39": {
 			"label": "DOWN Power Level",
@@ -244,11 +245,12 @@
 		},
 		"42": {
 			"label": "DOWN Power Associated",
-			"description": "Defines the status of Group 3 devices",
+			"description": "Defines the status of Group 3 devices. Allowable range: 0-99, 255",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 99,
-			"defaultValue": 0
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"unsigned": true
 		},
 		"43": {
 			"label": "Energy Level",

--- a/packages/config/config/devices/0x0149/wsp1.json
+++ b/packages/config/config/devices/0x0149/wsp1.json
@@ -40,17 +40,21 @@
 		},
 		"2": {
 			"label": "Level used to control group 4",
+			"description": "Allowable range: 0-99, 255",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 100,
-			"defaultValue": 100
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		"3": {
 			"label": "Level used to control group 5",
+			"description": "Allowable range: 0-99, 255",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 100,
-			"defaultValue": 100
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		"4": {
 			"label": "Overvoltage level",
@@ -86,10 +90,12 @@
 		},
 		"7": {
 			"label": "Level used to control group 3",
+			"description": "Allowable range: 0-99, 255",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 99,
-			"defaultValue": 0
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"unsigned": true
 		},
 		"8": {
 			"label": "Overcurrent level",
@@ -125,10 +131,12 @@
 		},
 		"11": {
 			"label": "Level used to control group 2",
+			"description": "Allowable range: 0-99, 255",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 99,
-			"defaultValue": 0
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"unsigned": true
 		}
 	}
 }

--- a/packages/config/config/devices/0x0149/wte.json
+++ b/packages/config/config/devices/0x0149/wte.json
@@ -17,11 +17,12 @@
 	"paramInformation": {
 		"1": {
 			"label": "Start-up status",
-			"description": "Defines the status of the device, in term of light level, following a restart.",
+			"description": "Defines the status of the device, in term of light level, following a restart. Allowable range: 0-99, 255",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 99,
-			"defaultValue": -1
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		"2": {
 			"label": "Fade On Time",

--- a/packages/config/config/devices/0x0175/mt02648.json
+++ b/packages/config/config/devices/0x0175/mt02648.json
@@ -17,11 +17,12 @@
 	"paramInformation": {
 		"2": {
 			"label": "Basic Set Level",
-			"description": "Setting the BASIC command value to turn on the light.",
+			"description": "Allowable range: 0-99, 255",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 100,
-			"defaultValue": -1
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		"3": {
 			"label": "PIR Sensitivity",

--- a/packages/config/config/devices/0x0175/pst02-1b.json
+++ b/packages/config/config/devices/0x0175/pst02-1b.json
@@ -27,10 +27,12 @@
 	"paramInformation": {
 		"2": {
 			"label": "Basic Set Level",
+			"description": "Allowable range: 0-99, 255",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 100,
-			"defaultValue": -1
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		"3": {
 			"label": "PIR Sensitivity",


### PR DESCRIPTION
I've noticed a few instances where config files still used unsigned ranges of -1 .. 99 for Basic Set config params instead of 0..99, 255. This PR fixes it.