### PR TITLE
fix(config): clean up configuration and correct param ranges for Steinel XLED Home 2

### DIFF
--- a/packages/config/config/devices/0x0271/xled_home_2.json
+++ b/packages/config/config/devices/0x0271/xled_home_2.json
@@ -132,7 +132,7 @@
 			"#": "16",
 			"label": "MOTION_ DISABLE",
 			"description": "Motion Off behaviour (timeout)",
-			"valueSize": 0,
+			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 0

--- a/packages/config/config/devices/0x0271/xled_home_2.json
+++ b/packages/config/config/devices/0x0271/xled_home_2.json
@@ -147,86 +147,127 @@
 		},
 		{
 			"#": "10",
-			"label": "Basic CC Off Command: Turn Off Duration",
-			"description": "Light stays off until motion plus configured duration: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
+			"label": "Z-Wave Off Command: Turn Off Duration",
+			"description": "On motion detection, light turns off for the configured duration: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 10,
 			"options": [
 				{
-					"label": "Until motion, no timeout",
+					"label": "Turn off immediately, until motion detected",
 					"value": 0
 				},
 				{
-					"label": "Without waiting for motion, Duration of param 1 (Light Duration After Motion)",
+					"label": "Turn off immediately for duration of param 1 (Light Duration After Motion) or until motion detected",
 					"value": 255
 				}
 			]
 		},
 		{
 			"#": "11",
-			"label": "Basic CC On Command: Turn On Duration",
-			"description": "Light stays on until motion plus configured duration: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
+			"label": "Z-Wave On Command: Turn On Duration",
+			"description": "Light turns on for the configured duration, then waits for motion to return to normal operation: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
 			"valueSize": 2,
 			"minValue": 2,
 			"maxValue": 255,
 			"defaultValue": 255,
 			"options": [
 				{
-					"label": "Until motion, no timeout",
+					"label": "Turn on, wait for motion immediately",
 					"value": 0
 				},
 				{
-					"label": "Without waiting for motion, Duration of param 1 (Light Duration After Motion)",
+					"label": "Turn on immediately for duration of param 1 (Light Duration After Motion) or until motion detected",
 					"value": 255
 				}
 			]
 		},
 		{
 			"#": "12",
-			"label": "Basic CC Off Command: Motion Wait Timeout",
-			"description": "On behaviour time over (timeout)",
+			"label": "Z-Wave On / Off-On: Motion Wait Time Limit",
+			"description": "How long to wait for motion after the configured duration before returning to normal operation to prevent staying on forever: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
 			"valueSize": 2,
 			"minValue": 0,
-			"maxValue": 209,
-			"defaultValue": 204
+			"maxValue": 255,
+			"defaultValue": 204,
+			"options": [
+				{
+					"label": "Do not wait for motion",
+					"value": 0
+				},
+				{
+					"label": "Wait for motion indefinitely",
+					"value": 255
+				}
+			]
 		},
 		{
 			"#": "13",
-			"label": "ON_OFF_ BEHAVIOUR",
-			"description": "Sequence On-Off behaviour (timeout)",
+			"label": "Z-Wave On-Off Sequence: Turn Off Duration",
+			"description": "On motion detection, light turns off for the configured duration: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
 			"valueSize": 2,
 			"minValue": 0,
-			"maxValue": 209,
-			"defaultValue": 204
+			"maxValue": 255,
+			"defaultValue": 204,
+			"options": [
+				{
+					"label": "Immediately, until motion detected",
+					"value": 0
+				},
+				{
+					"label": "Ignore sequence, treat like off command",
+					"value": 255
+				}
+			]
 		},
 		{
 			"#": "14",
-			"label": "OFF_ON_ BEHAVIOUR",
-			"description": "Sequence Off-On behaviour (timeout)",
+			"label": "Z-Wave Off-On Sequence: Turn On Duration",
+			"description": "Light turns on for the configured duration, then waits for motion to return to normal operation: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
 			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 209,
-			"defaultValue": 204
+			"minValue": 2,
+			"maxValue": 255,
+			"defaultValue": 204,
+			"options": [
+				{
+					"label": "Turn on, wait for motion immediately",
+					"value": 0
+				},
+				{
+					"label": "Ignore sequence, treat like on command",
+					"value": 255
+				}
+			]
 		},
 		{
 			"#": "15",
-			"label": "SEQUENCE_ TIME",
-			"description": "Sequence timing",
+			"label": "Sequence Timing",
+			"description": "Maximum delay between on-off or off-on commands to treat as a sequence",
 			"valueSize": 1,
+			"unit": "0.1 s",
 			"minValue": 10,
 			"maxValue": 50,
 			"defaultValue": 10
 		},
 		{
 			"#": "16",
-			"label": "MOTION_ DISABLE",
-			"description": "Motion Off behaviour (timeout)",
+			"label": "Motion Sensor Disable Timeout",
+			"description": "How long to disable internal motion sensor after Basic Set command to motion endpoint: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 0
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Ignore command, sensor permanently enabled",
+					"value": 0
+				},
+				{
+					"label": "Ignore command, sensor permanently disabled",
+					"value": 255
+				}
+			]
 		}
 	]
 }

--- a/packages/config/config/devices/0x0271/xled_home_2.json
+++ b/packages/config/config/devices/0x0271/xled_home_2.json
@@ -132,9 +132,9 @@
 			"#": "16",
 			"label": "MOTION_ DISABLE",
 			"description": "Motion Off behaviour (timeout)",
-			"valueSize": 2,
-			"minValue": 2,
-			"maxValue": 209,
+			"valueSize": 0,
+			"minValue": 0,
+			"maxValue": 255,
 			"defaultValue": 0
 		}
 	]

