### PR TITLE
fix(config): correct LED Indicator Control parameter for ZEN27

### DIFF
--- a/packages/config/config/devices/0x027a/zen27_2.1-2.6.json
+++ b/packages/config/config/devices/0x027a/zen27_2.1-2.6.json
@@ -58,7 +58,7 @@
 					"value": 0
 				},
 				{
-					"label": "LED is on when switch is off",
+					"label": "LED is on when switch is on",
 					"value": 1
 				},
 				{


### PR DESCRIPTION
Per Zooz's documentation:
https://www.support.getzooz.com/kb/article/314-zen27-s2-dimmer-ver-3-01-advanced-settings/

LED Indicator Control
Values: 0 – LED indicator is on when switch is off, LED indicator is off when switch is on (default); 1 – LED indicator is on when switch is on, LED indicator is off when switch is off; 2 – LED indicator is always OFF; 3 – LED indicator is always ON. NOTE: tap the upper paddle 6 times quickly to change this mode.

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

Fixed LED Indicator Control parameter for ZEN27
