### PR TITLE
perf: experiment with native (Rust) CRC16 implementation

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -6,6 +6,7 @@
     -   [Migrating to v6](getting-started/migrating-to-v6.md)
     -   [Migrating to v7](getting-started/migrating-to-v7.md)
     -   [Migrating to v8](getting-started/migrating-to-v8.md)
+    -   [Migrating to v9](getting-started/migrating-to-v9.md)
     -   [Sponsoring the development](getting-started/sponsoring.md)
 
 -   API

--- a/docs/api/CCs/_sidebar.md
+++ b/docs/api/CCs/_sidebar.md
@@ -6,6 +6,7 @@
     -   [Migrating to v6](getting-started/migrating-to-v6.md)
     -   [Migrating to v7](getting-started/migrating-to-v7.md)
     -   [Migrating to v8](getting-started/migrating-to-v8.md)
+    -   [Migrating to v9](getting-started/migrating-to-v9.md)
     -   [Sponsoring the development](getting-started/sponsoring.md)
 
 -   API

--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -640,13 +640,13 @@ readonly nodes: ReadonlyMap<number, ZWaveNode>
 
 This property contains a map of all nodes that you can access by their node ID, e.g. `nodes.get(2)` for node 2.
 
-### `libraryVersion`
+### `sdkVersion`
 
 ```ts
-readonly libraryVersion: string
+readonly sdkVersion: string
 ```
 
-Returns the Z-Wave library version that is supported by the controller hardware.
+Returns the Z-Wave SDK version that is supported by the controller hardware.
 
 > [!WARNING]
 > This property is only defined after the controller interview!
@@ -657,7 +657,7 @@ Returns the Z-Wave library version that is supported by the controller hardware.
 readonly type: ZWaveLibraryTypes
 ```
 
-Returns the type of the Z-Wave library that is supported by the controller hardware. The following values are possible:
+Returns the type of the Z-Wave library that is supported by the controller hardware. The following values are defined, although only `"Static Controller"` or `"Bridge Controller"` will realistically be possible:
 
 <!-- #import ZWaveLibraryTypes from "zwave-js" -->
 
@@ -710,7 +710,7 @@ Returns the ID of the controller in the current network.
 * readonly wasRealPrimary: boolean
 * readonly isStaticUpdateController: boolean
 * readonly isSlave: boolean
-* readonly serialApiVersion: string
+* readonly firmwareVersion: string
 * readonly manufacturerId: number
 * readonly productType: number
 * readonly productId: number

--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -611,7 +611,7 @@ interface ZWaveOptions {
 		sendDataCallback: number; // >=10000, default: 65000 ms
 
 		/** How much time a node gets to process a request and send a response */
-		report: number; // [1000...40000], default: 10000 ms
+		report: number; // [500...10000], default: 1000 ms
 
 		/** How long generated nonces are valid */
 		nonce: number; // [3000...20000], default: 5000 ms

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -1169,5 +1169,11 @@ interface NodeStatistics {
 	commandsDroppedTX: number;
 	/** No. of Get-type commands where the node's response did not come in time */
 	timeoutResponse: number;
+
+	/**
+	 * Average round-trip-time in ms of commands to this node.
+	 * Consecutive measurements are combined using an exponential moving average.
+	 */
+	rtt?: number;
 }
 ```

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -150,14 +150,6 @@ getAllEndpoints(): Endpoint[]
 
 This method returns an array of all endpoints on this node. At each index `i` the returned array contains the endpoint instance that would be returned by `getEndpoint(i)`.
 
