### PR TITLE
fix(config): correct parameter 40 & 42, Qubino ZMNHTD

### DIFF
--- a/packages/config/config/devices/0x0159/zmnhtd.json
+++ b/packages/config/config/devices/0x0159/zmnhtd.json
@@ -91,7 +91,7 @@
 			"#": "40",
 			"label": "Power reporting (Watts) on power change",
 			"unit": "%",
-			"valueSize": 2,
+			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 100,
 			"defaultValue": 10

--- a/packages/config/config/devices/0x0159/zmnhtd.json
+++ b/packages/config/config/devices/0x0159/zmnhtd.json
@@ -99,11 +99,11 @@
 		{
 			"#": "42",
 			"label": "Power reporting (Watts) by time interval",
-			"unit": "%",
+			"unit": "seconds",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 32535,
-			"defaultValue": 0
+			"defaultValue": 600
 		},
 		{
 			"#": "45",


### PR DESCRIPTION
The new value size is noted in the device manual and has been tested on
my home network.