### PR TITLE
fix(config): update ZCOMBO-G units/metadata

### DIFF
--- a/packages/config/config/devices/0x0138/zcombo-g.json
+++ b/packages/config/config/devices/0x0138/zcombo-g.json
@@ -25,7 +25,7 @@
 		"1": {
 			"label": "SuperVision report timeout",
 			"description": "ZCOMBO will send the message over SuperVision Command Class and it will wait for the SuperVision report from the Controller for the SuperVision report timeout time.",
-			"unit": "seconds",
+			"unit": "ms",
 			"valueSize": 2,
 			"minValue": 500,
 			"maxValue": 5000,
@@ -44,7 +44,7 @@
 		"3": {
 			"label": "SuperVision wait time",
 			"description": "Before retrying the message, ZCOMBO will wait for the SuperVision wait time. Actual wait time is calculated using the formula: Wait Time = SuperVision wait time base-value + random-value + (attempt-count x 5 seconds). The random value will be between 100 and 1100 milliseconds.",
-			"unit": "s",
+			"unit": "seconds",
 			"valueSize": 2,
 			"minValue": 1,
 			"maxValue": 60,
@@ -53,6 +53,7 @@
 		}
 	},
 	"metadata": {
+		"wakeup": "WAKEUP\n1. Slide battery door open and then closed with the batteries inserted.",
 		"inclusion": "ADD\n1. Slide battery door open.\n2. Insert batteries checking the correct orientation.\n3. Press and hold the test button. Keep it held down as you slide the battery drawer closed. You may then release the button.\nNOTE: Use only your finger or thumb on the test button. The use of any other instrument is strictly prohibited",
 		"exclusion": "REMOVE\n1. Slide battery door open.\n2. Remove and re-insert batteries checking the correct orientation.\n3. Press and hold the test button. Keep it held down as you slide the battery drawer closed. You may then release the button.\nNOTE: Use only your finger or thumb on the test button. The use of any other instrument is strictly prohibited",
 		"reset": "RESET DEVICE\nIf the device is powered up with the test button held down for 10+ seconds, the device will reset all Z-Wave settings and leave the network.\nUpon completion of the Reset operation, the LED will glow and the horn will sound for ~1 second.\nPlease use this procedure only when the network primary controller is missing or otherwise inoperable",


### PR DESCRIPTION
I noticed that the SuperVision report timeout was erroneously using seconds instead of milliseconds, so changed to ms as per the style guide, and changed s for the SuperVision wait time to seconds as well, also per the style guide.

Added a wakeup field to metadata as well just to clarify that a short press of the test button is not sufficient to wake the device.