### PR TITLE
feat: make `min/maxValue` optional if `allowManualEntry` is `false`

### DIFF
--- a/maintenance/schemas/device-config.json
+++ b/maintenance/schemas/device-config.json
@@ -517,7 +517,7 @@
 				},
 				"allowManualEntry": {
 					"const": false,
-					"description": "Whether this parameter accepts any value between minValue and maxValue. If false, options must be used to specify the allowed values."
+					"description": "Whether this parameter accepts any value between minValue and maxValue. If false, minValue and maxValue are optional, but options must be used to specify the allowed values."
 				},
 				"options": {
 					"type": "array",
@@ -563,23 +563,10 @@
 						}
 					},
 					"then": {
-						"required": [
-							"#",
-							"label",
-							"valueSize",
-							"minValue",
-							"maxValue"
-						]
+						"required": ["#", "label", "valueSize"]
 					},
 					"else": {
-						"required": [
-							"#",
-							"label",
-							"valueSize",
-							"minValue",
-							"maxValue",
-							"defaultValue"
-						]
+						"required": ["#", "label", "valueSize", "defaultValue"]
 					}
 				},
 				{


### PR DESCRIPTION
fixes: https://github.com/zwave-js/node-zwave-js/issues/3159