### PR TITLE
fix(config): clarify dim level parameter label for GE/Jasco 26932 / 26933 / ZW3008

### DIFF
--- a/packages/config/config/devices/0x0063/26932_26933_zw3008.json
+++ b/packages/config/config/devices/0x0063/26932_26933_zw3008.json
@@ -69,7 +69,7 @@
 		},
 		{
 			"#": "2",
-			"label": "Dim Level",
+			"label": "Associated Dim Level",
 			"description": "Brightness of associated light(s)",
 			"valueSize": 1,
 			"minValue": 0,


### PR DESCRIPTION
Tweak the label of parameter 2 to highlight it's the dim level sent to *associated* lights, not the switch itself.

I missed that it said it in the description. Crossed checked with: https://drzwave.blog/2021/02/16/jasco-motion-dimmer-explained/
