### PR TITLE
feat(config): support adding comments to devices

### DIFF
--- a/maintenance/schemas/device-config.json
+++ b/maintenance/schemas/device-config.json
@@ -310,6 +310,20 @@
 				"manual": {
 					"type": "string",
 					"description": "A link to the device manual"
+				},
+				"comments": {
+					"oneOf": [
+						{
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/comment"
+							},
+							"minItems": 1
+						},
+						{
+							"$ref": "#/definitions/comment"
+						}
+					]
 				}
 			},
 			"additionalProperties": false,
@@ -572,6 +586,21 @@
 					"required": ["#", "$import"]
 				}
 			]
+		},
+		"comment": {
+			"type": "object",
+			"properties": {
+				"level": {
+					"type": "string",
+					"enum": ["info", "warning", "error"]
+				},
+				"text": {
+					"type": "string",
+					"description": "The actual comment"
+				}
+			},
+			"additionalProperties": false,
+			"required": ["level", "text"]
 		}
 	}
 }

--- a/packages/config/config/devices/0x0002/drs11.json
+++ b/packages/config/config/devices/0x0002/drs11.json
@@ -1,0 +1,22 @@
+{
+	"manufacturer": "Danfoss",
+	"manufacturerId": "0x0002",
+	"label": "DRS11",
+	"description": "Room Thermostat",
+	"devices": [
+		{
+			"productType": "0x8003",
+			"productId": "0x8001"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"metadata": {
+		"comments": {
+			"level": "error",
+			"text": "This device only supports proprietary commands and is not usable in Z-Wave JS."
+		}
+	}
+}

--- a/packages/config/src/Devices.ts
+++ b/packages/config/src/Devices.ts
@@ -1284,10 +1284,26 @@ export class DeviceMetadata {
 			"exclusion",
 			"reset",
 			"manual",
+			"comments",
 		] as const) {
 			if (prop in definition) {
 				const value = definition[prop];
-				if (typeof value !== "string") {
+				if (prop === "comments") {
+					const isComment = (opt: unknown) =>
+						isObject(opt) &&
+						typeof opt.level === "string" &&
+						typeof opt.text === "string";
+
+					const isValid =
+						(isArray(value) && value.every(isComment)) ||
+						isComment(value);
+					if (!isValid)
+						throwInvalidConfig(
+							"devices",
+							`packages/config/config/devices/${filename}:
+The metadata entry comments is invalid!`,
+						);
+				} else if (typeof value !== "string") {
 					throwInvalidConfig(
 						"devices",
 						`packages/config/config/devices/${filename}:
@@ -1309,4 +1325,11 @@ The metadata entry ${prop} must be a string!`,
 	public readonly reset?: string;
 	/** A link to the device manual */
 	public readonly manual?: string;
+	/** Comments for this device */
+	public readonly comments?: DeviceComment | DeviceComment[];
+}
+
+export interface DeviceComment {
+	level: "info" | "warning" | "error";
+	text: string;
 }


### PR DESCRIPTION
With this PR, config files can have one or more comments in the metadata. These have a text and 3 different levels:
- `info`: general information, like hints for configuration
- `warning`: Should be displayed with a ⚠ to warn the user of potential issues
- `error`: Meant to warn the user of unusable devices or other severe issues. Should be shown in red with an appropriate icon, e.g. ❌.

closes: #3932