### PR TITLE
fix(config): update Philio PST02A and PST02B to use partial config parameters (5, 6, 7)

### DIFF
--- a/packages/config/config/devices/0x013c/psm02.json
+++ b/packages/config/config/devices/0x013c/psm02.json
@@ -2,7 +2,7 @@
 	"manufacturer": "Philio Technology Corp",
 	"manufacturerId": "0x013c",
 	"label": "PSM02",
-	"description": "Slim Multi-Sensor",
+	"description": "Slim Multi-Sensor (Door/Motion/Temperature/Illumination)",
 	"devices": [
 		{
 			"productType": "0x0002",
@@ -103,4 +103,9 @@
 			"defaultValue": 12
 		}
 	}
+	"metadata": {
+		"inclusion": "Turn the primary controller of Z-Wave network into inclusion mode, triple click tamper switch within 1.5 seconds",
+		"exclusion": "Turn the primary controller of Z-Wave network into exclusion mode, triple click tamper switch within 1.5 seconds",
+		"reset": "Pressing tamper key four times within 1.5 seconds and do not release the tamper key in the 4th  pressed, and the LED will light ON. After 3 seconds the LED will turn OFF, after that within 2 seconds, release the tamper key. If successful, the LED will light ON one second. Otherwise, the LED will flash once. IDs are excluded and all settings will reset to factory default.",
+		}
 }

--- a/packages/config/config/devices/0x013c/psm02.json
+++ b/packages/config/config/devices/0x013c/psm02.json
@@ -269,7 +269,7 @@
 			]
 		},
 		"7[0x04]": {
-			"label": "PIR super sensitivity mode",
+			"label": "PIR Super Sensitivity Mode",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,

--- a/packages/config/config/devices/0x013c/psm02.json
+++ b/packages/config/config/devices/0x013c/psm02.json
@@ -48,12 +48,107 @@
 			"maxValue": 100,
 			"defaultValue": 100
 		},
