### PR TITLE
fix(config): clarify parameter function for Aeotec Smart Switch 7

### DIFF
--- a/packages/config/config/devices/0x0371/zwa023.json
+++ b/packages/config/config/devices/0x0371/zwa023.json
@@ -147,7 +147,8 @@
 		},
 		{
 			"#": "19",
-			"$import": "~/0x0086/templates/aeotec_template.json#auto_report_interval",
+			"label": "Threshold Check Interval",
+			"description": "Defines the frequency at which the automatic reporting thresholds are evaluated",
 			"valueSize": 1,
 			"unit": "seconds",
 			"minValue": 0,

--- a/packages/config/config/devices/0x0371/zwa023.json
+++ b/packages/config/config/devices/0x0371/zwa023.json
@@ -70,7 +70,7 @@
 		},
 		{
 			"#": "6",
-			"label": "Power Report Threshhold (Scene)",
+			"label": "Power Report Threshold (Scene)",
 			"description": "Power consumption at which to send a scene activation set command",
 			"valueSize": 2,
 			"unit": "W",

--- a/packages/config/config/devices/0x0371/zwa023.json
+++ b/packages/config/config/devices/0x0371/zwa023.json
@@ -70,7 +70,7 @@
 		},
 		{
 			"#": "6",
-			"label": "Power Report Threshhold",
+			"label": "Power Report Threshhold (Scene)",
 			"description": "Power consumption at which to send a scene activation set command",
 			"valueSize": 2,
 			"unit": "W",
@@ -154,6 +154,7 @@
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 5,
+			"unsigned": true,
 			"options": [
 				{
 					"label": "Disable",


### PR DESCRIPTION
Clarifies that the parameter defines the time at which the thresholds are checked, not the reporting time. Confirmed in the manual.