### PR TITLE
feat: expose RSSI and routes as part of node statistics

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -269,6 +269,71 @@ To get around this:
 2. Batch all `getNodeNeighbors` requests together
 3. Turn the radio back on with `controller.toggleRF(true`)
 
+### `getKnownLifelineRoutes`
+
+The routing table of the controller is stored in its memory and not easily accessible during normal operation. Z-Wave JS gets around this by keeping statistics for each node that include the last used routes, the used repeaters, procotol and speed, as well as RSSI readings. This information can be read using
+
+```ts
+getKnownLifelineRoutes(): ReadonlyMap<number, LifelineRoutes>
+```
+
+This has some limitations:
+
+-   The information is dynamically built using TX status reports and may not be accurate at all times.
+-   It may not be available immediately after startup or at all if the controller doesn't support this feature.
+-   It only includes information about the routes between the controller and nodes, not between individual nodes.
+
+> [!NOTE] To keep information returned by this method updated, subscribe to each node's `"statistics"` event and use the included information.
+
+The returned objects have the following shape:
+
+<!-- #import LifelineRoutes from "zwave-js" -->
+
+```ts
+interface LifelineRoutes {
+	/** The last working route from the controller to this node. */
+	lwr?: RouteStatistics;
+	/** The next to last working route from the controller to this node. */
+	nlwr?: RouteStatistics;
+}
+```
+
+<!-- #import RouteStatistics from "zwave-js" -->
+
+```ts
+interface RouteStatistics {
+	/** The protocol and used data rate for this route */
+	protocolDataRate: ProtocolDataRate;
+	/** Which nodes are repeaters for this route */
+	repeaters: number[];
+
+	/** The RSSI of the ACK frame received by the controller */
+	rssi?: RSSI;
+	/**
+	 * The RSSI of the ACK frame received by each repeater.
+	 * If this is set, it has the same length as the repeaters array.
+	 */
+	repeaterRSSI?: RSSI[];
+
+	/**
+	 * The node IDs of the nodes between which the transmission failed most recently.
+	 * Is only set if there recently was a transmission failure.
+	 */
+	routeFailedBetween?: [number, number];
+}
+```
+
+<!-- #import ProtocolDataRate from "zwave-js" -->
+
+```ts
+declare enum ProtocolDataRate {
+	ZWave_9k6 = 1,
+	ZWave_40k = 2,
+	ZWave_100k = 3,
+	LongRange_100k = 4,
+}
+```
+
 ### `healNode`
 
 ```ts

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -1175,5 +1175,40 @@ interface NodeStatistics {
 	 * Consecutive measurements are combined using an exponential moving average.
 	 */
 	rtt?: number;
+	/**
+	 * Average RSSI of frames received by this node in dBm.
+	 * Consecutive non-error measurements are combined using an exponential moving average.
+	 */
+	rssi?: RSSI;
+
+	/** The last working route between the controller and this node. */
+	lwr?: RouteStatistics;
+	/** The next to last working route between the controller and this node. */
+	nlwr?: RouteStatistics;
+}
+```
+
+<!-- #import RouteStatistics from "zwave-js" -->
+
+```ts
+interface RouteStatistics {
+	/** The protocol and used data rate for this route */
+	protocolDataRate: ProtocolDataRate;
+	/** Which nodes are repeaters for this route */
+	repeaters: number[];
+
+	/** The RSSI of the ACK frame received by the controller */
+	ackRSSI?: RSSI;
+	/**
+	 * The RSSI of the ACK frame received by each repeater.
+	 * If this is set, it has the same length as the repeaters array.
+	 */
+	ackRepeaterRSSI?: RSSI[];
+
+	/**
+	 * The node IDs of the nodes between which the transmission failed most recently.
+	 * Is only set if there recently was a transmission failure.
+	 */
+	routeFailedBetween?: [number, number];
 }
 ```

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -1175,15 +1175,16 @@ interface NodeStatistics {
 	 * Consecutive measurements are combined using an exponential moving average.
 	 */
 	rtt?: number;
+
 	/**
 	 * Average RSSI of frames received by this node in dBm.
 	 * Consecutive non-error measurements are combined using an exponential moving average.
 	 */
 	rssi?: RSSI;
 
-	/** The last working route between the controller and this node. */
+	/** The last working route from the controller to this node. */
 	lwr?: RouteStatistics;
-	/** The next to last working route between the controller and this node. */
+	/** The next to last working route from the controller to this node. */
 	nlwr?: RouteStatistics;
 }
 ```
@@ -1198,12 +1199,12 @@ interface RouteStatistics {
 	repeaters: number[];
 
 	/** The RSSI of the ACK frame received by the controller */
-	ackRSSI?: RSSI;
+	rssi?: RSSI;
 	/**
 	 * The RSSI of the ACK frame received by each repeater.
 	 * If this is set, it has the same length as the repeaters array.
 	 */
-	ackRepeaterRSSI?: RSSI[];
+	repeaterRSSI?: RSSI[];
 
 	/**
 	 * The node IDs of the nodes between which the transmission failed most recently.

--- a/packages/zwave-js/src/Controller.ts
+++ b/packages/zwave-js/src/Controller.ts
@@ -7,6 +7,11 @@ export type {
 export type { ControllerStatistics } from "./lib/controller/ControllerStatistics";
 export { ZWaveFeature } from "./lib/controller/Features";
 export * from "./lib/controller/Inclusion";
-export { RSSI, RssiError, TXReport } from "./lib/controller/SendDataShared";
+export {
+	isRssiError,
+	RSSI,
+	RssiError,
+	TXReport,
+} from "./lib/controller/SendDataShared";
 export type { ZWaveLibraryTypes } from "./lib/controller/ZWaveLibraryTypes";
 export { RFRegion } from "./lib/serialapi/misc/SerialAPISetupMessages";

--- a/packages/zwave-js/src/Node.ts
+++ b/packages/zwave-js/src/Node.ts
@@ -4,6 +4,7 @@ export {
 	NodeType,
 	NODE_ID_BROADCAST,
 	NODE_ID_MAX,
+	ProtocolDataRate,
 	ProtocolVersion,
 } from "@zwave-js/core";
 export { DeviceClass } from "./lib/node/DeviceClass";
@@ -17,6 +18,7 @@ export {
 	InterviewStage,
 	LifelineHealthCheckResult,
 	LifelineHealthCheckSummary,
+	LifelineRoutes,
 	NodeInterviewFailedEventArgs,
 	NodeStatus,
 	RefreshInfoOptions,

--- a/packages/zwave-js/src/Node.ts
+++ b/packages/zwave-js/src/Node.ts
@@ -9,7 +9,10 @@ export {
 export { DeviceClass } from "./lib/node/DeviceClass";
 export { Endpoint } from "./lib/node/Endpoint";
 export { ZWaveNode } from "./lib/node/Node";
-export type { NodeStatistics } from "./lib/node/NodeStatistics";
+export type {
+	NodeStatistics,
+	RouteStatistics,
+} from "./lib/node/NodeStatistics";
 export {
 	InterviewStage,
 	LifelineHealthCheckResult,

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -90,7 +90,7 @@ import type { Message } from "../message/Message";
 import type { SuccessIndicator } from "../message/SuccessIndicator";
 import { DeviceClass } from "../node/DeviceClass";
 import { ZWaveNode } from "../node/Node";
-import { InterviewStage, NodeStatus } from "../node/Types";
+import { InterviewStage, LifelineRoutes, NodeStatus } from "../node/Types";
 import { VirtualNode } from "../node/VirtualNode";
 import {
 	GetBackgroundRSSIRequest,
@@ -4193,6 +4193,26 @@ ${associatedNodes.join(", ")}`,
 			);
 			throw e;
 		}
