### PR TITLE
fix: work around buggy serial API cmd bitmask encoding in firmware 7.15

### DIFF
--- a/packages/zwave-js/src/lib/serialapi/misc/SerialAPISetupMessages.test.ts
+++ b/packages/zwave-js/src/lib/serialapi/misc/SerialAPISetupMessages.test.ts
@@ -1,0 +1,24 @@
+import type { Driver } from "../../driver/Driver";
+import { Message } from "../../message/Message";
+import { createEmptyMockDriver } from "../../test/mocks";
+import { SerialAPISetup_GetSupportedCommandsResponse } from "./SerialAPISetupMessages";
+
+const fakeDriver = createEmptyMockDriver() as unknown as Driver;
+
+describe("SerialAPISetupMessages", () => {
+	it("GetSupportedCommandsResponse with extended bitmask parses correctly", () => {
+		const data = Buffer.from(
+			"0116010b01fe160103000100000001000000000000000109",
+			"hex",
+		);
+
+		const msg = Message.from(fakeDriver, data);
+		expect(msg).toBeInstanceOf(SerialAPISetup_GetSupportedCommandsResponse);
+		const supported = (msg as SerialAPISetup_GetSupportedCommandsResponse)
+			.supportedCommands;
+
+		expect(supported).toEqual([
+			0x01, 0x02, 0x04, 0x08, 0x10, 0x11, 0x20, 0x40, 0x80,
+		]);
+	});
+});

--- a/packages/zwave-js/src/lib/serialapi/misc/SerialAPISetupMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/misc/SerialAPISetupMessages.ts
@@ -197,7 +197,12 @@ export class SerialAPISetup_GetSupportedCommandsResponse extends SerialAPISetupR
 			// Parse it as a bitmask
 			this.supportedCommands = parseBitMask(
 				this.payload.slice(1),
-				SerialAPISetupCommand.GetSupportedCommands,
+				// According to the Host API specification, the first bit (bit 0) should be GetSupportedCommands
+				// However, at least in Z-Wave SDK 7.15, the entire bitmask is shifted by 1 bit and
+				// GetSupportedCommands is encoded in the second bit (bit 1)
+
+				// TODO: When this is fixed, make the start value dependent on the SDK version
+				SerialAPISetupCommand.Unsupported,
 			);
 		} else {
 			// This module only uses the single byte power-of-2 bitmask. Decode it manually


### PR DESCRIPTION
fixes: #3367 