### PR TITLE
fix: send S2 public key immediately, ignore KexSet until DSK verified

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -2360,7 +2360,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> {
 								// Ignore errors
 							});
 					} else {
-						// Us not being able to repeatedly decode the command means we need to abort the bootstrapping process
+						// Us repeatedly not being able to decode the command means we need to abort the bootstrapping process
 						// because the PIN is wrong
 						this.controllerLog.logNode(nodeId, {
 							message: `${message}, cannot decode command. Aborting the S2 bootstrapping process...`,


### PR DESCRIPTION
With this PR, the controller's public key is sent to the included node immediately instead of waiting for DSK verification so the node doesn't abort the bootstrapping silently.
Until the DSK is verified, the repeated KexSet from the node are now ignored.

fixes: #3624 

