### PR TITLE
fix(config): treat Basic Set as event for ZW15S

### DIFF
--- a/packages/config/config/devices/0x011a/zw15s.json
+++ b/packages/config/config/devices/0x011a/zw15s.json
@@ -48,5 +48,9 @@
 				}
 			]
 		}
-	]
+	],
+	"compat": {
+		// Enable double-tap support
+		"treatBasicSetAsEvent": true
+	}
 }


### PR DESCRIPTION
A double-tap isn't treated as a scene, only a BasicCCSet.

Config browser link: https://devices.zwave-js.io/?jumpTo=0x011a:0x0101:0x0101:0.0

Double-tapping on or off of the ZW15S switch is supposed to be an event that can be listened to but currently nothing is dispatched. The first press turns the attached load on or off respectively. One can listen for the event from the 2nd press to do something else. (I relied on this behaviour in openzwave for many years.)

Double tap on after the fix (value: 255):
```
2021-12-19T06:49:45.250Z SERIAL « 0x010900040006032001ff29                                            (11 bytes)
2021-12-19T06:49:45.251Z SERIAL » [ACK]                                                                   (0x06)
2021-12-19T06:49:45.251Z DRIVER « [Node 006] [REQ] [ApplicationCommand]
                                  └─[BasicCCSet]
                                      target value: 255
2021-12-19T06:49:45.252Z CNTRLR   [Node 006] treating BasicCC::Set as a value event
2021-12-19T06:49:45.252Z CNTRLR   [Node 006] [!] [Basic] event: 255                                 [Endpoint 0]
```

Double-tap off after the fix (value: 0):
```
2021-12-19T06:51:57.129Z SERIAL « 0x01090004000603200100d6                                            (11 bytes)
2021-12-19T06:51:57.129Z SERIAL » [ACK]                                                                   (0x06)
2021-12-19T06:51:57.130Z DRIVER « [Node 006] [REQ] [ApplicationCommand]
                                  └─[BasicCCSet]
                                      target value: 0
2021-12-19T06:51:57.131Z CNTRLR   [Node 006] treating BasicCC::Set as a value event
2021-12-19T06:51:57.131Z CNTRLR   [Node 006] [!] [Basic] event: 0                                   [Endpoint 0]
```