### PR TITLE
fix(config): spelling mistake in manufacturer name

### DIFF
--- a/packages/config/config/devices/0x0312/mp24z.json
+++ b/packages/config/config/devices/0x0312/mp24z.json
@@ -1,5 +1,5 @@
 {
-	"manufacturer": "Ministon",
+	"manufacturer": "Minoston",
 	"manufacturerId": "0x0312",
 	"label": "MP24Z",
 	"description": "Outdoor Smart Plug - 2 channel",

--- a/packages/config/config/devices/0x0312/ms13z.json
+++ b/packages/config/config/devices/0x0312/ms13z.json
@@ -1,5 +1,5 @@
 {
-	"manufacturer": "Ministon",
+	"manufacturer": "Minoston",
 	"manufacturerId": "0x0312",
 	"label": "MS13Z",
 	"description": "Smart Dimmer Toggle Switch",


### PR DESCRIPTION
The manufacturer's name was misspelled.

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

PR description here