-### `isControllerNode`
-
-```ts
-isControllerNode(): boolean
-```
-
-This is a little utility function to check if this node is the controller.
-
 ### `hasSecurityClass`
 
 ```ts
@@ -582,6 +574,14 @@ This property tracks the status a node in the network currently has (or is belie
 -   `NodeStatus.Alive (4)` - Nodes that **don't** support the `WakeUp` CC are considered alive while they do respond. Note that the status may switch from alive to awake/asleep once it is discovered that a node does support the `WakeUp` CC.
 
 Changes of a node's status are broadcasted using the corresponding events - see below.
+
+### `isControllerNode`
+
+```ts
+readonly isControllerNode: boolean
+```
+
+Returns whether this node is the controller node, i.e. has the ID of the primary controller.
 
 ### `interviewStage`
 

--- a/docs/getting-started/migrating-to-v9.md
+++ b/docs/getting-started/migrating-to-v9.md
@@ -3,7 +3,7 @@
 The recent rewrite of the message queue made it much simpler to support use cases that go beyond executing a simple Serial API command.
 Examples are requesting Security S0 nonces (which was relatively convoluted before), handling other multi-step commands, as well as the ability to time individual commands.
 
-The latter allows us to be more spec-compliant in that we now time out much faster while waiting for a response to a GET request. Since this required a breaking chance, we use the opportunity to collect some more breaking changes in version 9.x.
+The latter allows us to be more spec-compliant in that we now time out much faster while waiting for a response to a GET request. Since this required a breaking change, we use the opportunity to collect some more breaking changes in version 9.x.
 
 ## Faster timeout while waiting for a response to a GET request
 

--- a/docs/getting-started/migrating-to-v9.md
+++ b/docs/getting-started/migrating-to-v9.md
@@ -23,3 +23,7 @@ While working on the SmartStart feature it was noticed that some properties and 
 -   Renamed the `serialApiGt(e)` and `serialApiLt(e)` methods to `sdkVersionGt(e)` and `sdkVersionLt(e)` respectively. These methods were checking the Z-Wave SDK version and not the Serial API which is versioned differently. This affects the `Controller` class.
 -   Renamed the `SerialAPIVersion` type to `SDKVersion`.
 -   Renamed the `serialApiVersion` property to `firmwareVersion`, because it was referring to a Z-Wave Stick's firmware version and not the Serial API version. This affects the `Controller` and the `GetSerialApiCapabilitiesResponse` classes.
+
+## Converted the `isControllerNode` method on the `ZWaveNode` class to a readonly property
+
+While there is no hard style guide governing this, we tend to use readonly properties for static things like a node's IDs and methods for (potentially) dynamic things like endpoint counts. Since the controller node ID doesn't change during usage, this feels more "correct".

--- a/docs/getting-started/migrating-to-v9.md
+++ b/docs/getting-started/migrating-to-v9.md
@@ -1,0 +1,25 @@
+# Migrating to v9
+
+The recent rewrite of the message queue made it much simpler to support use cases that go beyond executing a simple Serial API command.
+Examples are requesting Security S0 nonces (which was relatively convoluted before), handling other multi-step commands, as well as the ability to time individual commands.
+
+The latter allows us to be more spec-compliant in that we now time out much faster while waiting for a response to a GET request. Since this required a breaking chance, we use the opportunity to collect some more breaking changes in version 9.x.
+
+## Faster timeout while waiting for a response to a GET request
+
+Previously, we waited for a fixed 10 seconds after a GET request was acknowledged. Now we measure the round trip time (RTT) and wait _RTT + 1 second_ before timing out like the Z-Wave specifications recommend. This makes for a much snappier experience, but means we had to change the range and default of the driver option `timeouts.report`.
+
+Previously this had a range of `1000-40000 ms` with a default of `10000`, now it has a range of `500-10000 ms` and a default of `1000`. If your application allows to configure this, you might have to change the validation.
+
+## Removed the unsupported `route` parameter from `SendDataBridgeRequest`
+
+It has been found that no relevant version of the Serial API uses this parameter. The corresponding parameter has therefore been removed from `SendDataBridgeRequest`. To override the route used by the protocol, **Application Priority Routes** (not supported yet) have to be used.
+
+## Rename properties and methods of the `Controller` class (and related message classes)
+
+While working on the SmartStart feature it was noticed that some properties and methods of the `Controller` class and by extension some of the message classes had a misleading name. This has been fixed in version 9. The individual changes are:
+
+-   Renamed the `libraryVersion` property to `sdkVersion` because it references the Z-Wave SDK version. This affects the `Controller` and the `GetControllerVersionResponse` classes.
+-   Renamed the `serialApiGt(e)` and `serialApiLt(e)` methods to `sdkVersionGt(e)` and `sdkVersionLt(e)` respectively. These methods were checking the Z-Wave SDK version and not the Serial API which is versioned differently. This affects the `Controller` class.
+-   Renamed the `SerialAPIVersion` type to `SDKVersion`.
+-   Renamed the `serialApiVersion` property to `firmwareVersion`, because it was referring to a Z-Wave Stick's firmware version and not the Serial API version. This affects the `Controller` and the `GetSerialApiCapabilitiesResponse` classes.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@alcalzone/jsonl-db": "^2.4.1",
+    "@zwave-js/crc16-ccitt": "~1.0.0",
     "@zwave-js/shared": "8.10.0",
     "@zwave-js/winston-daily-rotate-file": "^4.5.6-0",
     "alcalzone-shared": "^4.0.1",

--- a/packages/core/src/util/crc.test.ts
+++ b/packages/core/src/util/crc.test.ts
@@ -18,14 +18,5 @@ describe("lib/util/crc", () => {
 		it("input: A x 256", () => {
 			expect(CRC16_CCITT(Buffer.alloc(256, "A", "ascii"))).toBe(0xe938);
 		});
-
-		it("chained with start values", () => {
-			const input = "123456789";
-			let crc: number | undefined;
-			for (let i = 0; i < input.length; i++) {
-				crc = CRC16_CCITT(Buffer.from(input[i], "ascii"), crc);
-			}
-			expect(crc).toBe(0xe5cc);
-		});
 	});
 });

--- a/packages/core/src/util/crc.ts
+++ b/packages/core/src/util/crc.ts
@@ -1,15 +1,29 @@
-// Implementation based on SDS13782
+import {
+	CRC16_CCITT as CRC16_CCITT_native,
+	CRC16_CCITT_FE95,
+} from "@zwave-js/crc16-ccitt";
+import { num2hex } from "@zwave-js/shared";
+import { ZWaveError, ZWaveErrorCodes } from "..";
+
 export function CRC16_CCITT(data: Buffer, startValue: number = 0x1d0f): number {
-	let crc = startValue;
-	const poly = 0x1021;
+	// Use native CRC implementations for better performance
+	if (startValue === 0x1d0f) return CRC16_CCITT_native(data);
+	else if (startValue === 0xfe95) return CRC16_CCITT_FE95(data);
 
-	for (let i = 0; i < data.length; i++) {
-		for (let bitMask = 0x80; bitMask !== 0; bitMask >>= 1) {
-			const xorFlag = !!(data[i] & bitMask) !== !!(crc & 0x8000);
-			crc <<= 1;
+	throw new ZWaveError(
+		`Unsupported CRC16 start value ${num2hex(startValue)}`,
+		ZWaveErrorCodes.Argument_Invalid,
+	);
+	// let crc = startValue;
+	// const poly = 0x1021;
 
-			if (xorFlag) crc ^= poly;
-		}
-	}
-	return crc & 0xffff;
+	// for (let i = 0; i < data.length; i++) {
+	// 	for (let bitMask = 0x80; bitMask !== 0; bitMask >>= 1) {
+	// 		const xorFlag = !!(data[i] & bitMask) !== !!(crc & 0x8000);
+	// 		crc <<= 1;
+
+	// 		if (xorFlag) crc ^= poly;
+	// 	}
+	// }
+	// return crc & 0xffff;
 }

--- a/packages/zwave-js/src/lib/commandclass/CRC16CC.ts
+++ b/packages/zwave-js/src/lib/commandclass/CRC16CC.ts
@@ -89,8 +89,9 @@ export class CRC16CCCommandEncapsulation extends CRC16CC {
 			const ccBuffer = this.payload.slice(0, -2);
 
 			// Verify the CRC
-			let expectedCRC = CRC16_CCITT(this.headerBuffer);
-			expectedCRC = CRC16_CCITT(ccBuffer, expectedCRC);
+			const expectedCRC = CRC16_CCITT(
+				Buffer.concat([this.headerBuffer, ccBuffer]),
+			);
 			const actualCRC = this.payload.readUInt16BE(
 				this.payload.length - 2,
 			);
@@ -117,8 +118,9 @@ export class CRC16CCCommandEncapsulation extends CRC16CC {
 
 		// Compute and save the CRC16 in the payload
 		// The CC header is included in the CRC computation
-		let crc = CRC16_CCITT(this.headerBuffer);
-		crc = CRC16_CCITT(commandBuffer, crc);
+		const crc = CRC16_CCITT(
+			Buffer.concat([this.headerBuffer, commandBuffer]),
+		);
 		this.payload.writeUInt16BE(crc, this.payload.length - 2);
 
 		return super.serialize();

--- a/packages/zwave-js/src/lib/commandclass/FirmwareUpdateMetaDataCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/FirmwareUpdateMetaDataCC.ts
@@ -549,8 +549,10 @@ export class FirmwareUpdateMetaDataCCReport extends FirmwareUpdateMetaDataCC {
 		if (this.version >= 2) {
 			// Compute and save the CRC16 in the payload
 			// The CC header is included in the CRC computation
-			let crc = CRC16_CCITT(Buffer.from([this.ccId, this.ccCommand]));
-			crc = CRC16_CCITT(commandBuffer, crc);
+			const headerBuffer = Buffer.from([this.ccId, this.ccCommand]);
+			const crc = CRC16_CCITT(
+				Buffer.concat([headerBuffer, commandBuffer]),
+			);
 			this.payload = Buffer.concat([
 				commandBuffer,
 				Buffer.allocUnsafe(2),

--- a/packages/zwave-js/src/lib/commandclass/ManufacturerSpecificCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ManufacturerSpecificCC.ts
@@ -160,7 +160,7 @@ export class ManufacturerSpecificCC extends CommandClass {
 			"Manufacturer Specific"
 		].withOptions({ priority: MessagePriority.NodeQuery });
 
-		if (!node.isControllerNode()) {
+		if (!node.isControllerNode) {
 			this.driver.controllerLog.logNode(node.id, {
 				endpoint: this.endpointIndex,
 				message: `Interviewing ${this.ccName}...`,

--- a/packages/zwave-js/src/lib/commandclass/TransportServiceCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/TransportServiceCC.ts
@@ -121,8 +121,9 @@ export class TransportServiceCCFirstSegment extends TransportServiceCC {
 				this.ccCommand | this.payload[0],
 			]);
 			const ccBuffer = this.payload.slice(1, -2);
-			let expectedCRC = CRC16_CCITT(headerBuffer);
-			expectedCRC = CRC16_CCITT(ccBuffer, expectedCRC);
+			const expectedCRC = CRC16_CCITT(
+				Buffer.concat([headerBuffer, ccBuffer]),
+			);
 			const actualCRC = this.payload.readUInt16BE(
 				this.payload.length - 2,
 			);
@@ -185,8 +186,8 @@ export class TransportServiceCCFirstSegment extends TransportServiceCC {
 		// Compute and save the CRC16 in the payload
 		// The CC header is included in the CRC computation
 		const headerBuffer = Buffer.from([this.ccId, this.ccCommand]);
-		let crc = CRC16_CCITT(headerBuffer);
-		crc = CRC16_CCITT(this.payload.slice(0, -2), crc);
+		const commandBuffer = this.payload.slice(0, -2);
+		const crc = CRC16_CCITT(Buffer.concat([headerBuffer, commandBuffer]));
 		// Write the checksum into the last two bytes of the payload
 		this.payload.writeUInt16BE(crc, this.payload.length - 2);
 
@@ -251,8 +252,9 @@ export class TransportServiceCCSubsequentSegment extends TransportServiceCC {
 				this.ccCommand | this.payload[0],
 			]);
 			const ccBuffer = this.payload.slice(1, -2);
-			let expectedCRC = CRC16_CCITT(headerBuffer);
-			expectedCRC = CRC16_CCITT(ccBuffer, expectedCRC);
+			const expectedCRC = CRC16_CCITT(
+				Buffer.concat([headerBuffer, ccBuffer]),
+			);
 			const actualCRC = this.payload.readUInt16BE(
 				this.payload.length - 2,
 			);
@@ -389,8 +391,8 @@ export class TransportServiceCCSubsequentSegment extends TransportServiceCC {
 		// Compute and save the CRC16 in the payload
 		// The CC header is included in the CRC computation
 		const headerBuffer = Buffer.from([this.ccId, this.ccCommand]);
-		let crc = CRC16_CCITT(headerBuffer);
-		crc = CRC16_CCITT(this.payload.slice(0, -2), crc);
+		const commandBuffer = this.payload.slice(0, -2);
+		const crc = CRC16_CCITT(Buffer.concat([headerBuffer, commandBuffer]));
 		// Write the checksum into the last two bytes of the payload
 		this.payload.writeUInt16BE(crc, this.payload.length - 2);
 

--- a/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
@@ -220,7 +220,7 @@ export class WakeUpCC extends CommandClass {
 		// In this case, do now mark this CC as interviewed completely
 		let hadCriticalTimeout = false;
 
-		if (node.isControllerNode()) {
+		if (node.isControllerNode) {
 			this.driver.controllerLog.logNode(
 				node.id,
 				`skipping wakeup configuration for the controller`,

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -251,7 +251,7 @@ import { ZWaveLibraryTypes } from "./ZWaveLibraryTypes";
 import { protocolVersionToSDKVersion } from "./ZWaveSDKVersions";
 
 export type HealNodeStatus = "pending" | "done" | "failed" | "skipped";
-export type SerialAPIVersion =
+export type SDKVersion =
 	| `${number}.${number}`
 	| `${number}.${number}.${number}`;
 
@@ -321,14 +321,14 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 		);
 	}
 
-	private _libraryVersion: string | undefined;
-	public get libraryVersion(): string | undefined {
-		return this._libraryVersion;
-	}
-
 	private _type: ZWaveLibraryTypes | undefined;
 	public get type(): ZWaveLibraryTypes | undefined {
 		return this._type;
+	}
+
+	private _sdkVersion: string | undefined;
+	public get sdkVersion(): string | undefined {
+		return this._sdkVersion;
 	}
 
 	private _homeId: number | undefined;
@@ -373,48 +373,39 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 		return this._isSlave;
 	}
 
-	private _serialApiVersion: string | undefined;
-	public get serialApiVersion(): string | undefined {
-		return this._serialApiVersion;
-	}
-
-	/** Checks if the Serial API version is greater than the given one */
-	public serialApiGt(version: SerialAPIVersion): boolean | undefined {
-		// TODO: Rename these to sdkVersionGt(e) etc...
-		if (this._libraryVersion === undefined) {
+	/** Checks if the SDK version is greater than the given one */
+	public sdkVersionGt(version: SDKVersion): boolean | undefined {
+		if (this._sdkVersion === undefined) {
 			return undefined;
 		}
-		const sdkVersion = protocolVersionToSDKVersion(this._libraryVersion);
+		const sdkVersion = protocolVersionToSDKVersion(this._sdkVersion);
 		return semver.gt(padVersion(sdkVersion), padVersion(version));
 	}
 
-	/** Checks if the Serial API version is greater than or equal to the given one */
-	public serialApiGte(version: SerialAPIVersion): boolean | undefined {
-		// TODO: Rename these to sdkVersionGt(e) etc...
-		if (this._libraryVersion === undefined) {
+	/** Checks if the SDK version is greater than or equal to the given one */
+	public sdkVersionGte(version: SDKVersion): boolean | undefined {
+		if (this._sdkVersion === undefined) {
 			return undefined;
 		}
-		const sdkVersion = protocolVersionToSDKVersion(this._libraryVersion);
+		const sdkVersion = protocolVersionToSDKVersion(this._sdkVersion);
 		return semver.gte(padVersion(sdkVersion), padVersion(version));
 	}
 
-	/** Checks if the Serial API version is lower than the given one */
-	public serialApiLt(version: SerialAPIVersion): boolean | undefined {
-		// TODO: Rename these to sdkVersionGt(e) etc...
-		if (this._libraryVersion === undefined) {
+	/** Checks if the SDK version is lower than the given one */
+	public sdkVersionLt(version: SDKVersion): boolean | undefined {
+		if (this._sdkVersion === undefined) {
 			return undefined;
 		}
-		const sdkVersion = protocolVersionToSDKVersion(this._libraryVersion);
+		const sdkVersion = protocolVersionToSDKVersion(this._sdkVersion);
 		return semver.lt(padVersion(sdkVersion), padVersion(version));
 	}
 
-	/** Checks if the Serial API version is lower than or equal to the given one */
-	public serialApiLte(version: SerialAPIVersion): boolean | undefined {
-		// TODO: Rename these to sdkVersionGt(e) etc...
-		if (this._libraryVersion === undefined) {
+	/** Checks if the SDK version is lower than or equal to the given one */
+	public sdkVersionLte(version: SDKVersion): boolean | undefined {
+		if (this._sdkVersion === undefined) {
 			return undefined;
 		}
-		const sdkVersion = protocolVersionToSDKVersion(this._libraryVersion);
+		const sdkVersion = protocolVersionToSDKVersion(this._sdkVersion);
 		return semver.lte(padVersion(sdkVersion), padVersion(version));
 	}
 
@@ -431,6 +422,11 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 	private _productId: number | undefined;
 	public get productId(): number | undefined {
 		return this._productId;
+	}
+
+	private _firmwareVersion: string | undefined;
+	public get firmwareVersion(): string | undefined {
+		return this._firmwareVersion;
 	}
 
 	private _supportedFunctionTypes: FunctionType[] | undefined;
@@ -478,7 +474,7 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 	public supportsFeature(feature: ZWaveFeature): boolean | undefined {
 		switch (feature) {
 			case ZWaveFeature.SmartStart:
-				return this.serialApiGte(minFeatureVersions[feature]);
+				return this.sdkVersionGte(minFeatureVersions[feature]);
 		}
 	}
 
@@ -695,14 +691,14 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 					supportCheck: false,
 				},
 			);
-		this._serialApiVersion = apiCaps.serialApiVersion;
+		this._firmwareVersion = apiCaps.firmwareVersion;
 		this._manufacturerId = apiCaps.manufacturerId;
 		this._productType = apiCaps.productType;
 		this._productId = apiCaps.productId;
 		this._supportedFunctionTypes = apiCaps.supportedFunctionTypes;
 		this.driver.controllerLog.print(
 			`received API capabilities:
