### PR TITLE
feat: implement node/route health check

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -349,6 +349,8 @@ checkHealth(
 
 Checks the health of connection between the controller and this node and returns the results. The test is done in multiple rounds (1...10, default: 5), which can be configured using the first parameter. To monitor the progress, the optional `onProgress` callback can be used.
 
+> [!WARNING] This should **NOT** be done while there is a lot of traffic on the network because it will negatively impact the test results.
+
 The returned object contains the measurements of each round as well as a final rating (which is the worst of all round ratings):
 
 ```ts

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -429,6 +429,8 @@ The health rating is computed similar to Silabs' PC Controller IMA tool where 10
 
 > [!NOTE] This test builds on some functionality that is not available for all controller or nodes. If the node does not support `Powerlevel CC` or the controller does not support TX reports, this check will be less reliable.
 
+> [!NOTE] The test results are also printed to the driver logs. If you want to format the results in the same way in your application, you can use the `formatLifelineHealthCheckSummary` and/or `formatLifelineHealthCheckRound` methods which are exposed from `zwave-js/Utils`.
+
 ### `checkRouteHealth`
 
 ```ts
@@ -510,6 +512,8 @@ The health rating expressed as a number from 0 (not working at all) to 10 (perfe
 |   ❌ 0 |           10 |                - |               - |
 
 > [!NOTE] Due to missing insight into re-routing attempts between two nodes, some of the values for the lifeline health rating don't exist here. Furthermore, it is not guaranteed that a route between two nodes and lifeline with the same health rating have the same quality.
+
+> [!NOTE] The test results are also printed to the driver logs. If you want to format the results in the same way in your application, you can use the `formatRouteHealthCheckSummary` and/or `formatRouteHealthCheckRound` methods which are exposed from `zwave-js/Utils`.
 
 ## ZWaveNode properties
 

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -404,22 +404,22 @@ interface LifelineHealthCheckResult {
 
 The health rating is computed similar to Silabs' PC Controller IMA tool where 10 means _perfect_ and 0 means _not working at all_. The following table shows which requirements must be fulfilled to achieve a given rating. If the min. powerlevel or SNR margin can not be measured, the condition is assumed to be fulfilled.
 
-| Rating | Failed pings | Route changes | No. of neighbors | min. powerlevel | SNR margin |
-| -----: | -----------: | ------------: | ---------------: | --------------: | ---------: |
-|  ✅ 10 |            0 |             0 |              > 2 |        ≤ −6 dBm |   ≥ 17 dBm |
-|   🟢 9 |            0 |             1 |              > 2 |        ≤ −6 dBm |   ≥ 17 dBm |
-|   🟢 8 |            0 |           ≤ 1 |              ≤ 2 |        ≤ −6 dBm |   ≥ 17 dBm |
-|   🟢 7 |            0 |           ≤ 1 |              > 2 |               - |          - |
-|   🟢 6 |            0 |           ≤ 1 |              ≤ 2 |               - |          - |
-|        |              |               |                  |                 |            |
-|   🟡 5 |            0 |           ≤ 4 |                - |               - |          - |
-|   🟡 4 |            0 |           > 4 |                - |               - |          - |
-|        |              |               |                  |                 |            |
-|   🔴 3 |            1 |             - |                - |               - |          - |
-|   🔴 2 |            2 |             - |                - |               - |          - |
-|   🔴 1 |          ≤ 9 |             - |                - |               - |          - |
-|        |              |               |                  |                 |            |
-|   ❌ 0 |           10 |             - |                - |               - |          - |
+| Rating | Failed pings |   Latency | No. of neighbors | min. powerlevel | SNR margin |
+| -----: | -----------: | --------: | ---------------: | --------------: | ---------: |
+|  ✅ 10 |            0 |   ≤ 50 ms |              > 2 |        ≤ −6 dBm |   ≥ 17 dBm |
+|   🟢 9 |            0 |  ≤ 100 ms |              > 2 |        ≤ −6 dBm |   ≥ 17 dBm |
+|   🟢 8 |            0 |  ≤ 100 ms |              ≤ 2 |        ≤ −6 dBm |   ≥ 17 dBm |
+|   🟢 7 |            0 |  ≤ 100 ms |              > 2 |               - |          - |
+|   🟢 6 |            0 |  ≤ 100 ms |              ≤ 2 |               - |          - |
+|        |              |           |                  |                 |            |
+|   🟡 5 |            0 |  ≤ 250 ms |                - |               - |          - |
+|   🟡 4 |            0 |  ≤ 500 ms |                - |               - |          - |
+|        |              |           |                  |                 |            |
+|   🔴 3 |            1 | ≤ 1000 ms |                - |               - |          - |
+|   🔴 2 |          ≤ 2 | > 1000 ms |                - |               - |          - |
+|   🔴 1 |          ≤ 9 |         - |                - |               - |          - |
+|        |              |           |                  |                 |            |
+|   ❌ 0 |           10 |         - |                - |               - |          - |
 
 > [!NOTE] This test builds on some functionality that is not available for all controller or nodes. If the node does not support `Powerlevel CC` or the controller does not support TX reports, this check will be less reliable.
 

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -338,25 +338,25 @@ Depending on the number of test frames and involved hops, this may take a while.
 
 > [!ATTENTION] This will throw when the target node is a FLiRS node or a sleeping node that is not awake.
 
-### `checkHealth`
+### `checkLifelineHealth`
 
 ```ts
-checkHealth(
+checkLifelineHealth(
 	rounds?: number,
 	onProgress?: (round: number, totalRounds: number, lastRating: number) => void,
 ): Promise<HealthCheckSummary>
 ```
 
-Checks the health of connection between the controller and this node and returns the results. The test is done in multiple rounds (1...10, default: 5), which can be configured using the first parameter. To monitor the progress, the optional `onProgress` callback can be used.
+Checks the health of the connection between the controller and this node and returns the results. The test is done in multiple rounds (1...10, default: 5), which can be configured using the first parameter. To monitor the progress, the optional `onProgress` callback can be used.
 
 > [!WARNING] This should **NOT** be done while there is a lot of traffic on the network because it will negatively impact the test results.
 
 The returned object contains the measurements of each round as well as a final rating (which is the worst of all round ratings):
 
 ```ts
-interface HealthCheckSummary {
+interface LifelineHealthCheckSummary {
 	/** The check results of each round */
-	results: HealthCheckResult[];
+	results: LifelineHealthCheckResult[];
 	/** The health rating expressed as a number from 0 (not working at all) to 10 (perfect connectivity). */
 	rating: number;
 }
@@ -364,10 +364,10 @@ interface HealthCheckSummary {
 
 where each result looks as follows:
 
-<!-- #import HealthCheckResult from "zwave-js" -->
+<!-- #import LifelineHealthCheckResult from "zwave-js" -->
 
 ```ts
-interface HealthCheckResult {
+interface LifelineHealthCheckResult {
 	/**
 	 * How many route changes were needed. Lower = better, ideally 0.
 	 *
@@ -397,7 +397,7 @@ interface HealthCheckResult {
 	 */
 	snrMargin?: number;
 
-	/** See {@link HealthCheckSummary.rating} */
+	/** See {@link LifelineHealthCheckSummary.rating} */
 	rating: number;
 }
 ```

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -369,11 +369,17 @@ where each result looks as follows:
 ```ts
 interface LifelineHealthCheckResult {
 	/**
-	 * How many route changes were needed. Lower = better, ideally 0.
+	 * How many times at least one new route was needed. Lower = better, ideally 0.
 	 *
 	 * Only available if the controller supports TX reports.
 	 */
 	routeChanges?: number;
+	/**
+	 * The maximum time it took to send a ping to the node. Lower = better, ideally 10 ms.
+	 *
+	 * Will use the time in TX reports if available, otherwise fall back to measuring the round trip time.
+	 */
+	latency: number;
 	/** How many routing neighbors this node has. Higher = better, ideally > 2. */
 	numNeighbors: number;
 	/** How many pings were not ACKed by the node. Lower = better, ideally 0. */

--- a/packages/shared/src/misc.test.ts
+++ b/packages/shared/src/misc.test.ts
@@ -1,4 +1,4 @@
-import { throttle } from "./misc";
+import { discreteBinarySearch, throttle } from "./misc";
 
 describe("throttle()", () => {
 	const originalDateNow = Date.now;
@@ -84,5 +84,79 @@ describe("throttle()", () => {
 		expect(spy).toHaveBeenCalledTimes(2);
 		expect(spy).not.toHaveBeenCalledWith(2);
 		expect(spy).toHaveBeenCalledWith(4);
+	});
+});
+
+describe("discreteBinarySearch()", () => {
+	it("test case 1", async () => {
+		const [rangeMin, rangeMax] = [0, 9];
+		const values = [0, 0, 0, 0, 0, 1, 1, 1, 1, 1];
+		expect(
+			await discreteBinarySearch(
+				rangeMin,
+				rangeMax,
+				(i) => values[i] === 0,
+			),
+		).toBe(4);
+	});
+
+	it("test case 2", async () => {
+		const [rangeMin, rangeMax] = [0, 9];
+		const values = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+		expect(
+			await discreteBinarySearch(
+				rangeMin,
+				rangeMax,
+				(i) => values[i] === 0,
+			),
+		).toBe(9);
+	});
+
+	it("test case 3", async () => {
+		const [rangeMin, rangeMax] = [0, 6];
+		const values = [0, 1, 1, 1, 1, 1, 1];
+		expect(
+			await discreteBinarySearch(
+				rangeMin,
+				rangeMax,
+				(i) => values[i] === 0,
+			),
+		).toBe(0);
+	});
+
+	it("test case 4", async () => {
+		const [rangeMin, rangeMax] = [0, 6];
+		const values = [1, 1, 1, 1, 1, 1, 1];
+		expect(
+			await discreteBinarySearch(
+				rangeMin,
+				rangeMax,
+				(i) => values[i] === 0,
+			),
+		).toBe(undefined);
+	});
+
+	it("test case 5", async () => {
+		const [rangeMin, rangeMax] = [0, 0];
+		const values = [0];
+		expect(
+			await discreteBinarySearch(
+				rangeMin,
+				rangeMax,
+				(i) => values[i] === 0,
+			),
+		).toBe(0);
+	});
+
+	it("test case 6", async () => {
+		const [rangeMin, rangeMax] = [1, -1];
+		const values: number[] = [];
+		expect(
+			await discreteBinarySearch(
+				rangeMin,
+				rangeMax,
+				(i) => values[i] === 0,
+			),
+		).toBe(undefined);
 	});
 });

--- a/packages/shared/src/misc.ts
+++ b/packages/shared/src/misc.ts
@@ -92,3 +92,30 @@ export function padVersion(version: string): string {
 	if (version.split(".").length === 3) return version;
 	return version + ".0";
 }
+
+/** Finds the highest discrete value in [rangeMin...rangeMax] where executor returns true. */
+export async function discreteBinarySearch(
+	rangeMin: number,
+	rangeMax: number,
+	executor: (value: number) => boolean | PromiseLike<boolean>,
+): Promise<number | undefined> {
+	let min = rangeMin;
+	let max = rangeMax;
+	while (min < max) {
+		const mid = min + Math.floor((max - min + 1) / 2);
+
+		const result = await executor(mid);
+		if (result) {
+			min = mid;
+		} else {
+			max = mid - 1;
+		}
+	}
+
+	if (min === rangeMin) {
+		// We didn't test this yet
+		const result = await executor(min);
+		if (!result) return undefined;
+	}
+	return min;
+}

--- a/packages/zwave-js/src/Node.ts
+++ b/packages/zwave-js/src/Node.ts
@@ -6,6 +6,8 @@ export type { NodeStatistics } from "./lib/node/NodeStatistics";
 export {
 	DataRate,
 	FLiRS,
+	HealthCheckResult,
+	HealthCheckSummary,
 	InterviewStage,
 	NodeInterviewFailedEventArgs,
 	NodeStatus,

--- a/packages/zwave-js/src/Node.ts
+++ b/packages/zwave-js/src/Node.ts
@@ -13,6 +13,8 @@ export {
 	NodeStatus,
 	NodeType,
 	ProtocolVersion,
+	RouteHealthCheckResult,
+	RouteHealthCheckSummary,
 	ZWaveNodeEvents,
 } from "./lib/node/Types";
 export { VirtualEndpoint } from "./lib/node/VirtualEndpoint";

--- a/packages/zwave-js/src/Node.ts
+++ b/packages/zwave-js/src/Node.ts
@@ -6,9 +6,9 @@ export type { NodeStatistics } from "./lib/node/NodeStatistics";
 export {
 	DataRate,
 	FLiRS,
-	HealthCheckResult,
-	HealthCheckSummary,
 	InterviewStage,
+	LifelineHealthCheckResult,
+	LifelineHealthCheckSummary,
 	NodeInterviewFailedEventArgs,
 	NodeStatus,
 	NodeType,

--- a/packages/zwave-js/src/Utils.ts
+++ b/packages/zwave-js/src/Utils.ts
@@ -10,3 +10,10 @@ export type {
 	Protocols,
 	QRProvisioningInformation,
 } from "@zwave-js/core";
+export {
+	formatLifelineHealthCheckRound,
+	formatLifelineHealthCheckSummary,
+	formatRouteHealthCheckRound,
+	formatRouteHealthCheckSummary,
+	healthCheckRatingToWord,
+} from "./lib/node/HealthCheck";

--- a/packages/zwave-js/src/lib/controller/BridgeApplicationCommandRequest.ts
+++ b/packages/zwave-js/src/lib/controller/BridgeApplicationCommandRequest.ts
@@ -110,7 +110,7 @@ export class BridgeApplicationCommandRequest
 				break;
 			// case this.rssi < RSSI_RESERVED_START:
 			default:
-				message.RSSI = `${this.rssi} dBms`;
+				message.RSSI = `${this.rssi} dBm`;
 				break;
 		}
 		return {

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -92,6 +92,10 @@ import { ZWaveNode } from "../node/Node";
 import { InterviewStage, NodeStatus } from "../node/Types";
 import { VirtualNode } from "../node/VirtualNode";
 import {
+	GetBackgroundRSSIRequest,
+	GetBackgroundRSSIResponse,
+} from "../serialapi/misc/GetBackgroundRSSIMessages";
+import {
 	NodeIDType,
 	RFRegion,
 	SerialAPISetupCommand,
@@ -236,6 +240,7 @@ import {
 	RequestNodeNeighborUpdateReport,
 	RequestNodeNeighborUpdateRequest,
 } from "./RequestNodeNeighborUpdateMessages";
+import type { RSSI } from "./SendDataShared";
 import {
 	SetSerialApiTimeoutsRequest,
 	SetSerialApiTimeoutsResponse,
@@ -4151,7 +4156,10 @@ ${associatedNodes.join(", ")}`,
 	/**
 	 * Returns the known list of neighbors for a node
 	 */
-	public async getNodeNeighbors(nodeId: number): Promise<readonly number[]> {
+	public async getNodeNeighbors(
+		nodeId: number,
+		onlyRepeaters: boolean = false,
+	): Promise<readonly number[]> {
 		this.driver.controllerLog.logNode(nodeId, {
 			message: "requesting node neighbors...",
 			direction: "outbound",
@@ -4161,7 +4169,7 @@ ${associatedNodes.join(", ")}`,
 				new GetRoutingInfoRequest(this.driver, {
 					nodeId,
 					removeBadLinks: false,
-					removeNonRepeaters: false,
+					removeNonRepeaters: onlyRepeaters,
 				}),
 			);
 			this.driver.controllerLog.logNode(nodeId, {
@@ -4733,5 +4741,21 @@ ${associatedNodes.join(", ")}`,
 		}
 		// Close NVM
 		await this.externalNVMClose();
+	}
+
+	/**
+	 * Request the most recent background RSSI levels detected by the controller.
+	 *
+	 * **Note:** This only returns useful values if something was transmitted recently.
+	 */
+	public async getBackgroundRSSI(): Promise<{
+		rssiChannel0: RSSI;
+		rssiChannel1: RSSI;
+		rssiChannel2?: RSSI;
+	}> {
+		const ret = await this.driver.sendMessage<GetBackgroundRSSIResponse>(
+			new GetBackgroundRSSIRequest(this.driver),
+		);
+		return pick(ret, ["rssiChannel0", "rssiChannel1", "rssiChannel2"]);
 	}
 }

--- a/packages/zwave-js/src/lib/controller/SendDataShared.ts
+++ b/packages/zwave-js/src/lib/controller/SendDataShared.ts
@@ -91,7 +91,10 @@ export function parseRSSI(payload: Buffer, offset: number = 0): RSSI {
 	return ret;
 }
 
-function tryParseRSSI(payload: Buffer, offset: number = 0): RSSI | undefined {
+export function tryParseRSSI(
+	payload: Buffer,
+	offset: number = 0,
+): RSSI | undefined {
 	if (payload.length <= offset) return;
 	return parseRSSI(payload, offset);
 }

--- a/packages/zwave-js/src/lib/message/Constants.ts
+++ b/packages/zwave-js/src/lib/message/Constants.ts
@@ -105,7 +105,7 @@ export enum FunctionType {
 
 	UNKNOWN_FUNC_ClearNetworkStats = 0x39,
 	UNKNOWN_FUNC_GetNetworkStats = 0x3a,
-	UNKNOWN_FUNC_GetBackgroundRSSI = 0x3b,
+	GetBackgroundRSSI = 0x3b, // request the most recent background RSSI levels detected
 	UNKNOWN_FUNC_RemoveNodeIdFromNetwork = 0x3f,
 
 	FUNC_ID_ZW_SET_LEARN_NODE_STATE = 0x40, // Not implemented

--- a/packages/zwave-js/src/lib/node/HealthCheck.ts
+++ b/packages/zwave-js/src/lib/node/HealthCheck.ts
@@ -1,0 +1,141 @@
+import { getEnumMemberName } from "@zwave-js/shared";
+import { padStart } from "alcalzone-shared/strings";
+import { Powerlevel } from "../commandclass/PowerlevelCC";
+import type {
+	LifelineHealthCheckResult,
+	LifelineHealthCheckSummary,
+	RouteHealthCheckResult,
+	RouteHealthCheckSummary,
+} from "./Types";
+
+export const healthCheckTestFrameCount = 10;
+
+export function healthCheckRatingToWord(rating: number): string {
+	return rating >= 10
+		? "perfect"
+		: rating >= 6
+		? "good"
+		: rating >= 4
+		? "acceptable"
+		: rating >= 1
+		? "bad"
+		: "dead";
+}
+
+export function formatLifelineHealthCheckRound(
+	round: number,
+	numRounds: number,
+	result: LifelineHealthCheckResult,
+): string {
+	const ret = [
+		`· round ${padStart(
+			round.toString(),
+			Math.floor(Math.log10(numRounds) + 1),
+			" ",
+		)} - rating: ${result.rating} (${healthCheckRatingToWord(
+			result.rating,
+		)})`,
+		`  failed pings → node:             ${result.failedPingsNode}/${healthCheckTestFrameCount}`,
+		`  max. latency:                    ${result.latency.toFixed(1)} ms`,
+		result.routeChanges != undefined
+			? `  route changes:                   ${result.routeChanges}`
+			: "",
+		result.snrMargin != undefined
+			? `  SNR margin:                      ${result.snrMargin} dBm`
+			: "",
+		result.failedPingsController != undefined
+			? `  failed pings → controller:       ${result.failedPingsController}/${healthCheckTestFrameCount} at normal power`
+			: result.minPowerlevel != undefined
+			? `  min. node powerlevel w/o errors: ${getEnumMemberName(
+					Powerlevel,
+					result.minPowerlevel,
+			  )}`
+			: "",
+	]
+		.filter((line) => !!line)
+		.join("\n");
+	return ret;
+}
+
+export function formatLifelineHealthCheckSummary(
+	summary: LifelineHealthCheckSummary,
+): string {
+	return `
+rating:                   ${summary.rating} (${healthCheckRatingToWord(
+		summary.rating,
+	)})
+no. of routing neighbors: ${
+		summary.results[summary.results.length - 1].numNeighbors
+	}
+ 
+Check rounds:
+${summary.results
+	.map((r, i) =>
+		formatLifelineHealthCheckRound(i + 1, summary.results.length, r),
+	)
+	.join("\n \n")}`.trim();
+}
+
+export function formatRouteHealthCheckRound(
+	sourceNodeId: number,
+	targetNodeId: number,
+	round: number,
+	numRounds: number,
+	result: RouteHealthCheckResult,
+): string {
+	const ret = [
+		`· round ${padStart(
+			round.toString(),
+			Math.floor(Math.log10(numRounds) + 1),
+			" ",
+		)} - rating: ${result.rating} (${healthCheckRatingToWord(
+			result.rating,
+		)})`,
+		result.failedPingsToTarget != undefined
+			? `  failed pings ${sourceNodeId} → ${targetNodeId}:      ${result.failedPingsToTarget}/${healthCheckTestFrameCount}`
+			: result.minPowerlevelSource != undefined
+			? `  Node ${sourceNodeId} min. powerlevel w/o errors: ${getEnumMemberName(
+					Powerlevel,
+					result.minPowerlevelSource,
+			  )}`
+			: "",
+		result.failedPingsToSource != undefined
+			? `  failed pings ${targetNodeId} → ${sourceNodeId}:      ${result.failedPingsToSource}/${healthCheckTestFrameCount}`
+			: result.minPowerlevelTarget != undefined
+			? `  Node ${targetNodeId} min. powerlevel w/o errors: ${getEnumMemberName(
+					Powerlevel,
+					result.minPowerlevelTarget,
+			  )}`
+			: "",
+	]
+		.filter((line) => !!line)
+		.join("\n");
+	return ret;
+}
+
+export function formatRouteHealthCheckSummary(
+	sourceNodeId: number,
+	targetNodeId: number,
+	summary: RouteHealthCheckSummary,
+): string {
+	return `
+rating:                   ${summary.rating} (${healthCheckRatingToWord(
+		summary.rating,
+	)})
+no. of routing neighbors: ${
+		summary.results[summary.results.length - 1].numNeighbors
+	}
+ 
+Check rounds:
+${summary.results
+	.map((r, i) =>
+		formatRouteHealthCheckRound(
+			sourceNodeId,
+			targetNodeId,
+			i + 1,
+			summary.results.length,
+			r,
+		),
+	)
+	.join("\n \n")}`.trim();
+}

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -173,8 +173,8 @@ import {
 import type {
 	DataRate,
 	FLiRS,
-	HealthCheckResult,
-	HealthCheckSummary,
+	LifelineHealthCheckResult,
+	LifelineHealthCheckSummary,
 	TranslatedValueID,
 	ZWaveNodeEventCallbacks,
 	ZWaveNodeValueEventCallbacks,
@@ -4007,14 +4007,14 @@ protocol version:      ${this._protocolVersion}`;
 	/**
 	 * Checks the health of connection between the controller and this node and returns the results.
 	 */
-	public async checkHealth(
+	public async checkLifelineHealth(
 		rounds: number = 5,
 		onProgress?: (
 			round: number,
 			totalRounds: number,
 			lastRating: number,
 		) => void,
-	): Promise<HealthCheckSummary> {
+	): Promise<LifelineHealthCheckSummary> {
 		if (rounds > 10 || rounds < 1) {
 			throw new ZWaveError(
 				"The number of health check rounds must be between 1 and 10!",
@@ -4027,7 +4027,7 @@ protocol version:      ${this._protocolVersion}`;
 		const start = Date.now();
 
 		/** Computes a health rating from a health check result */
-		const computeRating = (result: HealthCheckResult) => {
+		const computeRating = (result: LifelineHealthCheckResult) => {
 			const failedPings = Math.max(
 				result.failedPingsController ?? 0,
 				result.failedPingsNode,
@@ -4065,12 +4065,12 @@ protocol version:      ${this._protocolVersion}`;
 
 		this.driver.controllerLog.logNode(
 			this.id,
-			`Starting health check (${rounds} round${
+			`Starting lifeline health check (${rounds} round${
 				rounds !== 1 ? "s" : ""
 			})...`,
 		);
 
-		const results: HealthCheckResult[] = [];
+		const results: LifelineHealthCheckResult[] = [];
 		for (let round = 1; round <= rounds; round++) {
 			// Determine the number of repeating neighbors
 			const numNeighbors = (
@@ -4119,7 +4119,7 @@ protocol version:      ${this._protocolVersion}`;
 				}
 			}
 
-			const ret: HealthCheckResult = {
+			const ret: LifelineHealthCheckResult = {
 				failedPingsNode,
 				numNeighbors,
 				routeChanges,
@@ -4190,7 +4190,10 @@ protocol version:      ${this._protocolVersion}`;
 		const duration = Date.now() - start;
 
 		const rating = Math.min(...results.map((r) => r.rating));
-		const formatRound = (round: number, result: HealthCheckResult) => {
+		const formatRound = (
+			round: number,
+			result: LifelineHealthCheckResult,
+		) => {
 			const ret = [
 				`· round ${padStart(
 					round.toString(),
@@ -4219,7 +4222,7 @@ protocol version:      ${this._protocolVersion}`;
 		};
 		this.driver.controllerLog.logNode(
 			this.id,
-			`Health check complete in ${duration} ms
+			`Lifeline health check complete in ${duration} ms
 rating:                   ${rating} (${ratingToWord(rating)})
 no. of routing neighbors: ${results[results.length - 1].numNeighbors}
  

--- a/packages/zwave-js/src/lib/node/Types.ts
+++ b/packages/zwave-js/src/lib/node/Types.ts
@@ -230,3 +230,62 @@ export interface LifelineHealthCheckSummary {
 	 */
 	rating: number;
 }
+
+/** Represents the result of one health check round of a route between two nodes */
+export interface RouteHealthCheckResult {
+	/** How many routing neighbors this node has. Higher = better, ideally > 2. */
+	numNeighbors: number;
+	/**
+	 * How many pings were not ACKed by the target node. Lower = better, ideally 0.
+	 *
+	 * Only available if the source node supports Powerlevel CC
+	 */
+	failedPingsToTarget?: number;
+	/**
+	 * How many pings were not ACKed by the source node. Lower = better, ideally 0.
+	 *
+	 * Only available if the target node supports Powerlevel CC
+	 */
+	failedPingsToSource?: number;
+	/**
+	 * The minimum powerlevel where all pings from the source node were ACKed by the target node. Higher = better, ideally 6dBm or more.
+	 *
+	 * Only available if the source node supports Powerlevel CC
+	 */
+	minPowerlevelSource?: Powerlevel;
+	/**
+	 * The minimum powerlevel where all pings from the target node were ACKed by the source node. Higher = better, ideally 6dBm or more.
+	 *
+	 * Only available if the source node supports Powerlevel CC
+	 */
+	minPowerlevelTarget?: Powerlevel;
+
+	/** See {@link RouteHealthCheckSummary.rating} */
+	rating: number;
+}
+
+export interface RouteHealthCheckSummary {
+	/** The check results of each round */
+	results: RouteHealthCheckResult[];
+	/**
+	 * The health rating expressed as a number from 0 (not working at all) to 10 (perfect connectivity).
+	 * See {@link LifelineHealthCheckSummary.rating} for a detailed description.
+	 *
+	 * Because the connection between two nodes can only be evaluated with successful pings, the ratings 4, 5 and 9
+	 * cannot be achieved in this test:
+	 *
+	 * | Rating | Failed pings | No. of neighbors | min. powerlevel |
+	 * | -----: | -----------: | ---------------: | --------------: |
+	 * | ✅  10 |            0 |              > 2 |        ≤ −6 dBm |
+	 * | 🟢   8 |            0 |              ≤ 2 |        ≤ −6 dBm |
+	 * | 🟢   7 |            0 |              > 2 |               - |
+	 * | 🟢   6 |            0 |              ≤ 2 |               - |
+	 * |        |              |                  |                 |
+	 * | 🔴   3 |            1 |                - |               - |
+	 * | 🔴   2 |            2 |                - |               - |
+	 * | 🔴   1 |          ≤ 9 |                - |               - |
+	 * |        |              |                  |                 |
+	 * | ❌   0 |           10 |                - |               - |
+	 */
+	rating: number;
+}

--- a/packages/zwave-js/src/lib/node/Types.ts
+++ b/packages/zwave-js/src/lib/node/Types.ts
@@ -166,8 +166,8 @@ export enum NodeType {
 	"Routing End Node",
 }
 
-/** Represents the result of one check round, usually 10 pings in both directions */
-export interface HealthCheckResult {
+/** Represents the result of one health check round of a node's lifeline */
+export interface LifelineHealthCheckResult {
 	/**
 	 * How many route changes were needed. Lower = better, ideally 0.
 	 *
@@ -197,13 +197,13 @@ export interface HealthCheckResult {
 	 */
 	snrMargin?: number;
 
-	/** See {@link HealthCheckSummary.rating} */
+	/** See {@link LifelineHealthCheckSummary.rating} */
 	rating: number;
 }
 
-export interface HealthCheckSummary {
+export interface LifelineHealthCheckSummary {
 	/** The check results of each round */
-	results: HealthCheckResult[];
+	results: LifelineHealthCheckResult[];
 	/**
 	 * The health rating expressed as a number from 0 (not working at all) to 10 (perfect connectivity).
 	 * The rating is calculated evaluating the test results of the worst round similar to Silabs' PC controller.

--- a/packages/zwave-js/src/lib/node/Types.ts
+++ b/packages/zwave-js/src/lib/node/Types.ts
@@ -169,11 +169,17 @@ export enum NodeType {
 /** Represents the result of one health check round of a node's lifeline */
 export interface LifelineHealthCheckResult {
 	/**
-	 * How many route changes were needed. Lower = better, ideally 0.
+	 * How many times at least one new route was needed. Lower = better, ideally 0.
 	 *
 	 * Only available if the controller supports TX reports.
 	 */
 	routeChanges?: number;
+	/**
+	 * The average time it took to send a ping. Lower = better, ideally close to 0.
+	 *
+	 * Will use the time in TX reports if available, otherwise fall back to measuring the round trip time.
+	 */
+	latency: number;
 	/** How many routing neighbors this node has. Higher = better, ideally > 2. */
 	numNeighbors: number;
 	/** How many pings were not ACKed by the node. Lower = better, ideally 0. */
@@ -209,19 +215,19 @@ export interface LifelineHealthCheckSummary {
 	 * The rating is calculated evaluating the test results of the worst round similar to Silabs' PC controller.
 	 * Each rating is only achieved if all the requirements are fulfilled.
 	 *
-	 * | Rating | Failed pings | Route changes | No. of neighbors | min. powerlevel | SNR margin |
+	 * | Rating | Failed pings | Latency       | No. of neighbors | min. powerlevel | SNR margin |
 	 * | -----: | -----------: | ------------: | ---------------: | --------------: | ---------: |
-	 * | ✅  10 |            0 |             0 |              > 2 |        ≤ −6 dBm |   ≥ 17 dBm |
-	 * | 🟢   9 |            0 |             1 |              > 2 |        ≤ −6 dBm |   ≥ 17 dBm |
-	 * | 🟢   8 |            0 |           ≤ 1 |              ≤ 2 |        ≤ −6 dBm |   ≥ 17 dBm |
-	 * | 🟢   7 |            0 |           ≤ 1 |              > 2 |               - |          - |
-	 * | 🟢   6 |            0 |           ≤ 1 |              ≤ 2 |               - |          - |
+	 * | ✅  10 |            0 |      ≤  50 ms |              > 2 |        ≤ −6 dBm |   ≥ 17 dBm |
+	 * | 🟢   9 |            0 |      ≤ 100 ms |              > 2 |        ≤ −6 dBm |   ≥ 17 dBm |
+	 * | 🟢   8 |            0 |      ≤ 100 ms |              ≤ 2 |        ≤ −6 dBm |   ≥ 17 dBm |
+	 * | 🟢   7 |            0 |      ≤ 100 ms |              > 2 |               - |          - |
+	 * | 🟢   6 |            0 |      ≤ 100 ms |              ≤ 2 |               - |          - |
 	 * |        |              |               |                  |                 |            |
-	 * | 🟡   5 |            0 |           ≤ 4 |                - |               - |          - |
-	 * | 🟡   4 |            0 |           > 4 |                - |               - |          - |
+	 * | 🟡   5 |            0 |      ≤ 250 ms |                - |               - |          - |
+	 * | 🟡   4 |            0 |      ≤ 500 ms |                - |               - |          - |
 	 * |        |              |               |                  |                 |            |
-	 * | 🔴   3 |            1 |             - |                - |               - |          - |
-	 * | 🔴   2 |            2 |             - |                - |               - |          - |
+	 * | 🔴   3 |            1 |     ≤ 1000 ms |                - |               - |          - |
+	 * | 🔴   2 |          ≤ 2 |     > 1000 ms |                - |               - |          - |
 	 * | 🔴   1 |          ≤ 9 |             - |                - |               - |          - |
 	 * |        |              |               |                  |                 |            |
 	 * | ❌   0 |           10 |             - |                - |               - |          - |

--- a/packages/zwave-js/src/lib/node/Types.ts
+++ b/packages/zwave-js/src/lib/node/Types.ts
@@ -175,7 +175,7 @@ export interface LifelineHealthCheckResult {
 	 */
 	routeChanges?: number;
 	/**
-	 * The average time it took to send a ping. Lower = better, ideally close to 0.
+	 * The maximum time it took to send a ping to the node. Lower = better, ideally 10 ms.
 	 *
 	 * Will use the time in TX reports if available, otherwise fall back to measuring the round trip time.
 	 */

--- a/packages/zwave-js/src/lib/serialapi/misc/GetBackgroundRSSIMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/misc/GetBackgroundRSSIMessages.ts
@@ -1,0 +1,53 @@
+import type { MessageOrCCLogEntry, MessageRecord } from "@zwave-js/core";
+import {
+	parseRSSI,
+	RSSI,
+	rssiToString,
+	tryParseRSSI,
+} from "../../controller/SendDataShared";
+import type { Driver } from "../../driver/Driver";
+import {
+	FunctionType,
+	MessagePriority,
+	MessageType,
+} from "../../message/Constants";
+import {
+	expectedResponse,
+	Message,
+	MessageDeserializationOptions,
+	messageTypes,
+	priority,
+} from "../../message/Message";
+
+@messageTypes(MessageType.Request, FunctionType.GetBackgroundRSSI)
+@priority(MessagePriority.Normal)
+@expectedResponse(FunctionType.GetBackgroundRSSI)
+export class GetBackgroundRSSIRequest extends Message {}
+
+@messageTypes(MessageType.Response, FunctionType.GetBackgroundRSSI)
+export class GetBackgroundRSSIResponse extends Message {
+	public constructor(driver: Driver, options: MessageDeserializationOptions) {
+		super(driver, options);
+		this.rssiChannel0 = parseRSSI(this.payload, 0);
+		this.rssiChannel1 = parseRSSI(this.payload, 1);
+		this.rssiChannel2 = tryParseRSSI(this.payload, 2);
+	}
+
+	public readonly rssiChannel0: RSSI;
+	public readonly rssiChannel1: RSSI;
+	public readonly rssiChannel2?: RSSI;
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		const message: MessageRecord = {
+			"channel 0": rssiToString(this.rssiChannel0),
+			"channel 1": rssiToString(this.rssiChannel1),
+		};
+		if (this.rssiChannel2 != undefined) {
+			message["channel 2"] = rssiToString(this.rssiChannel2);
+		}
+		return {
+			...super.toLogEntry(),
+			message,
+		};
+	}
+}

--- a/test/run.ts
+++ b/test/run.ts
@@ -2,15 +2,19 @@
 // import { Driver } from "../packages/zwave-js";
 
 // To test without Sentry reporting
+import { wait } from "alcalzone-shared/async";
 import path from "path";
 import "reflect-metadata";
 import { Driver } from "../packages/zwave-js/src/lib/driver/Driver";
 
 process.on("unhandledRejection", (_r) => {
-	// debugger;
+	debugger;
 });
 
 const driver = new Driver("COM5", {
+	// logConfig: {
+	// 	logToFile: true,
+	// },
 	securityKeys: {
 		S0_Legacy: Buffer.from("0102030405060708090a0b0c0d0e0f10", "hex"),
 		S2_Unauthenticated: Buffer.from(
@@ -33,255 +37,18 @@ const driver = new Driver("COM5", {
 })
 	.on("error", console.error)
 	.once("driver ready", async () => {
-		// driver.controller.on("statistics updated", (s) => {
-		// 	console.debug(s);
-		// });
-		// for (const node of driver.controller.nodes.values()) {
-		// 	node.on("statistics updated", (_node, s) => {
-		// 		console.debug({
-		// 			node: _node.id,
-		// 			...s,
-		// 		});
-		// 	});
-		// }
-		// const cc = new CommandClass(driver, {
-		// 	nodeId: 24,
-		// 	ccId: 0x5d,
-		// 	ccCommand: 0x02,
-		// 	payload: Buffer.from([1, 2, 3]),
-		// });
-		// await driver.sendCommand(cc);
-		// console.log("OK");
-		// const node = driver.controller.nodes.get(21)!;
-		// node.keepAwake = true;
-		// node.once("interview completed", async () => {
-		// 	console.error(`
-		// 	20 ready
-		// 	`);
-		// 	await require("alcalzone-shared/async").wait(2000);
-		// 	await node.commandClasses.Security.getNonce({
-		// 		standalone: true,
-		// 		storeAsFreeNonce: true,
-		// 	});
-		// 	let bg = new ConfigurationCCGet(driver, {
-		// 		nodeId: 20,
-		// 		parameter: 4,
-		// 	});
-		// 	await node.commandClasses.Security.sendEncapsulated(bg, true);
-		// 	bg = new ConfigurationCCGet(driver, {
-		// 		nodeId: 20,
-		// 		parameter: 4,
-		// 	});
-		// 	await node.commandClasses.Security.sendEncapsulated(bg);
-		// });
-		// 		// 	// const updater = await fs.readFile(
-		// 		// 	// 	"C:\\Repositories\\node-zwave-js\\firmwares\\MultiSensor_OTA_Security_ZW050x_EU_V1_11_hex__TargetZwave__.hex",
-		// 		// 	// );
-		// 		// 	// const firmware = extractFirmware(updater, "hex");
-		// 		// 	// // const firmware = {
-		// 		// 	// // 	data: updater,
-		// 		// 	// // 	firmwareTarget: undefined,
-		// 		// 	// // };
-		// 		// 	// node.on("firmware update progress", (node, sent, total) => {
-		// 		// 	// 	console.warn(`Firmware update progress: ${sent}/${total}`);
-		// 		// 	// });
-		// 		// 	// node.on("firmware update finished", (node, status, waitTime) => {
-		// 		// 	// 	console.warn(
-		// 		// 	// 		`Firmware update done with status ${getEnumMemberName(
-		// 		// 	// 			FirmwareUpdateStatus,
-		// 		// 	// 			status,
-		// 		// 	// 		)}`,
-		// 		// 	// 	);
-		// 		// 	// 	console.warn(`wait time: ${waitTime ?? "undefined"}`);
-		// 		// 	// });
-		// 		// 	// await node.beginFirmwareUpdate(
-		// 		// 	// 	firmware.data,
-		// 		// 	// 	firmware.firmwareTarget,
-		// 		// 	// );
-		// 		// 	// await require("alcalzone-shared/async").wait(5000);
-		// 		// 	// await node.abortFirmwareUpdate();
-		// 		// 	// const test = new FirmwareUpdateMetaDataCC(driver, {
-		// 		// 	// 	nodeId: 12,
-		// 		// 	// });
-		// 		// 	// console.log(`max payload: ${driver.computeNetCCPayloadSize(test)}`);
-		// 		// 	// // await require("alcalzone-shared/async").wait(5000);
-		// 		// 	// const firmware = await node.commandClasses[
-		// 		// 	// 	"Firmware Update Meta Data"
-		// 		// 	// ].getMetaData();
-		// 		// 	// console.dir(firmware);
-		// 		// 	// // await require("alcalzone-shared/async").wait(5000);
-		// 		// 	// await node.commandClasses[
-		// 		// 	// 	"Firmware Update Meta Data"
-		// 		// 	// ].requestUpdate({
-		// 		// 	// 	manufacturerId: firmware.manufacturerId,
-		// 		// 	// 	firmwareId: 0,
-		// 		// 	// 	checksum: 0x0815,
-		// 		// 	// });
-		// 		// });
-		// 		// await require("alcalzone-shared/async").wait(5000);
-		// 		// console.error();
-		// 		// console.error("EXCLUSION");
-		// 		// console.error();
-		// 		// await driver.controller.beginExclusion();
-		// 		// await require("alcalzone-shared/async").wait(60000);
-		// 		// await driver.controller.stopExclusion();
-		// 		// await require("alcalzone-shared/async").wait(5000);
-		// 		// console.error();
-		// 		// console.error("INCLUSION");
-		// 		// console.error();
-		// 		// await driver.controller.beginInclusion();
-		// 		// await require("alcalzone-shared/async").wait(60000);
-		// 		// await driver.controller.stopInclusion();
-		// 		// console.log(`sending application info...`);
-		// 		// // A list of all CCs the controller will respond to
-		// 		// const supportedCCs = [CommandClasses.Time];
-		// 		// // Turn the CCs into buffers and concat them
-		// 		// const supportedCCBuffer = Buffer.concat(
-		// 		// 	supportedCCs.map(cc =>
-		// 		// 		cc >= 0xf1
-		// 		// 			? // extended CC
-		// 		// 			  Buffer.from([cc >>> 8, cc & 0xff])
-		// 		// 			: // normal CC
-		// 		// 			  Buffer.from([cc]),
-		// 		// 	),
-		// 		// );
-		// 		// const appInfoMsg = new Message(driver, {
-		// 		// 	type: MessageType.Request,
-		// 		// 	functionType: FunctionType.FUNC_ID_SERIAL_API_APPL_NODE_INFORMATION,
-		// 		// 	payload: Buffer.concat([
-		// 		// 		Buffer.from([
-		// 		// 			0x01, // APPLICATION_NODEINFO_LISTENING
-		// 		// 			GenericDeviceClasses["Static Controller"],
-		// 		// 			0x01, // specific static PC controller
-		// 		// 			supportedCCBuffer.length, // length of supported CC list
-		// 		// 		]),
-		// 		// 		// List of supported CCs
-		// 		// 		supportedCCBuffer,
-		// 		// 	]),
-		// 		// });
-		// 		// await driver.sendMessage(appInfoMsg, {
-		// 		// 	priority: 0, //MessagePriority.Controller,
-		// 		// 	supportCheck: false,
-		// 		// });
-		// 		// await driver.hardReset();
-		// 		// await require("alcalzone-shared/async").wait(25000);
-		// 		// console.error();
-		// 		// console.error("HEAL");
-		// 		// console.error();
-		// 		// driver.controller.beginHealingNetwork();
-		// 		// console.error();
-		// 		// console.error("INCLUSION");
-		// 		// console.error();
-		// 		// await driver.controller.beginInclusion();
-		// 		// await require("alcalzone-shared/async").wait(60000);
-		// 		// await driver.controller.stopInclusion();
-		// 		// await driver.controller.beginExclusion();
-		// 		// await require("alcalzone-shared/async").wait(60000);
-		// 		// await driver.controller.stopExclusion();
-		// 		// const node = driver.controller.nodes.get(4)!;
-		// 		// node.once("ready", async () => {
-		// 		// 	console.log(node.status);
-		// 		// });
-		// 		// await driver.controller.healNetwork();
-		// 		// console.error();
-		// 		// 	console.error("GOGOGO");
-		// 		// 	console.error();
-		// 		// 	await wait(5000);
-		// 		// 	// heat
-		// 		// 	await node.commandClasses["Thermostat Setpoint"].set(0x01, 29, 0);
-		// 		// 	await node.commandClasses["Thermostat Mode"].set(0x1);
-		// 		// 	await wait(5000);
-		// 		// 	await node.commandClasses["Thermostat Setpoint"].set(0x01, 22, 0);
-		// 		// 	await wait(2000);
-		// 		// 	await node.commandClasses["Thermostat Mode"].set(0x0);
-		// 		// });
-		// 		// const node = driver.controller.nodes.get(4)!;
-		// 		// node.keepAwake = true;
-		// 		// node.once("interview completed", async () => {
-		// 		// 	// console.dir(
-		// 		// 	// 	node.getValue(
-		// 		// 	// 		CommandClasses.Configuration,
-		// 		// 	// 		undefined,
-		// 		// 	// 		"paramInformation",
-		// 		// 	// 	),
-		// 		// 	// );
-		// 		// 	const config = node.commandClasses.Configuration;
-		// 		// 	await config.scanParameters();
-		// 		// 	console.log("Scan finished!");
-		// 		// 	await driver.saveNetworkToCache();
-		// 		// });
-		// 		// const node2 = driver.controller.nodes.get(2)!;
-		// 		// node2.on("value added", args =>
-		// 		// 	console.log(`[Node ${2}] value added: ${JSON.stringify(args)}`),
-		// 		// );
-		// 		// node2.on("value updated", args =>
-		// 		// 	console.log(`[Node ${2}] value updated: ${JSON.stringify(args)}`),
-		// 		// );
-		// 		// node2.on("value removed", args =>
-		// 		// 	console.log(`[Node ${2}] value removed: ${JSON.stringify(args)}`),
-		// 		// );
+		await wait(2500);
+		const health = await driver.controller.nodes
+			.getOrThrow(2)
+			.checkRouteHealth(3, 3, (n, t, r) => {
+				console.debug(`Health check round ${n}/${t}: rating = ${r}`);
+			});
+
+		await wait(100);
+		process.exit(0);
 	});
 void driver.start();
 // driver.enableStatistics({
 // 	applicationName: "test",
 // 	applicationVersion: "0.0.1",
 // });
-
-// // // @ts-check
-// // require("reflect-metadata");
-
-// // import { wait } from "alcalzone-shared/async";
-// // import { Driver } from "../src/lib/driver/Driver";
-
-// // const d = new Driver("COM3").once("driver ready", async () => {
-// // 	for (const nodeId of [2, 3]) {
-// // 		const node = d.controller!.nodes.get(nodeId)!;
-// // 		node.on("value added", args =>
-// // 			console.log(
-// // 				`[Node ${nodeId}] value added: ${JSON.stringify(args)}`,
-// // 			),
-// // 		);
-// // 		node.on("value updated", args =>
-// // 			console.log(
-// // 				`[Node ${nodeId}] value updated: ${JSON.stringify(args)}`,
-// // 			),
-// // 		);
-// // 		node.on("value removed", args =>
-// // 			console.log(
-// // 				`[Node ${nodeId}] value removed: ${JSON.stringify(args)}`,
-// // 			),
-// // 		);
-// // 	}
-
-// // 	// d.controller.nodes.get(2).on("value added", (args) => {
-// // 	// 	console.log(`value added: cc=${args.commandClass}, propertyName=${args.propertyName} => value=${args.newValue}`);
-// // 	// })
-
-// // 	// await d.sendMessage(new HardResetRequest(d));
-// // 	// await wait(10000);
-
-// // 	// const resp = await d.sendMessage(new RequestNodeInfoRequest(2));
-
-// // 	// await d.controller.beginInclusion();
-// // 	// await wait(30000);
-// // 	// await d.controller.stopInclusion();
-
-// // 	// const resp = await d.sendMessage(new AddNodeToNetworkRequest(AddNodeType.Any, true, true));
-// // 	// console.log(JSON.stringify(resp, null, 4));
-
-// // 	// node.on("interview completed", async () => {
-// // 	// 	const report = await d.sendCommand(new BatteryCCGet(d, { nodeId: 2 }));
-// // 	// 	console.log(JSON.stringify(report));
-
-// // 	// 	await wait(30000);
-
-// // 	// 	await d.destroy();
-// // 	// 	process.exit(0);
-// // 	// });
-
-// // 	await wait(600000);
-// // 	await d.destroy();
-// // 	process.exit(0);
-// // 	// const resp = await d.sendMessage(new SetSerialApiTimeoutsRequest());
-// // });
-// // d.start();


### PR DESCRIPTION
This PR adds two methods to the `ZWaveNode` class to test the connection quality between the controller and the node or the node and another node.

#### `checkLifelineHealth` method - test the connection quality between the controller
In multiple rounds, it will test whether re-routing attempts are necessary, how many packets are dropped and (if supported by the node) what the minimum powerlevel for a reliable connection is. These results are combined into a health rating similar to how Silabs' PC controller does it, where 10 is a perfect connection and 0 means _not working at all_:

| Rating | Failed pings | Latency       | No. of neighbors | min. powerlevel | SNR margin |
| -----: | -----------: | ------------: | ---------------: | --------------: | ---------: |
| ✅  10 |            0 |      ≤  50 ms |              > 2 |        ≤ −6 dBm |   ≥ 17 dBm |
| 🟢   9 |            0 |      ≤ 100 ms |              > 2 |        ≤ −6 dBm |   ≥ 17 dBm |
| 🟢   8 |            0 |      ≤ 100 ms |              ≤ 2 |        ≤ −6 dBm |   ≥ 17 dBm |
| 🟢   7 |            0 |      ≤ 100 ms |              > 2 |               - |          - |
| 🟢   6 |            0 |      ≤ 100 ms |              ≤ 2 |               - |          - |
|        |              |               |                  |                 |            |
| 🟡   5 |            0 |      ≤ 250 ms |                - |               - |          - |
| 🟡   4 |            0 |      ≤ 500 ms |                - |               - |          - |
|        |              |               |                  |                 |            |
| 🔴   3 |            1 |     ≤ 1000 ms |                - |               - |          - |
| 🔴   2 |          ≤ 2 |     > 1000 ms |                - |               - |          - |
| 🔴   1 |          ≤ 9 |             - |                - |               - |          - |
|        |              |               |                  |                 |            |
| ❌   0 |           10 |             - |                - |               - |          - |

This check is done in multiple rounds (configurable) where the final health rating is equal to the one of the worst check round.

#### `checkRouteHealth` method - test the connection quality between this node and the target node
In multiple rounds, it will test how many packets are dropped and what the minimum powerlevel for a reliable connection is. This will be done on one or both of the nodes, depending on which ones support `Powerlevel CC`.
These results are combined into a health rating similar to the one above:

| Rating | Failed pings | No. of neighbors | min. powerlevel |
| -----: | -----------: | ---------------: | --------------: |
|  ✅ 10 |            0 |              > 2 |        ≤ −6 dBm |
|   🟢 8 |            0 |              ≤ 2 |        ≤ −6 dBm |
|   🟢 7 |            0 |              > 2 |               - |
|   🟢 6 |            0 |              ≤ 2 |               - |
|        |              |                  |                 |
|   🔴 3 |            1 |                - |               - |
|   🔴 2 |            2 |                - |               - |
|   🔴 1 |          ≤ 9 |                - |               - |
|        |              |                  |                 |
|   ❌ 0 |           10 |                - |               - |

Due to missing insight into re-routing attempts between two nodes or the round-trip-times of their tests, some of the values for the lifeline health rating don't exist here. Furthermore, it is not guaranteed that a route between two nodes and lifeline with the same health rating have the same quality.
