### PR TITLE
fix: correctly forward command errors and improve nonce handling and sequencing

### DIFF
--- a/packages/zwave-js/src/lib/driver/CommandQueueMachine.ts
+++ b/packages/zwave-js/src/lib/driver/CommandQueueMachine.ts
@@ -134,13 +134,16 @@ const notifyResult = sendParent((ctx: CommandQueueContext, evt: any) => ({
 	},
 }));
 
-const notifyError = sendParent<CommandQueueContext, any, CommandQueueEvent>(
-	(ctx, evt) => ({
+const notifyError = sendParent((ctx: CommandQueueContext, evt: any) => ({
+	type: "forward",
+	from: "QUEUE",
+	to: ctx.callbackIDs.get(ctx.currentTransaction!),
+	payload: {
 		type: "command_error",
 		error: evt.data,
 		transaction: ctx.currentTransaction,
-	}),
-);
+	},
+}));
 
 export function createCommandQueueMachine(
 	implementations: ServiceImplementations,

--- a/packages/zwave-js/src/lib/driver/SendThreadMachine.ts
+++ b/packages/zwave-js/src/lib/driver/SendThreadMachine.ts
@@ -184,24 +184,37 @@ const guards: MachineOptions<SendThreadContext, SendThreadEvent>["guards"] = {
 		// The send queue is sorted automatically. If the first message is for a sleeping node, all messages in the queue are.
 		// There are a few exceptions:
 		// 1. Pings may be used to determine whether a node is really asleep.
-		// 2. Responses to nonce requests must always be sent, because some sleeping nodes may try to send us encrypted messages.
+		// 2. Responses to nonce requests must be sent independent of the node status, because some sleeping nodes may try to send us encrypted messages.
 		//    If we don't send them, they block the send queue
 		// 3. Nodes that can sleep but do not support wakeup: https://github.com/zwave-js/node-zwave-js/discussions/1537
 		//    We need to try and send messages to them even if they are asleep, because we might never hear from them
 
-		// 3.
+		// While the queue is busy, we may not start any transaction, except nonce responses to the node we're currently communicating with
+		if (meta.state.matches("busy")) {
+			if (nextTransaction.priority === MessagePriority.Nonce) {
+				for (const active of ctx.activeTransactions.values()) {
+					if (
+						active.transaction.message.getNodeId() ===
+						nextTransaction.message.getNodeId()
+					) {
+						return true;
+					}
+				}
+			}
+			return false;
+		}
+
+		// While not busy, always reply to nonce requests
 		if (nextTransaction.priority === MessagePriority.Nonce) return true;
+		// And send pings
+		if (messageIsPing(message)) return true;
+		// Or controller messages
+		if (!targetNode) return true;
 
-		// While the queue is busy, we may not start any transaction that is not a nonce response
-		if (meta.state.matches("busy")) return false;
-
-		// 1./2.
 		return (
-			!targetNode ||
 			targetNode.status !== NodeStatus.Asleep ||
 			(!targetNode.supportsCC(CommandClasses["Wake Up"]) &&
-				targetNode.interviewStage >= InterviewStage.NodeInfo) ||
-			messageIsPing(message)
+				targetNode.interviewStage >= InterviewStage.NodeInfo)
 		);
 	},
 	hasNoActiveTransactions: (ctx) => ctx.activeTransactions.size === 0,

--- a/packages/zwave-js/src/lib/test/driver/sendDataCallbackMessageOrder.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/sendDataCallbackMessageOrder.test.ts
@@ -233,7 +233,7 @@ describe("regression tests", () => {
 			{ nonce: sentNonce, receiver: 17 },
 		);
 		const encap = SecurityCC.encapsulate(driver17, configReport);
-		encap.nonceId = sentNonce[0];
+		encap.nonce = sentNonce;
 		const msg = new ApplicationCommandRequest(driver17, {
 			command: encap,
 		});

--- a/test/run.ts
+++ b/test/run.ts
@@ -2,7 +2,6 @@
 // import { Driver } from "../packages/zwave-js";
 
 // To test without Sentry reporting
-import { wait } from "alcalzone-shared/async";
 import path from "path";
 import "reflect-metadata";
 import { Driver } from "../packages/zwave-js/src/lib/driver/Driver";
@@ -37,15 +36,7 @@ const driver = new Driver("COM5", {
 })
 	.on("error", console.error)
 	.once("driver ready", async () => {
-		await wait(2500);
-		const health = await driver.controller.nodes
-			.getOrThrow(2)
-			.checkRouteHealth(3, 3, (n, t, r) => {
-				console.debug(`Health check round ${n}/${t}: rating = ${r}`);
-			});
-
-		await wait(100);
-		process.exit(0);
+		// Test code
 	});
 void driver.start();
 // driver.enableStatistics({


### PR DESCRIPTION
Apparently the `notifyError` action wasn't correctly rewritten along with the others, so the command errors got lost.
We now also immediately use/reserve S0 nonces for outgoing messages instead of waiting until the the command is serialized to avoid them timing out in the meantime.

This also prevents S2 messages from stalling when there was a problem generating the next nonce, but it does not yet prevent this from happening.

Furthermore, we no longer reply to nonce requests while waiting for a callback from a different node. This should avoid the situation with 700 series sticks where this reply takes so long that the nonce has already timed out again.

fixes: #3914