### PR TITLE
feat(config): additional Product ID for HS-WX300

### DIFF
--- a/packages/config/config/devices/0x000c/hs-wx300.json
+++ b/packages/config/config/devices/0x000c/hs-wx300.json
@@ -7,6 +7,10 @@
 		{
 			"productType": "0x4447",
 			"productId": "0x4037"
+		},
+		{
+			"productType": "0x4447",
+			"productId: "0x4036"
 		}
 	],
 	"firmwareVersion": {

--- a/packages/config/config/devices/0x000c/hs-wx300.json
+++ b/packages/config/config/devices/0x000c/hs-wx300.json
@@ -10,7 +10,7 @@
 		},
 		{
 			"productType": "0x4447",
-			"productId: "0x4036"
+			"productId": "0x4036"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
I read in the changelog that the HomeSeer HS-WX300 had added support, and I got some new dimmer/switch combos for finishing the basement.

When I added it (via zwavejs2mqtt), it very much didn't look like it was supported. A little digging and it seemed my device had a different ID code. Not 100% sure this is how you add support for this, but thought I'd try to help.
