### PR TITLE
feat: allow resetting the granted security classes during re-interview

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -185,10 +185,22 @@ Returns the highest security class this node was granted or `undefined` if that 
 ### `refreshInfo`
 
 ```ts
-refreshInfo(): Promise<void>
+refreshInfo(options?: RefreshInfoOptions): Promise<void>
 ```
 
-Resets all information about this node and forces a fresh interview.
+Resets (almost) all information about this node and forces a fresh interview. The information about granted security classes is not reset by default, but can be reset by setting the `resetSecurityClasses` option to `true`.
+
+<!-- #import RefreshInfoOptions from "zwave-js" -->
+
+```ts
+interface RefreshInfoOptions {
+	/**
+	 * Whether a re-interview should also reset the known security classes.
+	 * Default: false
+	 */
+	resetSecurityClasses?: boolean;
+}
+```
 
 > [!WARNING] After calling this method, the node will no longer be `ready`. Keep this in mind if you rely on the `ready` state in your application.
 

--- a/packages/zwave-js/src/Node.ts
+++ b/packages/zwave-js/src/Node.ts
@@ -13,6 +13,7 @@ export {
 	NodeStatus,
 	NodeType,
 	ProtocolVersion,
+	RefreshInfoOptions,
 	RouteHealthCheckResult,
 	RouteHealthCheckSummary,
 	ZWaveNodeEvents,

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -180,6 +180,7 @@ import type {
 	FLiRS,
 	LifelineHealthCheckResult,
 	LifelineHealthCheckSummary,
+	RefreshInfoOptions,
 	RouteHealthCheckResult,
 	RouteHealthCheckSummary,
 	TranslatedValueID,
@@ -1190,14 +1191,19 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner {
 	 * **WARNING:** Take care NOT to call this method when the node is already being interviewed.
 	 * Otherwise the node information may become inconsistent.
 	 */
-	public async refreshInfo(): Promise<void> {
+	public async refreshInfo(options: RefreshInfoOptions = {}): Promise<void> {
 		// It does not make sense to re-interview the controller. All important information is queried
 		// directly via the serial API
 		if (this.isControllerNode()) return;
 
+		const { resetSecurityClasses = false } = options;
+
 		// preserve the node name and location, since they might not be stored on the node
 		const name = this.name;
 		const location = this.location;
+
+		// Force a new detection of security classes if desired
+		if (resetSecurityClasses) this.securityClasses.clear();
 
 		this._interviewAttempts = 0;
 		this.interviewStage = InterviewStage.None;

--- a/packages/zwave-js/src/lib/node/Types.ts
+++ b/packages/zwave-js/src/lib/node/Types.ts
@@ -295,3 +295,11 @@ export interface RouteHealthCheckSummary {
 	 */
 	rating: number;
 }
+
+export interface RefreshInfoOptions {
+	/**
+	 * Whether a re-interview should also reset the known security classes.
+	 * Default: false
+	 */
+	resetSecurityClasses?: boolean;
+}


### PR DESCRIPTION
There are some rare cases when the information about a node's security classes is wrong in the cache. Until now, this information is not reset with a re-interview.

This PR introduces an option parameter to `ZWaveNode.refreshInfo` which allows resetting the security class information in the cache too:
```js
// preserves security classes:
node.refreshInfo();

// resets security classes
node.refreshInfo({ resetSecurityClasses: true });
```

Note that this does not change the security classes that have been granted.

fixes: https://github.com/zwave-js/node-zwave-js/issues/3615