### PR TITLE
log unexpected bytes when reading frames from serial

### DIFF
--- a/packages/serial/src/Logger.ts
+++ b/packages/serial/src/Logger.ts
@@ -53,6 +53,23 @@ export class SerialLogger extends ZWaveLoggerBase<SerialLogContext> {
 			this.logMessageHeader(direction, MessageHeaders.CAN);
 	}
 
+	/**
+	 * Logs receipt of an unexpected byte, instead of a ACK, NAK, CAN, or data frame
+	 */
+        public whut(direction: DataDirection, data: Buffer): void {
+		if (this.isVisible())
+			this.logger.log({
+				level: SERIAL_LOGLEVEL,
+				message: `garble. unexpected byte 0x${data[0].toString("hex")}`,
+				secondaryTags: `(${data.length} bytes)`,
+				direction: getDirectionPrefix(direction),
+				context: {
+					source: "serial",
+					direction,
+				},
+		});
+	}
+
 	private logMessageHeader(
 		direction: DataDirection,
 		header: MessageHeaders,

--- a/packages/serial/src/SerialAPIParser.ts
+++ b/packages/serial/src/SerialAPIParser.ts
@@ -53,6 +53,10 @@ export class SerialAPIParser extends Transform {
 						// INS12350: A host or a Z-Wave chip waiting for new traffic MUST ignore all other
 						// byte values than 0x06 (ACK), 0x15 (NAK), 0x18 (CAN) or 0x01 (Data frame).
 						// Just skip this byte
+
+						// we should log this
+						// because corrupted message, a firmware bug, or a logic problem
+						this.logger.whut("inbound", this.receiveBuffer);
 					}
 				}
 				// Continue with the next byte


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

SerialAPIParser silently drops unexpected bytes when reading a frame.
This now logs them when they happen.
