### PR TITLE
refactor: remove unsupported route parameter from SendDataBridgeRequest

### DIFF
--- a/packages/zwave-js/src/lib/controller/SendDataBridgeMessages.ts
+++ b/packages/zwave-js/src/lib/controller/SendDataBridgeMessages.ts
@@ -60,7 +60,6 @@ interface SendDataBridgeRequestOptions<
 > extends MessageBaseOptions {
 	command: CCType;
 	sourceNodeId?: number;
-	route?: [number, number, number, number];
 	transmitOptions?: TransmitOptions;
 	maxSendAttempts?: number;
 }
@@ -84,16 +83,8 @@ export class SendDataBridgeRequest<CCType extends CommandClass = CommandClass>
 			);
 		}
 
-		if (options.route && options.route.length !== 4) {
-			throw new ZWaveError(
-				`The route must consist of exactly 4 entries!`,
-				ZWaveErrorCodes.Argument_Invalid,
-			);
-		}
-
 		this.sourceNodeId =
 			options.sourceNodeId ?? driver.controller.ownNodeId!;
-		this.route = options.route ?? [0, 0, 0, 0];
 
 		this.command = options.command;
 		this.transmitOptions =
@@ -109,8 +100,6 @@ export class SendDataBridgeRequest<CCType extends CommandClass = CommandClass>
 	public command: SinglecastCC<CCType>;
 	/** Options regarding the transmission of the message */
 	public transmitOptions: TransmitOptions;
-	/** Which route to use for the transmission */
-	public route: [number, number, number, number];
 
 	private _maxSendAttempts: number = 1;
 	/** The number of times the driver may try to send this message */
@@ -130,14 +119,7 @@ export class SendDataBridgeRequest<CCType extends CommandClass = CommandClass>
 				serializedCC.length,
 			]),
 			serializedCC,
-			Buffer.from([
-				this.transmitOptions,
-				this.route[0],
-				this.route[1],
-				this.route[2],
-				this.route[3],
-				this.callbackId,
-			]),
+			Buffer.from([this.transmitOptions, 0, 0, 0, 0, this.callbackId]),
 		]);
 
 		return super.serialize();
@@ -158,7 +140,6 @@ export class SendDataBridgeRequest<CCType extends CommandClass = CommandClass>
 			message: {
 				"source node id": this.sourceNodeId,
 				"transmit options": num2hex(this.transmitOptions),
-				route: this.route.join(", "),
 				"callback id": this.callbackId,
 			},
 		};

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -3450,10 +3450,7 @@ ${handlers.length} left`,
 	/** Wraps a CC in the correct SendData message to use for sending */
 	public createSendDataMessage(
 		command: CommandClass,
-		options: Pick<
-			SendCommandOptions,
-			"autoEncapsulate" | "maxSendAttempts" | "transmitOptions"
-		> = {},
+		options: Omit<SendCommandOptions, keyof SendMessageOptions> = {},
 	): SendDataMessage {
 		let msg: SendDataMessage;
 		if (command.isSinglecast()) {


### PR DESCRIPTION
Apparently it was never supported by 500-series sticks (SDK 6.x+), so we can just remove it.