### PR TITLE
fix: avoid including `undefined` properties in configuration metadata

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
@@ -1298,7 +1298,7 @@ alters capabilities: ${!!properties.altersCapabilities}`;
 		for (const [param, info] of config.entries()) {
 			// We need to make the config information compatible with the
 			// format that ConfigurationCC reports
-			const paramInfo: Partial<ConfigurationMetadata> = {
+			const paramInfo: Partial<ConfigurationMetadata> = stripUndefined({
 				// TODO: Make this smarter! (0...1 ==> boolean)
 				type: "number",
 				valueSize: info.valueSize,
@@ -1324,7 +1324,7 @@ alters capabilities: ${!!properties.altersCapabilities}`;
 				label: info.label,
 				description: info.description,
 				isFromConfig: true,
-			};
+			});
 			this.extendParamInformation(
 				param.parameter,
 				param.valueBitMask,


### PR DESCRIPTION
found during investigation of https://github.com/zwave-js/zwavejs2mqtt/issues/1758