### PR TITLE
feat(config): add manufacturer Inteset 0x039a

### DIFF
--- a/packages/config/config/manufacturers.json
+++ b/packages/config/config/manufacturers.json
@@ -688,6 +688,7 @@
 	"0x0397": "Teptron AB",
 	"0x0398": "Calix",
 	"0x0399": "Hubitat",
+	"0x039a": "Inteset",
 	"0x039b": "Reply S.p.A.",
 	"0x039c": "Foxconn Industrial Internet",
 	"0x039d": "ECS",


### PR DESCRIPTION
Adding Manufacturer Inteset and device WR01Z.  Seems to be a clone of Shenzhen Neo Electronics Co with a different manufacturer ID.