-		"5": {
-			"label": "Operation Mode",
+		"5[0x01]": {
+			"label": "Security Mode",
 			"valueSize": 1,
 			"minValue": 0,
-			"maxValue": 127,
-			"defaultValue": 0
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		"5[0x02]": {
+			"label": "Test Mode",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		"5[0x04]": {
+			"label": "Door Window Function",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
+		},
+		"5[0x08]": {
+			"label": "Temperature Scale",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Fahrenheit",
+					"value": 0
+				},
+				{
+					"label": "Celsius",
+					"value": 1
+				}
+			]
+		},
+		"5[0x10]": {
+			"label": "Illumination Report on Trigger",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
+		},
+		"5[0x20]": {
+			"label": "Temperature Report on Trigger",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
 		},
 		"6[0x01]": {
 			"label": "Magnetic Integrate Illumination",

--- a/packages/config/config/devices/0x013c/psm02.json
+++ b/packages/config/config/devices/0x013c/psm02.json
@@ -18,6 +18,7 @@
 		"1": {
 			"label": "Reports",
 			"maxNodes": 7
+			"isLifeline": true
 		},
 		"2": {
 			"label": "Light Control",

--- a/packages/config/config/devices/0x013c/psm02.json
+++ b/packages/config/config/devices/0x013c/psm02.json
@@ -29,9 +29,10 @@
 		"2": {
 			"label": "Basic Set Level",
 			"valueSize": 1,
-			"minValue": -1,
-			"maxValue": 100,
-			"defaultValue": -1
+			"unsigned": true,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 255
 		},
 		"3": {
 			"label": "PIR Sensitivity",

--- a/packages/config/config/devices/0x013c/psm02.json
+++ b/packages/config/config/devices/0x013c/psm02.json
@@ -61,6 +61,108 @@
 			"maxValue": 127,
 			"defaultValue": 4
 		},
+		"7[0x02]": {
+			"label": "Send motion OFF report. ",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		"7[0x04]": {
+			"label": "PIR super sensitivity mode",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		"7[0x08]": {
+			"label": "Send Basic CC Off After Door Close",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
+		},
+		"7[0x10]": {
+			"label": "Notification Type",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Notification Report",
+					"value": 0
+				},
+				{
+					"label": "Binary Sensor Report",
+					"value": 1
+				}
+			]
+		},
+		"7[0x20]": {
+			"label": "Multi Command Encapsulated Auto Reports",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
+		},
+		"7[0x40]": {
+			"label": "Report Battery State When Triggered",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
+		},
 		"8": {
 			"label": "PIR Re-Detect Interval Time",
 			"valueSize": 1,

--- a/packages/config/config/devices/0x013c/psm02.json
+++ b/packages/config/config/devices/0x013c/psm02.json
@@ -395,7 +395,7 @@
 			"maxValue": 127,
 			"defaultValue": 12
 		}
-	}
+	},
 	"metadata": {
 		"inclusion": "Turn the primary controller of Z-Wave network into inclusion mode, triple click tamper switch within 1.5 seconds",
 		"exclusion": "Turn the primary controller of Z-Wave network into exclusion mode, triple click tamper switch within 1.5 seconds",

--- a/packages/config/config/devices/0x013c/psm02.json
+++ b/packages/config/config/devices/0x013c/psm02.json
@@ -14,6 +14,7 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
+	"supportsZWavePlus": false,
 	"associations": {
 		"1": {
 			"label": "Reports",

--- a/packages/config/config/devices/0x013c/psm02.json
+++ b/packages/config/config/devices/0x013c/psm02.json
@@ -399,6 +399,6 @@
 	"metadata": {
 		"inclusion": "Turn the primary controller of Z-Wave network into inclusion mode, triple click tamper switch within 1.5 seconds",
 		"exclusion": "Turn the primary controller of Z-Wave network into exclusion mode, triple click tamper switch within 1.5 seconds",
-		"reset": "Pressing tamper key four times within 1.5 seconds and do not release the tamper key in the 4th  pressed, and the LED will light ON. After 3 seconds the LED will turn OFF, after that within 2 seconds, release the tamper key. If successful, the LED will light ON one second. Otherwise, the LED will flash once. IDs are excluded and all settings will reset to factory default.",
-		}
+		"reset": "Pressing tamper key four times within 1.5 seconds and do not release the tamper key in the 4th  pressed, and the LED will light ON. After 3 seconds the LED will turn OFF, after that within 2 seconds, release the tamper key. If successful, the LED will light ON one second. Otherwise, the LED will flash once. IDs are excluded and all settings will reset to factory default."
+	}
 }

--- a/packages/config/config/devices/0x013c/psm02.json
+++ b/packages/config/config/devices/0x013c/psm02.json
@@ -14,7 +14,6 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
-	"supportsZWavePlus": false,
 	"associations": {
 		"1": {
 			"label": "Reports",

--- a/packages/config/config/devices/0x013c/psm02.json
+++ b/packages/config/config/devices/0x013c/psm02.json
@@ -55,12 +55,107 @@
 			"maxValue": 127,
 			"defaultValue": 0
 		},
-		"6": {
-			"label": "Multi-Sensor Function Switch",
+		"6[0x01]": {
+			"label": "Magnetic Integrate Illumination",
 			"valueSize": 1,
 			"minValue": 0,
-			"maxValue": 127,
-			"defaultValue": 4
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
+		},
+		"6[0x02]": {
+			"label": "PIR Integrate Illumination",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
+		},
+		"6[0x04]": {
+			"label": "Magnetic Integrate PIR",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
+		},
+		"6[0x08]": {
+			"label": "Device and Light Location",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Same Room",
+					"value": 0
+				},
+				{
+					"label": "Different Room",
+					"value": 1
+				}
+			]
+		},
+		"6[0x10]": {
+			"label": "5 Second Delay Light Off",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
+		},
+		"6[0x20]": {
+			"label": "Auto Turn Off Light",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
 		},
 		"7[0x02]": {
 			"label": "Send motion OFF report. ",

--- a/packages/config/config/devices/0x013c/psm02.json
+++ b/packages/config/config/devices/0x013c/psm02.json
@@ -17,7 +17,7 @@
 	"associations": {
 		"1": {
 			"label": "Reports",
-			"maxNodes": 7
+			"maxNodes": 7,
 			"isLifeline": true
 		},
 		"2": {

--- a/packages/config/config/devices/0x013c/psm02.json
+++ b/packages/config/config/devices/0x013c/psm02.json
@@ -252,7 +252,7 @@
 			]
 		},
 		"7[0x02]": {
-			"label": "Send motion OFF report. ",
+			"label": "Send Motion Off Report",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,

--- a/packages/config/config/devices/0x013c/psm02.json
+++ b/packages/config/config/devices/0x013c/psm02.json
@@ -399,6 +399,6 @@
 	"metadata": {
 		"inclusion": "Turn the primary controller of Z-Wave network into inclusion mode, triple click tamper switch within 1.5 seconds",
 		"exclusion": "Turn the primary controller of Z-Wave network into exclusion mode, triple click tamper switch within 1.5 seconds",
-		"reset": "Pressing tamper key four times within 1.5 seconds and do not release the tamper key in the 4th  pressed, and the LED will light ON. After 3 seconds the LED will turn OFF, after that within 2 seconds, release the tamper key. If successful, the LED will light ON one second. Otherwise, the LED will flash once. IDs are excluded and all settings will reset to factory default."
+		"reset": "Pressing tamper key four times within 1.5 seconds and do not release the tamper key in the 4th  pressed, and the LED will light on. After 3 seconds the LED will turn off, after that within 2 seconds, release the tamper key. If successful, the LED will light on one second. Otherwise, the LED will flash once. IDs are excluded and all settings will reset to factory default."
 	}
 }

--- a/packages/config/config/devices/0x013c/pst02a.json
+++ b/packages/config/config/devices/0x013c/pst02a.json
@@ -426,5 +426,4 @@
 		"exclusion": "Turn the primary controller of Z-Wave network into exclusion mode, triple click tamper switch within 1.5 seconds",
 		"reset": "Pressing tamper key four times within 1.5 seconds and do not release the tamper key in the 4th  pressed, and the LED will light on. After 3 seconds the LED will turn off, after that within 2 seconds, release the tamper key. If successful, the LED will light on one second. Otherwise, the LED will flash once. IDs are excluded and all settings will reset to factory default."
 	}
-
 }

--- a/packages/config/config/devices/0x013c/pst02a.json
+++ b/packages/config/config/devices/0x013c/pst02a.json
@@ -245,7 +245,7 @@
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
-			"defaultValue": 1,
+			"defaultValue": 0,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x013c/pst02a.json
+++ b/packages/config/config/devices/0x013c/pst02a.json
@@ -13,7 +13,6 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
-	"supportsZWavePlus": true,
 	"paramInformation": {
 		"2": {
 			"label": "Basic Set Level",
@@ -61,47 +60,292 @@
 				}
 			]
 		},
