### PR TITLE
fix(config): correct lifeline association and param 3 for ZWN-RSM2-PLUS

### DIFF
--- a/packages/config/config/devices/0x011a/zwn-rsm2.json
+++ b/packages/config/config/devices/0x011a/zwn-rsm2.json
@@ -18,45 +18,20 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
-	"endpoints": {
-		"0": {
-			"associations": {
-				"1": {
-					"label": "Lifeline",
-					"maxNodes": 1,
-					"isLifeline": true
-				},
-				"2": {
-					"label": "Switch Binary Report EP1",
-					"maxNodes": 3
-				},
-				"3": {
-					"label": "Switch Binary Report EP2",
-					"maxNodes": 3
-				}
-			}
-		},
+	"associations": {
 		"1": {
-			"associations": {
-				"1": {
-					"$import": "#endpoints/0/associations/1",
-					"isLifeline": false
-				},
-				"2": {
-					"$import": "#endpoints/0/associations/2"
-				}
-			}
+			"label": "Lifeline",
+			"maxNodes": 1,
+			"isLifeline": true,
+			"multiChannel": true
 		},
 		"2": {
-			"associations": {
-				"1": {
-					"$import": "#endpoints/0/associations/1",
-					"isLifeline": false
-				},
-				"2": {
-					"$import": "#endpoints/0/associations/3"
-				}
-			}
+			"label": "Switch Binary Report EP1",
+			"maxNodes": 3
+		},
+		"3": {
+			"label": "Switch Binary Report EP2",
+			"maxNodes": 3
 		}
 	},
 	"paramInformation": [

--- a/packages/config/config/devices/0x011a/zwn-rsm2.json
+++ b/packages/config/config/devices/0x011a/zwn-rsm2.json
@@ -18,19 +18,45 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
-	"associations": {
+	"endpoints": {
+		"0": {
+			"associations": {
+				"1": {
+					"label": "Lifeline",
+					"maxNodes": 1,
+					"isLifeline": true
+				},
+				"2": {
+					"label": "Switch Binary Report EP1",
+					"maxNodes": 3
+				},
+				"3": {
+					"label": "Switch Binary Report EP2",
+					"maxNodes": 3
+				}
+			}
+		},
 		"1": {
-			"label": "Lifeline",
-			"maxNodes": 1,
-			"isLifeline": true
+			"associations": {
+				"1": {
+					"$import": "#endpoints/0/associations/1",
+					"isLifeline": false
+				},
+				"2": {
+					"$import": "#endpoints/0/associations/2"
+				}
+			}
 		},
 		"2": {
-			"label": "Switch Binary Report EP1",
-			"maxNodes": 3
-		},
-		"3": {
-			"label": "Switch Binary Report EP2",
-			"maxNodes": 3
+			"associations": {
+				"1": {
+					"$import": "#endpoints/0/associations/1",
+					"isLifeline": false
+				},
+				"2": {
+					"$import": "#endpoints/0/associations/3"
+				}
+			}
 		}
 	},
 	"paramInformation": [
@@ -40,9 +66,20 @@
 			"description": "Send unsolicited status report to primary controller",
 			"valueSize": 1,
 			"minValue": 0,
-			"maxValue": 255,
+			"maxValue": 1,
 			"defaultValue": 0,
-			"unsigned": true
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disabled",
+					"value": 0
+				},
+				{
+					"label": "Send Broadcast",
+					"value": 1
+				}
+			]
 		}
 	],
 	"metadata": {

--- a/packages/config/config/devices/0x011a/zwn-rsm2.json
+++ b/packages/config/config/devices/0x011a/zwn-rsm2.json
@@ -62,5 +62,16 @@
 		"exclusion": "When the controller is in remove mode, press and release the program button of ZWN-RSM2 module, or Flick 3 times of the connected switch with Aux1 line (or Aux2 line) in 1.5 second. Then the controller will remove the module from current Z-Wave network",
 		"reset": "Once program button is pressed and hold for 10 second, the device will send a device reset locally notification to controller. Then clear all of information for the network, and restore factory defaults, and reset the module. Use this procedure only in the event that the network primary controller is missing or otherwise inoperable",
 		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/2242/ZWN-RSM2%202017-2-28.pdf"
+	},
+	"compat": {
+		"commandClasses": {
+			"add": {
+				// The device needs a multi channel lifeline association (target endpoint 0),
+				// but only reports support for V2, which doesn't allow this.
+				"0x8e": {
+					"version": 3
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
Fixes: #2280

- Force Endpoint 0 for Group 1 Associations Lifeline so that CurrentValue
  status reports are sent and processed.
- Define the one configuration parameters options as per mfg data

---

Did some experimentation to get this device to report manual local change (someone turns the switch off or on) and found that setting the Endpoint Target to 0 for Group 1 Association (Lifeline) did the trick.  I only found one other example of Endpoint usage in device configurations, so I hope I got this correct.  
