### PR TITLE
refactor: convert node.isControllerNode from method to property

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -150,8 +150,6 @@ getAllEndpoints(): Endpoint[]
 
 This method returns an array of all endpoints on this node. At each index `i` the returned array contains the endpoint instance that would be returned by `getEndpoint(i)`.
 
-This is a little utility function to check if this node is the controller.
-
 ### `hasSecurityClass`
 
 ```ts

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -150,12 +150,6 @@ getAllEndpoints(): Endpoint[]
 
 This method returns an array of all endpoints on this node. At each index `i` the returned array contains the endpoint instance that would be returned by `getEndpoint(i)`.
 
-### `isControllerNode`
-
-```ts
-isControllerNode(): boolean
-```
-
 This is a little utility function to check if this node is the controller.
 
 ### `hasSecurityClass`
@@ -566,6 +560,14 @@ This property tracks the status a node in the network currently has (or is belie
 -   `NodeStatus.Alive (4)` - Nodes that **don't** support the `WakeUp` CC are considered alive while they do respond. Note that the status may switch from alive to awake/asleep once it is discovered that a node does support the `WakeUp` CC.
 
 Changes of a node's status are broadcasted using the corresponding events - see below.
+
+### `isControllerNode`
+
+```ts
+readonly isControllerNode: boolean
+```
+
+Returns whether this node is the controller node, i.e. has the ID of the primary controller.
 
 ### `interviewStage`
 

--- a/docs/getting-started/migrating-to-v9.md
+++ b/docs/getting-started/migrating-to-v9.md
@@ -23,3 +23,7 @@ While working on the SmartStart feature it was noticed that some properties and 
 -   Renamed the `serialApiGt(e)` and `serialApiLt(e)` methods to `sdkVersionGt(e)` and `sdkVersionLt(e)` respectively. These methods were checking the Z-Wave SDK version and not the Serial API which is versioned differently. This affects the `Controller` class.
 -   Renamed the `SerialAPIVersion` type to `SDKVersion`.
 -   Renamed the `serialApiVersion` property to `firmwareVersion`, because it was referring to a Z-Wave Stick's firmware version and not the Serial API version. This affects the `Controller` and the `GetSerialApiCapabilitiesResponse` classes.
+
+## Converted the `isControllerNode` method on the `ZWaveNode` class to a readonly property
+
+While there is no hard style guide governing this, we tend to use readonly properties for static things like a node's IDs and methods for (potentially) dynamic things like endpoint counts. Since the controller node ID doesn't change during usage, this feels more "correct".

--- a/packages/zwave-js/src/lib/commandclass/ManufacturerSpecificCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ManufacturerSpecificCC.ts
@@ -160,7 +160,7 @@ export class ManufacturerSpecificCC extends CommandClass {
 			"Manufacturer Specific"
 		].withOptions({ priority: MessagePriority.NodeQuery });
 
-		if (!node.isControllerNode()) {
+		if (!node.isControllerNode) {
 			this.driver.controllerLog.logNode(node.id, {
 				endpoint: this.endpointIndex,
 				message: `Interviewing ${this.ccName}...`,

--- a/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
@@ -220,7 +220,7 @@ export class WakeUpCC extends CommandClass {
 		// In this case, do now mark this CC as interviewed completely
 		let hadCriticalTimeout = false;
 
-		if (node.isControllerNode()) {
+		if (node.isControllerNode) {
 			this.driver.controllerLog.logNode(
 				node.id,
 				`skipping wakeup configuration for the controller`,

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1191,8 +1191,8 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner {
 	private _hasEmittedNoS2NetworkKeyError: boolean = false;
 	private _hasEmittedNoS0NetworkKeyError: boolean = false;
 
-	/** Utility function to check if this node is the controller */
-	public isControllerNode(): boolean {
+	/** Returns whether this node is the controller */
+	public get isControllerNode(): boolean {
 		return this.id === this.driver.controller.ownNodeId;
 	}
 
@@ -1206,7 +1206,7 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner {
 	public async refreshInfo(options: RefreshInfoOptions = {}): Promise<void> {
 		// It does not make sense to re-interview the controller. All important information is queried
 		// directly via the serial API
-		if (this.isControllerNode()) return;
+		if (this.isControllerNode) return;
 
 		const { resetSecurityClasses = false } = options;
 
@@ -1308,7 +1308,7 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner {
 			await this.queryProtocolInfo();
 		}
 
-		if (!this.isControllerNode()) {
+		if (!this.isControllerNode) {
 			if (
 				(this.isListening || this.isFrequentListening) &&
 				this.status !== NodeStatus.Alive
@@ -1336,9 +1336,9 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner {
 		}
 
 		if (
-			(this.isControllerNode() &&
+			(this.isControllerNode &&
 				this.interviewStage === InterviewStage.ProtocolInfo) ||
-			(!this.isControllerNode() &&
+			(!this.isControllerNode &&
 				this.interviewStage === InterviewStage.CommandClasses)
 		) {
 			// Load a config file for this node if it exists and overwrite the previously reported information
@@ -1430,7 +1430,7 @@ protocol version:      ${this._protocolVersion}`;
 
 	/** Node interview: pings the node to see if it responds */
 	public async ping(): Promise<boolean> {
-		if (this.isControllerNode()) {
+		if (this.isControllerNode) {
 			this.driver.controllerLog.logNode(
 				this.id,
 				"is the controller node, cannot ping",
@@ -1465,7 +1465,7 @@ protocol version:      ${this._protocolVersion}`;
 	 * Request node info
 	 */
 	protected async queryNodeInfo(): Promise<void> {
-		if (this.isControllerNode()) {
+		if (this.isControllerNode) {
 			this.driver.controllerLog.logNode(
 				this.id,
 				"is the controller node, cannot query node info",
@@ -1563,7 +1563,7 @@ protocol version:      ${this._protocolVersion}`;
 
 	/** Step #? of the node interview */
 	protected async interviewCCs(): Promise<boolean> {
-		if (this.isControllerNode()) {
+		if (this.isControllerNode) {
 			this.driver.controllerLog.logNode(
 				this.id,
 				"is the controller node, cannot interview CCs",
@@ -2143,7 +2143,7 @@ protocol version:      ${this._protocolVersion}`;
 
 	/** Overwrites the reported configuration with information from a config file */
 	protected async overwriteConfig(): Promise<void> {
-		if (this.isControllerNode()) {
+		if (this.isControllerNode) {
 			// The device config was not loaded prior to this step because the Version CC is not interviewed.
 			// Therefore do it here.
 			await this.loadDeviceConfig();


### PR DESCRIPTION
While there is no hard style guide governing this, we tend to use readonly properties for static things like a node's IDs and methods for (potentially) dynamic things like endpoint counts. Since the controller node ID doesn't change during usage, this feels more "correct".

/cc @raman325 