### PR TITLE
feat(cc): add support for Humidity Control CCs

### DIFF
--- a/packages/config/config/scales.json
+++ b/packages/config/config/scales.json
@@ -10,6 +10,16 @@
 			"unit": "°F"
 		}
 	},
+	"humidity": {
+		"0x00": {
+			"label": "Percentage value",
+			"unit": "%"
+		},
+		"0x01": {
+			"label": "Absolute humidity",
+			"unit": "g/m³"
+		}
+	},
 	"mass": {
 		"0x00": {
 			"label": "Kilogram",

--- a/packages/config/config/sensorTypes.json
+++ b/packages/config/config/sensorTypes.json
@@ -45,16 +45,7 @@
 	},
 	"0x05": {
 		"label": "Humidity",
-		"scales": {
-			"0x00": {
-				"label": "Percentage value",
-				"unit": "%"
-			},
-			"0x01": {
-				"label": "Absolute humidity",
-				"unit": "g/m³"
-			}
-		}
+		"scales": "$SCALES:humidity"
 	},
 	"0x06": {
 		"label": "Velocity",

--- a/packages/zwave-js/src/lib/commandclass/API.ts
+++ b/packages/zwave-js/src/lib/commandclass/API.ts
@@ -417,6 +417,12 @@ export type CCToName<CC extends CommandClasses> = [CC] extends [
 	? "Entry Control"
 	: [CC] extends [typeof CommandClasses["Firmware Update Meta Data"]]
 	? "Firmware Update Meta Data"
+	: [CC] extends [typeof CommandClasses["Humidity Control Mode"]]
+	? "Humidity Control Mode"
+	: [CC] extends [typeof CommandClasses["Humidity Control Operating State"]]
+	? "Humidity Control Operating State"
+	: [CC] extends [typeof CommandClasses["Humidity Control Setpoint"]]
+	? "Humidity Control Setpoint"
 	: [CC] extends [typeof CommandClasses["Indicator"]]
 	? "Indicator"
 	: [CC] extends [typeof CommandClasses["Language"]]
@@ -547,6 +553,9 @@ export interface CCAPIs {
 	"Door Lock Logging": import("./DoorLockLoggingCC").DoorLockLoggingCCAPI;
 	"Entry Control": import("./EntryControlCC").EntryControlCCAPI;
 	"Firmware Update Meta Data": import("./FirmwareUpdateMetaDataCC").FirmwareUpdateMetaDataCCAPI;
+	"Humidity Control Mode": import("./HumidityControlModeCC").HumidityControlModeCCAPI;
+	"Humidity Control Operating State": import("./HumidityControlOperatingStateCC").HumidityControlOperatingStateCCAPI;
+	"Humidity Control Setpoint": import("./HumidityControlSetpointCC").HumidityControlSetpointCCAPI;
 	Indicator: import("./IndicatorCC").IndicatorCCAPI;
 	Language: import("./LanguageCC").LanguageCCAPI;
 	Lock: import("./LockCC").LockCCAPI;

--- a/packages/zwave-js/src/lib/commandclass/HumidityControlMode.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/HumidityControlMode.test.ts
@@ -1,0 +1,268 @@
+import { CommandClasses, enumValuesToMetadataStates } from "@zwave-js/core";
+import type { Driver } from "../driver/Driver";
+import { ZWaveNode } from "../node/Node";
+import { assertCC } from "../test/assertCC";
+import { createEmptyMockDriver } from "../test/mocks";
+import { getCCValueMetadata } from "./CommandClass";
+import {
+	HumidityControlMode,
+	HumidityControlModeCC,
+	HumidityControlModeCCGet,
+	HumidityControlModeCCReport,
+	HumidityControlModeCCSet,
+	HumidityControlModeCCSupportedGet,
+	HumidityControlModeCCSupportedReport,
+	HumidityControlModeCommand,
+} from "./HumidityControlModeCC";
+
+function buildCCBuffer(payload: Buffer): Buffer {
+	return Buffer.concat([
+		Buffer.from([
+			CommandClasses["Humidity Control Mode"], // CC
+		]),
+		payload,
+	]);
+}
+
+describe("lib/commandclass/HumidityControlModeCC => ", () => {
+	let fakeDriver: Driver;
+	let node: ZWaveNode;
+
+	beforeAll(() => {
+		fakeDriver = createEmptyMockDriver() as unknown as Driver;
+		node = new ZWaveNode(1, fakeDriver as any);
+		(fakeDriver.controller.nodes as any).set(1, node);
+		node.addCC(CommandClasses["Humidity Control Mode"], {
+			isSupported: true,
+			version: 2,
+		});
+	});
+
+	afterAll(() => {
+		node.destroy();
+	});
+
+	it("the Get command should serialize correctly", () => {
+		const cc = new HumidityControlModeCCGet(fakeDriver, {
+			nodeId: node.id,
+		});
+		const expected = buildCCBuffer(
+			Buffer.from([
+				HumidityControlModeCommand.Get, // CC Command
+			]),
+		);
+		expect(cc.serialize()).toEqual(expected);
+	});
+
+	it("the Set command should serialize correctly", () => {
+		const cc = new HumidityControlModeCCSet(fakeDriver, {
+			nodeId: node.id,
+			mode: HumidityControlMode.Auto,
+		});
+		const expected = buildCCBuffer(
+			Buffer.from([
+				HumidityControlModeCommand.Set, // CC Command
+				0x03, // target value
+			]),
+		);
+		expect(cc.serialize()).toEqual(expected);
+	});
+
+	it("the Report command should be deserialized correctly", () => {
+		const ccData = buildCCBuffer(
+			Buffer.from([
+				HumidityControlModeCommand.Report, // CC Command
+				HumidityControlMode.Auto, // current value
+			]),
+		);
+		const cc = new HumidityControlModeCCReport(fakeDriver, {
+			nodeId: node.id,
+			data: ccData,
+		});
+
+		expect(cc.mode).toBe(HumidityControlMode.Auto);
+	});
+
+	it("the Report command should set the correct value", () => {
+		const ccData = buildCCBuffer(
+			Buffer.from([
+				HumidityControlModeCommand.Report, // CC Command
+				HumidityControlMode.Auto, // current value
+			]),
+		);
+		new HumidityControlModeCCReport(fakeDriver, {
+			nodeId: node.id,
+			data: ccData,
+		});
+
+		const currentValue = node.valueDB.getValue({
+			commandClass: CommandClasses["Humidity Control Mode"],
+			property: "mode",
+		});
+		expect(currentValue).toEqual(HumidityControlMode.Auto);
+	});
+
+	it("the Report command should set the correct metadata", () => {
+		const ccData = buildCCBuffer(
+			Buffer.from([
+				HumidityControlModeCommand.Report, // CC Command
+				HumidityControlMode.Auto, // current value
+			]),
+		);
+		new HumidityControlModeCCReport(fakeDriver, {
+			nodeId: node.id,
+			data: ccData,
+		});
+
+		const currentValueMeta = getCCValueMetadata(
+			CommandClasses["Humidity Control Mode"],
+			"mode",
+		);
+		expect(currentValueMeta).toMatchObject({
+			states: enumValuesToMetadataStates(HumidityControlMode),
+			label: "Humidity control mode",
+		});
+	});
+
+	it("the SupportedGet command should serialize correctly", () => {
+		const cc = new HumidityControlModeCCSupportedGet(fakeDriver, {
+			nodeId: node.id,
+		});
+		const expected = buildCCBuffer(
+			Buffer.from([
+				HumidityControlModeCommand.SupportedGet, // CC Command
+			]),
+		);
+		expect(cc.serialize()).toEqual(expected);
+	});
+
+	it("the SupportedReport command should be deserialized correctly", () => {
+		const ccData = buildCCBuffer(
+			Buffer.from([
+				HumidityControlModeCommand.SupportedReport, // CC Command
+				(1 << HumidityControlMode.Off) |
+					(1 << HumidityControlMode.Auto),
+			]),
+		);
+		const cc = new HumidityControlModeCCSupportedReport(fakeDriver, {
+			nodeId: node.id,
+			data: ccData,
+		});
+
+		expect(cc.supportedModes).toEqual([
+			HumidityControlMode.Off,
+			HumidityControlMode.Auto,
+		]);
+	});
+
+	it("the SupportedReport command should set the correct metadata", () => {
+		const ccData = buildCCBuffer(
+			Buffer.from([
+				HumidityControlModeCommand.SupportedReport, // CC Command
+				(1 << HumidityControlMode.Off) |
+					(1 << HumidityControlMode.Auto),
+			]),
+		);
+		new HumidityControlModeCCSupportedReport(fakeDriver, {
+			nodeId: node.id,
+			data: ccData,
+		});
+
+		const currentValueMeta = getCCValueMetadata(
+			CommandClasses["Humidity Control Mode"],
+			"mode",
+		);
+		expect(currentValueMeta).toMatchObject({
+			states: {
+				0: "Off",
+				3: "Auto",
+			},
+			label: "Humidity control mode",
+		});
+	});
+
+	describe(`interview()`, () => {
+		beforeAll(() => {
+			fakeDriver.sendMessage
+				.mockImplementationOnce(() =>
+					Promise.resolve({
+						command: {
+							supportedModes: [
+								HumidityControlMode.Off,
+								HumidityControlMode.Humidify,
+								HumidityControlMode.Auto,
+							],
+						},
+					}),
+				)
+				.mockImplementationOnce(() =>
+					Promise.resolve({
+						command: { mode: HumidityControlMode.Humidify },
+					}),
+				);
+			fakeDriver.controller.nodes.set(node.id, node);
+		});
+		beforeEach(() => fakeDriver.sendMessage.mockClear());
+		afterAll(() => {
+			fakeDriver.sendMessage.mockImplementation(() => Promise.resolve());
+		});
+
+		it("should send a HumidityControlModeCC.SupportedGet and then .Get", async () => {
+			const cc = node.createCCInstance(
+				CommandClasses["Humidity Control Mode"],
+			)!;
+			await cc.interview();
+
+			expect(fakeDriver.sendMessage).toBeCalled();
+
+			assertCC(fakeDriver.sendMessage.mock.calls[0][0], {
+				cc: HumidityControlModeCC,
+				nodeId: node.id,
+				ccValues: {
+					ccCommand: HumidityControlModeCommand.SupportedGet,
+				},
+			});
+
+			assertCC(fakeDriver.sendMessage.mock.calls[1][0], {
+				cc: HumidityControlModeCC,
+				nodeId: node.id,
+				ccValues: {
+					ccCommand: HumidityControlModeCommand.Get,
+				},
+			});
+		});
+
+		it("should set mode value", async () => {
+			const cc = node.createCCInstance(
+				CommandClasses["Humidity Control Mode"],
+			)!;
+			await cc.interview();
+
+			const currentValue = node.valueDB.getValue({
+				commandClass: CommandClasses["Humidity Control Mode"],
+				property: "mode",
+			});
+			expect(currentValue).toEqual(HumidityControlMode.Auto);
+		});
+
+		it("should set mode metadata", async () => {
+			const cc = node.createCCInstance(
+				CommandClasses["Humidity Control Mode"],
+			)!;
+			await cc.interview();
+
+			const currentValueMeta = getCCValueMetadata(
+				CommandClasses["Humidity Control Mode"],
+				"mode",
+			);
+			expect(currentValueMeta).toMatchObject({
+				states: {
+					0: "Off",
+					1: "Humidify",
+					3: "Auto",
+				},
+				label: "Humidity control mode",
+			});
+		});
+	});
+});

--- a/packages/zwave-js/src/lib/commandclass/HumidityControlModeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/HumidityControlModeCC.ts
@@ -1,0 +1,383 @@
+import type { ValueID } from "@zwave-js/core";
+import {
+	CommandClasses,
+	enumValuesToMetadataStates,
+	Maybe,
+	MessageOrCCLogEntry,
+	MessageRecord,
+	parseBitMask,
+	validatePayload,
+	ValueMetadata,
+	ZWaveError,
+	ZWaveErrorCodes,
+} from "@zwave-js/core";
+import { getEnumMemberName, pick } from "@zwave-js/shared";
+import type { Driver } from "../driver/Driver";
+import { MessagePriority } from "../message/Constants";
+import {
+	CCAPI,
+	PollValueImplementation,
+	POLL_VALUE,
+	SetValueImplementation,
+	SET_VALUE,
+	throwUnsupportedProperty,
+	throwWrongValueType,
+} from "./API";
+import {
+	API,
+	CCCommand,
+	CCCommandOptions,
+	ccValue,
+	ccValueMetadata,
+	CommandClass,
+	commandClass,
+	CommandClassDeserializationOptions,
+	expectedCCResponse,
+	gotDeserializationOptions,
+	implementedVersion,
+} from "./CommandClass";
+
+// All the supported commands
+export enum HumidityControlModeCommand {
+	Set = 0x01,
+	Get = 0x02,
+	Report = 0x03,
+	SupportedGet = 0x04,
+	SupportedReport = 0x05,
+}
+
+export enum HumidityControlMode {
+	"Off" = 0x00,
+	"Humidify" = 0x01,
+	"De-humidify" = 0x02,
+	"Auto" = 0x03,
+}
+
+@API(CommandClasses["Humidity Control Mode"])
+export class HumidityControlModeCCAPI extends CCAPI {
+	public supportsCommand(cmd: HumidityControlModeCommand): Maybe<boolean> {
+		switch (cmd) {
+			case HumidityControlModeCommand.Get:
+			case HumidityControlModeCommand.SupportedGet:
+				return this.isSinglecast();
+			case HumidityControlModeCommand.Set:
+				return true; // This is mandatory
+		}
+		return super.supportsCommand(cmd);
+	}
+
+	protected [SET_VALUE]: SetValueImplementation = async (
+		{ property },
+		value,
+	): Promise<void> => {
+		const valueDB = this.endpoint.getNodeUnsafe()!.valueDB;
+		if (property === "mode") {
+			if (typeof value !== "number") {
+				throwWrongValueType(
+					this.ccId,
+					property,
+					"number",
+					typeof value,
+				);
+			}
+		} else {
+			throwUnsupportedProperty(this.ccId, property);
+		}
+
+		if (this.isSinglecast()) {
+			this.schedulePoll({ property });
+		}
+	};
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+	}): Promise<unknown> => {
+		switch (property) {
+			case "mode":
+				return (await this.get())?.[property];
+
+			default:
+				throwUnsupportedProperty(this.ccId, property);
+		}
+	};
+
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+	public async get() {
+		this.assertSupportsCommand(
+			HumidityControlModeCommand,
+			HumidityControlModeCommand.Get,
+		);
+
+		const cc = new HumidityControlModeCCGet(this.driver, {
+			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
+		});
+		const response =
+			await this.driver.sendCommand<HumidityControlModeCCReport>(
+				cc,
+				this.commandOptions,
+			);
+		if (response) {
+			return pick(response, ["mode"]);
+		}
+	}
+
+	public async set(mode: HumidityControlMode): Promise<void> {
+		this.assertSupportsCommand(
+			HumidityControlModeCommand,
+			HumidityControlModeCommand.Set,
+		);
+
+		const cc = new HumidityControlModeCCSet(this.driver, {
+			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
+			mode,
+		});
+		await this.driver.sendCommand(cc, this.commandOptions);
+	}
+
+	public async getSupportedModes(): Promise<
+		readonly HumidityControlMode[] | undefined
+	> {
+		this.assertSupportsCommand(
+			HumidityControlModeCommand,
+			HumidityControlModeCommand.SupportedGet,
+		);
+
+		const cc = new HumidityControlModeCCSupportedGet(this.driver, {
+			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
+		});
+		const response =
+			await this.driver.sendCommand<HumidityControlModeCCSupportedReport>(
+				cc,
+				this.commandOptions,
+			);
+		return response?.supportedModes;
+	}
+}
+
+@commandClass(CommandClasses["Humidity Control Mode"])
+@implementedVersion(2)
+export class HumidityControlModeCC extends CommandClass {
+	declare ccCommand: HumidityControlModeCommand;
+
+	public async interview(): Promise<void> {
+		const node = this.getNode()!;
+		const endpoint = this.getEndpoint()!;
+		const api = endpoint.commandClasses[
+			"Humidity Control Mode"
+		].withOptions({
+			priority: MessagePriority.NodeQuery,
+		});
+
+		this.driver.controllerLog.logNode(node.id, {
+			endpoint: this.endpointIndex,
+			message: `Interviewing ${this.ccName}...`,
+			direction: "none",
+		});
+
+		// First query the possible modes to set the metadata
+		this.driver.controllerLog.logNode(node.id, {
+			endpoint: this.endpointIndex,
+			message: "querying supported humidity control modes...",
+			direction: "outbound",
+		});
+
+		const supportedModes = await api.getSupportedModes();
+		if (supportedModes) {
+			const logMessage = `received supported humidity control modes:${supportedModes
+				.map(
+					(mode) =>
+						`\n· ${getEnumMemberName(HumidityControlMode, mode)}`,
+				)
+				.join("")}`;
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message: logMessage,
+				direction: "inbound",
+			});
+		} else {
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message:
+					"Querying supported humidity control modes timed out, skipping interview...",
+				level: "warn",
+			});
+			return;
+		}
+
+		await this.refreshValues();
+
+		// Remember that the interview is complete
+		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
+		const endpoint = this.getEndpoint()!;
+		const api = endpoint.commandClasses[
+			"Humidity Control Mode"
+		].withOptions({
+			priority: MessagePriority.NodeQuery,
+		});
+
+		// Query the current status
+		this.driver.controllerLog.logNode(node.id, {
+			endpoint: this.endpointIndex,
+			message: "querying current humidity control mode...",
+			direction: "outbound",
+		});
+		const currentStatus = await api.get();
+		if (currentStatus) {
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message:
+					"received current humidity control mode: " +
+					getEnumMemberName(HumidityControlMode, currentStatus.mode),
+				direction: "inbound",
+			});
+		}
+	}
+}
+
+interface HumidityControlModeCCSetOptions extends CCCommandOptions {
+	mode: HumidityControlMode;
+}
+
+@CCCommand(HumidityControlModeCommand.Set)
+export class HumidityControlModeCCSet extends HumidityControlModeCC {
+	public constructor(
+		driver: Driver,
+		options:
+			| CommandClassDeserializationOptions
+			| HumidityControlModeCCSetOptions,
+	) {
+		super(driver, options);
+		if (gotDeserializationOptions(options)) {
+			// TODO: Deserialize payload
+			throw new ZWaveError(
+				`${this.constructor.name}: deserialization not implemented`,
+				ZWaveErrorCodes.Deserialization_NotImplemented,
+			);
+		} else {
+			this.mode = options.mode;
+		}
+	}
+
+	public mode: HumidityControlMode;
+
+	public serialize(): Buffer {
+		this.payload = Buffer.from([this.mode & 0b1111]);
+		return super.serialize();
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		const message: MessageRecord = {
+			mode: getEnumMemberName(HumidityControlMode, this.mode),
+		};
+		return {
+			...super.toLogEntry(),
+			message,
+		};
+	}
+}
+
+@CCCommand(HumidityControlModeCommand.Report)
+export class HumidityControlModeCCReport extends HumidityControlModeCC {
+	public constructor(
+		driver: Driver,
+		options: CommandClassDeserializationOptions,
+	) {
+		super(driver, options);
+
+		validatePayload(this.payload.length == 1);
+		this._mode = this.payload[0] & 0b1111;
+
+		this.persistValues();
+	}
+
+	private _mode: HumidityControlMode;
+	@ccValue()
+	@ccValueMetadata({
+		...ValueMetadata.UInt8,
+		states: enumValuesToMetadataStates(HumidityControlMode),
+		label: "Humidity control mode",
+	})
+	public get mode(): HumidityControlMode {
+		return this._mode;
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		const message: MessageRecord = {
+			mode: getEnumMemberName(HumidityControlMode, this.mode),
+		};
+		return {
+			...super.toLogEntry(),
+			message,
+		};
+	}
+}
+
+@CCCommand(HumidityControlModeCommand.Get)
+@expectedCCResponse(HumidityControlModeCCReport)
+export class HumidityControlModeCCGet extends HumidityControlModeCC {}
+
+@CCCommand(HumidityControlModeCommand.SupportedReport)
+export class HumidityControlModeCCSupportedReport extends HumidityControlModeCC {
+	public constructor(
+		driver: Driver,
+		options: CommandClassDeserializationOptions,
+	) {
+		super(driver, options);
+
+		this._supportedModes = parseBitMask(
+			this.payload,
+			HumidityControlMode["Off"],
+		);
+
+		// Use this information to create the metadata for the mode property
+		const valueId: ValueID = {
+			commandClass: this.ccId,
+			endpoint: this.endpointIndex,
+			property: "mode",
+		};
+		// Only update the dynamic part
+		this.getValueDB().setMetadata(valueId, {
+			...ValueMetadata.UInt8,
+			states: enumValuesToMetadataStates(
+				HumidityControlMode,
+				this._supportedModes,
+			),
+		});
+
+		this.persistValues();
+	}
+
+	private _supportedModes: HumidityControlMode[];
+	@ccValue({ internal: true })
+	public get supportedModes(): readonly HumidityControlMode[] {
+		return this._supportedModes;
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: {
+				"supported modes": this.supportedModes
+					.map(
+						(mode) =>
+							`\n· ${getEnumMemberName(
+								HumidityControlMode,
+								mode,
+							)}`,
+					)
+					.join(""),
+			},
+		};
+	}
+}
+
+@CCCommand(HumidityControlModeCommand.SupportedGet)
+@expectedCCResponse(HumidityControlModeCCSupportedReport)
+export class HumidityControlModeCCSupportedGet extends HumidityControlModeCC {}

