### PR TITLE
fix: also reset message generator when missing ACK is handled

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -2470,7 +2470,7 @@ It is probably asleep, moving its messages to the wakeup queue.`,
 			// The handler for the asleep status will move the messages to the wakeup queue
 
 			node.markAsAsleep();
-			return true;
+			return this.mayMoveToWakeupQueue(transaction);
 		} else {
 			const errorMsg = `Node ${node.id} did not respond after ${transaction.message.maxSendAttempts} attempts, it is presumed dead`;
 			this.controllerLog.logNode(node.id, errorMsg, "warn");

--- a/packages/zwave-js/src/lib/driver/MessageGenerators.ts
+++ b/packages/zwave-js/src/lib/driver/MessageGenerators.ts
@@ -292,6 +292,11 @@ export function createMessageGenerator<TResponse extends Message = Message>(
 		current: undefined,
 		self: undefined,
 		start: () => {
+			const resetGenerator = () => {
+				generator.current = undefined;
+				generator.self = undefined;
+			};
+
 			async function* gen() {
 				// Determine which message generator implemenation should be used
 				let implementation: MessageGeneratorImplementation =
@@ -339,6 +344,7 @@ export function createMessageGenerator<TResponse extends Message = Message>(
 									generator.parent as any,
 								)
 							) {
+								resetGenerator();
 								return;
 							} else {
 								resultPromise.reject(
@@ -358,8 +364,7 @@ export function createMessageGenerator<TResponse extends Message = Message>(
 				}
 
 				resultPromise.resolve(result as TResponse);
-				generator.current = undefined;
-				generator.self = undefined;
+				resetGenerator();
 				return;
 			}
 			generator.self = gen();


### PR DESCRIPTION
fixes: #3795 
and avoid silently dropping/stalling transactions that cannot be moved to the wakeup queue