### PR TITLE
fix(config): update Z-Uno definition for custom configuration parameters

### DIFF
--- a/packages/config/config/devices/0x0115/v3.json
+++ b/packages/config/config/devices/0x0115/v3.json
@@ -204,6 +204,262 @@
 					"value": 1
 				}
 			]
+		},
+		{
+			"#": "64",
+			"label": "Custom parameter 64",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "65",
+			"label": "Custom parameter 65",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "66",
+			"label": "Custom parameter 66",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "67",
+			"label": "Custom parameter 67",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "68",
+			"label": "Custom parameter 68",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "69",
+			"label": "Custom parameter 69",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "70",
+			"label": "Custom parameter 70",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "71",
+			"label": "Custom parameter 71",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "72",
+			"label": "Custom parameter 72",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "73",
+			"label": "Custom parameter 73",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "74",
+			"label": "Custom parameter 74",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "75",
+			"label": "Custom parameter 75",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "76",
+			"label": "Custom parameter 76",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "77",
+			"label": "Custom parameter 77",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "78",
+			"label": "Custom parameter 78",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "79",
+			"label": "Custom parameter 79",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "80",
+			"label": "Custom parameter 80",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "81",
+			"label": "Custom parameter 81",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "82",
+			"label": "Custom parameter 82",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "83",
+			"label": "Custom parameter 83",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "84",
+			"label": "Custom parameter 84",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "85",
+			"label": "Custom parameter 85",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "86",
+			"label": "Custom parameter 86",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "87",
+			"label": "Custom parameter 87",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "88",
+			"label": "Custom parameter 88",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "89",
+			"label": "Custom parameter 89",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "90",
+			"label": "Custom parameter 90",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "91",
+			"label": "Custom parameter 91",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "92",
+			"label": "Custom parameter 92",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "93",
+			"label": "Custom parameter 93",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "94",
+			"label": "Custom parameter 94",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
+		},
+		{
+			"#": "95",
+			"label": "Custom parameter 95",
+			"valueSize": 2,
+			"minValue": -32768,
+			"maxValue": 32767,
+			"defaultValue": 0
 		}
 	],
 	"metadata": {


### PR DESCRIPTION
Add custom parameters for the Z-Uno.

The Z-Uno is an Arduino/ESP-like custom development board. It features 32 2-bytes user-configurable Z-Wave configuration slots. Unfortunately, the Home Assistant [Z-Wave JS](https://www.home-assistant.io/integrations/zwave_js#service-zwave_jsset_config_parameter) integration won't allow to set a parameter that is not defined in the backend:

![image](https://user-images.githubusercontent.com/9640353/149535819-7357e2ed-6f17-46c4-aaa8-569f060dc60d.png)

```
Logger: homeassistant.helpers.script.websocket_api_script
Source: components/zwave_js/services.py:354
First occurred: 2:36:15 PM (2 occurrences)
Last logged: 3:47:59 PM

websocket_api script: Error executing script. Unexpected error for call_service at pos 1: Configuration parameter with value ID 32-112-0-64 could not be found
websocket_api script: Error executing script. Unexpected error for call_service at pos 1: Configuration parameter with value ID 33-112-0-64 could not be found
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 381, in _async_step
    await getattr(self, handler)()
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 584, in _async_call_service_step
    await service_task
  File "/usr/src/homeassistant/homeassistant/core.py", line 1495, in async_call
    task.result()
  File "/usr/src/homeassistant/homeassistant/core.py", line 1530, in _execute_service
    await handler.job.target(service_call)
  File "/usr/src/homeassistant/homeassistant/components/zwave_js/services.py", line 354, in async_set_config_parameter
    zwave_value, cmd_status = await async_set_config_parameter(
  File "/usr/local/lib/python3.9/site-packages/zwave_js_server/util/node.py", line 65, in async_set_config_parameter
    raise NotFoundError(
zwave_js_server.exceptions.NotFoundError: Configuration parameter with value ID 32-112-0-64 could not be found
```

Not only this allows to set the parameters through HA's service, but this also allows to quickly display all of them, rather than having to go through the `Custom Configuration` input (which, BTW, is currently broken, as #2175 hasn't made it yet to HA).

Manufacturer doc: https://z-uno.z-wave.me/z-wave/configuration-parameters/ and https://z-uno.z-wave.me/Reference/ZUNO_SETUP_CFGPARAMETER_HANDLER/

Note: as opposed to what's stated in the doc:
> Parameters on the Z-Wave controller side are numbered from 64 to 96

Only `32` parameters are available, thus, only going up to `95` included.