### PR TITLE
fix(config): add fingerprint 0x0300:0xa10b to Sunricher SR-ZV9001T4-DIM

### DIFF
--- a/packages/config/config/devices/0x0330/sr-zv9001t4-dim.json
+++ b/packages/config/config/devices/0x0330/sr-zv9001t4-dim.json
@@ -21,7 +21,7 @@
 		{
 			"productType": "0x0300",
 			"productId": "0xa10b"
-		}		
+		}
 	],
 	"firmwareVersion": {
 		"min": "0.0",

--- a/packages/config/config/devices/0x0330/sr-zv9001t4-dim.json
+++ b/packages/config/config/devices/0x0330/sr-zv9001t4-dim.json
@@ -17,7 +17,11 @@
 		{
 			"productType": "0x0300",
 			"productId": "0xa10d"
-		}
+		},
+		{
+			"productType": "0x0300",
+			"productId": "0xa10b"
+		}		
 	],
 	"firmwareVersion": {
 		"min": "0.0",


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->
I have 2 of these devices and they have productId 0xa10b instead of 0xa10d.
