### PR TITLE
docs: remove nonexistent node method

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -158,14 +158,6 @@ isControllerNode(): boolean
 
 This is a little utility function to check if this node is the controller.
 
-### `isAwake`
-
-```ts
-isAwake(): boolean
-```
-
-Returns whether the node is currently assumed awake.
-
 ### `hasSecurityClass`
 
 ```ts


### PR DESCRIPTION
As far as I can tell this function no longer exists.