--- a/packages/zwave-js/src/lib/commandclass/HumidityControlOperatingState.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/HumidityControlOperatingState.test.ts
@@ -1,0 +1,102 @@
+import { CommandClasses, enumValuesToMetadataStates } from "@zwave-js/core";
+import type { Driver } from "../driver/Driver";
+import { ZWaveNode } from "../node/Node";
+import { assertCC } from "../test/assertCC";
+import { createEmptyMockDriver } from "../test/mocks";
+import { getCCValueMetadata } from "./CommandClass";
+import {
+	HumidityControlOperatingState,
+	HumidityControlOperatingStateCC,
+	HumidityControlOperatingStateCCGet,
+	HumidityControlOperatingStateCCReport,
+	HumidityControlOperatingStateCommand,
+} from "./HumidityControlOperatingStateCC";
+
+const fakeDriver = createEmptyMockDriver() as unknown as Driver;
+
+function buildCCBuffer(payload: Buffer): Buffer {
+	return Buffer.concat([
+		Buffer.from([
+			CommandClasses["Humidity Control Operating State"], // CC
+		]),
+		payload,
+	]);
+}
+
+describe("lib/commandclass/HumidityControlOperatingStateCC => ", () => {
+	it("the Get command should serialize correctly", () => {
+		const cc = new HumidityControlOperatingStateCCGet(fakeDriver, {
+			nodeId: 1,
+		});
+		const expected = buildCCBuffer(
+			Buffer.from([
+				HumidityControlOperatingStateCommand.Get, // CC Command
+			]),
+		);
+		expect(cc.serialize()).toEqual(expected);
+	});
+
+	it("the Report command should be deserialized correctly", () => {
+		const ccData = buildCCBuffer(
+			Buffer.from([
+				HumidityControlOperatingStateCommand.Report, // CC Command
+				HumidityControlOperatingState.Humidifying, // state
+			]),
+		);
+		const cc = new HumidityControlOperatingStateCCReport(fakeDriver, {
+			nodeId: 1,
+			data: ccData,
+		});
+
+		expect(cc.state).toBe(HumidityControlOperatingState.Humidifying);
+	});
+
+	it("the CC values should have the correct metadata", () => {
+		// Readonly, 0-99
+		const currentValueMeta = getCCValueMetadata(
+			CommandClasses["Humidity Control Operating State"],
+			"state",
+		);
+		expect(currentValueMeta).toMatchObject({
+			states: enumValuesToMetadataStates(HumidityControlOperatingState),
+			label: "Humidity control operating state",
+		});
+	});
+
+	describe(`interview()`, () => {
+		const fakeDriver = createEmptyMockDriver();
+		const node = new ZWaveNode(2, fakeDriver as unknown as Driver);
+
+		beforeAll(() => {
+			fakeDriver.sendMessage.mockImplementation(() =>
+				Promise.resolve({ command: {} }),
+			);
+			fakeDriver.controller.nodes.set(node.id, node);
+		});
+		beforeEach(() => fakeDriver.sendMessage.mockClear());
+		afterAll(() => {
+			fakeDriver.sendMessage.mockImplementation(() => Promise.resolve());
+			node.destroy();
+		});
+
+		it("should send a HumidityControlOperatingStateCC.Get", async () => {
+			node.addCC(CommandClasses["Humidity Control Operating State"], {
+				isSupported: true,
+			});
+			const cc = node.createCCInstance(
+				CommandClasses["Humidity Control Operating State"],
+			)!;
+			await cc.interview();
+
+			expect(fakeDriver.sendMessage).toBeCalled();
+
+			assertCC(fakeDriver.sendMessage.mock.calls[0][0], {
+				cc: HumidityControlOperatingStateCC,
+				nodeId: node.id,
+				ccValues: {
+					ccCommand: HumidityControlOperatingStateCommand.Get,
+				},
+			});
+		});
+	});
+});

