### PR TITLE
feat(config): add Parameter 17 to Zen71 Switch (firmware dependent)

### DIFF
--- a/packages/config/config/devices/0x027a/zen71.json
+++ b/packages/config/config/devices/0x027a/zen71.json
@@ -87,6 +87,27 @@
 		{
 			"#": "16",
 			"$import": "templates/zooz_template.json#association_reports"
+		},
+		{
+			"#": "17",
+			"$if": "firmwareVersion >= 10.0",
+			"label": "Local Inclusion/Exclusion/LED Changes",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
 		}
 	]
 }


### PR DESCRIPTION
Adds Parameter 17 to configs for FW version 10.0+.

Toggles local control of Inclusion, Exclusion, and LED settings.