### PR TITLE
fix: update the SUC node id after self-promotion

### DIFF
--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -848,6 +848,9 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 					true,
 					true,
 				);
+				if (result) {
+					this._sucNodeId = this._ownNodeId;
+				}
 				this.driver.controllerLog.print(
 					`Promotion to SUC/SIS ${result ? "succeeded" : "failed"}.`,
 					result ? undefined : "warn",


### PR DESCRIPTION
This is a small fix to update the controller's `_sucNodeId` with its own node id immediately after promoting itself. Currently the behavior is that the `subNodeId` property remains 0 in this case.