+	}
+
+	/**
+	 * Returns the known routes the controller will use to communicate with the nodes.
+	 *
+	 * This information is dynamically built using TX status reports and may not be accurate at all times.
+	 * Also, it may not be available immediately after startup or at all if the controller doesn't support this feature.
+	 *
+	 * **Note:** To keep information returned by this method updated, use the information contained in each node's `"statistics"` event.
+	 */
+	public getKnownLifelineRoutes(): ReadonlyMap<number, LifelineRoutes> {
+		const ret = new Map<number, LifelineRoutes>();
+		for (const node of this.nodes.values()) {
+			if (node.isControllerNode) continue;
+			ret.set(node.id, {
+				lwr: node.statistics.lwr,
+				nlwr: node.statistics.nlwr,
+			});
+		}
+		return ret;
 	}
 
 	/**

--- a/packages/zwave-js/src/lib/controller/SendDataShared.ts
+++ b/packages/zwave-js/src/lib/controller/SendDataShared.ts
@@ -82,6 +82,10 @@ export enum RssiError {
 	NoSignalDetected = 125,
 }
 
+export function isRssiError(rssi: RSSI): rssi is RssiError {
+	return rssi >= RssiError.NoSignalDetected;
+}
+
 // const RSSI_RESERVED_START = 11;
 
 /** A number between -128 and +124 dBm or one of the special values in {@link RssiError} indicating an error */

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -43,7 +43,6 @@ import {
 	createDeferredPromise,
 	DeferredPromise,
 } from "alcalzone-shared/deferred-promise";
