### PR TITLE
fix: do not send Supervision Reports when another transaction is active

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -74,11 +74,8 @@
 	"debug.javascript.unmapMissingSources": true,
 	"jest.jestCommandLine": "yarn jest",
 	"search.exclude": {
-		"**/.yarn": true,
-		"**/.pnp.*": true
+		"**/.yarn": true
 	},
-	"eslint.nodePath": ".yarn/sdks",
-	"prettier.prettierPath": ".yarn/sdks/prettier/index.js",
 	"[typescript]": {
 		"editor.autoClosingBrackets": "languageDefined"
 	}

--- a/packages/zwave-js/src/lib/commandclass/Security2CC.ts
+++ b/packages/zwave-js/src/lib/commandclass/Security2CC.ts
@@ -190,7 +190,7 @@ export class Security2CCAPI extends CCAPI {
 			await this.driver.sendMessage(msg, {
 				...this.commandOptions,
 				// Nonce requests must be handled immediately
-				priority: MessagePriority.Handshake,
+				priority: MessagePriority.Nonce,
 				// We don't want failures causing us to treat the node as asleep or dead
 				changeNodeStatusOnMissingACK: false,
 			});

--- a/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SecurityCC.ts
@@ -136,7 +136,7 @@ export class SecurityCCAPI extends PhysicalCCAPI {
 			{
 				...this.commandOptions,
 				// Nonce requests must be handled immediately
-				priority: MessagePriority.Handshake,
+				priority: MessagePriority.Nonce,
 				// Only try getting a nonce once
 				maxSendAttempts: 1,
 			},
@@ -200,7 +200,7 @@ export class SecurityCCAPI extends PhysicalCCAPI {
 			await this.driver.sendMessage(msg, {
 				...this.commandOptions,
 				// Nonce requests must be handled immediately
-				priority: MessagePriority.Handshake,
+				priority: MessagePriority.Nonce,
 				// We don't want failures causing us to treat the node as asleep or dead
 				changeNodeStatusOnMissingACK: false,
 			});

--- a/packages/zwave-js/src/lib/commandclass/SupervisionCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SupervisionCC.ts
@@ -108,8 +108,8 @@ export class SupervisionCCAPI extends PhysicalCCAPI {
 		try {
 			await this.driver.sendCommand(cc, {
 				...this.commandOptions,
-				// Supervision Reports must be sent immediately
-				priority: MessagePriority.Handshake,
+				// Supervision Reports must be prioritized over normal messages
+				priority: MessagePriority.Supervision,
 				// We don't want failures causing us to treat the node as asleep or dead
 				changeNodeStatusOnMissingACK: false,
 				// Only try sending the report once. If it fails, the node will ask again

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -2637,7 +2637,7 @@ It is probably asleep, moving its messages to the wakeup queue.`,
 						});
 						await this.sendCommand(cc, {
 							maxSendAttempts: 1,
-							priority: MessagePriority.Handshake,
+							priority: MessagePriority.Nonce,
 						});
 					},
 					sendSegmentsComplete: async () => {
@@ -2652,7 +2652,7 @@ It is probably asleep, moving its messages to the wakeup queue.`,
 						});
 						await this.sendCommand(cc, {
 							maxSendAttempts: 1,
-							priority: MessagePriority.Handshake,
+							priority: MessagePriority.Nonce,
 						});
 					},
 				},
@@ -2701,7 +2701,7 @@ It is probably asleep, moving its messages to the wakeup queue.`,
 				});
 				await this.sendCommand(cc, {
 					maxSendAttempts: 1,
-					priority: MessagePriority.Handshake,
+					priority: MessagePriority.Nonce,
 				});
 			}
 		}
@@ -3239,7 +3239,7 @@ ${handlers.length} left`,
 		if (node && success) {
 			if (node.canSleep) {
 				// Do not update the node status when we just responded to a nonce request
-				if (options.priority !== MessagePriority.Handshake) {
+				if (options.priority !== MessagePriority.Nonce) {
 					// If the node is not meant to be kept awake, try to send it back to sleep
 					if (!node.keepAwake) {
 						setImmediate(() => this.debounceSendNodeToSleep(node));
@@ -3324,8 +3324,8 @@ ${handlers.length} left`,
 			// that there is ever a points where all targets are awake
 			!(msg instanceof SendDataMulticastRequest) &&
 			!(msg instanceof SendDataMulticastBridgeRequest) &&
-			// Handshake messages are meant to be sent immediately
-			options.priority !== MessagePriority.Handshake
+			// Nonces have to be sent immediately
+			options.priority !== MessagePriority.Nonce
 		) {
 			if (options.priority === MessagePriority.NodeQuery) {
 				// Remember that this transaction was part of an interview
@@ -3384,9 +3384,9 @@ ${handlers.length} left`,
 
 		try {
 			const result = (await resultPromise) as TResponse;
-			// If this was a successful non-handshake message to a sleeping node, make sure it goes to sleep again
+			// If this was a successful non-nonce message to a sleeping node, make sure it goes to sleep again
 			if (
-				options.priority !== MessagePriority.Handshake &&
+				options.priority !== MessagePriority.Nonce &&
 				result &&
 				(result.functionType ===
 					FunctionType.BridgeApplicationCommand ||
@@ -3698,10 +3698,9 @@ ${handlers.length} left`,
 	private mayMoveToWakeupQueue(transaction: Transaction): boolean {
 		const msg = transaction.message;
 		switch (true) {
-			// Pings and handshake responses will block the send queue until wakeup,
-			// so they must be dropped
+			// Pings and nonces will block the send queue until wakeup, so they must be dropped
 			case messageIsPing(msg):
-			case transaction.priority === MessagePriority.Handshake:
+			case transaction.priority === MessagePriority.Nonce:
 			// We also don't want to immediately send the node to sleep when it wakes up
 			case isCommandClassContainer(msg) &&
 				msg.command instanceof WakeUpCCNoMoreInformation:

--- a/packages/zwave-js/src/lib/driver/SendThreadMachine.ts
+++ b/packages/zwave-js/src/lib/driver/SendThreadMachine.ts
@@ -184,15 +184,15 @@ const guards: MachineOptions<SendThreadContext, SendThreadEvent>["guards"] = {
 		// The send queue is sorted automatically. If the first message is for a sleeping node, all messages in the queue are.
 		// There are a few exceptions:
 		// 1. Pings may be used to determine whether a node is really asleep.
-		// 2. Responses to handshake requests must always be sent, because some sleeping nodes may try to send us encrypted messages.
+		// 2. Responses to nonce requests must always be sent, because some sleeping nodes may try to send us encrypted messages.
 		//    If we don't send them, they block the send queue
 		// 3. Nodes that can sleep but do not support wakeup: https://github.com/zwave-js/node-zwave-js/discussions/1537
 		//    We need to try and send messages to them even if they are asleep, because we might never hear from them
 
 		// 3.
-		if (nextTransaction.priority === MessagePriority.Handshake) return true;
+		if (nextTransaction.priority === MessagePriority.Nonce) return true;
 
-		// We may not start any non-handshake transaction while the queue is busy
+		// While the queue is busy, we may not start any transaction that is not a nonce response
 		if (meta.state.matches("busy")) return false;
 
 		// 1./2.
@@ -449,7 +449,7 @@ export function createSendThreadMachine(
 						trigger: { target: "idle" },
 					},
 				},
-				// While busy, only handshake responses may be sent
+				// While busy, only nonces may be sent
 				busy: {
 					id: "busy",
 					always: [

--- a/packages/zwave-js/src/lib/message/Constants.ts
+++ b/packages/zwave-js/src/lib/message/Constants.ts
@@ -1,19 +1,19 @@
-// TODO: The "Handshake" priority should be called differently
-
 /** The priority of messages, sorted from high (0) to low (>0) */
 export enum MessagePriority {
-	// Handshake messages have the highest priority because they are part of other transactions
-	// which have already started when the handshakes are needed (e.g. Security Nonce exchange)
-	//
+	// Outgoing nonces have the highest priority because they are part of other transactions
+	// which may already be in progress.
 	// Some nodes don't respond to our requests if they are waiting for a nonce, so those need to be handled first.
-	Handshake = 0,
+	Nonce = 0,
 	// Controller commands usually finish quickly and should be preferred over node queries
 	Controller,
-	// Pings (NoOP) are used for device probing at startup and for network diagnostics
-	Ping,
 	// Multistep controller commands typically require user interaction but still
 	// should happen at a higher priority than any node data exchange
 	MultistepController,
+	// Supervision responses must be prioritized over other messages because the nodes requesting them
+	// will get impatient otherwise.
+	Supervision,
+	// Pings (NoOP) are used for device probing at startup and for network diagnostics
+	Ping,
 	// Whenever sleeping devices wake up, their queued messages must be handled quickly
 	// because they want to go to sleep soon. So prioritize them over non-sleeping devices
 	WakeUp,

--- a/packages/zwave-js/src/lib/test/driver/sendDataCallbackMessageOrder.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/sendDataCallbackMessageOrder.test.ts
@@ -66,7 +66,7 @@ describe("regression tests", () => {
 		jest.setTimeout(5000);
 		// Repro from #1144
 
-		// A send data request for an outgoing handshake response is received after the response we expected
+		// A send data request for an outgoing nonce response is received after the response we expected
 		// This causes it to get matched to the following message
 
 		const node15 = new ZWaveNode(15, driver);


### PR DESCRIPTION
Another step towards fixing #3811. While not present in the logs there, it could happen that a `Supervision Get` is answered while waiting for a nonce from a node, potentially causing issues with the secure transaction due to timeouts or an invalidated SPAN state.
This was because the `Supervision Report` incorrectly had a `Handshake` priority. This has now been changed while also renaming this priority to `Nonce` to make it clearer what it is meant for.