### PR TITLE
fix(config): several units and re-trigger parameter 5 default on ZP3111-5

### DIFF
--- a/packages/config/config/devices/0x0109/zp3111-5.json
+++ b/packages/config/config/devices/0x0109/zp3111-5.json
@@ -65,7 +65,7 @@
 			"#": "5",
 			"label": "Trigger Interval",
 			"description": "Set the trigger interval for motion sensor re-activation.",
-			"unit": "seconds",
+			"unit": "minutes",
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 255,

--- a/packages/config/config/devices/0x0109/zp3111-5.json
+++ b/packages/config/config/devices/0x0109/zp3111-5.json
@@ -69,7 +69,7 @@
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 255,
-			"defaultValue": 180,
+			"defaultValue": 3,
 			"unsigned": true
 		},
 		{

--- a/packages/config/config/devices/0x0109/zp3111-5.json
+++ b/packages/config/config/devices/0x0109/zp3111-5.json
@@ -46,7 +46,7 @@
 			"#": "3",
 			"label": "Humidity",
 			"description": "Configure Relative Humidity",
-			"unit": "percent",
+			"unit": "%",
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 50,
@@ -55,7 +55,7 @@
 		{
 			"#": "4",
 			"label": "Light Sensor",
-			"unit": "percent",
+			"unit": "%",
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 50,


### PR DESCRIPTION
I recently ran into a problem with a ZP3111-5. The device was included and showed a trigger refresh of 3 seconds and so I changed it to 180. Well, then it was only re-triggering once every 3 hours. Digging through what appears to be the manufacturer's manual, they indicate the default is 3 minutes and that parameter 5 is supposed to be minutes.

https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/2479/ZP3111-5_R2_20170316.pdf

