### PR TITLE
feat: preserve additional entries in provisioning information

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -140,7 +140,9 @@ interface PlannedProvisioningEntry {
 }
 ```
 
-> [!NOTE] The intended use case for this is inclusion after scanning a S2 QR code. Otherwise, care must be taken to give correct information. If the included node has a different DSK than the provided one, the secure inclusion will fail. Furthermore, the node will be granted only those security classes that are requested and the provided list. If there is no overlap, the secure inclusion will fail.
+> [!NOTE] The `provisioning` property accepts `QRProvisioningInformation` which is returned by [`parseQRCodeString`](api/utils.md#parse-s2-or-smartstart-qr-code-strings). You just need to make sure that the QR code is an `S2` QR code by checking the `version` field.
+
+> [!ATTENTION] The intended use case for this is inclusion after scanning a S2 QR code. Otherwise, care must be taken to give correct information. If the included node has a different DSK than the provided one, the secure inclusion will fail. Furthermore, the node will be granted only those security classes that are requested and the provided list. If there is no overlap, the secure inclusion will fail.
 
 ### `stopInclusion`
 
@@ -191,6 +193,8 @@ interface PlannedProvisioningEntry {
 	[prop: string]: any;
 }
 ```
+
+> [!NOTE] This method accepts a `QRProvisioningInformation` which is returned by [`parseQRCodeString`](api/utils.md#parse-s2-or-smartstart-qr-code-strings). You just need to make sure that the QR code is a `SmartStart` QR code by checking the `version` field.
 
 ### `unprovisionSmartStartNode`
 
@@ -324,6 +328,10 @@ type ReplaceNodeOptions =
 	| {
 			strategy: InclusionStrategy.Security_S2;
 			userCallbacks: InclusionUserCallbacks;
+	  }
+	| {
+			strategy: InclusionStrategy.Security_S2;
+			provisioning: PlannedProvisioningEntry;
 	  }
 	| {
 			strategy:

--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -185,32 +185,41 @@ interface PlannedProvisioningEntry {
 	/** The device specific key (DSK) in the form aaaaa-bbbbb-ccccc-ddddd-eeeee-fffff-11111-22222 */
 	dsk: string;
 	securityClasses: SecurityClass[];
+	/**
+	 * Additional properties to be stored in this provisioning entry, e.g. the device ID from a scanned QR code
+	 */
+	[prop: string]: any;
 }
 ```
 
 ### `unprovisionSmartStartNode`
 
 ```ts
-unprovisionSmartStartNode(dskOrNodeId: Buffer | number): void
+unprovisionSmartStartNode(dskOrNodeId: string | number): void
 ```
 
-Removes the given DSK or node ID from the controller's SmartStart provisioning list. The DSK must be given as a buffer.
+Removes the given DSK or node ID from the controller's SmartStart provisioning list.
 
 > [!NOTE] If this entry corresponds to an already-included node, it will **NOT** be excluded.
 
 ### `getProvisioningEntry`
 
 ```ts
-getProvisioningEntry(dsk: Buffer): SmartStartProvisioningEntry | undefined
+getProvisioningEntry(dsk: string): SmartStartProvisioningEntry | undefined
 ```
 
 Returns the entry for the given DSK from the controller's SmartStart provisioning list. The returned entry (if found) has the following shape:
 
 ```ts
 interface SmartStartProvisioningEntry {
-	dsk: Buffer;
+	/** The device specific key (DSK) in the form aaaaa-bbbbb-ccccc-ddddd-eeeee-fffff-11111-22222 */
+	dsk: string;
 	securityClasses: SecurityClass[];
 	nodeId?: number;
+	/**
+	 * Additional properties to be stored in this provisioning entry, e.g. the device ID from a scanned QR code
+	 */
+	[prop: string]: any;
 }
 ```
 

--- a/packages/core/src/security/QR.test.ts
+++ b/packages/core/src/security/QR.test.ts
@@ -39,7 +39,7 @@ describe("QR code parsing", () => {
 		);
 		expect(result).toEqual({
 			version: QRCodeVersion.SmartStart,
-			requestedKeys: [
+			securityClasses: [
 				SecurityClass.S2_Unauthenticated,
 				SecurityClass.S2_Authenticated,
 			],
@@ -60,7 +60,7 @@ describe("QR code parsing", () => {
 		);
 		expect(result).toEqual({
 			version: QRCodeVersion.SmartStart,
-			requestedKeys: [
+			securityClasses: [
 				SecurityClass.S2_Unauthenticated,
 				SecurityClass.S2_Authenticated,
 				SecurityClass.S2_AccessControl,
@@ -83,7 +83,7 @@ describe("QR code parsing", () => {
 		);
 		expect(result).toEqual({
 			version: QRCodeVersion.S2,
-			requestedKeys: [
+			securityClasses: [
 				SecurityClass.S2_Unauthenticated,
 				SecurityClass.S2_Authenticated,
 			],

--- a/packages/core/src/security/QR.ts
+++ b/packages/core/src/security/QR.ts
@@ -87,7 +87,8 @@ export interface ProvisioningInformation_SupportedProtocols {
 
 export type QRProvisioningInformation = {
 	version: QRCodeVersion;
-	requestedKeys: SecurityClass[];
+	/** The security classes that are requested by this device */
+	securityClasses: SecurityClass[];
 	dsk: string;
 } & ProvisioningInformation_ProductType &
 	ProvisioningInformation_ProductId &
@@ -226,11 +227,11 @@ export function parseQRCodeString(qr: string): QRProvisioningInformation {
 	if (checksum !== expectedChecksum) fail("invalid checksum");
 
 	const requestedKeysBitmask = readUInt8(qr, 9);
-	const requestedKeys = parseBitMask(
+	const securityClasses = parseBitMask(
 		Buffer.from([requestedKeysBitmask]),
 		SecurityClass.S2_Unauthenticated,
 	);
-	if (!requestedKeys.every((k) => k in SecurityClass)) {
+	if (!securityClasses.every((k) => k in SecurityClass)) {
 		fail("invalid security class requested");
 	}
 
@@ -244,7 +245,7 @@ export function parseQRCodeString(qr: string): QRProvisioningInformation {
 
 	const ret = {
 		version,
-		requestedKeys,
+		securityClasses,
 		dsk: dskToString(dsk),
 	} as QRProvisioningInformation;
 

--- a/packages/zwave-js/src/lib/controller/Inclusion.ts
+++ b/packages/zwave-js/src/lib/controller/Inclusion.ts
@@ -137,6 +137,10 @@ export interface PlannedProvisioningEntry {
 	/** The device specific key (DSK) in the form aaaaa-bbbbb-ccccc-ddddd-eeeee-fffff-11111-22222 */
 	dsk: string;
 	securityClasses: SecurityClass[];
+	/**
+	 * Additional properties to be stored in this provisioning entry, e.g. the device ID from a scanned QR code
+	 */
+	[prop: string]: any;
 }
 
 export interface IncludedProvisioningEntry extends PlannedProvisioningEntry {


### PR DESCRIPTION
This PR renames the `requestedKeys` property in `QRProvisioningInformation` to `securityClasses` so it matches the signature of the `PlannedProvisioningEntry` and `IncludedProvisioningEntry` interfaces.

This allows directly using a `QRProvisioningInformation` for the inclusion of S2 or SmartStart nodes using `beginInclusion` or `provisionSmartStartNode` respectively.