### PR TITLE
fix: treat more node queries like SendData

### DIFF
--- a/packages/zwave-js/src/lib/controller/SendDataShared.ts
+++ b/packages/zwave-js/src/lib/controller/SendDataShared.ts
@@ -4,6 +4,10 @@ import {
 	stripUndefined,
 } from "@zwave-js/core";
 import { num2hex } from "@zwave-js/shared";
+import { AssignReturnRouteRequestTransmitReport } from "./AssignReturnRouteMessages";
+import { AssignSUCReturnRouteRequestTransmitReport } from "./AssignSUCReturnRouteMessages";
+import { DeleteReturnRouteRequestTransmitReport } from "./DeleteReturnRouteMessages";
+import { DeleteSUCReturnRouteRequestTransmitReport } from "./DeleteSUCReturnRouteMessages";
 import {
 	SendDataBridgeRequest,
 	SendDataBridgeRequestTransmitReport,
@@ -28,6 +32,14 @@ export type SendDataTransmitReport =
 	| SendDataMulticastRequestTransmitReport
 	| SendDataBridgeRequestTransmitReport
 	| SendDataMulticastBridgeRequestTransmitReport;
+
+/** All message classes that are a callback with a transmit report */
+export type TransmitReport =
+	| SendDataTransmitReport
+	| AssignReturnRouteRequestTransmitReport
+	| AssignSUCReturnRouteRequestTransmitReport
+	| DeleteReturnRouteRequestTransmitReport
+	| DeleteSUCReturnRouteRequestTransmitReport;
 
 export enum TransmitOptions {
 	NotSet = 0,
@@ -327,6 +339,17 @@ export function isSendDataTransmitReport(
 		msg instanceof SendDataMulticastRequestTransmitReport ||
 		msg instanceof SendDataBridgeRequestTransmitReport ||
 		msg instanceof SendDataMulticastBridgeRequestTransmitReport
+	);
+}
+
+export function isTransmitReport(msg: unknown): msg is TransmitReport {
+	if (!msg) return false;
+	return (
+		isSendDataTransmitReport(msg) ||
+		msg instanceof AssignReturnRouteRequestTransmitReport ||
+		msg instanceof AssignSUCReturnRouteRequestTransmitReport ||
+		msg instanceof DeleteReturnRouteRequestTransmitReport ||
+		msg instanceof DeleteSUCReturnRouteRequestTransmitReport
 	);
 }
 

--- a/packages/zwave-js/src/lib/driver/TransactionMachine.ts
+++ b/packages/zwave-js/src/lib/driver/TransactionMachine.ts
@@ -11,7 +11,11 @@ import {
 import { messageIsPing } from "../commandclass/NoOperationCC";
 import { SendDataMulticastBridgeRequest } from "../controller/SendDataBridgeMessages";
 import { SendDataMulticastRequest } from "../controller/SendDataMessages";
-import { isSendData, SendDataMessage } from "../controller/SendDataShared";
+import {
+	isSendData,
+	isTransmitReport,
+	SendDataMessage,
+} from "../controller/SendDataShared";
 import type { Message } from "../message/Message";
 import type { CommandQueueEvent } from "./CommandQueueMachine";
 import {
@@ -258,9 +262,10 @@ export function createTransactionMachine(
 					error: (_) => undefined,
 				}),
 				rememberCommandFailure: assign((ctx, evt: any) => {
-					// For SendData messages, a NOK callback still contains useful info we need to evaluate
+					// For messages that were sent to a node, a NOK callback still contains useful info we need to evaluate
 					if (
-						isSendData(ctx.transaction.parts.current) &&
+						(isSendData(ctx.transaction.parts.current) ||
+							isTransmitReport(evt.result)) &&
 						evt.reason === "callback NOK"
 					) {
 						return {


### PR DESCRIPTION
With this PR we handle AssignSUCReturnRoute commands and similar like SendData. For example, we now evaluate the transmit status to determine if a node can sleep and update its status accordingly.

fixes: #3924