### PR TITLE
fix(config): fix configurations for Aeotec ZW111 and FT111

### DIFF
--- a/packages/config/config/devices/0x0086/templates/aeotec_template.json
+++ b/packages/config/config/devices/0x0086/templates/aeotec_template.json
@@ -300,7 +300,29 @@
 			}
 		]
 	},
-	"notification_report_type": {
+	"multilevel_report_type": {
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 2,
+		"defaultValue": 1,
+		"unsigned": true,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Disable",
+				"value": 0
+			},
+			{
+				"label": "Basic CC Report",
+				"value": 1
+			},
+			{
+				"label": "MultiLevel Switch CC Report",
+				"value": 2
+			}
+		]
+	},
+	"multilevel_set_report_type": {
 		"valueSize": 1,
 		"minValue": 0,
 		"maxValue": 2,
@@ -317,7 +339,7 @@
 				"value": 1
 			},
 			{
-				"label": "MultiLevel Switch CC Report",
+				"label": "MultiLevel Switch CC Set",
 				"value": 2
 			}
 		]
@@ -1999,7 +2021,7 @@
 				"value": 2
 			},
 			{
-				"label": "Load and association group 3",
+				"label": "Load and association group 4",
 				"value": 3
 			}
 		]

--- a/packages/config/config/devices/0x0086/zw111.json
+++ b/packages/config/config/devices/0x0086/zw111.json
@@ -75,12 +75,12 @@
 		},
 		{
 			"#": "81",
-			"$import": "templates/aeotec_template.json#notification_report_type",
+			"$import": "templates/aeotec_template.json#multilevel_set_report_type",
 			"label": "Send Notifications to Associated Devices (Group 3)"
 		},
 		{
 			"#": "82",
-			"$import": "templates/aeotec_template.json#notification_report_type",
+			"$import": "templates/aeotec_template.json#multilevel_set_report_type",
 			"label": "Send Notifications to Associated Devices (Group 4)"
 		},
 		{

--- a/packages/config/config/devices/0x016a/ft111.json
+++ b/packages/config/config/devices/0x016a/ft111.json
@@ -62,12 +62,12 @@
 		},
 		{
 			"#": "81",
-			"$import": "~/0x0086/templates/aeotec_template.json#notification_report_type",
+			"$import": "~/0x0086/templates/aeotec_template.json#enable_notification_basic_set_only",
 			"label": "Send Notifications to Associated Devices (Group 3)"
 		},
 		{
 			"#": "82",
-			"$import": "~/0x0086/templates/aeotec_template.json#notification_report_type",
+			"$import": "~/0x0086/templates/aeotec_template.json#enable_notification_basic_set_only",
 			"label": "Send Notifications to Associated Devices (Group 4)"
 		},
 		{

--- a/packages/config/config/devices/0x0371/zw141.json
+++ b/packages/config/config/devices/0x0371/zw141.json
@@ -250,22 +250,8 @@
 		},
 		{
 			"#": "80",
-			"$import": "~/0x0086/templates/aeotec_template.json#notification_report_type",
-			"label": "Command Report Type",
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Basic CC Report",
-					"value": 1
-				},
-				{
-					"label": "MultiLevel Switch CC Report",
-					"value": 2
-				}
-			]
+			"$import": "~/0x0086/templates/aeotec_template.json#multilevel_report_type",
+			"label": "Command Report Type"
 		},
 		{
 			"#": "85",


### PR DESCRIPTION
For ZW111, change param 81 and 82 option to Multilevel Switch CC Set (was incorrectly Report - see https://aeotec.freshdesk.com/helpdesk/attachments/6102435346) and fixed label for control destination s2.
For FT111, change param 81 and 82 to none/basic set only (see https://manuals-backend.z-wave.info/make.php?lang=en&sku=FT111-C&cert=ZC10-17035487)

BREAKING_CHANGE: FT111 now has one option less for config param 81/82 compared to before, however this matches all available documentation.