### PR TITLE
fix: add fallback to config file for associations' max node counts

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/AssociationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/AssociationCC.ts
@@ -302,7 +302,14 @@ export class AssociationCC extends CommandClass {
 		return (
 			this.getValueDB().getValue(
 				getMaxNodesValueId(this.endpointIndex, groupId),
-			) ?? 0
+			) ??
+			// If the information is not available, fall back to the configuration file if possible
+			// This can happen on some legacy devices which have "hidden" association groups
+			this.getNodeUnsafe()?.deviceConfig?.getAssociationConfigForEndpoint(
+				this.endpointIndex,
+				groupId,
+			)?.maxNodes ??
+			0
 		);
 	}
 


### PR DESCRIPTION
If a config file knows about an association group the node doesn't report, we now take the max node count from the config file instead of returning 0.

fixes: #4072