### PR TITLE
fix: don't serialize node ID in provisioning list

### DIFF
--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -4142,7 +4142,13 @@ ${associatedNodes.join(", ")}`,
 			controller: {
 				supportsSoftReset: this.supportsSoftReset,
 				provisioningList: this.provisioningList.map((e) => {
-					const { dsk, securityClasses, ...rest } = e;
+					const {
+						dsk,
+						securityClasses,
+						// Node ID is not saved - we update it when deserializing nodes
+						nodeId,
+						...rest
+					} = e;
 					return {
 						dsk,
 						securityClasses: securityClasses.map(
@@ -4178,7 +4184,13 @@ ${associatedNodes.join(", ")}`,
 				entries: for (const entry of serialized.controller
 					.provisioningList) {
 					if (!isObject(entry)) continue;
-					const { dsk, securityClasses: secClasses, ...rest } = entry;
+					const {
+						dsk,
+						securityClasses: secClasses,
+						// Node ID is ignored - we update it when deserializing nodes
+						nodeId,
+						...rest
+					} = entry;
 					if (typeof entry.dsk !== "string") continue;
 					if (!isArray(entry.securityClasses)) continue;
 					if (!isValidDSK(entry.dsk)) continue;


### PR DESCRIPTION
This avoids the cache going out of sync when switching between applications