-import { roundTo } from "alcalzone-shared/math";
 import { isArray, isObject } from "alcalzone-shared/typeguards";
 import { randomBytes } from "crypto";
 import type { EventEmitter } from "events";
@@ -3263,25 +3262,13 @@ ${handlers.length} left`,
 					node.incrementStatistics("commandsDroppedTX");
 				} else {
 					node.incrementStatistics("commandsTX");
-					if (msg.rtt) {
-						const rttMs = msg.rtt / 1e6;
-						node.updateStatistics((current) => ({
-							...current,
-							rtt:
-								current.rtt != undefined
-									? roundTo(
-											current.rtt * 0.9 + rttMs * 0.1,
-											1,
-									  )
-									: roundTo(rttMs, 1),
-						}));
-					}
+					node.updateRTT(msg);
 				}
 
 				// Notify listeners about the status report if one was received
 				if (hasTXReport(result)) {
 					options.onTXReport?.(result.txReport);
-					// TODO: Update statistics based on the TX report
+					node.updateRouteStatistics(result.txReport);
 				}
 			}
 

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -4533,13 +4533,11 @@ ${formatRouteHealthCheckSummary(this.id, otherNode.id, summary)}`,
 			const newStats: RouteStatistics = {
 				protocolDataRate: txReport.routeSpeed,
 				repeaters: (txReport.repeaterNodeIds ?? []) as number[],
-				ackRSSI:
-					txReport.ackRSSI ??
-					ret.lwr?.ackRSSI ??
-					RssiError.NotAvailable,
+				rssi:
+					txReport.ackRSSI ?? ret.lwr?.rssi ?? RssiError.NotAvailable,
 			};
 			if (txReport.ackRepeaterRSSI != undefined) {
-				newStats.ackRepeaterRSSI = txReport.ackRepeaterRSSI as number[];
+				newStats.repeaterRSSI = txReport.ackRepeaterRSSI as number[];
 			}
 			if (
 				txReport.failedRouteLastFunctionalNodeId &&

--- a/packages/zwave-js/src/lib/node/NodeStatistics.ts
+++ b/packages/zwave-js/src/lib/node/NodeStatistics.ts
@@ -1,3 +1,5 @@
+import type { ProtocolDataRate } from "@zwave-js/core";
+import type { RSSI } from "../controller/SendDataShared";
 import { StatisticsHost } from "../driver/Statistics";
 
 export class NodeStatisticsHost extends StatisticsHost<NodeStatistics> {
@@ -36,4 +38,46 @@ export interface NodeStatistics {
 	 * Consecutive measurements are combined using an exponential moving average.
 	 */
 	rtt?: number;
+	/**
+	 * Average RSSI of frames received by this node in dBm.
+	 * Consecutive non-error measurements are combined using an exponential moving average.
+	 */
+	rssi?: RSSI;
+
+	/** The last working route between the controller and this node. */
+	lwr?: RouteStatistics;
+	/** The next to last working route between the controller and this node. */
+	nlwr?: RouteStatistics;
+}
+
+export interface RouteStatistics {
+	/** The protocol and used data rate for this route */
+	protocolDataRate: ProtocolDataRate;
+	/** Which nodes are repeaters for this route */
+	repeaters: number[];
+
+	/** The RSSI of the ACK frame received by the controller */
+	ackRSSI?: RSSI;
+	/**
+	 * The RSSI of the ACK frame received by each repeater.
+	 * If this is set, it has the same length as the repeaters array.
+	 */
+	ackRepeaterRSSI?: RSSI[];
+
+	/**
+	 * The node IDs of the nodes between which the transmission failed most recently.
+	 * Is only set if there recently was a transmission failure.
+	 */
+	routeFailedBetween?: [number, number];
+}
+
+/** Checks if the given route statistics belong to the same route */
+export function routeStatisticsEquals(
+	r1: RouteStatistics,
+	r2: RouteStatistics,
+): boolean {
+	if (r1.repeaters.length !== r2.repeaters.length) return false;
+	if (!r1.repeaters.every((node) => r2.repeaters.includes(node)))
+		return false;
+	return true;
 }

--- a/packages/zwave-js/src/lib/node/NodeStatistics.ts
+++ b/packages/zwave-js/src/lib/node/NodeStatistics.ts
@@ -38,15 +38,16 @@ export interface NodeStatistics {
 	 * Consecutive measurements are combined using an exponential moving average.
 	 */
 	rtt?: number;
+
 	/**
 	 * Average RSSI of frames received by this node in dBm.
 	 * Consecutive non-error measurements are combined using an exponential moving average.
 	 */
 	rssi?: RSSI;
 
-	/** The last working route between the controller and this node. */
+	/** The last working route from the controller to this node. */
 	lwr?: RouteStatistics;
-	/** The next to last working route between the controller and this node. */
+	/** The next to last working route from the controller to this node. */
 	nlwr?: RouteStatistics;
 }
 
@@ -57,12 +58,12 @@ export interface RouteStatistics {
 	repeaters: number[];
 
 	/** The RSSI of the ACK frame received by the controller */
-	ackRSSI?: RSSI;
+	rssi?: RSSI;
 	/**
 	 * The RSSI of the ACK frame received by each repeater.
 	 * If this is set, it has the same length as the repeaters array.
 	 */
-	ackRepeaterRSSI?: RSSI[];
+	repeaterRSSI?: RSSI[];
 
 	/**
 	 * The node IDs of the nodes between which the transmission failed most recently.

--- a/packages/zwave-js/src/lib/node/Types.ts
+++ b/packages/zwave-js/src/lib/node/Types.ts
@@ -14,6 +14,7 @@ import type {
 	ZWaveNotificationCallbackParams_PowerlevelCC,
 } from "../commandclass/PowerlevelCC";
 import type { ZWaveNode } from "./Node";
+import type { RouteStatistics } from "./NodeStatistics";
 
 export interface TranslatedValueID extends ValueID {
 	commandClassName: string;
@@ -293,4 +294,12 @@ export interface RefreshInfoOptions {
 	 * Default: true
 	 */
 	waitForWakeup?: boolean;
+}
+
+/** The last known routes between the controller and a node */
+export interface LifelineRoutes {
+	/** The last working route from the controller to this node. */
+	lwr?: RouteStatistics;
+	/** The next to last working route from the controller to this node. */
+	nlwr?: RouteStatistics;
 }


### PR DESCRIPTION
With this PR, we expose the TX statistics (if enabled and supported) as part of the node statistics. In particular, this includes information about:
- `rssi`, either one of the `RssiError` values or an exponential moving average of the most recent RSSI readings
- `lwr` and `nlwr`, the (**n**ext to) **l**ast **w**orking **r**oute used in communication with the node, including RSSI readings, protocol/route speed and (when rerouting was necessary) broken links. Whenever the reported route changes, the previous LWR becomes the NLWR and the new route becomes the LWR. Note that this is an estimation of what the controller does internally and might not be the same at all times.

The PR also adds a new controller method `getKnownLifelineRoutes`, which gives an initial view of the known routes, that can later be updated using the node's statistics events.