### PR TITLE
fix(config): add product ID `0x0164` to SimonTech Roller Blind

### DIFF
--- a/packages/config/config/devices/0x0267/10002080-13x.json
+++ b/packages/config/config/devices/0x0267/10002080-13x.json
@@ -34,6 +34,10 @@
 		},
 		{
 			"productType": "0x0004",
+			"productId": "0x0164"
+		},
+		{
+			"productType": "0x0004",
 			"productId": "0x0177"
 		}
 	],


### PR DESCRIPTION
Hi,
I have some devices from Simon Tech (0x0267) installed at my new house. So I'm testing if all the devices are correctly recognized by zwave-js.
All the roller blind are x0267-0x0004-0x0000, except one, that It's x0267-0x0004-0x0164. So I add to this config file.

CrAcO

PD: This is my first PR. Hi to every one.