### PR TITLE
fix product ID for EU version of Ring Contact Sensor v2

### DIFF
--- a/packages/config/config/devices/0x0346/contact_sensor_gen2.json
+++ b/packages/config/config/devices/0x0346/contact_sensor_gen2.json
@@ -11,7 +11,7 @@
 		},
 		{
 			"productType": "0x0201",
-			"productId": "0x0401",
+			"productId": "0x0301",
 			"zwaveAllianceId": 4147
 		}
 	],


### PR DESCRIPTION
According to the z-wave alliance product DB, the Product ID for the EU version of the Ring Contact Sendor v2 needs to be 0x0301 and not 0x0401.

See: [https://products.z-wavealliance.org/products/4147?selectedFrequencyId=-1](https://products.z-wavealliance.org/products/4147?selectedFrequencyId=-1)
