### PR TITLE
fix(config): spelling in label for Honeywell 39349 

### DIFF
--- a/packages/config/config/devices/0x0039/39349.json
+++ b/packages/config/config/devices/0x0039/39349.json
@@ -31,7 +31,7 @@
 					"value": 0
 				},
 				{
-					"label": "Led on when load is on, LED off when laod is off (default)",
+					"label": "Led on when load is on, LED off when load is off (default)",
 					"value": 1
 				},
 				{


### PR DESCRIPTION
Fix spelling for "load" on Honeywell 39349 / ZW1002