-		"5": {
-			"label": "Operation Mode",
-			"description": "Mode of operation and enabled multisensor functions",
+		"5[0x02]": {
+			"label": "Test Mode",
 			"valueSize": 1,
 			"minValue": 0,
-			"maxValue": 127,
+			"maxValue": 1,
 			"defaultValue": 0,
 			"options": [
 				{
-					"label": "Set Celsius",
-					"value": 8
+					"label": "Disable",
+					"value": 0
 				},
 				{
-					"label": "Preset: Celsius and LED on = Bits: 00001010 = 10",
-					"value": 10
+					"label": "Enable",
+					"value": 1
 				}
 			]
 		},
-		"6": {
-			"label": "Multi-Sensor Function Switch",
-			"description": "Enable or disable functions of the multisensor.",
+		"5[0x04]": {
+			"label": "Door/Window Function",
 			"valueSize": 1,
 			"minValue": 0,
-			"maxValue": 127,
-			"defaultValue": 4
-		},
-		"7": {
-			"label": "Customer Function",
-			"description": "Enable or disable functions of the multisensor.",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 127,
-			"defaultValue": 20,
+			"maxValue": 1,
+			"defaultValue": 0,
 			"options": [
 				{
-					"label": "Setting: 0010100",
-					"value": 20
+					"label": "Disable",
+					"value": 1
 				},
 				{
-					"label": "Setting: 00010110",
-					"value": 22
+					"label": "Enable",
+					"value": 0
+				}
+			]
+		},
+		"5[0x08]": {
+			"label": "Temperature Scale",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Fahrenheit",
+					"value": 0
+				},
+				{
+					"label": "Celsius",
+					"value": 1
+				}
+			]
+		},
+		"5[0x10]": {
+			"label": "Illumination Report on Trigger",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
+		},
+		"5[0x20]": {
+			"label": "Temperature Report on Trigger",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
+		},
+		"6[0x01]": {
+			"label": "Magnetic Integrate Illumination",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
+		},
+		"6[0x02]": {
+			"label": "PIR Integrate Illumination",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
+		},
+		"6[0x04]": {
+			"label": "Magnetic Integrate PIR",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
+		},
+		"6[0x08]": {
+			"label": "Device and Light Location",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Same Room",
+					"value": 0
+				},
+				{
+					"label": "Different Room",
+					"value": 1
+				}
+			]
+		},
+		"6[0x10]": {
+			"label": "5 Second Delay Light Off",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
+		},
+		"6[0x20]": {
+			"label": "Auto Turn Off Light",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
+		},
+		"7[0x02]": {
+			"label": "Send Motion Off Report",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		"7[0x04]": {
+			"label": "PIR Super Sensitivity Mode",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		"7[0x08]": {
+			"label": "Send Basic CC Off After Door Close",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
+		},
+		"7[0x10]": {
+			"label": "Notification Type",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Notification Report",
+					"value": 0
+				},
+				{
+					"label": "Binary Sensor Report",
+					"value": 1
+				}
+			]
+		},
+		"7[0x20]": {
+			"label": "Multi Command Encapsulated Auto Reports",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
+		},
+		"7[0x40]": {
+			"label": "Report Battery State When Triggered",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
 				}
 			]
 		},
