### PR TITLE
feat: expose controller method to convert and restore NVM backups

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -601,12 +601,32 @@ Creates a backup of the NVM and returns the raw data as a Buffer. The optional a
 > [!NOTE] `backupNVMRaw` automatically turns the Z-Wave radio on/off during the backup.
 
 ```ts
+restoreNVM(
+	nvmData: Buffer,
+	convertProgress?: (bytesRead: number, total: number) => void,
+	restoreProgress?: (bytesWritten: number, total: number) => void,
+): Promise<void>
+```
+
+Restores an NVM backup that was created with `backupNVMRaw`.
+
+?> If the given buffer is in a different NVM format, it is **converted automatically**. If the conversion is not supported, the operation fails.
+
+The optional `convertProgress` and `restoreProgress` callbacks can be used to monitor the progress of the operation, which may take several seconds up to a few minutes depending on the NVM size.
+
+> [!NOTE] `restoreNVM` automatically turns the Z-Wave radio on/off during the restore.
+
+> [!WARNING] A failure during this process may brick your controller. Use at your own risk!
+
+```ts
 restoreNVMRaw(nvmData: Buffer, onProgress?: (bytesWritten: number, total: number) => void): Promise<void>
 ```
 
 Restores an NVM backup that was created with `backupNVMRaw`. The optional 2nd argument can be used to monitor the progress of the operation, which may take several seconds up to a few minutes depending on the NVM size.
 
 > [!NOTE] `restoreNVMRaw` automatically turns the Z-Wave radio on/off during the restore.
+
+> [!WARNING] The given buffer is **NOT** checked for compatibility with the current stick. To have Z-Wave JS do that, use the `restoreNVM` method instead.
 
 > [!WARNING] A failure during this process may brick your controller. Use at your own risk!
 

--- a/packages/core/src/error/ZWaveError.ts
+++ b/packages/core/src/error/ZWaveError.ts
@@ -58,6 +58,17 @@ export enum ZWaveErrorCodes {
 	/** A Serial API command resulted in an error response */
 	Controller_CommandError,
 
+	/** The given NVM version/format is unsupported */
+	NVM_NotSupported = 280,
+	/** Could not parse the JSON representation of an NVM due to invalid data */
+	NVM_InvalidJSON,
+	/** A required NVM3 object was not found while deserializing the NVM */
+	NVM_ObjectNotFound,
+	/** The parsed NVM or NVM content has an invalid format */
+	NVM_InvalidFormat,
+	/** Not enough space in the NVM */
+	NVM_NoSpace,
+
 	CC_Invalid = 300,
 	CC_NoNodeID,
 	CC_NotSupported,

--- a/packages/nvmedit/package.json
+++ b/packages/nvmedit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwave-js/nvmedit",
-  "version": "8.7.6",
+  "version": "8.9.0-beta.3",
   "description": "zwave-js: library to edit NVM backups",
   "publishConfig": {
     "access": "public"

--- a/packages/nvmedit/src/convert.test.ts
+++ b/packages/nvmedit/src/convert.test.ts
@@ -1,7 +1,7 @@
 import { cloneDeep } from "@zwave-js/shared";
 import fs from "fs-extra";
 import path from "path";
-import { jsonToNVM } from ".";
+import { jsonToNVM, migrateNVM } from ".";
 import {
 	json500To700,
 	json700To500,
@@ -183,5 +183,22 @@ describe("NVM conversion tests", () => {
 				expect(output).toEqual(expected);
 			});
 		}
+	});
+
+	it("700 to 700 migration shortcut", async () => {
+		const fixturesDir = path.join(
+			__dirname,
+			"../test/fixtures/nvm_700_binary",
+		);
+
+		const nvmSource = await fs.readFile(
+			path.join(fixturesDir, "ctrlr_backup_700_7.11.bin"),
+		);
+		const nvmTarget = await fs.readFile(
+			path.join(fixturesDir, "ctrlr_backup_700_7.16_1.bin"),
+		);
+		const converted = migrateNVM(nvmSource, nvmTarget);
+
+		expect(converted).toEqual(nvmSource);
 	});
 });

