### PR TITLE
fix(test): correctly delete env variable in ConfigManager Test

### DIFF
--- a/packages/config/src/ConfigManager.test.ts
+++ b/packages/config/src/ConfigManager.test.ts
@@ -105,7 +105,7 @@ describe("ConfigManager", () => {
 
 		beforeEach(async () => {
 			await fs.emptyDir(tempDir);
-			process.env.ZWAVEJS_EXTERNAL_CONFIG = undefined;
+			delete process.env.ZWAVEJS_EXTERNAL_CONFIG;
 			jest.resetModules();
 		});
 


### PR DESCRIPTION
fixes #3384 