-  serial API version:  ${this._serialApiVersion}
+  firmware version:    ${this._firmwareVersion}
   manufacturer ID:     ${num2hex(this._manufacturerId)}
   product type:        ${num2hex(this._productType)}
   product ID:          ${num2hex(this._productId)}
@@ -729,12 +725,12 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 					supportCheck: false,
 				},
 			);
-		this._libraryVersion = version.libraryVersion;
+		this._sdkVersion = version.sdkVersion;
 		this._type = version.controllerType;
 		this.driver.controllerLog.print(
 			`received version info:
   controller type: ${ZWaveLibraryTypes[this._type]}
-  library version: ${this._libraryVersion}`,
+  library version: ${this._sdkVersion}`,
 		);
 
 		this.driver.controllerLog.print(
@@ -948,7 +944,7 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 			getFirmwareVersionsMetadata(),
 		);
 		controllerValueDB.setValue(getFirmwareVersionsValueId(), [
-			this._serialApiVersion,
+			this._firmwareVersion,
 		]);
 
 		if (
@@ -4536,7 +4532,7 @@ ${associatedNodes.join(", ")}`,
 
 		let ret: Buffer;
 		try {
-			if (this.serialApiGte("7.0")) {
+			if (this.sdkVersionGte("7.0")) {
 				ret = await this.backupNVMRaw700(onProgress);
 			} else {
 				ret = await this.backupNVMRaw500(onProgress);
@@ -4665,7 +4661,7 @@ ${associatedNodes.join(", ")}`,
 				"Converting NVM to target format...",
 			);
 			let targetNVM: Buffer;
-			if (this.serialApiGte("7.0")) {
+			if (this.sdkVersionGte("7.0")) {
 				targetNVM = await this.backupNVMRaw700(convertProgress);
 			} else {
 				targetNVM = await this.backupNVMRaw500(convertProgress);
@@ -4673,7 +4669,7 @@ ${associatedNodes.join(", ")}`,
 			const convertedNVM = migrateNVM(nvmData, targetNVM);
 
 			this.driver.controllerLog.print("Restoring NVM backup...");
-			if (this.serialApiGte("7.0")) {
+			if (this.sdkVersionGte("7.0")) {
 				await this.restoreNVMRaw700(convertedNVM, restoreProgress);
 			} else {
 				await this.restoreNVMRaw500(convertedNVM, restoreProgress);
@@ -4725,7 +4721,7 @@ ${associatedNodes.join(", ")}`,
 		}
 
 		try {
-			if (this.serialApiGte("7.0")) {
+			if (this.sdkVersionGte("7.0")) {
 				await this.restoreNVMRaw700(nvmData, onProgress);
 			} else {
 				await this.restoreNVMRaw500(nvmData, onProgress);

--- a/packages/zwave-js/src/lib/controller/Features.ts
+++ b/packages/zwave-js/src/lib/controller/Features.ts
@@ -1,4 +1,4 @@
-import type { SerialAPIVersion } from "./Controller";
+import type { SDKVersion } from "./Controller";
 
 /** A named list of Z-Wave features */
 export enum ZWaveFeature {
@@ -6,6 +6,6 @@ export enum ZWaveFeature {
 	SmartStart,
 }
 
-export const minFeatureVersions: Record<ZWaveFeature, SerialAPIVersion> = {
+export const minFeatureVersions: Record<ZWaveFeature, SDKVersion> = {
 	[ZWaveFeature.SmartStart]: "6.81",
 };

--- a/packages/zwave-js/src/lib/controller/GetControllerVersionMessages.ts
+++ b/packages/zwave-js/src/lib/controller/GetControllerVersionMessages.ts
@@ -25,8 +25,8 @@ export class GetControllerVersionResponse extends Message {
 		super(driver, options);
 
 		// The payload consists of a zero-terminated string and a uint8 for the controller type
-		this._libraryVersion = cpp2js(this.payload.toString("ascii"));
-		this._controllerType = this.payload[this.libraryVersion.length + 1];
+		this._sdkVersion = cpp2js(this.payload.toString("ascii"));
+		this._controllerType = this.payload[this.sdkVersion.length + 1];
 	}
 
 	private _controllerType: ZWaveLibraryTypes;
@@ -34,15 +34,15 @@ export class GetControllerVersionResponse extends Message {
 		return this._controllerType;
 	}
 
-	private _libraryVersion: string;
-	public get libraryVersion(): string {
-		return this._libraryVersion;
+	private _sdkVersion: string;
+	public get sdkVersion(): string {
+		return this._sdkVersion;
 	}
 
 	public toJSON(): JSONObject {
 		return super.toJSONInherited({
 			controllerType: this.controllerType,
-			libraryVersion: this.libraryVersion,
+			sdkVersion: this.sdkVersion,
 		});
 	}
 }

--- a/packages/zwave-js/src/lib/controller/GetSerialApiCapabilitiesMessages.ts
+++ b/packages/zwave-js/src/lib/controller/GetSerialApiCapabilitiesMessages.ts
@@ -29,7 +29,7 @@ export class GetSerialApiCapabilitiesResponse extends Message {
 		super(driver, options);
 
 		// The first 8 bytes are the api version, manufacturer id, product type and product id
-		this._serialApiVersion = `${this.payload[0]}.${this.payload[1]}`;
+		this._firmwareVersion = `${this.payload[0]}.${this.payload[1]}`;
 		this._manufacturerId = this.payload.readUInt16BE(2);
 		this._productType = this.payload.readUInt16BE(4);
 		this._productId = this.payload.readUInt16BE(6);
@@ -38,9 +38,9 @@ export class GetSerialApiCapabilitiesResponse extends Message {
 		this._supportedFunctionTypes = parseBitMask(functionBitMask);
 	}
 
-	private _serialApiVersion: string;
-	public get serialApiVersion(): string {
-		return this._serialApiVersion;
+	private _firmwareVersion: string;
+	public get firmwareVersion(): string {
+		return this._firmwareVersion;
 	}
 
 	private _manufacturerId: number;
@@ -65,7 +65,7 @@ export class GetSerialApiCapabilitiesResponse extends Message {
 
 	public toJSON(): JSONObject {
 		return super.toJSONInherited({
-			serialApiVersion: this.serialApiVersion,
+			firmwareVersion: this.firmwareVersion,
 			manufacturerId: this.manufacturerId,
 			productType: this.productType,
 			productId: this.productId,

--- a/packages/zwave-js/src/lib/controller/SendDataBridgeMessages.ts
+++ b/packages/zwave-js/src/lib/controller/SendDataBridgeMessages.ts
@@ -60,7 +60,6 @@ interface SendDataBridgeRequestOptions<
 > extends MessageBaseOptions {
 	command: CCType;
 	sourceNodeId?: number;
-	route?: [number, number, number, number];
 	transmitOptions?: TransmitOptions;
 	maxSendAttempts?: number;
 }
@@ -84,16 +83,8 @@ export class SendDataBridgeRequest<CCType extends CommandClass = CommandClass>
 			);
 		}
 
-		if (options.route && options.route.length !== 4) {
-			throw new ZWaveError(
-				`The route must consist of exactly 4 entries!`,
-				ZWaveErrorCodes.Argument_Invalid,
-			);
-		}
-
 		this.sourceNodeId =
 			options.sourceNodeId ?? driver.controller.ownNodeId!;
-		this.route = options.route ?? [0, 0, 0, 0];
 
 		this.command = options.command;
 		this.transmitOptions =
@@ -109,8 +100,6 @@ export class SendDataBridgeRequest<CCType extends CommandClass = CommandClass>
 	public command: SinglecastCC<CCType>;
 	/** Options regarding the transmission of the message */
 	public transmitOptions: TransmitOptions;
-	/** Which route to use for the transmission */
-	public route: [number, number, number, number];
 
 	private _maxSendAttempts: number = 1;
 	/** The number of times the driver may try to send this message */
@@ -130,14 +119,7 @@ export class SendDataBridgeRequest<CCType extends CommandClass = CommandClass>
 				serializedCC.length,
 			]),
 			serializedCC,
-			Buffer.from([
-				this.transmitOptions,
-				this.route[0],
-				this.route[1],
-				this.route[2],
-				this.route[3],
-				this.callbackId,
-			]),
+			Buffer.from([this.transmitOptions, 0, 0, 0, 0, this.callbackId]),
 		]);
 
 		return super.serialize();
@@ -158,7 +140,6 @@ export class SendDataBridgeRequest<CCType extends CommandClass = CommandClass>
 			message: {
 				"source node id": this.sourceNodeId,
 				"transmit options": num2hex(this.transmitOptions),
-				route: this.route.join(", "),
 				"callback id": this.callbackId,
 			},
 		};

--- a/packages/zwave-js/src/lib/driver/CommandQueueMachine.ts
+++ b/packages/zwave-js/src/lib/driver/CommandQueueMachine.ts
@@ -330,8 +330,6 @@ export function createCommandQueueMachine(
 		{
 			services: {
 				executeSerialAPICommand: (ctx) => {
-					// If there is an error while creating the command machine (e.g. during message serialization)
-					// wrap it in a rejected promise, so xstate can handle it
 					try {
 						return createSerialAPICommandMachine(
 							ctx.currentTransaction!.parts.current!,
@@ -339,6 +337,8 @@ export function createCommandQueueMachine(
 							params,
 						);
 					} catch (e) {
+						// If there is an error while creating the command machine (e.g. during message serialization)
+						// wrap it in a rejected promise, so xstate can handle it
 						implementations.log(
 							`Unexpected error during SerialAPI command: ${getErrorMessage(
 								e,

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -3500,10 +3500,7 @@ ${handlers.length} left`,
 	/** Wraps a CC in the correct SendData message to use for sending */
 	public createSendDataMessage(
 		command: CommandClass,
-		options: Pick<
-			SendCommandOptions,
-			"autoEncapsulate" | "maxSendAttempts" | "transmitOptions"
-		> = {},
+		options: Omit<SendCommandOptions, keyof SendMessageOptions> = {},
 	): SendDataMessage {
 		let msg: SendDataMessage;
 		if (command.isSinglecast()) {

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -43,6 +43,7 @@ import {
 	createDeferredPromise,
 	DeferredPromise,
 } from "alcalzone-shared/deferred-promise";
+import { roundTo } from "alcalzone-shared/math";
 import { isArray, isObject } from "alcalzone-shared/typeguards";
 import { randomBytes } from "crypto";
 import type { EventEmitter } from "events";
@@ -190,7 +191,7 @@ const defaultOptions: ZWaveOptions = {
 		ack: 1000,
 		byte: 150,
 		response: 1600,
-		report: 10000,
+		report: 1000, // ReportTime timeout SHOULD be set to CommandTime + 1 second
 		nonce: 5000,
 		sendDataCallback: 65000, // as defined in INS13954
 		refreshValue: 5000, // Default should handle most slow devices until we have a better solution
@@ -244,9 +245,9 @@ function checkOptions(options: ZWaveOptions): void {
 			ZWaveErrorCodes.Driver_InvalidOptions,
 		);
 	}
-	if (options.timeouts.report < 1000 || options.timeouts.report > 40000) {
+	if (options.timeouts.report < 500 || options.timeouts.report > 10000) {
 		throw new ZWaveError(
-			`The Report timeout must be between 1000 and 40000 milliseconds!`,
+			`The Report timeout must be between 500 and 10000 milliseconds!`,
 			ZWaveErrorCodes.Driver_InvalidOptions,
 		);
 	}
@@ -3262,6 +3263,19 @@ ${handlers.length} left`,
 					node.incrementStatistics("commandsDroppedTX");
 				} else {
 					node.incrementStatistics("commandsTX");
+					if (msg.rtt) {
+						const rttMs = msg.rtt / 1e6;
+						node.updateStatistics((current) => ({
+							...current,
+							rtt:
+								current.rtt != undefined
+									? roundTo(
+											current.rtt * 0.9 + rttMs * 0.1,
+											1,
+									  )
+									: roundTo(rttMs, 1),
+						}));
+					}
 				}
 
 				// Notify listeners about the status report if one was received

--- a/packages/zwave-js/src/lib/driver/MessageGenerators.ts
+++ b/packages/zwave-js/src/lib/driver/MessageGenerators.ts
@@ -32,7 +32,7 @@ export type MessageGeneratorImplementation = (
 	 */
 	onMessageSent: (msg: Message, result: Message | undefined) => void,
 
-	/** Can be used to extend the timeout wa */
+	/** Can be used to extend the timeout waiting for a response from a node to the sent message */
 	additionalCommandTimeoutMs?: number,
 ) => AsyncGenerator<Message, Message, Message>;
 

--- a/packages/zwave-js/src/lib/driver/SerialAPICommandMachine.ts
+++ b/packages/zwave-js/src/lib/driver/SerialAPICommandMachine.ts
@@ -316,7 +316,11 @@ export function getSerialAPICommandMachineOptions(
 ): SerialAPICommandMachineOptions {
 	return {
 		services: {
-			send: (ctx) => sendData(ctx.data),
+			send: (ctx) => {
+				// Mark the message as sent immediately before actually sending
+				ctx.msg.markAsSent();
+				return sendData(ctx.data);
+			},
 			notifyRetry: (ctx) => {
 				notifyRetry?.(
 					"SerialAPI",

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -20,7 +20,7 @@ export interface ZWaveOptions {
 		sendDataCallback: number; // >=10000, default: 65000 ms
 
 		/** How much time a node gets to process a request and send a response */
-		report: number; // [1000...40000], default: 10000 ms
+		report: number; // [500...10000], default: 1000 ms
 
 		/** How long generated nonces are valid */
 		nonce: number; // [3000...20000], default: 5000 ms

--- a/packages/zwave-js/src/lib/message/Message.ts
+++ b/packages/zwave-js/src/lib/message/Message.ts
@@ -2,6 +2,7 @@
 
 import {
 	getNodeTag,
+	highResTimestamp,
 	MessageOrCCLogEntry,
 	ZWaveError,
 	ZWaveErrorCodes,
@@ -366,6 +367,35 @@ export class Message {
 		const nodeId = this.getNodeId();
 		if (nodeId != undefined)
 			return this.driver.controller.nodes.get(nodeId);
+	}
+
+	private _transmissionTimestamp: number | undefined;
+	/** The timestamp when this message was (last) transmitted (in nanoseconds) */
+	public get transmissionTimestamp(): number | undefined {
+		return this._transmissionTimestamp;
+	}
+
+	/** Marks this message as sent and sets the transmission timestamp */
+	public markAsSent(): void {
+		this._transmissionTimestamp = highResTimestamp();
+		this._completedTimestamp = undefined;
+	}
+
+	private _completedTimestamp: number | undefined;
+	public get completedTimestamp(): number | undefined {
+		return this._completedTimestamp;
+	}
+
+	/** Marks this message as completed and sets the corresponding timestamp */
+	public markAsCompleted(): void {
+		this._completedTimestamp = highResTimestamp();
+	}
+
+	/** Returns the round trip time of this message from transmission until completion. */
+	public get rtt(): number | undefined {
+		if (this._transmissionTimestamp == undefined) return undefined;
+		if (this._completedTimestamp == undefined) return undefined;
+		return this._completedTimestamp - this._transmissionTimestamp;
 	}
 }
 

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1207,8 +1207,8 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner {
 	private _hasEmittedNoS2NetworkKeyError: boolean = false;
 	private _hasEmittedNoS0NetworkKeyError: boolean = false;
 
-	/** Utility function to check if this node is the controller */
-	public isControllerNode(): boolean {
+	/** Returns whether this node is the controller */
+	public get isControllerNode(): boolean {
 		return this.id === this.driver.controller.ownNodeId;
 	}
 
@@ -1222,7 +1222,7 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner {
 	public async refreshInfo(options: RefreshInfoOptions = {}): Promise<void> {
 		// It does not make sense to re-interview the controller. All important information is queried
 		// directly via the serial API
-		if (this.isControllerNode()) return;
+		if (this.isControllerNode) return;
 
 		const { resetSecurityClasses = false, waitForWakeup = true } = options;
 		// Unless desired, don't forget the information about sleeping nodes immediately, so they continue to function
@@ -1333,7 +1333,7 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner {
 			await this.queryProtocolInfo();
 		}
 
-		if (!this.isControllerNode()) {
+		if (!this.isControllerNode) {
 			if (
 				(this.isListening || this.isFrequentListening) &&
 				this.status !== NodeStatus.Alive
@@ -1361,9 +1361,9 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner {
 		}
 
 		if (
-			(this.isControllerNode() &&
+			(this.isControllerNode &&
 				this.interviewStage === InterviewStage.ProtocolInfo) ||
-			(!this.isControllerNode() &&
+			(!this.isControllerNode &&
 				this.interviewStage === InterviewStage.CommandClasses)
 		) {
 			// Load a config file for this node if it exists and overwrite the previously reported information
@@ -1455,7 +1455,7 @@ protocol version:      ${this._protocolVersion}`;
 
 	/** Node interview: pings the node to see if it responds */
 	public async ping(): Promise<boolean> {
-		if (this.isControllerNode()) {
+		if (this.isControllerNode) {
 			this.driver.controllerLog.logNode(
 				this.id,
 				"is the controller node, cannot ping",
@@ -1490,7 +1490,7 @@ protocol version:      ${this._protocolVersion}`;
 	 * Request node info
 	 */
 	protected async queryNodeInfo(): Promise<void> {
-		if (this.isControllerNode()) {
+		if (this.isControllerNode) {
 			this.driver.controllerLog.logNode(
 				this.id,
 				"is the controller node, cannot query node info",
@@ -1588,7 +1588,7 @@ protocol version:      ${this._protocolVersion}`;
 
 	/** Step #? of the node interview */
 	protected async interviewCCs(): Promise<boolean> {
-		if (this.isControllerNode()) {
+		if (this.isControllerNode) {
 			this.driver.controllerLog.logNode(
 				this.id,
 				"is the controller node, cannot interview CCs",
@@ -2168,7 +2168,7 @@ protocol version:      ${this._protocolVersion}`;
 
 	/** Overwrites the reported configuration with information from a config file */
 	protected async overwriteConfig(): Promise<void> {
-		if (this.isControllerNode()) {
+		if (this.isControllerNode) {
 			// The device config was not loaded prior to this step because the Version CC is not interviewed.
 			// Therefore do it here.
 			await this.loadDeviceConfig();

--- a/packages/zwave-js/src/lib/node/NodeStatistics.ts
+++ b/packages/zwave-js/src/lib/node/NodeStatistics.ts
@@ -30,4 +30,10 @@ export interface NodeStatistics {
 	commandsDroppedTX: number;
 	/** No. of Get-type commands where the node's response did not come in time */
 	timeoutResponse: number;
+
+	/**
+	 * Average round-trip-time in ms of commands to this node.
+	 * Consecutive measurements are combined using an exponential moving average.
+	 */
+	rtt?: number;
 }

--- a/packages/zwave-js/src/lib/test/messages.ts
+++ b/packages/zwave-js/src/lib/test/messages.ts
@@ -17,6 +17,8 @@ const defaultImplementations = {
 	toLogEntry: () => ({ tags: [] }),
 	needsCallbackId: () => true,
 	getCallbackTimeout: () => undefined,
+	markAsSent: () => void 0,
+	markAsCompleted: () => void 0,
 };
 
 export const dummyResponseOK = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3247,6 +3247,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@napi-rs/triples@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@napi-rs/triples@npm:1.1.0"
+  checksum: 8da77d47ec15704b1936f5f3995951459fc5d604bf2ed400d9579e3356dc0aeb486b217a503f675dda653221751e1fd5dcaaf8de1bab3c71853e8cfd72309709
+  languageName: node
+  linkType: hard
+
+"@node-rs/helper@npm:^1.2.1":
+  version: 1.3.0
+  resolution: "@node-rs/helper@npm:1.3.0"
+  dependencies:
+    "@napi-rs/triples": ^1.1.0
+  checksum: 1d081759530f3daaab12e510b001c74ebc009ee6f02c3136a2eefb34aca2554d8e3ca0b1beb2bbd32b49994109cbbaaec2396bf18ca6876db2724d9684a74841
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -4217,6 +4233,7 @@ __metadata:
     "@types/jest": ^26.0.24
     "@types/node": ^15.12.5
     "@types/triple-beam": ^1.3.2
+    "@zwave-js/crc16-ccitt": ~1.0.0
     "@zwave-js/shared": 8.10.0
     "@zwave-js/winston-daily-rotate-file": ^4.5.6-0
     alcalzone-shared: ^4.0.1
@@ -4233,6 +4250,146 @@ __metadata:
     winston-transport: "*"
   languageName: unknown
   linkType: soft
+
+"@zwave-js/crc16-ccitt-android-arm-eabi@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@zwave-js/crc16-ccitt-android-arm-eabi@npm:1.0.0"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@zwave-js/crc16-ccitt-android-arm64@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@zwave-js/crc16-ccitt-android-arm64@npm:1.0.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@zwave-js/crc16-ccitt-darwin-arm64@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@zwave-js/crc16-ccitt-darwin-arm64@npm:1.0.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@zwave-js/crc16-ccitt-darwin-x64@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@zwave-js/crc16-ccitt-darwin-x64@npm:1.0.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@zwave-js/crc16-ccitt-freebsd-x64@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@zwave-js/crc16-ccitt-freebsd-x64@npm:1.0.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@zwave-js/crc16-ccitt-linux-arm-gnueabihf@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@zwave-js/crc16-ccitt-linux-arm-gnueabihf@npm:1.0.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@zwave-js/crc16-ccitt-linux-arm64-gnu@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@zwave-js/crc16-ccitt-linux-arm64-gnu@npm:1.0.0"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@zwave-js/crc16-ccitt-linux-arm64-musl@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@zwave-js/crc16-ccitt-linux-arm64-musl@npm:1.0.0"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@zwave-js/crc16-ccitt-linux-x64-gnu@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@zwave-js/crc16-ccitt-linux-x64-gnu@npm:1.0.0"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@zwave-js/crc16-ccitt-linux-x64-musl@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@zwave-js/crc16-ccitt-linux-x64-musl@npm:1.0.0"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@zwave-js/crc16-ccitt-win32-arm64-msvc@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@zwave-js/crc16-ccitt-win32-arm64-msvc@npm:1.0.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@zwave-js/crc16-ccitt-win32-ia32-msvc@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@zwave-js/crc16-ccitt-win32-ia32-msvc@npm:1.0.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@zwave-js/crc16-ccitt-win32-x64-msvc@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@zwave-js/crc16-ccitt-win32-x64-msvc@npm:1.0.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@zwave-js/crc16-ccitt@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "@zwave-js/crc16-ccitt@npm:1.0.0"
+  dependencies:
+    "@node-rs/helper": ^1.2.1
+    "@zwave-js/crc16-ccitt-android-arm-eabi": 1.0.0
+    "@zwave-js/crc16-ccitt-android-arm64": 1.0.0
+    "@zwave-js/crc16-ccitt-darwin-arm64": 1.0.0
+    "@zwave-js/crc16-ccitt-darwin-x64": 1.0.0
+    "@zwave-js/crc16-ccitt-freebsd-x64": 1.0.0
+    "@zwave-js/crc16-ccitt-linux-arm-gnueabihf": 1.0.0
+    "@zwave-js/crc16-ccitt-linux-arm64-gnu": 1.0.0
+    "@zwave-js/crc16-ccitt-linux-arm64-musl": 1.0.0
+    "@zwave-js/crc16-ccitt-linux-x64-gnu": 1.0.0
+    "@zwave-js/crc16-ccitt-linux-x64-musl": 1.0.0
+    "@zwave-js/crc16-ccitt-win32-arm64-msvc": 1.0.0
+    "@zwave-js/crc16-ccitt-win32-ia32-msvc": 1.0.0
+    "@zwave-js/crc16-ccitt-win32-x64-msvc": 1.0.0
+  dependenciesMeta:
+    "@zwave-js/crc16-ccitt-android-arm-eabi":
+      optional: true
+    "@zwave-js/crc16-ccitt-android-arm64":
+      optional: true
+    "@zwave-js/crc16-ccitt-darwin-arm64":
+      optional: true
+    "@zwave-js/crc16-ccitt-darwin-x64":
+      optional: true
+    "@zwave-js/crc16-ccitt-freebsd-x64":
+      optional: true
+    "@zwave-js/crc16-ccitt-linux-arm-gnueabihf":
+      optional: true
+    "@zwave-js/crc16-ccitt-linux-arm64-gnu":
+      optional: true
+    "@zwave-js/crc16-ccitt-linux-arm64-musl":
+      optional: true
+    "@zwave-js/crc16-ccitt-linux-x64-gnu":
+      optional: true
+    "@zwave-js/crc16-ccitt-linux-x64-musl":
+      optional: true
+    "@zwave-js/crc16-ccitt-win32-arm64-msvc":
+      optional: true
+    "@zwave-js/crc16-ccitt-win32-ia32-msvc":
+      optional: true
+    "@zwave-js/crc16-ccitt-win32-x64-msvc":
+      optional: true
+  checksum: 30c44ef2cb7f050c463093e639b06cb0ff2eb6373c30245d88c0382008f858862ca78073c54dad1fecccd76ef2dc83390e64b8bf426b704d20464f6180765bff
+  languageName: node
+  linkType: hard
 
 "@zwave-js/file-stream-rotator@npm:^0.5.8-0":
   version: 0.5.8-0


### PR DESCRIPTION
CRC16 isn't used a ton, but even with only 10 bytes payload, the Rust implementation is ~40% faster, scaling up to 32x for larger payloads:
```
PERF JS:
10 bytes: 0.05 ms = 204.30 KB/s, result = 0xbab9
100 bytes: 0.06 ms = 1.60 MB/s, result = 0xc427
1000 bytes: 1.99 ms = 490.88 KB/s, result = 0x829e
10000 bytes: 1.64 ms = 5.81 MB/s, result = 0x8c17
100000 bytes: 6.27 ms = 15.21 MB/s, result = 0x7b4
1000000 bytes: 64.61 ms = 14.76 MB/s, result = 0xe416

PERF RUST:
10 bytes: 0.03 ms = 292.38 KB/s, result = 0xbab9
100 bytes: 0.01 ms = 9.26 MB/s, result = 0xc427
1000 bytes: 0.00 ms = 207.32 MB/s, result = 0x829e
10000 bytes: 0.02 ms = 431.53 MB/s, result = 0x8c17
100000 bytes: 0.20 ms = 474.94 MB/s, result = 0x7b4
1000000 bytes: 2.02 ms = 471.72 MB/s, result = 0xe416
```

This can serve as a nice experiment to investigate where it makes sense to defer CPU intensive tasks to Rust.