--- a/packages/nvmedit/src/convert.ts
+++ b/packages/nvmedit/src/convert.ts
@@ -1173,6 +1173,21 @@ export function migrateNVM(source: Buffer, target: Buffer): Buffer {
 		}
 	}
 
+	// Short circuit if the source and target protocol versions are compatible
+	if (!sourceIs500 && !targetIs500) {
+		const sourceProtocolVersion = sourceJSON.controller.protocolVersion;
+		const targetProtocolVersion = targetJSON.controller.protocolVersion;
+
+		// The 700 series firmware can automatically upgrade backups from a previous protocol version
+		// Not sure when that ability was added, but let's assume 7.16 supports it to be on the safe side
+		if (
+			semver.gte(targetProtocolVersion, "7.16.0") &&
+			semver.gte(targetProtocolVersion, sourceProtocolVersion)
+		) {
+			return source;
+		}
+	}
+
 	// In any case, preserve the application version of the target stick
 	sourceJSON.controller.applicationVersion =
 		targetJSON.controller.applicationVersion;

--- a/packages/nvmedit/src/files/ControllerInfoFile.ts
+++ b/packages/nvmedit/src/files/ControllerInfoFile.ts
@@ -1,4 +1,4 @@
-import { stripUndefined } from "@zwave-js/core";
+import { stripUndefined, ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
 import { buffer2hex } from "@zwave-js/shared";
 import type { NVM3Object } from "../nvm3/object";
 import {
@@ -66,7 +66,10 @@ export class ControllerInfoFile extends NVMFile {
 				this.primaryLongRangeChannelId = this.payload[20];
 				this.dcdcConfig = this.payload[21];
 			} else {
-				throw new Error(`Unsupported payload length`);
+				throw new ZWaveError(
+					`Unsupported payload length`,
+					ZWaveErrorCodes.NVM_InvalidFormat,
+				);
 			}
 		} else {
 			this.homeId = options.homeId;

--- a/packages/nvmedit/src/files/SUCUpdateEntriesFile.ts
+++ b/packages/nvmedit/src/files/SUCUpdateEntriesFile.ts
@@ -1,4 +1,10 @@
-import { CommandClasses, encodeCCList, parseCCList } from "@zwave-js/core";
+import {
+	CommandClasses,
+	encodeCCList,
+	parseCCList,
+	ZWaveError,
+	ZWaveErrorCodes,
+} from "@zwave-js/core";
 import {
 	SUC_MAX_UPDATES,
 	SUC_UPDATE_ENTRY_SIZE,
@@ -58,7 +64,10 @@ export function encodeSUCUpdateEntry(
 		ret[1] = entry.changeType;
 		const ccList = encodeCCList(entry.supportedCCs, entry.controlledCCs);
 		if (ccList.length > SUC_UPDATE_NODEPARM_MAX) {
-			throw new Error("Cannot encode SUC update entry, too many CCs");
+			throw new ZWaveError(
+				"Cannot encode SUC update entry, too many CCs",
+				ZWaveErrorCodes.Argument_Invalid,
+			);
 		}
 		ccList.copy(ret, 2);
 	}

--- a/packages/nvmedit/src/nvm3/nvm.ts
+++ b/packages/nvmedit/src/nvm3/nvm.ts
@@ -1,3 +1,4 @@
+import { ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
 import { pick } from "@zwave-js/shared";
 import {
 	FLASH_MAX_PAGE_SIZE,
@@ -159,7 +160,10 @@ export function encodeNVM(
 		const nextPage = () => {
 			pageIndex++;
 			if (pageIndex >= pages.length) {
-				throw new Error("Not enough pages!");
+				throw new ZWaveError(
+					"Not enough pages!",
+					ZWaveErrorCodes.NVM_NoSpace,
+				);
 			}
 			currentPage = pages[pageIndex];
 			offsetInPage = NVM3_PAGE_HEADER_SIZE;

--- a/packages/nvmedit/src/nvm3/object.ts
+++ b/packages/nvmedit/src/nvm3/object.ts
@@ -1,3 +1,4 @@
+import { ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
 import {
 	FragmentType,
 	NVM3_CODE_LARGE_SHIFT,
@@ -71,7 +72,10 @@ export function readObject(
 	}
 
 	if (buffer.length < offset + headerSize + fragmentLength) {
-		throw new Error("Incomplete object in buffer!");
+		throw new ZWaveError(
+			"Incomplete object in buffer!",
+			ZWaveErrorCodes.NVM_InvalidFormat,
+		);
 	}
 
 	let data: Buffer | undefined;

--- a/packages/nvmedit/src/nvm3/page.ts
+++ b/packages/nvmedit/src/nvm3/page.ts
@@ -1,3 +1,4 @@
+import { ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
 import {
 	FLASH_MAX_PAGE_SIZE,
 	NVM3_MIN_PAGE_SIZE,
@@ -44,10 +45,16 @@ export function readPage(
 	const version = buffer.readUInt16LE(offset);
 	const magic = buffer.readUInt16LE(offset + 2);
 	if (magic !== NVM3_PAGE_MAGIC) {
-		throw new Error("Not a valid NVM3 page!");
+		throw new ZWaveError(
+			"Not a valid NVM3 page!",
+			ZWaveErrorCodes.NVM_InvalidFormat,
+		);
 	}
 	if (version !== 0x01) {
-		throw new Error(`Unsupported NVM3 page version: ${version}`);
+		throw new ZWaveError(
+			`Unsupported NVM3 page version: ${version}`,
+			ZWaveErrorCodes.NVM_NotSupported,
+		);
 	}
 
 	// The erase counter is saved twice, once normally, once inverted
@@ -66,7 +73,10 @@ export function readPage(
 	);
 
 	if (eraseCount !== (~eraseCountInv & NVM3_PAGE_COUNTER_MASK)) {
-		throw new Error("Invalid erase count!");
+		throw new ZWaveError(
+			"Invalid erase count!",
+			ZWaveErrorCodes.NVM_InvalidFormat,
+		);
 	}
 
 	// Page status
@@ -82,7 +92,10 @@ export function readPage(
 	const actualPageSize = Math.min(pageSize, FLASH_MAX_PAGE_SIZE);
 
 	if (buffer.length < offset + actualPageSize) {
-		throw new Error("Incomplete page in buffer!");
+		throw new ZWaveError(
+			"Incomplete page in buffer!",
+			ZWaveErrorCodes.NVM_InvalidFormat,
+		);
 	}
 
 	const formatInfo = buffer.readUInt16LE(offset + 18);

--- a/packages/nvmedit/src/nvm3/utils.ts
+++ b/packages/nvmedit/src/nvm3/utils.ts
@@ -1,3 +1,4 @@
+import { ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
 import { NVMFile } from "../files/NVMFile";
 import { FragmentType, ObjectType, PageStatus } from "./consts";
 import type { NVM3Object } from "./object";
@@ -26,7 +27,10 @@ export function validateBergerCode(
 	numBits: number = 32,
 ): void {
 	if (computeBergerCode(word, numBits) !== code) {
-		throw new Error("Berger Code validation failed!");
+		throw new ZWaveError(
+			"Berger Code validation failed!",
+			ZWaveErrorCodes.NVM_InvalidFormat,
+		);
 	}
 }
 
@@ -60,7 +64,10 @@ export function validateBergerCodeMulti(
 		numBits -= 32;
 	}
 	if (actual !== expected!) {
-		throw new Error("Berger Code validation failed!");
+		throw new ZWaveError(
+			"Berger Code validation failed!",
+			ZWaveErrorCodes.NVM_InvalidFormat,
+		);
 	}
 }
 

--- a/packages/nvmedit/src/nvm500/NVMParser.ts
+++ b/packages/nvmedit/src/nvm500/NVMParser.ts
@@ -3,6 +3,8 @@ import {
 	encodeBitMask,
 	MAX_NODES,
 	parseBitMask,
+	ZWaveError,
+	ZWaveErrorCodes,
 } from "@zwave-js/core";
 import { num2hex, pick, sum } from "@zwave-js/shared";
 import { SUC_MAX_UPDATES } from "../consts";
@@ -79,7 +81,11 @@ export function createParser(nvm: Buffer): NVMParser | undefined {
 export class NVMParser {
 	public constructor(private readonly impl: NVM500Details, nvm: Buffer) {
 		this.parse(nvm);
-		if (!this.isValid()) throw new Error("Invalid NVM!");
+		if (!this.isValid())
+			throw new ZWaveError(
+				"Invalid NVM!",
+				ZWaveErrorCodes.NVM_InvalidFormat,
+			);
 	}
 
 	/** Tests if the given NVM is a valid NVM for this parser version */
@@ -136,8 +142,9 @@ export class NVMParser {
 
 			if (entry.offset != undefined && entry.offset !== offset) {
 				// The entry has a defined offset but is at the wrong location
-				throw new Error(
+				throw new ZWaveError(
 					`${entry.name} is at wrong location in NVM buffer!`,
+					ZWaveErrorCodes.NVM_InvalidFormat,
 				);
 			}
 
@@ -173,8 +180,9 @@ export class NVMParser {
 					case NVMEntryType.NVMModuleDescriptor: {
 						const ret = parseNVMModuleDescriptor(buffer);
 						if (ret.size !== moduleSize) {
-							throw new Error(
+							throw new ZWaveError(
 								"NVM module descriptor size does not match module size!",
+								ZWaveErrorCodes.NVM_InvalidFormat,
 							);
 						}
 						return ret;

--- a/packages/zwave-js/package.json
+++ b/packages/zwave-js/package.json
@@ -59,6 +59,7 @@
     "@sentry/node": "^6.15.0",
     "@zwave-js/config": "8.9.0-beta.3",
     "@zwave-js/core": "8.9.0-beta.3",
+    "@zwave-js/nvmedit": "8.9.0-beta.3",
     "@zwave-js/serial": "8.9.0-beta.3",
     "@zwave-js/shared": "8.9.0-beta.3",
     "alcalzone-shared": "^4.0.1",

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -4681,17 +4681,37 @@ ${associatedNodes.join(", ")}`,
 			await this.toggleRF(true);
 		}
 
-		if (this.driver.options.enableSoftReset) {
-			this.driver.controllerLog.print(
-				"Activating restored NVM backup...",
-			);
-			await this.driver.softReset();
-		} else {
-			this.driver.controllerLog.print(
-				"Soft reset not enabled, cannot automatically activate restored NVM backup!",
-				"warn",
-			);
-		}
+		// After a restored NVM backup, the controller's capabilities may have changed. At the very least reset the information
+		// about soft reset capability
+		this._supportsSoftReset = undefined;
+
+		// Normally we'd only need to soft reset the stick, but we also need to re-interview the controller and potentially all nodes.
+		// Just forcing a restart of the driver seems easier.
+
+		// if (this.driver.options.enableSoftReset) {
+		// 	this.driver.controllerLog.print(
+		// 		"Activating restored NVM backup...",
+		// 	);
+		// 	await this.driver.softReset();
+		// } else {
+		// 	this.driver.controllerLog.print(
+		// 		"Soft reset not enabled, cannot automatically activate restored NVM backup!",
+		// 		"warn",
+		// 	);
+		// }
+
+		this.driver.controllerLog.print(
+			"Restarting driver to activate restored NVM backup...",
+		);
+
+		this.driver.emit(
+			"error",
+			new ZWaveError(
+				"Applying the NVM backup requires a driver restart!",
+				ZWaveErrorCodes.Driver_Failed,
+			),
+		);
+		await this.driver.destroy();
 	}
 
 	/**
@@ -4733,17 +4753,37 @@ ${associatedNodes.join(", ")}`,
 		// so you can figure out which pages you don't have to save or restore. If you do this, you need to make sure to issue a
 		// "factory reset" before restoring the NVM - that'll blank out the NVM to 0xffs before initializing it.
 
-		if (this.driver.options.enableSoftReset) {
-			this.driver.controllerLog.print(
-				"Activating restored NVM backup...",
-			);
-			await this.driver.softReset();
-		} else {
-			this.driver.controllerLog.print(
-				"Soft reset not enabled, cannot automatically activate restored NVM backup!",
-				"warn",
-			);
-		}
+		// After a restored NVM backup, the controller's capabilities may have changed. At the very least reset the information
+		// about soft reset capability
+		this._supportsSoftReset = undefined;
+
+		// Normally we'd only need to soft reset the stick, but we also need to re-interview the controller and potentially all nodes.
+		// Just forcing a restart of the driver seems easier.
+
+		// if (this.driver.options.enableSoftReset) {
+		// 	this.driver.controllerLog.print(
+		// 		"Activating restored NVM backup...",
+		// 	);
+		// 	await this.driver.softReset();
+		// } else {
+		// 	this.driver.controllerLog.print(
+		// 		"Soft reset not enabled, cannot automatically activate restored NVM backup!",
+		// 		"warn",
+		// 	);
+		// }
+
+		this.driver.controllerLog.print(
+			"Restarting driver to activate restored NVM backup...",
+		);
+
+		this.driver.emit(
+			"error",
+			new ZWaveError(
+				"Activating the NVM backup requires a driver restart!",
+				ZWaveErrorCodes.Driver_Failed,
+			),
+		);
+		await this.driver.destroy();
 	}
 
 	private async restoreNVMRaw500(

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -22,6 +22,7 @@ import {
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
+import { migrateNVM } from "@zwave-js/nvmedit";
 import {
 	flatMap,
 	getEnumMemberName,
@@ -4630,6 +4631,73 @@ ${associatedNodes.join(", ")}`,
 
 	/**
 	 * Restores an NVM backup that was created with `backupNVMRaw`. The Z-Wave radio is turned off/on automatically.
+	 * If the given buffer is in a different NVM format, it is converted automatically. If the conversion is not supported, the operation fails.
+	 *
+	 * **WARNING:** A failure during this process may brick your controller. Use at your own risk!
+	 *
+	 * @param nvmData The NVM backup to be restored
+	 * @param convertProgress Can be used to monitor the progress of the NVM conversion, which may take several seconds up to a few minutes depending on the NVM size
+	 * @param restoreProgress Can be used to monitor the progress of the restore operation, which may take several seconds up to a few minutes depending on the NVM size
+	 */
+	public async restoreNVM(
+		nvmData: Buffer,
+		convertProgress?: (bytesRead: number, total: number) => void,
+		restoreProgress?: (bytesWritten: number, total: number) => void,
+	): Promise<void> {
+		// Turn Z-Wave radio off to avoid having the protocol write to the NVM while dumping it
+		if (!(await this.toggleRF(false))) {
+			throw new ZWaveError(
+				"Could not turn off the Z-Wave radio before restoring NVM backup!",
+				ZWaveErrorCodes.Controller_ResponseNOK,
+			);
+		}
+
+		// Restoring a potentially incompatible NVM happens in three steps:
+		// 1. the current NVM is read
+		// 2. the given NVM data is converted to match the current format
+		// 3. the converted data is written to the NVM
+
+		try {
+			this.driver.controllerLog.print(
+				"Converting NVM to target format...",
+			);
+			let targetNVM: Buffer;
+			if (this.serialApiGte("7.0")) {
+				targetNVM = await this.backupNVMRaw700(convertProgress);
+			} else {
+				targetNVM = await this.backupNVMRaw500(convertProgress);
+			}
+			const convertedNVM = migrateNVM(nvmData, targetNVM);
+
+			this.driver.controllerLog.print("Restoring NVM backup...");
+			if (this.serialApiGte("7.0")) {
+				await this.restoreNVMRaw700(convertedNVM, restoreProgress);
+			} else {
+				await this.restoreNVMRaw500(convertedNVM, restoreProgress);
+			}
+			this.driver.controllerLog.print("NVM backup restored");
+		} finally {
+			// Whatever happens, turn Z-Wave radio back on
+			await this.toggleRF(true);
+		}
+
+		if (this.driver.options.enableSoftReset) {
+			this.driver.controllerLog.print(
+				"Activating restored NVM backup...",
+			);
+			await this.driver.softReset();
+		} else {
+			this.driver.controllerLog.print(
+				"Soft reset not enabled, cannot automatically activate restored NVM backup!",
+				"warn",
+			);
+		}
+	}
+
+	/**
+	 * Restores an NVM backup that was created with `backupNVMRaw`. The Z-Wave radio is turned off/on automatically.
+	 *
+	 * **WARNING:** The given buffer is NOT checked for compatibility with the current stick. To have Z-Wave JS do that, use the {@link restoreNVM} method instead.
 	 *
 	 * **WARNING:** A failure during this process may brick your controller. Use at your own risk!
 	 * @param nvmData The raw NVM backup to be restored

--- a/packages/zwave-js/tsconfig.build.json
+++ b/packages/zwave-js/tsconfig.build.json
@@ -13,6 +13,9 @@
 			"path": "../core/tsconfig.build.json"
 		},
 		{
+			"path": "../nvmedit/tsconfig.build.json"
+		},
+		{
 			"path": "../serial/tsconfig.build.json"
 		},
 		{

--- a/packages/zwave-js/tsconfig.json
+++ b/packages/zwave-js/tsconfig.json
@@ -13,6 +13,9 @@
 			"path": "../maintenance/tsconfig.build.json"
 		},
 		{
+			"path": "../nvmedit/tsconfig.build.json"
+		},
+		{
 			"path": "../serial/tsconfig.build.json"
 		},
 		{

--- a/yarn.lock
+++ b/yarn.lock
@@ -4252,7 +4252,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@zwave-js/nvmedit@workspace:*, @zwave-js/nvmedit@workspace:packages/nvmedit":
+"@zwave-js/nvmedit@8.9.0-beta.3, @zwave-js/nvmedit@workspace:*, @zwave-js/nvmedit@workspace:packages/nvmedit":
   version: 0.0.0-use.local
   resolution: "@zwave-js/nvmedit@workspace:packages/nvmedit"
   dependencies:
@@ -14440,6 +14440,7 @@ typescript@^4.4.3:
     "@zwave-js/config": 8.9.0-beta.3
     "@zwave-js/core": 8.9.0-beta.3
     "@zwave-js/maintenance": 8.9.0-beta.3
+    "@zwave-js/nvmedit": 8.9.0-beta.3
     "@zwave-js/serial": 8.9.0-beta.3
     "@zwave-js/shared": 8.9.0-beta.3
     "@zwave-js/testing": 8.9.0-beta.3


### PR DESCRIPTION
This PR adds the `restoreNVM` (without `...Raw`) method to the `Controller` class which enables restoring backups from a different protocol version, thus allowing an easy migration between 500 and 700 series sticks.
The backup is automatically converted to the format required by the currently plugged-in stick and will fail if there is no supported migration.

In order to apply the restored backup, the stick needs to be soft reset. Also a re-interview is potentially necessary. Therefore we force a driver restart after restoring a backup by destroying it and emitting a `Driver_Failed` error now.

**WARNING:** This is still experimental functionality. Use at your own risk and make backups first!