--- a/packages/config/config/devices/0x0271/xled_home_2.json
+++ b/packages/config/config/devices/0x0271/xled_home_2.json
@@ -16,85 +16,176 @@
 	"paramInformation": [
 		{
 			"#": "1",
-			"label": "Time",
-			"description": "Duration of light after motion detection.",
+			"label": "Light Duration After Motion",
 			"valueSize": 2,
+			"unit": "seconds",
 			"minValue": 5,
 			"maxValue": 900,
 			"defaultValue": 180
 		},
 		{
 			"#": "2",
-			"label": "LIGHT",
-			"description": "Light threshold [lx]",
+			"label": "Light Threshold",
+			"description": "Allowable Range: 2-2000. Moving the potentiometer overwrites the current setting.",
 			"valueSize": 2,
-			"minValue": 2,
+			"unit": "lux",
+			"minValue": 0,
 			"maxValue": 2000,
-			"defaultValue": 2000
+			"defaultValue": 2000,
+			"options": [
+				{
+					"label": "Execute learn sequence",
+					"value": 0
+				}
+			]
 		},
 		{
 			"#": "5",
-			"label": "SENSITIVITY",
-			"description": "Motion Radar Sensitivity [%]",
+			"label": "Motion Sensor Sensitivity",
+			"description": "Moving the potentiometer overwrites the current setting.",
 			"valueSize": 1,
+			"unit": "%",
 			"minValue": 2,
 			"maxValue": 100,
 			"defaultValue": 100
 		},
 		{
 			"#": "6",
-			"label": "BRIGHTNES MEAS 1 INTERVAL",
-			"description": "Brightness measuring interval [min]",
+			"label": "Brightness Measuring Interval",
+			"description": "Lamp switches off shortly and measures the ambient light.",
 			"valueSize": 1,
+			"unit": "minutes",
 			"minValue": 5,
 			"maxValue": 120,
-			"defaultValue": 0
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
 		},
 		{
 			"#": "8",
-			"label": "GLOBAL_LIGHT",
-			"description": "Use external Ambient Light value",
+			"label": "External Ambient Light Sensor",
+			"description": "Measurements from associated Z-Wave light sensors are preferred if not older than 30 minutes.",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
-			"defaultValue": 1
+			"defaultValue": 1,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
 		},
 		{
-			"#": "9",
-			"label": "SLAVE_MODE",
-			"description": "Disable local control",
+			"#": "9[0x01]",
+			"label": "External Control",
+			"description": "When enabled, the lamp is controlled externally via Z-Wave and internal sensors are not used.",
 			"valueSize": 1,
 			"minValue": 0,
-			"maxValue": 4,
-			"defaultValue": 2
+			"maxValue": 1,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "9[0x02]",
+			"label": "Gateway Check",
+			"description": "External Control disabled: Lamp signalizes failure to reach the gateway. External Control enabled: Lamp falls back to normal mode after gateway could not be reached repeatedly.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "9[0x04]",
+			"label": "Permanently On",
+			"description": "When enabled, overrides the External Control and Gateway Check parameters",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
 		},
 		{
 			"#": "10",
-			"label": "(OFF_BEHAVIOUR)",
-			"description": "Off behaviour (timeout)",
+			"label": "Basic CC Off Command: Turn Off Duration",
+			"description": "Light stays off until motion plus configured duration: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 10,
 			"options": [
 				{
-					"label": "Lamp/relay is switched off for TIME (cfg 1)",
+					"label": "Until motion, no timeout",
+					"value": 0
+				},
+				{
+					"label": "Without waiting for motion, Duration of param 1 (Light Duration After Motion)",
 					"value": 255
 				}
 			]
 		},
 		{
 			"#": "11",
-			"label": "ON_BEHAVIOUR",
-			"description": "On behaviour (timeout)",
+			"label": "Basic CC On Command: Turn On Duration",
+			"description": "Light stays on until motion plus configured duration: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
 			"valueSize": 2,
 			"minValue": 2,
-			"maxValue": 209,
-			"defaultValue": 255
+			"maxValue": 255,
+			"defaultValue": 255,
+			"options": [
+				{
+					"label": "Until motion, no timeout",
+					"value": 0
+				},
+				{
+					"label": "Without waiting for motion, Duration of param 1 (Light Duration After Motion)",
+					"value": 255
+				}
+			]
 		},
 		{
 			"#": "12",
-			"label": "ON_TIME_OVER",
+			"label": "Basic CC Off Command: Motion Wait Timeout",
 			"description": "On behaviour time over (timeout)",
 			"valueSize": 2,
 			"minValue": 0,

--- a/packages/config/config/devices/0x0271/xled_home_2.json
+++ b/packages/config/config/devices/0x0271/xled_home_2.json
@@ -55,7 +55,7 @@
 			"description": "Lamp switches off shortly and measures the ambient light.",
 			"valueSize": 1,
 			"unit": "minutes",
-			"minValue": 5,
+			"minValue": 0,
 			"maxValue": 120,
 			"defaultValue": 0,
 			"options": [
@@ -169,7 +169,7 @@
 			"label": "Z-Wave On Command: Turn On Duration",
 			"description": "Light turns on for the configured duration, then waits for motion to return to normal operation: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
 			"valueSize": 2,
-			"minValue": 2,
+			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 255,
 			"options": [
@@ -226,7 +226,7 @@
 			"label": "Z-Wave Off-On Sequence: Turn On Duration",
 			"description": "Light turns on for the configured duration, then waits for motion to return to normal operation: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
 			"valueSize": 2,
-			"minValue": 2,
+			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 204,
 			"options": [


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

MOTION_ DISABLE corr
