### PR TITLE
fix: disallow Node.js releases that are dev or don't support subpath export patterns

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/sponsors/AlCalzone/"
   },
   "engines": {
-    "node": ">=12.22.2 <16.9.0 || >16.9.0"
+    "node": ">=12.22.2 <13 || >=14.13.0 <15 || >= 16 <16.9.0 || >16.9.0"
   },
   "scripts": {
     "prebuild": "yarn ts maintenance/prebuild.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/sponsors/AlCalzone/"
   },
   "engines": {
-    "node": ">=12.22.2 <16.9.0 || >16.9.0"
+    "node": ">=12.22.2 <13 || >=14.13.0 <15 || >= 16 <16.9.0 || >16.9.0"
   },
   "scripts": {
     "build": "tsc -b tsconfig.build.json",

--- a/packages/maintenance/package.json
+++ b/packages/maintenance/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/sponsors/AlCalzone/"
   },
   "engines": {
-    "node": ">=12.22.2 <16.9.0 || >16.9.0"
+    "node": ">=12.22.2 <13 || >=14.13.0 <15 || >= 16 <16.9.0 || >16.9.0"
   },
   "scripts": {
     "build": "tsc -b tsconfig.build.json",

--- a/packages/serial/package.json
+++ b/packages/serial/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/sponsors/AlCalzone/"
   },
   "engines": {
-    "node": ">=12.22.2 <16.9.0 || >16.9.0"
+    "node": ">=12.22.2 <13 || >=14.13.0 <15 || >= 16 <16.9.0 || >16.9.0"
   },
   "scripts": {
     "build": "tsc -b tsconfig.build.json",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/sponsors/AlCalzone/"
   },
   "engines": {
-    "node": ">=v12.22.2"
+    "node": ">=12.22.2 <13 || >=14.13.0 <15 || >= 16 <16.9.0 || >16.9.0"
   },
   "dependencies": {
     "alcalzone-shared": "^4.0.1",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/sponsors/AlCalzone/"
   },
   "engines": {
-    "node": ">=12.22.2 <16.9.0 || >16.9.0"
+    "node": ">=12.22.2 <13 || >=14.13.0 <15 || >= 16 <16.9.0 || >16.9.0"
   },
   "scripts": {
     "build": "tsc -b tsconfig.build.json",

--- a/packages/zwave-js/package.json
+++ b/packages/zwave-js/package.json
@@ -40,7 +40,7 @@
     "url": "https://github.com/sponsors/AlCalzone/"
   },
   "engines": {
-    "node": ">=12.22.2 <16.9.0 || >16.9.0"
+    "node": ">=12.22.2 <13 || >=14.13.0 <15 || >= 16 <16.9.0 || >16.9.0"
   },
   "scripts": {
     "b": "yarn ts maintenance/_build.ts",


### PR DESCRIPTION
specifically Node 13, 15 and 14.0 through 14.12.x