### PR TITLE
fix: gate SmartStart behind SDK 6.81+, add method to test support

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -4,6 +4,24 @@ The controller instance contains information about the controller and a list of 
 
 ## Controller methods
 
+### `supportsFeature`
+
+```ts
+supportsFeature(feature: ZWaveFeature): boolean | undefined
+```
+
+Some Z-Wave features are not available on all controllers and can potentially create unwanted situations. The `supportsFeature` method must be used to check for support before using certain features. It returns a boolean indicating whether the feature is supported or `undefined` if this information isn't known yet.
+
+The available features to test for are:
+
+<!-- #import ZWaveFeature from "zwave-js" -->
+
+```ts
+enum ZWaveFeature {
+	SmartStart,
+}
+```
+
 ### `beginInclusion`
 
 ```ts
@@ -16,10 +34,6 @@ The options parameter is used to specify the inclusion strategy and provide call
 
 -   `InclusionStrategy.Default`: Prefer _Security S2_ if supported, use _Security S0_ if absolutely necessary (e.g. for legacy locks) or if opted in with the `forceSecurity` flag, don't use encryption otherwise.  
     **This is the recommended** strategy and should be used unless there is a good reason not to.
-
--   `InclusionStrategy.SmartStart`: Include using SmartStart (requires Security S2). Can't include devices that do not support SmartStart.  
-    **Should be preferred** over `Default` if supported, because it is easier for the user.  
-    **WARNING:** This is not supported yet!
 
 -   `InclusionStrategy.Insecure`: Don't use encryption, even if supported.  
     **Not recommended**, because S2 should be used where possible.
@@ -177,6 +191,8 @@ provisionSmartStartNode(entry: PlannedProvisioningEntry): void
 ```
 
 Adds the given entry (DSK and security classes) to the controller's SmartStart provisioning list or replaces an existing entry. The node will be included out of band when it powers up.
+
+> [!ATTENTION] This method will throw when SmartStart is not supported by the controller!
 
 The parameter has the following shape:
 

