### PR TITLE
feat: add node method to wait for wakeup

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -174,6 +174,16 @@ getHighestSecurityClass(): SecurityClass | undefined
 
 Returns the highest security class this node was granted or `undefined` if that information isn't known yet. This can be used to distinguish whether a node is communicating with S2, S0 or insecure.
 
+### `waitForWakeup`
+
+```ts
+waitForWakeup(): Promise<void>
+```
+
+Returns a promise that resolves when the node wakes up the next time or immediately if the node is already awake.
+
+> [!WARNING] This will throw if the node does not support wakeup or is not a sleeping node.
+
 ### `refreshInfo`
 
 ```ts

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -466,6 +466,22 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner {
 		this.statusMachine.send("AWAKE");
 	}
 
+	/** Returns a promise that resolves when the node wakes up the next time or immediately if the node is already awake. */
+	public waitForWakeup(): Promise<void> {
+		if (!this.canSleep || !this.supportsCC(CommandClasses["Wake Up"])) {
+			throw new ZWaveError(
+				`Node ${this.id} does not support wakeup!`,
+				ZWaveErrorCodes.CC_NotSupported,
+			);
+		} else if (this._status === NodeStatus.Awake) {
+			return Promise.resolve();
+		}
+
+		return new Promise((resolve) => {
+			this.once("wake up", () => resolve());
+		});
+	}
+
 	// The node is only ready when the interview has been completed
 	// to a certain degree
 


### PR DESCRIPTION
This PR adds the `waitForWakeup` to the node class, allowing to easily queue actions for when a sleeping node wakes up, for example:
```ts
// Make sure the node is awake for the next action
await node.waitForWakeup();
// Refresh config param
await node.commandClasses.Configuration.get(1);
```