### PR TITLE
feat(config): add fingerprint to Popp & Co POPE700342

### DIFF
--- a/packages/config/config/devices/0x0154/pope700342.json
+++ b/packages/config/config/devices/0x0154/pope700342.json
@@ -7,7 +7,8 @@
 		{
 			"productType": "0x0004",
 			"productId": "0x000d"
-		},{
+		},
+		{
 			"productType": "0x0004",
 			"productId": "0x0010"
 		}

--- a/packages/config/config/devices/0x0154/pope700342.json
+++ b/packages/config/config/devices/0x0154/pope700342.json
@@ -7,6 +7,9 @@
 		{
 			"productType": "0x0004",
 			"productId": "0x000d"
+		},{
+			"productType": "0x0004",
+			"productId": "0x0010"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
New device comes with FW 3.5 and `productID` set to `0x0010`. I've written an email to Popp support asking if there are any additional changes (their published manual has not been updated and still refers to `0x000d` and FW 3.05 instead).