### PR TITLE
fix(config): add fingerprint for AU/NZ model of Aeotec ZW141

### DIFF
--- a/packages/config/config/devices/0x0371/zw141.json
+++ b/packages/config/config/devices/0x0371/zw141.json
@@ -12,6 +12,10 @@
 		{
 			"productType": "0x0103",
 			"productId": "0x008d"
+		},
+		{
+			"productType": "0x0203",
+			"productId": "0x008d"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
Product type 0x0203 fails to map correctly to this config.

Have included this product type variant so it maps correctly to this config.
