### PR TITLE
fix: interpret the callback status for Set SUC NodeID command correctly

### DIFF
--- a/packages/zwave-js/src/lib/controller/SetSUCNodeIDMessages.ts
+++ b/packages/zwave-js/src/lib/controller/SetSUCNodeIDMessages.ts
@@ -21,7 +21,12 @@ import {
 	priority,
 } from "../message/Message";
 import type { SuccessIndicator } from "../message/SuccessIndicator";
-import { TransmitOptions, TransmitStatus } from "./SendDataShared";
+import { TransmitOptions } from "./SendDataShared";
+
+export enum SetSUCNodeIdStatus {
+	Succeeded = 0x05,
+	Failed = 0x06,
+}
 
 export interface SetSUCNodeIdRequestOptions extends MessageBaseOptions {
 	sucNodeId?: number;
@@ -124,12 +129,12 @@ export class SetSUCNodeIdRequestStatusReport
 		this._status = this.payload[1];
 	}
 
-	private _status: TransmitStatus;
-	public get status(): TransmitStatus {
+	private _status: SetSUCNodeIdStatus;
+	public get status(): SetSUCNodeIdStatus {
 		return this._status;
 	}
 
 	public isOK(): boolean {
-		return this._status === TransmitStatus.OK;
+		return this._status === SetSUCNodeIdStatus.Succeeded;
 	}
 }


### PR DESCRIPTION
According to the spec, the callback for the Set SUC NodeID Command doesn't return a `TransmitStatus` enum but instead a status value specific to the command.

See:
![image](https://user-images.githubusercontent.com/6445614/147109598-79991f9a-10f3-4ca1-a2e3-15cde920cf26.png)

If I were to guess, I believe this got mixed up with the Send SUC NodeID Command ("Set" vs "Send"), which does return a `TransmitStatus` in the callback (and is unimplemented as `UNKNOWN_FUNC_SEND_SUC_ID` in zwave-js currently)