@@ -176,5 +420,11 @@
 			"maxValue": 99,
 			"defaultValue": 1
 		}
+	},
+	"metadata": {
+		"inclusion": "Turn the primary controller of Z-Wave network into inclusion mode, triple click tamper switch within 1.5 seconds",
+		"exclusion": "Turn the primary controller of Z-Wave network into exclusion mode, triple click tamper switch within 1.5 seconds",
+		"reset": "Pressing tamper key four times within 1.5 seconds and do not release the tamper key in the 4th  pressed, and the LED will light on. After 3 seconds the LED will turn off, after that within 2 seconds, release the tamper key. If successful, the LED will light on one second. Otherwise, the LED will flash once. IDs are excluded and all settings will reset to factory default."
 	}
+
 }

--- a/packages/config/config/devices/0x013c/pst02a.json
+++ b/packages/config/config/devices/0x013c/pst02a.json
@@ -66,6 +66,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",
@@ -83,6 +84,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",
@@ -100,6 +102,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Fahrenheit",
@@ -117,6 +120,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",
@@ -134,6 +138,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",
@@ -151,6 +156,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",
@@ -168,6 +174,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",
@@ -185,6 +192,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 1,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",
@@ -202,6 +210,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Same Room",
@@ -219,6 +228,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",
@@ -236,6 +246,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 1,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",
@@ -253,6 +264,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",
@@ -270,6 +282,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 1,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",
@@ -287,6 +300,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",
@@ -304,6 +318,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Notification Report",
@@ -321,6 +336,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",
@@ -338,6 +354,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 1,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",