--- a/packages/shared/src/misc.ts
+++ b/packages/shared/src/misc.ts
@@ -89,5 +89,6 @@ export function mergeDeep(
 
 /** Pads a firmware version string, so it can be compared with semver */
 export function padVersion(version: string): string {
+	if (version.split(".").length === 3) return version;
 	return version + ".0";
 }

--- a/packages/zwave-js/src/Controller.ts
+++ b/packages/zwave-js/src/Controller.ts
@@ -4,6 +4,7 @@ export type {
 	ZWaveController,
 } from "./lib/controller/Controller";
 export type { ControllerStatistics } from "./lib/controller/ControllerStatistics";
+export { ZWaveFeature } from "./lib/controller/Features";
 export * from "./lib/controller/Inclusion";
 export type { ZWaveLibraryTypes } from "./lib/controller/ZWaveLibraryTypes";
 export { RFRegion } from "./lib/serialapi/misc/SerialAPISetupMessages";

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -165,7 +165,7 @@ import {
 } from "./ControllerStatistics";
 import { DeleteReturnRouteRequest } from "./DeleteReturnRouteMessages";
 import { DeleteSUCReturnRouteRequest } from "./DeleteSUCReturnRouteMessages";
-import { ZWaveFeature } from "./Features";
+import { minFeatureVersions, ZWaveFeature } from "./Features";
 import {
 	GetControllerCapabilitiesRequest,
 	GetControllerCapabilitiesResponse,
@@ -245,7 +245,9 @@ import { ZWaveLibraryTypes } from "./ZWaveLibraryTypes";
 import { protocolVersionToSDKVersion } from "./ZWaveSDKVersions";
 
 export type HealNodeStatus = "pending" | "done" | "failed" | "skipped";
-type SerialAPIVersion = `${number}.${number}` | `${number}.${number}.${number}`;
+export type SerialAPIVersion =
+	| `${number}.${number}`
+	| `${number}.${number}.${number}`;
 
 export type ThrowingMap<K, V> = Map<K, V> & { getOrThrow(key: K): V };
 export type ReadonlyThrowingMap<K, V> = ReadonlyMap<K, V> & {
@@ -470,7 +472,7 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 	public supportsFeature(feature: ZWaveFeature): boolean | undefined {
 		switch (feature) {
 			case ZWaveFeature.SmartStart:
-				return this.serialApiGte("6.81");
+				return this.serialApiGte(minFeatureVersions[feature]);
 		}
 	}
 
@@ -748,6 +750,14 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
   is SIS present:      ${this._isSISPresent}
   was real primary:    ${this._wasRealPrimary}
   is a SUC:            ${this._isStaticUpdateController}`,
+		);
+		this.driver.controllerLog.print(
+			`supported Z-Wave features: ${Object.keys(ZWaveFeature)
+				.filter((k) => /^\d+$/.test(k))
+				.map((k) => parseInt(k) as ZWaveFeature)
+				.filter((feat) => this.supportsFeature(feat))
+				.map((feat) => `\n  · ${getEnumMemberName(ZWaveFeature, feat)}`)
+				.join("")}`,
 		);
 
 		// Figure out which sub commands of SerialAPISetup are supported

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -728,6 +728,15 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
   library version: ${this._libraryVersion}`,
 		);
 
+		this.driver.controllerLog.print(
+			`supported Z-Wave features: ${Object.keys(ZWaveFeature)
+				.filter((k) => /^\d+$/.test(k))
+				.map((k) => parseInt(k) as ZWaveFeature)
+				.filter((feat) => this.supportsFeature(feat))
+				.map((feat) => `\n  · ${getEnumMemberName(ZWaveFeature, feat)}`)
+				.join("")}`,
+		);
+
 		// find out what the controller can do
 		this.driver.controllerLog.print(`querying controller capabilities...`);
 		const ctrlCaps =
@@ -750,14 +759,6 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
   is SIS present:      ${this._isSISPresent}
   was real primary:    ${this._wasRealPrimary}
   is a SUC:            ${this._isStaticUpdateController}`,
-		);
-		this.driver.controllerLog.print(
-			`supported Z-Wave features: ${Object.keys(ZWaveFeature)
-				.filter((k) => /^\d+$/.test(k))
-				.map((k) => parseInt(k) as ZWaveFeature)
-				.filter((feat) => this.supportsFeature(feat))
-				.map((feat) => `\n  · ${getEnumMemberName(ZWaveFeature, feat)}`)
-				.join("")}`,
 		);
 
 		// Figure out which sub commands of SerialAPISetup are supported

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -165,6 +165,7 @@ import {
 } from "./ControllerStatistics";
 import { DeleteReturnRouteRequest } from "./DeleteReturnRouteMessages";
 import { DeleteSUCReturnRouteRequest } from "./DeleteSUCReturnRouteMessages";
+import { ZWaveFeature } from "./Features";
 import {
 	GetControllerCapabilitiesRequest,
 	GetControllerCapabilitiesResponse,
@@ -241,9 +242,10 @@ import {
 } from "./SetSerialApiTimeoutsMessages";
 import { SetSUCNodeIdRequest } from "./SetSUCNodeIDMessages";
 import { ZWaveLibraryTypes } from "./ZWaveLibraryTypes";
+import { protocolVersionToSDKVersion } from "./ZWaveSDKVersions";
 
 export type HealNodeStatus = "pending" | "done" | "failed" | "skipped";
-type SerialAPIVersion = `${number}.${number}`;
+type SerialAPIVersion = `${number}.${number}` | `${number}.${number}.${number}`;
 
 export type ThrowingMap<K, V> = Map<K, V> & { getOrThrow(key: K): V };
 export type ReadonlyThrowingMap<K, V> = ReadonlyMap<K, V> & {
@@ -370,46 +372,42 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 
 	/** Checks if the Serial API version is greater than the given one */
 	public serialApiGt(version: SerialAPIVersion): boolean | undefined {
-		if (this._serialApiVersion === undefined) {
+		// TODO: Rename these to sdkVersionGt(e) etc...
+		if (this._libraryVersion === undefined) {
 			return undefined;
 		}
-		return semver.gt(
-			padVersion(this._serialApiVersion),
-			padVersion(version),
-		);
+		const sdkVersion = protocolVersionToSDKVersion(this._libraryVersion);
+		return semver.gt(padVersion(sdkVersion), padVersion(version));
 	}
 
 	/** Checks if the Serial API version is greater than or equal to the given one */
 	public serialApiGte(version: SerialAPIVersion): boolean | undefined {
-		if (this._serialApiVersion === undefined) {
+		// TODO: Rename these to sdkVersionGt(e) etc...
+		if (this._libraryVersion === undefined) {
 			return undefined;
 		}
-		return semver.gte(
-			padVersion(this._serialApiVersion),
-			padVersion(version),
-		);
+		const sdkVersion = protocolVersionToSDKVersion(this._libraryVersion);
+		return semver.gte(padVersion(sdkVersion), padVersion(version));
 	}
 
 	/** Checks if the Serial API version is lower than the given one */
 	public serialApiLt(version: SerialAPIVersion): boolean | undefined {
-		if (this._serialApiVersion === undefined) {
+		// TODO: Rename these to sdkVersionGt(e) etc...
+		if (this._libraryVersion === undefined) {
 			return undefined;
 		}
-		return semver.lt(
-			padVersion(this._serialApiVersion),
-			padVersion(version),
-		);
+		const sdkVersion = protocolVersionToSDKVersion(this._libraryVersion);
+		return semver.lt(padVersion(sdkVersion), padVersion(version));
 	}
 
 	/** Checks if the Serial API version is lower than or equal to the given one */
 	public serialApiLte(version: SerialAPIVersion): boolean | undefined {
-		if (this._serialApiVersion === undefined) {
+		// TODO: Rename these to sdkVersionGt(e) etc...
+		if (this._libraryVersion === undefined) {
 			return undefined;
 		}
-		return semver.lte(
-			padVersion(this._serialApiVersion),
-			padVersion(version),
-		);
+		const sdkVersion = protocolVersionToSDKVersion(this._libraryVersion);
+		return semver.lte(padVersion(sdkVersion), padVersion(version));
 	}
 
 	private _manufacturerId: number | undefined;
@@ -463,6 +461,27 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 			);
 		}
 		return this._supportedSerialAPISetupCommands.indexOf(command) > -1;
+	}
+
+	/**
+	 * Tests if the controller supports a certain feature.
+	 * Returns `undefined` if this information isn't known yet.
+	 */
+	public supportsFeature(feature: ZWaveFeature): boolean | undefined {
+		switch (feature) {
+			case ZWaveFeature.SmartStart:
+				return this.serialApiGte("6.81");
+		}
+	}
+
+	/** Throws if the controller does not support a certain feature */
+	private assertFeature(feature: ZWaveFeature): void {
+		if (!this.supportsFeature(feature)) {
+			throw new ZWaveError(
+				`The controller does not support the ${feature} feature`,
+				ZWaveErrorCodes.Controller_NotSupported,
+			);
+		}
 	}
 
 	private _sucNodeId: number | undefined;
@@ -533,6 +552,9 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 
 	/** Adds the given entry (DSK and security classes) to the controller's SmartStart provisioning list or replaces an existing entry */
 	public provisionSmartStartNode(entry: PlannedProvisioningEntry): void {
+		// Make sure the controller supports SmartStart
+		this.assertFeature(ZWaveFeature.SmartStart);
+
 		const index = this._provisioningList.findIndex(
 			(e) => e.dsk === entry.dsk,
 		);
@@ -603,6 +625,9 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 	 * Automatically starts smart start inclusion if there are nodes pending inclusion.
 	 */
 	public autoProvisionSmartStart(): void {
+		// Make sure the controller supports SmartStart
+		if (!this.supportsFeature(ZWaveFeature.SmartStart)) return;
+
 		if (this.hasPlannedProvisioningEntries()) {
 			// SmartStart should be enabled
 			// eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -1038,7 +1063,11 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 	private setInclusionState(state: InclusionState): void {
 		if (this._inclusionState === state) return;
 		this._inclusionState = state;
-		if (state === InclusionState.Idle && this._smartStartEnabled) {
+		if (
+			state === InclusionState.Idle &&
+			this._smartStartEnabled &&
+			this.supportsFeature(ZWaveFeature.SmartStart)
+		) {
 			// If Smart Start was enabled before the inclusion/exclusion,
 			// enable it again and ignore errors
 
@@ -1315,6 +1344,13 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 	 * Resolves to `true` when the listening mode is started or was active, and `false` if it is scheduled for later activation.
 	 */
 	private async enableSmartStart(): Promise<boolean> {
+		if (!this.supportsFeature(ZWaveFeature.SmartStart)) {
+			this.driver.controllerLog.print(
+				`Smart Start is not supported by this controller, NOT enabling listening mode...`,
+				"warn",
+			);
+		}
+
 		this._smartStartEnabled = true;
 
 		if (this._inclusionState === InclusionState.Idle) {
@@ -1357,6 +1393,7 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 	 * Resolves to `true` when the listening mode is stopped, and `false` if was not active.
 	 */
 	private async disableSmartStart(): Promise<boolean> {
+		if (!this.supportsFeature(ZWaveFeature.SmartStart)) return true;
 		this._smartStartEnabled = false;
 
 		if (this._inclusionState === InclusionState.SmartStart) {

--- a/packages/zwave-js/src/lib/controller/Features.ts
+++ b/packages/zwave-js/src/lib/controller/Features.ts
@@ -1,0 +1,5 @@
+/** A named list of Z-Wave features */
+export enum ZWaveFeature {
+	// Available starting with Z-Wave SDK 6.81
+	SmartStart,
+}

--- a/packages/zwave-js/src/lib/controller/Features.ts
+++ b/packages/zwave-js/src/lib/controller/Features.ts
@@ -1,5 +1,11 @@
+import type { SerialAPIVersion } from "./Controller";
+
 /** A named list of Z-Wave features */
 export enum ZWaveFeature {
 	// Available starting with Z-Wave SDK 6.81
 	SmartStart,
 }
+
+export const minFeatureVersions: Record<ZWaveFeature, SerialAPIVersion> = {
+	[ZWaveFeature.SmartStart]: "6.81",
+};

--- a/packages/zwave-js/src/lib/controller/ZWaveSDKVersions.ts
+++ b/packages/zwave-js/src/lib/controller/ZWaveSDKVersions.ts
@@ -334,6 +334,9 @@ const versions = Object.freeze([
  * Defaults to the protocol version itself, which is the case for v7+
  */
 export function protocolVersionToSDKVersion(protocolVersion: string): string {
+	if (protocolVersion.startsWith("Z-Wave ")) {
+		protocolVersion = protocolVersion.substr(7);
+	}
 	return (
 		versions.find((v) => v.protocolVersion === protocolVersion)
 			?.sdkVersion ?? protocolVersion

--- a/packages/zwave-js/src/lib/controller/ZWaveSDKVersions.ts
+++ b/packages/zwave-js/src/lib/controller/ZWaveSDKVersions.ts
@@ -2,217 +2,340 @@
 const versions = Object.freeze([
 	// Z-Wave 700 uses 7.x SDK versions but also a different NVM format,
 	// so they don't appear here. The entries below this line are for the 500 series
+
+	// sdkVersion is formatted in a way that it is parsable by semver
+	// protocolVersion comes from the Z-Wave SDK and must not be reformatted
+
 	{
-		sdkVersion: "6.84.00",
+		sdkVersion: "6.84.0",
 		protocolVersion: "6.10.00",
 		serialAPIVersion: "8",
 	},
 	{
-		sdkVersion: "6.82.01",
+		sdkVersion: "6.82.1",
 		protocolVersion: "6.09.00",
 		serialAPIVersion: "8",
 	},
 	{
-		sdkVersion: "6.82.00",
+		sdkVersion: "6.82.0",
 		protocolVersion: "6.08.00",
 		serialAPIVersion: "8",
 	},
 	{
-		sdkVersion: "6.81.06",
+		sdkVersion: "6.81.6",
 		protocolVersion: "6.07.00",
 		serialAPIVersion: "8",
 	},
 	{
-		sdkVersion: "6.81.05",
+		sdkVersion: "6.81.5",
 		protocolVersion: "6.06.00",
 		serialAPIVersion: "8",
 	},
 	{
-		sdkVersion: "6.81.04",
+		sdkVersion: "6.81.4",
 		protocolVersion: "6.05.00",
 		serialAPIVersion: "8",
 	},
 	{
-		sdkVersion: "6.81.03",
+		sdkVersion: "6.81.3",
 		protocolVersion: "6.04.00",
 		serialAPIVersion: "8",
 	},
 	{
-		sdkVersion: "6.81.02",
+		sdkVersion: "6.81.2",
 		protocolVersion: "6.03.00",
 		serialAPIVersion: "8",
 	},
 	{
-		sdkVersion: "6.81.01",
+		sdkVersion: "6.81.1",
 		protocolVersion: "6.02.00",
 		serialAPIVersion: "8",
 	},
 	{
-		sdkVersion: "6.81.00",
+		sdkVersion: "6.81.0",
 		protocolVersion: "6.01.00",
 		serialAPIVersion: "8",
 	},
 	{
-		sdkVersion: "6.80.00 Beta",
+		sdkVersion: "6.80.0-beta",
 		protocolVersion: "6.01.00",
 		serialAPIVersion: "8",
 	},
 	{
-		sdkVersion: "6.71.03",
+		sdkVersion: "6.71.3",
 		protocolVersion: "5.03.00",
 		serialAPIVersion: "7",
 	},
 	{
-		sdkVersion: "6.71.02",
+		sdkVersion: "6.71.2",
 		protocolVersion: "5.02.00",
 		serialAPIVersion: "7",
 	},
 	{
-		sdkVersion: "6.71.01",
+		sdkVersion: "6.71.1",
 		protocolVersion: "4.61",
 		serialAPIVersion: "7",
 	},
 	{
-		sdkVersion: "6.71.00",
+		sdkVersion: "6.71.0",
 		protocolVersion: "4.60",
 		serialAPIVersion: "7",
 	},
 	{
-		sdkVersion: "6.70.01 Beta",
+		sdkVersion: "6.70.1-beta",
 		protocolVersion: "4.45",
 		serialAPIVersion: "6",
 	},
 	{
-		sdkVersion: "6.70.00 Beta",
+		sdkVersion: "6.70.0-beta",
 		protocolVersion: "4.28",
 		serialAPIVersion: "6",
 	},
 	{
-		sdkVersion: "6.61.01",
+		sdkVersion: "6.61.1",
 		protocolVersion: "4.62",
 		serialAPIVersion: "6",
 	},
 	{
-		sdkVersion: "6.61.00",
+		sdkVersion: "6.61.0",
 		protocolVersion: "4.33",
 		serialAPIVersion: "6",
 	},
 	{
-		sdkVersion: "6.60.00 Beta",
+		sdkVersion: "6.60.0-beta",
 		protocolVersion: "4.12",
 		serialAPIVersion: "6",
 	},
-	{ sdkVersion: "6.51.10", protocolVersion: "4.54", serialAPIVersion: "5" },
-	{ sdkVersion: "6.51.09", protocolVersion: "4.38", serialAPIVersion: "5" },
-	{ sdkVersion: "6.51.08", protocolVersion: "4.34", serialAPIVersion: "5" },
-	{ sdkVersion: "6.51.07", protocolVersion: "4.24", serialAPIVersion: "5" },
-	{ sdkVersion: "6.51.06", protocolVersion: "4.05", serialAPIVersion: "5" },
-	{ sdkVersion: "6.51.04", protocolVersion: "4.01", serialAPIVersion: "5" },
-	{ sdkVersion: "6.51.03", protocolVersion: "3.99", serialAPIVersion: "5" },
-	{ sdkVersion: "6.51.02", protocolVersion: "3.95", serialAPIVersion: "5" },
-	{ sdkVersion: "6.51.01", protocolVersion: "3.92", serialAPIVersion: "5" },
-	{ sdkVersion: "6.51.00", protocolVersion: "3.83", serialAPIVersion: "5" },
-	{ sdkVersion: "6.50.01", protocolVersion: "3.79", serialAPIVersion: "5" },
-	{ sdkVersion: "6.50.00", protocolVersion: "3.71", serialAPIVersion: "5" },
+	{
+		sdkVersion: "6.51.10",
+		protocolVersion: "4.54",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "6.51.9",
+		protocolVersion: "4.38",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "6.51.8",
+		protocolVersion: "4.34",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "6.51.7",
+		protocolVersion: "4.24",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "6.51.6",
+		protocolVersion: "4.05",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "6.51.4",
+		protocolVersion: "4.01",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "6.51.3",
+		protocolVersion: "3.99",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "6.51.2",
+		protocolVersion: "3.95",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "6.51.1",
+		protocolVersion: "3.92",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "6.51.0",
+		protocolVersion: "3.83",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "6.50.1",
+		protocolVersion: "3.79",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "6.50.0",
+		protocolVersion: "3.71",
+		serialAPIVersion: "5",
+	},
 	// The entries below this line are for the 300 or 400 series
 	{
-		sdkVersion: "6.11.01 (JP)",
+		sdkVersion: "6.11.1", // JP only
 		protocolVersion: "3.53",
 		serialAPIVersion: "5",
 	},
 	{
-		sdkVersion: "6.11.00 (JP)",
+		sdkVersion: "6.11.0", // JP only
 		protocolVersion: "3.45",
 		serialAPIVersion: "5",
 	},
 	{
-		sdkVersion: "6.10.01 (JP)",
+		sdkVersion: "6.10.1", // JP only
 		protocolVersion: "3.38",
 		serialAPIVersion: "5",
 	},
-	{ sdkVersion: "6.10.00", protocolVersion: "3.35", serialAPIVersion: "5" },
-	{ sdkVersion: "6.02.00", protocolVersion: "3.41", serialAPIVersion: "5" },
-	{ sdkVersion: "6.01.03", protocolVersion: "3.37", serialAPIVersion: "5" },
-	{ sdkVersion: "6.01.02", protocolVersion: "3.33", serialAPIVersion: "5" },
 	{
-		sdkVersion: "6.01.01 (2-ch)",
+		sdkVersion: "6.10.0",
+		protocolVersion: "3.35",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "6.2.0",
+		protocolVersion: "3.41",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "6.1.3",
+		protocolVersion: "3.37",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "6.1.2",
+		protocolVersion: "3.33",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "6.1.1", // 2-ch
 		protocolVersion: "3.26",
 		serialAPIVersion: "5",
 	},
-	{ sdkVersion: "6.01.00", protocolVersion: "3.10", serialAPIVersion: "5" },
 	{
-		sdkVersion: "6.00.05 Beta 1",
+		sdkVersion: "6.1.0",
+		protocolVersion: "3.10",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "6.0.5-beta",
 		protocolVersion: "3.07",
 		serialAPIVersion: "5",
 	},
 	{
-		sdkVersion: "6.00.04 Beta 1",
+		sdkVersion: "6.0.4-beta",
 		protocolVersion: "3.06",
 		serialAPIVersion: "5",
 	},
 	{
-		sdkVersion: "6.00 Beta 1 Patch 3",
+		sdkVersion: "6.0.3-beta",
 		protocolVersion: "3.04",
 		serialAPIVersion: "5",
 	},
 	{
-		sdkVersion: "6.00 Beta 1 Patch 2",
+		sdkVersion: "6.0.2-beta",
 		protocolVersion: "3.03",
 		serialAPIVersion: "5",
 	},
 	{
-		sdkVersion: "6.00 Beta 1 Patch 1",
+		sdkVersion: "6.0.1-beta",
 		protocolVersion: "2.99",
 		serialAPIVersion: "5",
 	},
 	{
-		sdkVersion: "6.00 Beta 1",
+		sdkVersion: "6.0.0-beta",
 		protocolVersion: "2.96",
 		serialAPIVersion: "5",
 	},
-	{ sdkVersion: "5.03.00", protocolVersion: "3.28", serialAPIVersion: "5" },
 	{
-		sdkVersion: "5.02 Patch 3",
+		sdkVersion: "5.3.0",
+		protocolVersion: "3.28",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "5.2.3",
 		protocolVersion: "2.78",
 		serialAPIVersion: "5",
 	},
 	{
-		sdkVersion: "5.02 Patch 2",
+		sdkVersion: "5.2.2",
 		protocolVersion: "2.64",
 		serialAPIVersion: "5",
 	},
 	{
-		sdkVersion: "5.02 Patch 1",
+		sdkVersion: "5.2.1",
 		protocolVersion: "2.51",
 		serialAPIVersion: "5",
 	},
-	{ sdkVersion: "5.02", protocolVersion: "2.48", serialAPIVersion: "5" },
-	{ sdkVersion: "5.01", protocolVersion: "2.36", serialAPIVersion: "5" },
 	{
-		sdkVersion: "5.00 Beta 1 Patch 1",
+		sdkVersion: "5.2.0",
+		protocolVersion: "2.48",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "5.1.0",
+		protocolVersion: "2.36",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "5.0.1-beta",
 		protocolVersion: "2.22",
 		serialAPIVersion: "5",
 	},
 	{
-		sdkVersion: "5.00 Beta 1",
+		sdkVersion: "5.0.0-beta",
 		protocolVersion: "2.16",
 		serialAPIVersion: "5",
 	},
-	{ sdkVersion: "4.55.00", protocolVersion: "3.67", serialAPIVersion: "5" },
-	{ sdkVersion: "4.54.02", protocolVersion: "3.52", serialAPIVersion: "5" },
-	{ sdkVersion: "4.54.01", protocolVersion: "3.42", serialAPIVersion: "5" },
-	{ sdkVersion: "4.54.00", protocolVersion: "3.40", serialAPIVersion: "5" },
-	{ sdkVersion: "4.53.01", protocolVersion: "3.36", serialAPIVersion: "5" },
-	{ sdkVersion: "4.53.00", protocolVersion: "3.34", serialAPIVersion: "5" },
-	{ sdkVersion: "4.52.01", protocolVersion: "3.22", serialAPIVersion: "5" },
-	{ sdkVersion: "4.52.00", protocolVersion: "3.20", serialAPIVersion: "5" },
-	{ sdkVersion: "4.51", protocolVersion: "2.97", serialAPIVersion: "5" },
+	{
+		sdkVersion: "4.55.0",
+		protocolVersion: "3.67",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "4.54.2",
+		protocolVersion: "3.52",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "4.54.1",
+		protocolVersion: "3.42",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "4.54.0",
+		protocolVersion: "3.40",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "4.53.1",
+		protocolVersion: "3.36",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "4.53.0",
+		protocolVersion: "3.34",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "4.52.1",
+		protocolVersion: "3.22",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "4.52.0",
+		protocolVersion: "3.20",
+		serialAPIVersion: "5",
+	},
+	{
+		sdkVersion: "4.51.0",
+		protocolVersion: "2.97",
+		serialAPIVersion: "5",
+	},
 ]);
 
-/** Looks up which SDK version is being used for a given protocol version */
-export function protocolVersionToSDKVersion(
-	protocolVersion: string,
-): string | undefined {
-	return versions.find((v) => v.protocolVersion === protocolVersion)
-		?.sdkVersion;
+/**
+ * Looks up which SDK version is being used for a given protocol version.
+ * Defaults to the protocol version itself, which is the case for v7+
+ */
+export function protocolVersionToSDKVersion(protocolVersion: string): string {
+	return (
+		versions.find((v) => v.protocolVersion === protocolVersion)
+			?.sdkVersion ?? protocolVersion
+	);
 }


### PR DESCRIPTION
New investigations have shown that SmartStart is only supported in SDK 6.81+ and using it will prevent inclusion of new nodes on older sticks. Therefore it is now gated by the SDK version and trying to provision a node on an older stick will throw. Already provisioned nodes will stay on the list but won't be auto-included.

Before using SmartStart, checking for support is now mandatory with `controller.supportsFeature(ZWaveFeature.SmartStart)`.

fixes: #2320