### PR TITLE
fix(config): Add Heatit Z-Push Button 4 variant product ID

### DIFF
--- a/packages/config/config/devices/0x019b/heatit_z_push_button_4.json
+++ b/packages/config/config/devices/0x019b/heatit_z_push_button_4.json
@@ -6,6 +6,10 @@
 	"devices": [
 		{
 			"productType": "0x0300",
+			"productId": "0xa305"
+		},
+		{
+			"productType": "0x0300",
 			"productId": "0xa306"
 		}
 	],


### PR DESCRIPTION
Missing variant. This Product ID is listed at:
https://products.z-wavealliance.org/products/3828?selectedFrequencyId=1