### PR TITLE
fix(config): update CT100 device config fIle

### DIFF
--- a/packages/config/config/devices/0x0098/ct100.json
+++ b/packages/config/config/devices/0x0098/ct100.json
@@ -46,7 +46,7 @@
 			"description": "Send report about Thermostat Mode, Thermostat Operating State, Fan Mode, Fan State, Setpoint, Sensor Multilevel",
 			"maxNodes": 2,
 			"isLifeline": true
-		}	
+		}
 	},
 	"paramInformation": [
 		{

--- a/packages/config/config/devices/0x0098/ct100.json
+++ b/packages/config/config/devices/0x0098/ct100.json
@@ -42,10 +42,220 @@
 	},
 	"associations": {
 		"1": {
-			"label": "Group 1",
+			"label": "Lifeline",
 			"description": "Send report about Thermostat Mode, Thermostat Operating State, Fan Mode, Fan State, Setpoint, Sensor Multilevel",
 			"maxNodes": 2,
 			"isLifeline": true
+		}	
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"label": "Temperature Reporting Threshold",
+			"description": "Reporting threshold for changes in the ambient temperature",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 4,
+			"defaultValue": 2,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disabled",
+					"value": 0
+				},
+				{
+					"label": "0.5° F",
+					"value": 1
+				},
+				{
+					"label": "1.0° F",
+					"value": 2
+				},
+				{
+					"label": "1.5° F",
+					"value": 3
+				},
+				{
+					"label": "2.0° F",
+					"value": 4
+				}
+			]
+		},
+		{
+			"#": "2",
+			"label": "HVAC Settings",
+			"description": "Configured HVAC settings",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 0,
+			"defaultValue": 0,
+			"readOnly": true
+		},
+		{
+			"#": "3",
+			"label": "Utility Lock Enable/Disable",
+			"description": "Prevents setpoint changes at thermostat",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"unsigned": true,
+			"writeOnly": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Utility lock disabled",
+					"value": 0
+				},
+				{
+					"label": "Utility lock enabled",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "4",
+			"label": "Power Status",
+			"description": "C-Wire / Battery Status",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 0,
+			"defaultValue": 0,
+			"readOnly": true
+		},
+		{
+			"#": "5",
+			"label": "Humidity Reporting Threshold",
+			"description": "Reporting threshold for changes in the relative humidity",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disabled",
+					"value": 0
+				},
+				{
+					"label": "3% RH",
+					"value": 1
+				},
+				{
+					"label": "5% RH",
+					"value": 2
+				},
+				{
+					"label": "10% RH",
+					"value": 3
+				}
+			]
+		},
+		{
+			"#": "6",
+			"label": "Auxiliary/Emergency",
+			"description": "Enables or disables auxiliary / emergency heating",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Auxiliary/Emergency heat disabled",
+					"value": 0
+				},
+				{
+					"label": "Auxiliary/Emergency heat enabled",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "7",
+			"label": "Thermostat Swing Temperature",
+			"description": "Variance allowed from setpoint to engage HVAC",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 8,
+			"defaultValue": 2,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "0.5° F",
+					"value": 1
+				},
+				{
+					"label": "1.0° F",
+					"value": 2
+				},
+				{
+					"label": "1.5° F",
+					"value": 3
+				},
+				{
+					"label": "2.0° F",
+					"value": 4
+				},
+				{
+					"label": "2.5° F",
+					"value": 5
+				},
+				{
+					"label": "3.0° F",
+					"value": 6
+				},
+				{
+					"label": "3.5° F",
+					"value": 7
+				},
+				{
+					"label": "4.0° F",
+					"value": 8
+				}
+			]
+		},
+		{
+			"#": "9",
+			"label": "Thermostat Recovery Mode",
+			"description": "Fast or Economy recovery mode",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 2,
+			"defaultValue": 2,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Fast recovery mode",
+					"value": 1
+				},
+				{
+					"label": "Economy recovery mode",
+					"value": 2
+				}
+			]
+		},
+		{
+			"#": "12",
+			"label": "Multicast",
+			"description": "Enable or disables Multicast",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Multicast disabled",
+					"value": 0
+				},
+				{
+					"label": "Multicast enabled",
+					"value": 1
+				}
+			]
 		}
-	}
+	]
 }


### PR DESCRIPTION
Updated CT100 Config file. Device is fundamentally the same as the CT100-Plus, with a few differences. Crosschecked with the OpenZWave device config for reference and everything is the same.

PS. It is my first time pulling a proper PR so I apologize if this is not fully completed or acceptable. 
However, the file was tested on my ZwaveJS instance and worked fine, providing critical functions to the device in question.