### PR TITLE
fix: don't cancel scheduled polls for value updates caused by the driver

### DIFF
--- a/packages/core/src/values/ValueDB.ts
+++ b/packages/core/src/values/ValueDB.ts
@@ -21,6 +21,11 @@ export interface TranslatedValueID extends ValueID {
 export interface ValueUpdatedArgs extends ValueID {
 	prevValue: unknown;
 	newValue: unknown;
+	/**
+	 * Whether this value update was caused by the driver itself or the node.
+	 * If not set, it is assumed that the value update was caused by the node.
+	 */
+	source?: "driver" | "node";
 }
 
 export interface ValueAddedArgs extends ValueID {
@@ -131,6 +136,8 @@ export interface SetValueOptions {
 	 * When this is `false`, the value will not be stored and a `value notification` event will be emitted instead (implies `noEvent: false`).
 	 */
 	stateful?: boolean;
+	/** Allows defining the source of a value update */
+	source?: ValueUpdatedArgs["source"];
 }
 
 /**
@@ -225,6 +232,8 @@ export class ValueDB extends TypedEventEmitter<ValueDBEventCallbacks> {
 			if (this._db.has(dbKey)) {
 				event = "value updated";
 				(cbArg as ValueUpdatedArgs).prevValue = this._db.get(dbKey);
+				if (options.source)
+					(cbArg as ValueUpdatedArgs).source = options.source;
 			} else {
 				event = "value added";
 			}

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -860,7 +860,7 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner {
 					valueId,
 					value,
 					!!this.driver.options.emitValueUpdateAfterSetValue
-						? undefined
+						? { source: "driver" }
 						: { noEvent: true },
 				);
 			}

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -230,6 +230,9 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner {
 			this._valueDB.on(
 				event,
 				(args: ValueUpdatedArgs | ValueRemovedArgs) => {
+					// Value updates caused by the driver should never cancel a scheduled poll
+					if ("source" in args && args.source === "driver") return;
+
 					if (this.cancelScheduledPoll(args)) {
 						this.driver.controllerLog.logNode(
 							this.nodeId,
@@ -334,30 +337,37 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner {
 	): void {
 		// Try to retrieve the speaking CC name
 		const outArg = this.translateValueID(arg);
+		// @ts-expect-error This can happen for value updated events
+		if ("source" in outArg) delete outArg.source;
+
 		// If this is a metadata event, make sure we return the merged metadata
 		if ("metadata" in outArg) {
 			(outArg as unknown as MetadataUpdatedArgs).metadata =
 				this.getValueMetadata(arg);
 		}
-		// Log the value change
+
 		const ccInstance = this.createCCInstanceInternal(arg.commandClass);
 		const isInternalValue =
 			ccInstance && ccInstance.isInternalValue(arg.property as any);
-		// I don't like the splitting and any but its the easiest solution here
-		const [changeTarget, changeType] = eventName.split(" ");
-		const logArgument = {
-			...outArg,
-			nodeId: this.nodeId,
-			internal: isInternalValue,
-		};
-		if (changeTarget === "value") {
-			this.driver.controllerLog.value(
-				changeType as any,
-				logArgument as any,
-			);
-		} else if (changeTarget === "metadata") {
-			this.driver.controllerLog.metadataUpdated(logArgument);
+		if ((arg as any as ValueUpdatedArgs).source !== "driver") {
+			// Log the value change, except for updates caused by the driver itself
+			// I don't like the splitting and any but its the easiest solution here
+			const [changeTarget, changeType] = eventName.split(" ");
+			const logArgument = {
+				...outArg,
+				nodeId: this.nodeId,
+				internal: isInternalValue,
+			};
+			if (changeTarget === "value") {
+				this.driver.controllerLog.value(
+					changeType as any,
+					logArgument as any,
+				);
+			} else if (changeTarget === "metadata") {
+				this.driver.controllerLog.metadataUpdated(logArgument);
+			}
 		}
+
 		//Don't expose value events for internal value IDs...
 		if (isInternalValue) return;
 		// ... and root values ID that mirrors endpoint functionality

--- a/packages/zwave-js/src/lib/node/Types.ts
+++ b/packages/zwave-js/src/lib/node/Types.ts
@@ -34,7 +34,8 @@ export type NodeInterviewFailedEventArgs = {
 );
 
 export type ZWaveNodeValueAddedArgs = ValueAddedArgs & TranslatedValueID;
-export type ZWaveNodeValueUpdatedArgs = ValueUpdatedArgs & TranslatedValueID;
+export type ZWaveNodeValueUpdatedArgs = Omit<ValueUpdatedArgs, "source"> &
+	TranslatedValueID;
 export type ZWaveNodeValueRemovedArgs = ValueRemovedArgs & TranslatedValueID;
 export type ZWaveNodeValueNotificationArgs = ValueNotificationArgs &
 	TranslatedValueID;


### PR DESCRIPTION
#3751 broke the value verification by always canceling it. Now we jump through a few hoops to re-enable it.