### PR TITLE
feat(config): add Sunricher RGBW and CCT wall controllers

### DIFF
--- a/packages/config/config/devices/0x0330/templates/sunricher_template.json
+++ b/packages/config/config/devices/0x0330/templates/sunricher_template.json
@@ -1,18 +1,18 @@
 {
 	"scene_command_type": {
 		"label": "Scene Command Type",
-		"description": "Set to choose between CENTRAL_SCENE or SCENE_ACTIVATION command types",
 		"valueSize": 1,
 		"minValue": 0,
 		"maxValue": 1,
 		"defaultValue": 0,
+		"allowManualEntry": false,
 		"options": [
 			{
-				"label": "CENTRAL_SCENE",
+				"label": "Central Scene",
 				"value": 0
 			},
 			{
-				"label": "SCENE_ACTIVATION",
+				"label": "Scene Activation",
 				"value": 1
 			}
 		]

--- a/packages/config/config/devices/0x0330/templates/sunricher_template.json
+++ b/packages/config/config/devices/0x0330/templates/sunricher_template.json
@@ -1,0 +1,20 @@
+{
+	"scene_command_type": {
+		"label": "Scene Command Type",
+		"description": "Set to choose between CENTRAL_SCENE or SCENE_ACTIVATION command types",
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 1,
+		"defaultValue": 0,
+		"options": [
+			{
+				"label": "CENTRAL_SCENE",
+				"value": 0
+			},
+			{
+				"label": "SCENE_ACTIVATION",
+				"value": 1
+			}
+		]
+	}
+}

--- a/packages/config/config/devices/0x0330/zv9001t-cct.json
+++ b/packages/config/config/devices/0x0330/zv9001t-cct.json
@@ -1,0 +1,28 @@
+{
+	"manufacturer": "Sunricher",
+	"manufacturerId": "0x0330",
+	"label": "ZV9001T-CCT",
+	"description": "CCT Wall Controller",
+	"devices": [
+		{
+			"productType": "0x0300",
+			"productId": "0xa104"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"supportsZWavePlus": true,
+	"paramInformation": {
+		"3": {
+			"$import": "templates/sunricher_template.json#scene_command_type"
+		}
+	},
+	"metadata": {
+		"inclusion": "Short press the “inclusion/exclusion” button, or press and hold down “ALL ON/OFF” button for over 3 seconds, the wall controller will be set to inclusion mode, and waiting to be included, then LED indicator turns on and blinks 6 times quickly to indicate successful inclusion.",
+		"exclusion": "Short press the “inclusion/exclusion” button, or press and hold down “ALL ON/OFF” button for over 3 seconds, the wall controller will be set to exclusion mode, and waiting to be excluded, then LED indicator turns on and shows 3 short blinks and 1 long blink to indicate successful exclusion.",
+		"reset": "Press and hold down “inclusion/exclusion” button for over 8 seconds, LED indicator blinks slowly to indicate successful factory reset, release “inclusion/exclusion” button, the wall controller will restart automatically.",
+		"manual": "https://www.sunricher.com/media/resources/manual/SR-ZV9001T-CCT-EU%20Instruction.pdf"
+	}
+}

--- a/packages/config/config/devices/0x0330/zv9001t-cct.json
+++ b/packages/config/config/devices/0x0330/zv9001t-cct.json
@@ -13,7 +13,6 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
-	"supportsZWavePlus": true,
 	"paramInformation": {
 		"3": {
 			"$import": "templates/sunricher_template.json#scene_command_type"

--- a/packages/config/config/devices/0x0330/zv9003t-rgbw.json
+++ b/packages/config/config/devices/0x0330/zv9003t-rgbw.json
@@ -13,7 +13,6 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
-	"supportsZWavePlus": true,
 	"paramInformation": {
 		"3": {
 			"$import": "templates/sunricher_template.json#scene_command_type"

--- a/packages/config/config/devices/0x0330/zv9003t-rgbw.json
+++ b/packages/config/config/devices/0x0330/zv9003t-rgbw.json
@@ -1,0 +1,28 @@
+{
+	"manufacturer": "Sunricher",
+	"manufacturerId": "0x0330",
+	"label": "ZV9003T-RGBW",
+	"description": "RGBW Wall Controller",
+	"devices": [
+		{
+			"productType": "0x0300",
+			"productId": "0xa108"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"supportsZWavePlus": true,
+	"paramInformation": {
+		"3": {
+			"$import": "templates/sunricher_template.json#scene_command_type"
+		}
+	},
+	"metadata": {
+		"inclusion": "Short press the “inclusion/exclusion” button, or press and hold down “ALL ON/OFF” button for over 3 seconds, the wall controller will be set to inclusion mode, and waiting to be included, then LED indicator turns on and blinks 6 times quickly to indicate successful inclusion.",
+		"exclusion": "Short press the “inclusion/exclusion” button, or press and hold down “ALL ON/OFF” button for over 3 seconds, the wall controller will be set to exclusion mode, and waiting to be excluded, then LED indicator turns on and shows 3 short blinks and 1 long blink to indicate successful exclusion.",
+		"reset": "Press and hold down “inclusion/exclusion” button for over 8 seconds, LED indicator blinks slowly to indicate successful factory reset, release “inclusion/exclusion” button, the wall controller will restart automatically.",
+		"manual": "https://www.sunricher.com/media/resources/manual/SR-ZV9001T-RGBW-EU%20Instruction.pdf"
+	}
+}


### PR DESCRIPTION
Add configuration for Sunricher ZV9003T-RGBW and ZV9001T-CCT wall
mounted secondary controllers.  This allows the scene command type
configuration to be set.