--- a/packages/zwave-js/src/lib/commandclass/HumidityControlSetpoint.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/HumidityControlSetpoint.test.ts
@@ -247,7 +247,7 @@ describe("lib/commandclass/HumidityControlSetpointCC => ", () => {
 			},
 		);
 
-		expect(cc.scaleSupported).toEqual([
+		expect(cc.supportedScales).toEqual([
 			new Scale(0, {
 				label: "Percentage value",
 				unit: "%",
@@ -329,7 +329,7 @@ describe("lib/commandclass/HumidityControlSetpointCC => ", () => {
 
 	describe(`interview()`, () => {
 		beforeAll(async () => {
-			const scaleSupported = [
+			const supportedScales = [
 				new Scale(0, { label: "Percentage", unit: "%" }),
 				new Scale(1, { label: "Absolute", unit: "g/m³" }),
 			];
@@ -348,7 +348,7 @@ describe("lib/commandclass/HumidityControlSetpointCC => ", () => {
 				.mockImplementationOnce(() =>
 					// ScaleSupportedGet for Humidifier
 					Promise.resolve({
-						command: { scaleSupported: scaleSupported },
+						command: { supportedScales: supportedScales },
 					}),
 				)
 				.mockImplementationOnce(() =>
@@ -357,15 +357,15 @@ describe("lib/commandclass/HumidityControlSetpointCC => ", () => {
 						command: {
 							minValue: 1,
 							maxValue: 99,
-							minValueScale: scaleSupported[0].key,
-							maxValueScale: scaleSupported[0].key,
+							minValueScale: supportedScales[0].key,
+							maxValueScale: supportedScales[0].key,
 						},
 					}),
 				)
 				.mockImplementationOnce(() =>
 					// ScaleSupportedGet for Auto
 					Promise.resolve({
-						command: { scaleSupported: scaleSupported },
+						command: { supportedScales: supportedScales },
 					}),
 				)
 				.mockImplementationOnce(() =>
@@ -374,8 +374,8 @@ describe("lib/commandclass/HumidityControlSetpointCC => ", () => {
 						command: {
 							minValue: 54,
 							maxValue: 71,
-							minValueScale: scaleSupported[1].key,
-							maxValueScale: scaleSupported[1].key,
+							minValueScale: supportedScales[1].key,
+							maxValueScale: supportedScales[1].key,
 						},
 					}),
 				)
@@ -385,7 +385,7 @@ describe("lib/commandclass/HumidityControlSetpointCC => ", () => {
 						command: {
 							type: HumidityControlSetpointType.Humidifier,
 							value: 71,
-							scale: scaleSupported[0],
+							scale: supportedScales[0],
 						},
 					}),
 				)
@@ -395,7 +395,7 @@ describe("lib/commandclass/HumidityControlSetpointCC => ", () => {
 						command: {
 							type: HumidityControlSetpointType.Auto,
 							value: 32,
-							scale: scaleSupported[1],
+							scale: supportedScales[1],
 						},
 					}),
 				);

--- a/packages/zwave-js/src/lib/commandclass/HumidityControlSetpoint.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/HumidityControlSetpoint.test.ts
@@ -1,0 +1,506 @@
+import { loadNamedScalesInternal, Scale } from "@zwave-js/config";
+import { CommandClasses, encodeFloatWithScale } from "@zwave-js/core";
+import type { Driver } from "../driver/Driver";
+import { ZWaveNode } from "../node/Node";
+import { assertCC } from "../test/assertCC";
+import { createEmptyMockDriver } from "../test/mocks";
+import {
+	HumidityControlSetpointCC,
+	HumidityControlSetpointCCCapabilitiesGet,
+	HumidityControlSetpointCCCapabilitiesReport,
+	HumidityControlSetpointCCGet,
+	HumidityControlSetpointCCReport,
+	HumidityControlSetpointCCScaleSupportedGet,
+	HumidityControlSetpointCCScaleSupportedReport,
+	HumidityControlSetpointCCSet,
+	HumidityControlSetpointCCSupportedGet,
+	HumidityControlSetpointCCSupportedReport,
+	HumidityControlSetpointCommand,
+	HumidityControlSetpointType,
+} from "./HumidityControlSetpointCC";
+
+function buildCCBuffer(payload: Buffer): Buffer {
+	return Buffer.concat([
+		Buffer.from([
+			CommandClasses["Humidity Control Setpoint"], // CC
+		]),
+		payload,
+	]);
+}
+
+describe("lib/commandclass/HumidityControlSetpointCC => ", () => {
+	let fakeDriver: Driver;
+	let node: ZWaveNode;
+
+	beforeAll(async () => {
+		fakeDriver = createEmptyMockDriver() as unknown as Driver;
+		await fakeDriver.configManager.loadNamedScales();
+		node = new ZWaveNode(1, fakeDriver as any);
+		(fakeDriver.controller.nodes as any).set(1, node);
+		node.addCC(CommandClasses["Humidity Control Setpoint"], {
+			isSupported: true,
+			version: 2,
+		});
+
+		loadNamedScalesInternal();
+	});
+
+	afterAll(() => {
+		node.destroy();
+	});
+
+	it("the Get command should serialize correctly", () => {
+		const cc = new HumidityControlSetpointCCGet(fakeDriver, {
+			nodeId: node.id,
+			setpointType: HumidityControlSetpointType.Humidifier,
+		});
+		const expected = buildCCBuffer(
+			Buffer.from([
+				HumidityControlSetpointCommand.Get, // CC Command
+				HumidityControlSetpointType.Humidifier, // type
+			]),
+		);
+		expect(cc.serialize()).toEqual(expected);
+	});
+
+	it("the Set command should serialize correctly", () => {
+		const cc = new HumidityControlSetpointCCSet(fakeDriver, {
+			nodeId: node.id,
+			setpointType: HumidityControlSetpointType.Humidifier,
+			value: 57,
+			scale: 1,
+		});
+		const expected = buildCCBuffer(
+			Buffer.concat([
+				Buffer.from([
+					HumidityControlSetpointCommand.Set, // CC Command
+					HumidityControlSetpointType.Humidifier, // type
+				]),
+				encodeFloatWithScale(57, 1),
+			]),
+		);
+		expect(cc.serialize()).toEqual(expected);
+	});
+
+	it("the Report command should be deserialized correctly", () => {
+		const ccData = buildCCBuffer(
+			Buffer.concat([
+				Buffer.from([
+					HumidityControlSetpointCommand.Report, // CC Command
+					HumidityControlSetpointType.Humidifier, // type
+				]),
+				encodeFloatWithScale(12, 1),
+			]),
+		);
+		const cc = new HumidityControlSetpointCCReport(fakeDriver, {
+			nodeId: node.id,
+			data: ccData,
+		});
+
+		expect(cc.type).toEqual(HumidityControlSetpointType.Humidifier);
+		expect(cc.scale).toMatchObject({
+			key: 1,
+			label: "Absolute humidity",
+			unit: "g/m³",
+		});
+		expect(cc.value).toBe(12);
+	});
+
+	it("the Report command should set the correct value", () => {
+		const ccData = buildCCBuffer(
+			Buffer.concat([
+				Buffer.from([
+					HumidityControlSetpointCommand.Report, // CC Command
+					HumidityControlSetpointType.Humidifier, // type
+				]),
+				encodeFloatWithScale(12, 1),
+			]),
+		);
+		new HumidityControlSetpointCCReport(fakeDriver, {
+			nodeId: node.id,
+			data: ccData,
+		});
+
+		const currentValue = node.valueDB.getValue({
+			commandClass: CommandClasses["Humidity Control Setpoint"],
+			property: "setpoint",
+			propertyKey: HumidityControlSetpointType.Humidifier,
+		});
+		expect(currentValue).toEqual(12);
+
+		const scaleValue = node.valueDB.getValue({
+			commandClass: CommandClasses["Humidity Control Setpoint"],
+			property: "setpointScale",
+			propertyKey: HumidityControlSetpointType.Humidifier,
+		});
+		expect(scaleValue).toEqual(1);
+	});
+
+	it("the Report command should set the correct metadata", () => {
+		const ccData = buildCCBuffer(
+			Buffer.concat([
+				Buffer.from([
+					HumidityControlSetpointCommand.Report, // CC Command
+					HumidityControlSetpointType.Humidifier, // type
+				]),
+				encodeFloatWithScale(12, 1),
+			]),
+		);
+		new HumidityControlSetpointCCReport(fakeDriver, {
+			nodeId: node.id,
+			data: ccData,
+		});
+
+		const setpointMeta = node.valueDB.getMetadata({
+			commandClass: CommandClasses["Humidity Control Setpoint"],
+			property: "setpoint",
+			propertyKey: HumidityControlSetpointType.Humidifier,
+		});
+		expect(setpointMeta).toMatchObject({
+			unit: "g/m³",
+			ccSpecific: {
+				setpointType: HumidityControlSetpointType.Humidifier,
+			},
+		});
+	});
+
+	it("the SupportedGet command should serialize correctly", () => {
+		const cc = new HumidityControlSetpointCCSupportedGet(fakeDriver, {
+			nodeId: node.id,
+		});
+		const expected = buildCCBuffer(
+			Buffer.from([
+				HumidityControlSetpointCommand.SupportedGet, // CC Command
+			]),
+		);
+		expect(cc.serialize()).toEqual(expected);
+	});
+
+	it("the SupportedReport command should be deserialized correctly", () => {
+		const ccData = buildCCBuffer(
+			Buffer.from([
+				HumidityControlSetpointCommand.SupportedReport, // CC Command
+				(1 << HumidityControlSetpointType.Humidifier) |
+					(1 << HumidityControlSetpointType.Auto),
+			]),
+		);
+		const cc = new HumidityControlSetpointCCSupportedReport(fakeDriver, {
+			nodeId: node.id,
+			data: ccData,
+		});
+
+		expect(cc.supportedSetpointTypes).toEqual([
+			HumidityControlSetpointType.Humidifier,
+			HumidityControlSetpointType.Auto,
+		]);
+	});
+
+	it("the SupportedReport command should set the correct value", () => {
+		const ccData = buildCCBuffer(
+			Buffer.from([
+				HumidityControlSetpointCommand.SupportedReport, // CC Command
+				(1 << HumidityControlSetpointType.Humidifier) |
+					(1 << HumidityControlSetpointType.Auto),
+			]),
+		);
+		new HumidityControlSetpointCCSupportedReport(fakeDriver, {
+			nodeId: node.id,
+			data: ccData,
+		});
+
+		const currentValue = node.valueDB.getValue({
+			commandClass: CommandClasses["Humidity Control Setpoint"],
+			property: "supportedSetpointTypes",
+		});
+		expect(currentValue).toEqual([
+			HumidityControlSetpointType.Humidifier,
+			HumidityControlSetpointType.Auto,
+		]);
+	});
+
+	it("the ScaleSupportedGet command should serialize correctly", () => {
+		const cc = new HumidityControlSetpointCCScaleSupportedGet(fakeDriver, {
+			nodeId: node.id,
+			setpointType: HumidityControlSetpointType.Auto,
+		});
+		const expected = buildCCBuffer(
+			Buffer.from([
+				HumidityControlSetpointCommand.ScaleSupportedGet, // CC Command
+				HumidityControlSetpointType.Auto, // type
+			]),
+		);
+		expect(cc.serialize()).toEqual(expected);
+	});
+
+	it("the ScaleSupportedReport command should be deserialized correctly", () => {
+		const ccData = buildCCBuffer(
+			Buffer.from([
+				HumidityControlSetpointCommand.ScaleSupportedReport, // CC Command
+				0b11, // percent + absolute
+			]),
+		);
+		const cc = new HumidityControlSetpointCCScaleSupportedReport(
+			fakeDriver,
+			{
+				nodeId: node.id,
+				data: ccData,
+			},
+		);
+
+		expect(cc.scaleSupported).toEqual([
+			new Scale(0, {
+				label: "Percentage value",
+				unit: "%",
+			}),
+			new Scale(1, {
+				label: "Absolute humidity",
+				unit: "g/m³",
+			}),
+		]);
+	});
+
+	it("the CapabilitiesGet command should serialize correctly", () => {
+		const cc = new HumidityControlSetpointCCCapabilitiesGet(fakeDriver, {
+			nodeId: node.id,
+			setpointType: HumidityControlSetpointType.Auto,
+		});
+		const expected = buildCCBuffer(
+			Buffer.from([
+				HumidityControlSetpointCommand.CapabilitiesGet, // CC Command
+				HumidityControlSetpointType.Auto, // type
+			]),
+		);
+		expect(cc.serialize()).toEqual(expected);
+	});
+
+	it("the CapabilitiesReport command should be deserialized correctly", () => {
+		const ccData = buildCCBuffer(
+			Buffer.concat([
+				Buffer.from([
+					HumidityControlSetpointCommand.CapabilitiesReport, // CC Command
+					HumidityControlSetpointType.Humidifier, // type
+				]),
+				encodeFloatWithScale(10, 1),
+				encodeFloatWithScale(90, 1),
+			]),
+		);
+		const cc = new HumidityControlSetpointCCCapabilitiesReport(fakeDriver, {
+			nodeId: node.id,
+			data: ccData,
+		});
+
+		expect(cc.type).toEqual(HumidityControlSetpointType.Humidifier);
+		expect(cc.minValue).toEqual(10);
+		expect(cc.minValueScale).toEqual(1);
+		expect(cc.maxValue).toEqual(90);
+		expect(cc.maxValueScale).toEqual(1);
+	});
+
+	it("the CapabilitiesReport command should set the correct metadata", () => {
+		const ccData = buildCCBuffer(
+			Buffer.concat([
+				Buffer.from([
+					HumidityControlSetpointCommand.Report, // CC Command
+					HumidityControlSetpointType.Humidifier, // type
+				]),
+				encodeFloatWithScale(10, 1),
+				encodeFloatWithScale(90, 1),
+			]),
+		);
+		new HumidityControlSetpointCCCapabilitiesReport(fakeDriver, {
+			nodeId: node.id,
+			data: ccData,
+		});
+
+		const setpointMeta = node.valueDB.getMetadata({
+			commandClass: CommandClasses["Humidity Control Setpoint"],
+			property: "setpoint",
+			propertyKey: HumidityControlSetpointType.Humidifier,
+		});
+		expect(setpointMeta).toMatchObject({
+			min: 10,
+			max: 90,
+			unit: "g/m³",
+			ccSpecific: {
+				setpointType: HumidityControlSetpointType.Humidifier,
+			},
+		});
+	});
+
+	describe(`interview()`, () => {
+		beforeAll(async () => {
+			const scaleSupported = [
+				new Scale(0, { label: "Percentage", unit: "%" }),
+				new Scale(1, { label: "Absolute", unit: "g/m³" }),
+			];
+			fakeDriver.sendMessage
+				.mockImplementationOnce(() =>
+					// SupportedGet
+					Promise.resolve({
+						command: {
+							supportedSetpointTypes: [
+								HumidityControlSetpointType.Humidifier,
+								HumidityControlSetpointType.Auto,
+							],
+						},
+					}),
+				)
+				.mockImplementationOnce(() =>
+					// ScaleSupportedGet for Humidifier
+					Promise.resolve({
+						command: { scaleSupported: scaleSupported },
+					}),
+				)
+				.mockImplementationOnce(() =>
+					// CapabilitiesGet for Humidifier
+					Promise.resolve({
+						command: {
+							minValue: 1,
+							maxValue: 99,
+							minValueScale: scaleSupported[0].key,
+							maxValueScale: scaleSupported[0].key,
+						},
+					}),
+				)
+				.mockImplementationOnce(() =>
+					// ScaleSupportedGet for Auto
+					Promise.resolve({
+						command: { scaleSupported: scaleSupported },
+					}),
+				)
+				.mockImplementationOnce(() =>
+					// CapabilitiesGet for Auto
+					Promise.resolve({
+						command: {
+							minValue: 54,
+							maxValue: 71,
+							minValueScale: scaleSupported[1].key,
+							maxValueScale: scaleSupported[1].key,
+						},
+					}),
+				)
+				.mockImplementationOnce(() =>
+					// Get for Humidifier
+					Promise.resolve({
+						command: {
+							type: HumidityControlSetpointType.Humidifier,
+							value: 71,
+							scale: scaleSupported[0],
+						},
+					}),
+				)
+				.mockImplementationOnce(() =>
+					// Get for Auto
+					Promise.resolve({
+						command: {
+							type: HumidityControlSetpointType.Auto,
+							value: 32,
+							scale: scaleSupported[1],
+						},
+					}),
+				);
+			fakeDriver.controller.nodes.set(node.id, node);
+		});
+		beforeEach(() => fakeDriver.sendMessage.mockClear());
+		afterAll(() => {
+			fakeDriver.sendMessage.mockImplementation(() => Promise.resolve());
+			node.destroy();
+		});
+
+		it("should send expected commands", async () => {
+			const cc = node.createCCInstance(
+				CommandClasses["Humidity Control Setpoint"],
+			)!;
+			await cc.interview();
+
+			expect(fakeDriver.sendMessage).toBeCalled();
+
+			assertCC(fakeDriver.sendMessage.mock.calls[0][0], {
+				cc: HumidityControlSetpointCC,
+				nodeId: node.id,
+				ccValues: {
+					ccCommand: HumidityControlSetpointCommand.SupportedGet,
+				},
+			});
+
+			assertCC(fakeDriver.sendMessage.mock.calls[1][0], {
+				cc: HumidityControlSetpointCC,
+				nodeId: node.id,
+				ccValues: {
+					ccCommand: HumidityControlSetpointCommand.ScaleSupportedGet,
+				},
+			});
+
+			assertCC(fakeDriver.sendMessage.mock.calls[2][0], {
+				cc: HumidityControlSetpointCC,
+				nodeId: node.id,
+				ccValues: {
+					ccCommand: HumidityControlSetpointCommand.CapabilitiesGet,
+				},
+			});
+
+			assertCC(fakeDriver.sendMessage.mock.calls[3][0], {
+				cc: HumidityControlSetpointCC,
+				nodeId: node.id,
+				ccValues: {
+					ccCommand: HumidityControlSetpointCommand.ScaleSupportedGet,
+				},
+			});
+
+			assertCC(fakeDriver.sendMessage.mock.calls[4][0], {
+				cc: HumidityControlSetpointCC,
+				nodeId: node.id,
+				ccValues: {
+					ccCommand: HumidityControlSetpointCommand.CapabilitiesGet,
+				},
+			});
+
+			assertCC(fakeDriver.sendMessage.mock.calls[5][0], {
+				cc: HumidityControlSetpointCC,
+				nodeId: node.id,
+				ccValues: {
+					ccCommand: HumidityControlSetpointCommand.Get,
+				},
+			});
+
+			assertCC(fakeDriver.sendMessage.mock.calls[6][0], {
+				cc: HumidityControlSetpointCC,
+				nodeId: node.id,
+				ccValues: {
+					ccCommand: HumidityControlSetpointCommand.Get,
+				},
+			});
+		});
+
+		it("should set setpointScale metadata", async () => {
+			const cc = node.createCCInstance(
+				CommandClasses["Humidity Control Setpoint"],
+			)!;
+			await cc.interview();
+
+			let setpointScaleMeta = node.valueDB.getMetadata({
+				commandClass: CommandClasses["Humidity Control Setpoint"],
+				property: "setpointScale",
+				propertyKey: HumidityControlSetpointType.Humidifier,
+			});
+			expect(setpointScaleMeta).toMatchObject({
+				states: {
+					0: "%",
+					1: "g/m³",
+				},
+			});
+
+			setpointScaleMeta = node.valueDB.getMetadata({
+				commandClass: CommandClasses["Humidity Control Setpoint"],
+				property: "setpointScale",
+				propertyKey: HumidityControlSetpointType.Auto,
+			});
+			expect(setpointScaleMeta).toMatchObject({
+				states: {
+					0: "%",
+					1: "g/m³",
+				},
+			});
+		});
+	});
+});

--- a/packages/zwave-js/src/lib/commandclass/HumidityControlSetpointCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/HumidityControlSetpointCC.ts
@@ -1,0 +1,939 @@
+import type { ConfigManager, Scale } from "@zwave-js/config";
+import type { ValueID, ValueMetadataNumeric } from "@zwave-js/core";
+import {
+	CommandClasses,
+	encodeFloatWithScale,
+	Maybe,
+	MessageOrCCLogEntry,
+	parseBitMask,
+	parseFloatWithScale,
+	validatePayload,
+	ValueMetadata,
+	ZWaveError,
+	ZWaveErrorCodes,
+} from "@zwave-js/core";
+import { getEnumMemberName, pick } from "@zwave-js/shared";
+import type { Driver } from "../driver/Driver";
+import { MessagePriority } from "../message/Constants";
+import {
+	CCAPI,
+	PollValueImplementation,
+	POLL_VALUE,
+	SetValueImplementation,
+	SET_VALUE,
+	throwUnsupportedProperty,
+	throwWrongValueType,
+} from "./API";
+import {
+	API,
+	CCCommand,
+	CCCommandOptions,
+	ccValue,
+	CommandClass,
+	commandClass,
+	CommandClassDeserializationOptions,
+	expectedCCResponse,
+	gotDeserializationOptions,
+	implementedVersion,
+} from "./CommandClass";
+
+// All the supported commands
+export enum HumidityControlSetpointCommand {
+	Set = 0x01,
+	Get = 0x02,
+	Report = 0x03,
+	SupportedGet = 0x04,
+	SupportedReport = 0x05,
+	ScaleSupportedGet = 0x06,
+	ScaleSupportedReport = 0x07,
+	CapabilitiesGet = 0x08,
+	CapabilitiesReport = 0x09,
+}
+
+export enum HumidityControlSetpointType {
+	"N/A" = 0x00,
+	"Humidifier" = 0x01, // CC v1
+	"De-humidifier" = 0x02, // CC v1
+	"Auto" = 0x03, // CC v2
+}
+
+const humidityControlSetpointScaleName = "humidity";
+function getScale(configManager: ConfigManager, scale: number): Scale {
+	return configManager.lookupNamedScale(
+		humidityControlSetpointScaleName,
+		scale,
+	);
+}
+function getSetpointUnit(configManager: ConfigManager, scale: number): string {
+	return getScale(configManager, scale).unit ?? "";
+}
+
+export interface HumidityControlSetpointValue {
+	value: number;
+	scale: number;
+}
+
+export interface HumidityControlSetpointCapabilities {
+	minValue: number;
+	minValueScale: number;
+	maxValue: number;
+	maxValueScale: number;
+}
+
+/**
+ * @publicAPI
+ */
+export type HumidityControlSetpointMetadata = ValueMetadata & {
+	ccSpecific: {
+		setpointType: HumidityControlSetpointType;
+	};
+};
+
+function getSupportedSetpointTypesValueID(endpoint: number): ValueID {
+	return {
+		commandClass: CommandClasses["Humidity Control Setpoint"],
+		property: "supportedSetpointTypes",
+		endpoint,
+	};
+}
+
+function getSetpointValueID(endpoint: number, setpointType: number): ValueID {
+	return {
+		commandClass: CommandClasses["Humidity Control Setpoint"],
+		endpoint,
+		property: "setpoint",
+		propertyKey: setpointType,
+	};
+}
+
+function getSetpointScaleValueID(
+	endpoint: number,
+	setpointType: number,
+): ValueID {
+	return {
+		commandClass: CommandClasses["Humidity Control Setpoint"],
+		endpoint,
+		property: "setpointScale",
+		propertyKey: setpointType,
+	};
+}
+
+@API(CommandClasses["Humidity Control Setpoint"])
+export class HumidityControlSetpointCCAPI extends CCAPI {
+	public supportsCommand(
+		cmd: HumidityControlSetpointCommand,
+	): Maybe<boolean> {
+		switch (cmd) {
+			case HumidityControlSetpointCommand.Get:
+			case HumidityControlSetpointCommand.SupportedGet:
+				return this.isSinglecast();
+			case HumidityControlSetpointCommand.Set:
+				return true; // This is mandatory
+			case HumidityControlSetpointCommand.CapabilitiesGet:
+				return this.isSinglecast();
+		}
+		return super.supportsCommand(cmd);
+	}
+
+	protected [SET_VALUE]: SetValueImplementation = async (
+		{ property, propertyKey },
+		value,
+	): Promise<void> => {
+		if (property !== "setpoint") {
+			throwUnsupportedProperty(this.ccId, property);
+		}
+		if (typeof propertyKey !== "number") {
+			throw new ZWaveError(
+				`${
+					CommandClasses[this.ccId]
+				}: "${property}" must be further specified by a numeric property key`,
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+		if (typeof value !== "number") {
+			throwWrongValueType(this.ccId, property, "number", typeof value);
+		}
+
+		const preferredScale = this.endpoint
+			.getNodeUnsafe()!
+			.getValue<number>(
+				getSetpointScaleValueID(this.endpoint.index, propertyKey),
+			);
+		await this.set(propertyKey, value, preferredScale ?? 0);
+
+		if (this.isSinglecast()) {
+			// Verify the current value after a delay
+			this.schedulePoll({ property, propertyKey });
+		}
+	};
+
+	protected [POLL_VALUE]: PollValueImplementation = async ({
+		property,
+		propertyKey,
+	}): Promise<unknown> => {
+		switch (property) {
+			case "setpoint":
+				if (typeof propertyKey !== "number") {
+					throw new ZWaveError(
+						`${
+							CommandClasses[this.ccId]
+						}: "${property}" must be further specified by a numeric property key`,
+						ZWaveErrorCodes.Argument_Invalid,
+					);
+				}
+
+				return (await this.get(propertyKey))?.value;
+			default:
+				throwUnsupportedProperty(this.ccId, property);
+		}
+	};
+
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+	public async get(setpointType: HumidityControlSetpointType) {
+		this.assertSupportsCommand(
+			HumidityControlSetpointCommand,
+			HumidityControlSetpointCommand.Get,
+		);
+
+		const cc = new HumidityControlSetpointCCGet(this.driver, {
+			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
+			setpointType,
+		});
+		const response =
+			await this.driver.sendCommand<HumidityControlSetpointCCReport>(
+				cc,
+				this.commandOptions,
+			);
+		if (!response) return;
+		return response.type === HumidityControlSetpointType["N/A"]
+			? // not supported
+			  undefined
+			: // supported
+			  {
+					value: response.value,
+					scale: response.scale,
+			  };
+	}
+
+	public async set(
+		setpointType: HumidityControlSetpointType,
+		value: number,
+		scale: number,
+	): Promise<void> {
+		this.assertSupportsCommand(
+			HumidityControlSetpointCommand,
+			HumidityControlSetpointCommand.Set,
+		);
+
+		const cc = new HumidityControlSetpointCCSet(this.driver, {
+			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
+			setpointType,
+			value,
+			scale,
+		});
+		await this.driver.sendCommand(cc, this.commandOptions);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+	public async getCapabilities(setpointType: HumidityControlSetpointType) {
+		this.assertSupportsCommand(
+			HumidityControlSetpointCommand,
+			HumidityControlSetpointCommand.CapabilitiesGet,
+		);
+
+		const cc = new HumidityControlSetpointCCCapabilitiesGet(this.driver, {
+			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
+			setpointType,
+		});
+		const response =
+			await this.driver.sendCommand<HumidityControlSetpointCCCapabilitiesReport>(
+				cc,
+				this.commandOptions,
+			);
+		if (response) {
+			return pick(response, [
+				"minValue",
+				"maxValue",
+				"minValueScale",
+				"maxValueScale",
+			]);
+		}
+	}
+
+	public async getSupportedSetpointTypes(): Promise<
+		readonly HumidityControlSetpointType[] | undefined
+	> {
+		this.assertSupportsCommand(
+			HumidityControlSetpointCommand,
+			HumidityControlSetpointCommand.SupportedGet,
+		);
+
+		const cc = new HumidityControlSetpointCCSupportedGet(this.driver, {
+			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
+		});
+		const response =
+			await this.driver.sendCommand<HumidityControlSetpointCCSupportedReport>(
+				cc,
+				this.commandOptions,
+			);
+		return response?.supportedSetpointTypes;
+	}
+
+	public async getScaleSupported(
+		setpointType: HumidityControlSetpointType,
+	): Promise<readonly Scale[] | undefined> {
+		this.assertSupportsCommand(
+			HumidityControlSetpointCommand,
+			HumidityControlSetpointCommand.SupportedGet,
+		);
+
+		const cc = new HumidityControlSetpointCCScaleSupportedGet(this.driver, {
+			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
+			setpointType,
+		});
+		const response =
+			await this.driver.sendCommand<HumidityControlSetpointCCScaleSupportedReport>(
+				cc,
+				this.commandOptions,
+			);
+
+		return response?.scaleSupported;
+	}
+}
+
+@commandClass(CommandClasses["Humidity Control Setpoint"])
+@implementedVersion(2)
+export class HumidityControlSetpointCC extends CommandClass {
+	declare ccCommand: HumidityControlSetpointCommand;
+
+	public translatePropertyKey(
+		property: string | number,
+		propertyKey: string | number,
+	): string | undefined {
+		if (property === "setpoint") {
+			return getEnumMemberName(
+				HumidityControlSetpointType,
+				propertyKey as any,
+			);
+		} else {
+			return super.translatePropertyKey(property, propertyKey);
+		}
+	}
+
+	public async interview(): Promise<void> {
+		const node = this.getNode()!;
+		const endpoint = this.getEndpoint()!;
+		const api = endpoint.commandClasses[
+			"Humidity Control Setpoint"
+		].withOptions({
+			priority: MessagePriority.NodeQuery,
+		});
+
+		this.driver.controllerLog.logNode(node.id, {
+			endpoint: this.endpointIndex,
+			message: `Interviewing ${this.ccName}...`,
+			direction: "none",
+		});
+
+		// Query the supported setpoint types
+		let setpointTypes: HumidityControlSetpointType[] = [];
+		this.driver.controllerLog.logNode(node.id, {
+			endpoint: this.endpointIndex,
+			message: "retrieving supported setpoint types...",
+			direction: "outbound",
+		});
+		const resp = await api.getSupportedSetpointTypes();
+		if (resp) {
+			setpointTypes = [...resp];
+			const logMessage =
+				"received supported setpoint types:\n" +
+				setpointTypes
+					.map((type) =>
+						getEnumMemberName(HumidityControlSetpointType, type),
+					)
+					.map((name) => `· ${name}`)
+					.join("\n");
+
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message: logMessage,
+				direction: "inbound",
+			});
+		} else {
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message:
+					"Querying supported setpoint types timed out, skipping interview...",
+				level: "warn",
+			});
+			return;
+		}
+
+		for (const type of setpointTypes) {
+			const setpointName = getEnumMemberName(
+				HumidityControlSetpointType,
+				type,
+			);
+			// Find out the capabilities of this setpoint
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message: `retrieving capabilities for setpoint ${setpointName}...`,
+				direction: "outbound",
+			});
+			const setpointScaleSupported = await api.getScaleSupported(type);
+			if (setpointScaleSupported) {
+				const logMessage = `received scale supported for setpoint ${setpointName}: 
+${setpointScaleSupported
+	.map((t) => `\n· ${t.key} ${t.unit} - ${t.label}`)
+	.join("")}`;
+				this.driver.controllerLog.logNode(node.id, {
+					endpoint: this.endpointIndex,
+					message: logMessage,
+					direction: "inbound",
+				});
+				const scaleValueId = getSetpointScaleValueID(
+					this.endpointIndex,
+					type,
+				);
+				const states: Record<number, string> = {};
+				for (const scale of setpointScaleSupported) {
+					if (scale.unit) states[scale.key] = scale.unit;
+				}
+				this.getValueDB().setMetadata(scaleValueId, {
+					...ValueMetadata.ReadOnlyUInt8,
+					states: states,
+				});
+			}
+			const setpointCaps = await api.getCapabilities(type);
+			if (setpointCaps) {
+				const minValueUnit = getSetpointUnit(
+					this.driver.configManager,
+					setpointCaps.minValueScale,
+				);
+				const maxValueUnit = getSetpointUnit(
+					this.driver.configManager,
+					setpointCaps.maxValueScale,
+				);
+				const logMessage = `received capabilities for setpoint ${setpointName}:
+minimum value: ${setpointCaps.minValue} ${minValueUnit}
+maximum value: ${setpointCaps.maxValue} ${maxValueUnit}`;
+				this.driver.controllerLog.logNode(node.id, {
+					endpoint: this.endpointIndex,
+					message: logMessage,
+					direction: "inbound",
+				});
+			}
+		}
+
+		// Query the current value for all setpoint types
+		await this.refreshValues();
+
+		// Remember that the interview is complete
+		this.interviewComplete = true;
+	}
+
+	public async refreshValues(): Promise<void> {
+		const node = this.getNode()!;
+		const endpoint = this.getEndpoint()!;
+		const api = endpoint.commandClasses[
+			"Humidity Control Setpoint"
+		].withOptions({
+			priority: MessagePriority.NodeQuery,
+		});
+
+		const setpointTypes: HumidityControlSetpointType[] =
+			this.getValueDB().getValue(
+				getSupportedSetpointTypesValueID(this.endpointIndex),
+			) ?? [];
+
+		// Query each setpoint's current value
+		for (const type of setpointTypes) {
+			const setpointName = getEnumMemberName(
+				HumidityControlSetpointType,
+				type,
+			);
+			// Every time, query the current value
+			this.driver.controllerLog.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message: `querying current value of setpoint ${setpointName}...`,
+				direction: "outbound",
+			});
+			const setpoint = await api.get(type);
+			if (setpoint) {
+				const logMessage = `received current value of setpoint ${setpointName}: ${
+					setpoint.value
+				} ${setpoint.scale.unit ?? ""}`;
+				this.driver.controllerLog.logNode(node.id, {
+					endpoint: this.endpointIndex,
+					message: logMessage,
+					direction: "inbound",
+				});
+			}
+		}
+	}
+}
+
+interface HumidityControlSetpointCCSetOptions extends CCCommandOptions {
+	setpointType: HumidityControlSetpointType;
+	value: number;
+	scale: number;
+}
+
+@CCCommand(HumidityControlSetpointCommand.Set)
+export class HumidityControlSetpointCCSet extends HumidityControlSetpointCC {
+	public constructor(
+		driver: Driver,
+		options:
+			| CommandClassDeserializationOptions
+			| HumidityControlSetpointCCSetOptions,
+	) {
+		super(driver, options);
+		if (gotDeserializationOptions(options)) {
+			// TODO: Deserialize payload
+			throw new ZWaveError(
+				`${this.constructor.name}: deserialization not implemented`,
+				ZWaveErrorCodes.Deserialization_NotImplemented,
+			);
+		} else {
+			this.setpointType = options.setpointType;
+			this.value = options.value;
+			this.scale = options.scale;
+		}
+	}
+
+	public setpointType: HumidityControlSetpointType;
+	public value: number;
+	public scale: number;
+
+	public serialize(): Buffer {
+		const override =
+			this.getNodeUnsafe()?.deviceConfig?.compat?.overrideFloatEncoding;
+		this.payload = Buffer.concat([
+			Buffer.from([this.setpointType & 0b1111]),
+			encodeFloatWithScale(this.value, this.scale, override),
+		]);
+		return super.serialize();
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		const scale = getScale(this.driver.configManager, this.scale);
+		return {
+			...super.toLogEntry(),
+			message: {
+				"setpoint type": getEnumMemberName(
+					HumidityControlSetpointType,
+					this.setpointType,
+				),
+				value: `${this.value} ${scale.unit}`,
+			},
+		};
+	}
+}
+
+@CCCommand(HumidityControlSetpointCommand.Report)
+export class HumidityControlSetpointCCReport extends HumidityControlSetpointCC {
+	public constructor(
+		driver: Driver,
+		options: CommandClassDeserializationOptions,
+	) {
+		super(driver, options);
+
+		validatePayload(this.payload.length >= 1);
+		this._type = this.payload[0] & 0b1111;
+		if (this._type === 0) {
+			// Not supported
+			this._value = 0;
+			this._scale = getScale(this.driver.configManager, 0);
+			return;
+		}
+
+		// parseFloatWithScale does its own validation
+		const { value, scale } = parseFloatWithScale(this.payload.slice(1));
+		this._value = value;
+		this._scale = getScale(this.driver.configManager, scale);
+
+		this.persistValues();
+	}
+
+	public persistValues(): boolean {
+		const valueDB = this.getValueDB();
+		const setpointValueId = getSetpointValueID(
+			this.endpointIndex,
+			this._type,
+		);
+		// Update the metadata when it is missing or the unit has changed
+		if (
+			(
+				valueDB.getMetadata(setpointValueId) as
+					| ValueMetadataNumeric
+					| undefined
+			)?.unit !== this._scale.unit
+		) {
+			valueDB.setMetadata(setpointValueId, {
+				...ValueMetadata.Number,
+				unit: this._scale.unit,
+				ccSpecific: {
+					setpointType: this._type,
+				},
+			});
+		}
+		valueDB.setValue(setpointValueId, this._value);
+
+		// Remember the device-preferred setpoint scale so it can be used in SET commands
+		const scaleValueId = getSetpointScaleValueID(
+			this.endpointIndex,
+			this._type,
+		);
+		valueDB.setValue(scaleValueId, this._scale.key);
+		return true;
+	}
+
+	private _type: HumidityControlSetpointType;
+	public get type(): HumidityControlSetpointType {
+		return this._type;
+	}
+
+	private _scale: Scale;
+	public get scale(): Scale {
+		return this._scale;
+	}
+
+	private _value: number;
+	public get value(): number {
+		return this._value;
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: {
+				"setpoint type": getEnumMemberName(
+					HumidityControlSetpointType,
+					this.type,
+				),
+				value: `${this.value} ${this.scale.unit}`,
+			},
+		};
+	}
+}
+
+function testResponseForHumidityControlSetpointGet(
+	sent: HumidityControlSetpointCCGet,
+	received: HumidityControlSetpointCCReport,
+) {
+	// We expect a Thermostat Setpoint Report that matches the requested setpoint type
+	return received.type === sent.setpointType;
+}
+
+interface HumidityControlSetpointCCGetOptions extends CCCommandOptions {
+	setpointType: HumidityControlSetpointType;
+}
+
+@CCCommand(HumidityControlSetpointCommand.Get)
+@expectedCCResponse(
+	HumidityControlSetpointCCReport,
+	testResponseForHumidityControlSetpointGet,
+)
+export class HumidityControlSetpointCCGet extends HumidityControlSetpointCC {
+	public constructor(
+		driver: Driver,
+		options:
+			| CommandClassDeserializationOptions
+			| HumidityControlSetpointCCGetOptions,
+	) {
+		super(driver, options);
+		if (gotDeserializationOptions(options)) {
+			// TODO: Deserialize payload
+			throw new ZWaveError(
+				`${this.constructor.name}: deserialization not implemented`,
+				ZWaveErrorCodes.Deserialization_NotImplemented,
+			);
+		} else {
+			this.setpointType = options.setpointType;
+		}
+	}
+
+	public setpointType: HumidityControlSetpointType;
+
+	public serialize(): Buffer {
+		this.payload = Buffer.from([this.setpointType & 0b1111]);
+		return super.serialize();
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: {
+				"setpoint type": getEnumMemberName(
+					HumidityControlSetpointType,
+					this.setpointType,
+				),
+			},
+		};
+	}
+}
+
+@CCCommand(HumidityControlSetpointCommand.SupportedReport)
+export class HumidityControlSetpointCCSupportedReport extends HumidityControlSetpointCC {
+	public constructor(
+		driver: Driver,
+		options: CommandClassDeserializationOptions,
+	) {
+		super(driver, options);
+
+		validatePayload(this.payload.length >= 1);
+		this._supportedSetpointTypes = parseBitMask(
+			this.payload,
+			HumidityControlSetpointType["N/A"],
+		);
+
+		this.persistValues();
+	}
+
+	private _supportedSetpointTypes: HumidityControlSetpointType[];
+	@ccValue({ internal: true })
+	public get supportedSetpointTypes(): readonly HumidityControlSetpointType[] {
+		return this._supportedSetpointTypes;
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: {
+				"supported setpoint types": this.supportedSetpointTypes
+					.map(
+						(t) =>
+							`\n· ${getEnumMemberName(
+								HumidityControlSetpointType,
+								t,
+							)}`,
+					)
+					.join(""),
+			},
+		};
+	}
+}
+
+@CCCommand(HumidityControlSetpointCommand.SupportedGet)
+@expectedCCResponse(HumidityControlSetpointCCSupportedReport)
+export class HumidityControlSetpointCCSupportedGet extends HumidityControlSetpointCC {}
+
+@CCCommand(HumidityControlSetpointCommand.ScaleSupportedReport)
+export class HumidityControlSetpointCCScaleSupportedReport extends HumidityControlSetpointCC {
+	public constructor(
+		driver: Driver,
+		options: CommandClassDeserializationOptions,
+	) {
+		super(driver, options);
+
+		validatePayload(this.payload.length >= 1);
+
+		const supportedScaleIndices = parseBitMask(this.payload, 0);
+		this._scaleSupported = supportedScaleIndices.map((scale) =>
+			getScale(this.driver.configManager, scale),
+		);
+
+		this.persistValues();
+	}
+
+	private _scaleSupported: Scale[];
+	public get scaleSupported(): Scale[] {
+		return this._scaleSupported;
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: {
+				"scale supported": this.scaleSupported
+					.map((t) => `\n· ${t.key} ${t.unit} - ${t.label}`)
+					.join(""),
+			},
+		};
+	}
+}
+
+interface HumidityControlSetpointCCScaleSupportedGetOptions
+	extends CCCommandOptions {
+	setpointType: HumidityControlSetpointType;
+}
+
+@CCCommand(HumidityControlSetpointCommand.ScaleSupportedGet)
+@expectedCCResponse(HumidityControlSetpointCCScaleSupportedReport)
+export class HumidityControlSetpointCCScaleSupportedGet extends HumidityControlSetpointCC {
+	public constructor(
+		driver: Driver,
+		options:
+			| CommandClassDeserializationOptions
+			| HumidityControlSetpointCCGetOptions,
+	) {
+		super(driver, options);
+		if (gotDeserializationOptions(options)) {
+			// TODO: Deserialize payload
+			throw new ZWaveError(
+				`${this.constructor.name}: deserialization not implemented`,
+				ZWaveErrorCodes.Deserialization_NotImplemented,
+			);
+		} else {
+			this.setpointType = options.setpointType;
+		}
+	}
+
+	public setpointType: HumidityControlSetpointType;
+
+	public serialize(): Buffer {
+		this.payload = Buffer.from([this.setpointType & 0b1111]);
+		return super.serialize();
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: {
+				"setpoint type": getEnumMemberName(
+					HumidityControlSetpointType,
+					this.setpointType,
+				),
+			},
+		};
+	}
+}
+
+@CCCommand(HumidityControlSetpointCommand.CapabilitiesReport)
+export class HumidityControlSetpointCCCapabilitiesReport extends HumidityControlSetpointCC {
+	public constructor(
+		driver: Driver,
+		options: CommandClassDeserializationOptions,
+	) {
+		super(driver, options);
+
+		validatePayload(this.payload.length >= 1);
+		this._type = this.payload[0] & 0b1111;
+		let bytesRead: number;
+		// parseFloatWithScale does its own validation
+		({
+			value: this._minValue,
+			scale: this._minValueScale,
+			bytesRead,
+		} = parseFloatWithScale(this.payload.slice(1)));
+		({ value: this._maxValue, scale: this._maxValueScale } =
+			parseFloatWithScale(this.payload.slice(1 + bytesRead)));
+
+		// Predefine the metadata
+		const valueId = getSetpointValueID(this.endpointIndex, this.type);
+		this.getValueDB().setMetadata(valueId, {
+			...ValueMetadata.Number,
+			min: this._minValue,
+			max: this._maxValue,
+			unit:
+				getSetpointUnit(
+					this.driver.configManager,
+					this._minValueScale,
+				) ||
+				getSetpointUnit(this.driver.configManager, this._maxValueScale),
+			ccSpecific: {
+				setpointType: this._type,
+			},
+		});
+
+		this.persistValues();
+	}
+
+	private _type: HumidityControlSetpointType;
+	public get type(): HumidityControlSetpointType {
+		return this._type;
+	}
+
+	private _minValue: number;
+	public get minValue(): number {
+		return this._minValue;
+	}
+
+	private _maxValue: number;
+	public get maxValue(): number {
+		return this._maxValue;
+	}
+
+	private _minValueScale: number;
+	public get minValueScale(): number {
+		return this._minValueScale;
+	}
+
+	private _maxValueScale: number;
+	public get maxValueScale(): number {
+		return this._maxValueScale;
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		const minValueScale = getScale(
+			this.driver.configManager,
+			this.minValueScale,
+		);
+		const maxValueScale = getScale(
+			this.driver.configManager,
+			this.maxValueScale,
+		);
+		return {
+			...super.toLogEntry(),
+			message: {
+				"setpoint type": getEnumMemberName(
+					HumidityControlSetpointType,
+					this.type,
+				),
+				"min value": `${this.minValue} ${minValueScale.unit}`,
+				"max value": `${this.maxValue} ${maxValueScale.unit}`,
+			},
+		};
+	}
+}
+
+interface HumidityControlSetpointCCCapabilitiesGetOptions
+	extends CCCommandOptions {
+	setpointType: HumidityControlSetpointType;
+}
+
+@CCCommand(HumidityControlSetpointCommand.CapabilitiesGet)
+@expectedCCResponse(HumidityControlSetpointCCCapabilitiesReport)
+export class HumidityControlSetpointCCCapabilitiesGet extends HumidityControlSetpointCC {
+	public constructor(
+		driver: Driver,
+		options:
+			| CommandClassDeserializationOptions
+			| HumidityControlSetpointCCCapabilitiesGetOptions,
+	) {
+		super(driver, options);
+		if (gotDeserializationOptions(options)) {
+			// TODO: Deserialize payload
+			throw new ZWaveError(
+				`${this.constructor.name}: deserialization not implemented`,
+				ZWaveErrorCodes.Deserialization_NotImplemented,
+			);
+		} else {
+			this.setpointType = options.setpointType;
+		}
+	}
+
+	public setpointType: HumidityControlSetpointType;
+
+	public serialize(): Buffer {
+		this.payload = Buffer.from([this.setpointType & 0b1111]);
+		return super.serialize();
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: {
+				"setpoint type": getEnumMemberName(
+					HumidityControlSetpointType,
+					this.setpointType,
+				),
+			},
+		};
+	}
+}

--- a/packages/zwave-js/src/lib/commandclass/HumidityControlSetpointCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/HumidityControlSetpointCC.ts
@@ -547,6 +547,7 @@ export class HumidityControlSetpointCCReport extends HumidityControlSetpointCC {
 
 		validatePayload(this.payload.length >= 1);
 		this._type = this.payload[0] & 0b1111;
+		// Setpoint type 0 is not defined in the spec, prevent devices from using it.
 		if (this._type === 0) {
 			// Not supported
 			this._value = 0;

--- a/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
@@ -629,11 +629,9 @@ export class ThermostatSetpointCCSet extends ThermostatSetpointCC {
 
 	public serialize(): Buffer {
 		// If a config file overwrites how the float should be encoded, use that information
-		const override =
-			this.getNodeUnsafe()?.deviceConfig?.compat?.overrideFloatEncoding;
 		this.payload = Buffer.concat([
 			Buffer.from([this.setpointType & 0b1111]),
-			encodeFloatWithScale(this.value, this.scale, override),
+			encodeFloatWithScale(this.value, this.scale),
 		]);
 		return super.serialize();
 	}

--- a/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
@@ -629,9 +629,11 @@ export class ThermostatSetpointCCSet extends ThermostatSetpointCC {
 
 	public serialize(): Buffer {
 		// If a config file overwrites how the float should be encoded, use that information
+		const override =
+			this.getNodeUnsafe()?.deviceConfig?.compat?.overrideFloatEncoding;
 		this.payload = Buffer.concat([
 			Buffer.from([this.setpointType & 0b1111]),
-			encodeFloatWithScale(this.value, this.scale),
+			encodeFloatWithScale(this.value, this.scale, override),
 		]);
 		return super.serialize();
 	}

--- a/packages/zwave-js/src/lib/commandclass/index.ts
+++ b/packages/zwave-js/src/lib/commandclass/index.ts
@@ -194,6 +194,32 @@ export {
 export type { FirmwareUpdateCapabilities } from "./FirmwareUpdateMetaDataCC";
 export { HailCC } from "./HailCC";
 export {
+	HumidityControlModeCC,
+	HumidityControlModeCCGet,
+	HumidityControlModeCCReport,
+	HumidityControlModeCCSet,
+	HumidityControlModeCCSupportedGet,
+	HumidityControlModeCCSupportedReport,
+} from "./HumidityControlModeCC";
+export {
+	HumidityControlOperatingStateCC,
+	HumidityControlOperatingStateCCGet,
+	HumidityControlOperatingStateCCReport,
+} from "./HumidityControlOperatingStateCC";
+export {
+	HumidityControlSetpointCC,
+	HumidityControlSetpointCCCapabilitiesGet,
+	HumidityControlSetpointCCCapabilitiesReport,
+	HumidityControlSetpointCCGet,
+	HumidityControlSetpointCCReport,
+	HumidityControlSetpointCCScaleSupportedGet,
+	HumidityControlSetpointCCScaleSupportedReport,
+	HumidityControlSetpointCCSet,
+	HumidityControlSetpointCCSupportedGet,
+	HumidityControlSetpointCCSupportedReport,
+} from "./HumidityControlSetpointCC";
+export type { HumidityControlSetpointMetadata } from "./HumidityControlSetpointCC";
+export {
 	IndicatorCC,
 	IndicatorCCGet,
 	IndicatorCCReport,


### PR DESCRIPTION
Adds the following CCs:
* Humidity Control Mode
* Humidity Control Operating State
* Humidity Control Setpoint

They are almost identical to the various `Thermostat` CCs, so a lot of the code in this PR is modelled around those.