--- a/packages/config/config/devices/0x013c/pst02b.json
+++ b/packages/config/config/devices/0x013c/pst02b.json
@@ -13,7 +13,6 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
-	"supportsZWavePlus": true,
 	"paramInformation": {
 		"2": {
 			"label": "Basic Set Level",
@@ -38,37 +37,173 @@
 			"maxValue": 100,
 			"defaultValue": 100
 		},
-		"5": {
-			"label": "Operation Mode",
-			"description": "Mode of operation and enabled multisensor functions",
+		"5[0x02]": {
+			"label": "Test Mode",
 			"valueSize": 1,
 			"minValue": 0,
-			"maxValue": 127,
-			"defaultValue": 0
-		},
-		"6": {
-			"label": "Multisensor Function Switch",
-			"description": "Enable or disable functions of the multisensor.",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 127,
-			"defaultValue": 4
-		},
-		"7": {
-			"label": "Customer Function",
-			"description": "Enable or disable functions of the multisensor. Not applicable for TSP01.",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 127,
+			"maxValue": 1,
 			"defaultValue": 0,
 			"options": [
 				{
-					"label": "Preset option for TSP01.",
+					"label": "Disable",
 					"value": 0
 				},
 				{
-					"label": "Preset for PST02B motion detection settings.",
-					"value": 22
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		"5[0x08]": {
+			"label": "Temperature Scale",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Fahrenheit",
+					"value": 0
+				},
+				{
+					"label": "Celsius",
+					"value": 1
+				}
+			]
+		},
+		"5[0x10]": {
+			"label": "Illumination Report on Trigger",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
+		},
+		"5[0x20]": {
+			"label": "Temperature Report on Trigger",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
+		},
+		"6[0x02]": {
+			"label": "PIR Integrate Illumination",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
+		},
+		"7[0x02]": {
+			"label": "Send Motion Off Report",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		"7[0x04]": {
+			"label": "PIR Super Sensitivity Mode",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		"7[0x10]": {
+			"label": "Notification Type",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Notification Report",
+					"value": 0
+				},
+				{
+					"label": "Binary Sensor Report",
+					"value": 1
+				}
+			]
+		},
+		"7[0x20]": {
+			"label": "Multi Command Encapsulated Auto Reports",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
+		},
+		"7[0x40]": {
+			"label": "Report Battery State When Triggered",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
 				}
 			]
 		},
@@ -140,5 +275,10 @@
 			"maxValue": 127,
 			"defaultValue": 1
 		}
+	},
+		"metadata": {
+		"inclusion": "Turn the primary controller of Z-Wave network into inclusion mode, triple click tamper switch within 1.5 seconds",
+		"exclusion": "Turn the primary controller of Z-Wave network into exclusion mode, triple click tamper switch within 1.5 seconds",
+		"reset": "Pressing tamper key four times within 1.5 seconds and do not release the tamper key in the 4th  pressed, and the LED will light on. After 3 seconds the LED will turn off, after that within 2 seconds, release the tamper key. If successful, the LED will light on one second. Otherwise, the LED will flash once. IDs are excluded and all settings will reset to factory default."
 	}
 }

--- a/packages/config/config/devices/0x013c/pst02b.json
+++ b/packages/config/config/devices/0x013c/pst02b.json
@@ -105,16 +105,16 @@
 				}
 			]
 		},
-		"6[0x02]": {
+		"6": {
 			"label": "PIR Integrate Illumination",
 			"valueSize": 1,
 			"minValue": 0,
-			"maxValue": 1,
+			"maxValue": 2,
 			"defaultValue": 0,
 			"options": [
 				{
 					"label": "Disable",
-					"value": 1
+					"value": 2
 				},
 				{
 					"label": "Enable",

--- a/packages/config/config/devices/0x013c/pst02b.json
+++ b/packages/config/config/devices/0x013c/pst02b.json
@@ -276,7 +276,7 @@
 			"defaultValue": 1
 		}
 	},
-		"metadata": {
+	"metadata": {
 		"inclusion": "Turn the primary controller of Z-Wave network into inclusion mode, triple click tamper switch within 1.5 seconds",
 		"exclusion": "Turn the primary controller of Z-Wave network into exclusion mode, triple click tamper switch within 1.5 seconds",
 		"reset": "Pressing tamper key four times within 1.5 seconds and do not release the tamper key in the 4th  pressed, and the LED will light on. After 3 seconds the LED will turn off, after that within 2 seconds, release the tamper key. If successful, the LED will light on one second. Otherwise, the LED will flash once. IDs are excluded and all settings will reset to factory default."

--- a/packages/config/config/devices/0x013c/pst02b.json
+++ b/packages/config/config/devices/0x013c/pst02b.json
@@ -43,6 +43,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",
@@ -60,6 +61,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Fahrenheit",
@@ -77,6 +79,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",
@@ -94,6 +97,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",
@@ -111,6 +115,7 @@
 			"minValue": 0,
 			"maxValue": 2,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",
@@ -128,6 +133,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",
@@ -145,6 +151,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 1,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",
@@ -162,6 +169,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Notification Report",
@@ -179,6 +187,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",
@@ -196,6 +205,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 1,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",


### PR DESCRIPTION
- Remove supportsZWavePlus: true
- Update configuration parameters 5, 6, and 7 to use partial parameters
- Add meta section with description for include, exclude, and reset