### PR TITLE
fix(config): add Momentary Toggle Switch to Hold Control Modes for Heltun HE-RS01

### DIFF
--- a/packages/config/config/devices/0x0344/he-rs01.json
+++ b/packages/config/config/devices/0x0344/he-rs01.json
@@ -65,27 +65,27 @@
 		},
 		{
 			"#": "41",
-			"$import": "templates/heltun_template.json#external_input_hold_control_mode",
+			"$import": "templates/heltun_template.json#external_input_hold_control_mode_4",
 			"label": "External Input S1: Hold Control Mode"
 		},
 		{
 			"#": "42",
-			"$import": "templates/heltun_template.json#external_input_hold_control_mode",
+			"$import": "templates/heltun_template.json#external_input_hold_control_mode_4",
 			"label": "External Input S2: Hold Control Mode"
 		},
 		{
 			"#": "43",
-			"$import": "templates/heltun_template.json#external_input_hold_control_mode",
+			"$import": "templates/heltun_template.json#external_input_hold_control_mode_4",
 			"label": "External Input S3: Hold Control Mode"
 		},
 		{
 			"#": "44",
-			"$import": "templates/heltun_template.json#external_input_hold_control_mode",
+			"$import": "templates/heltun_template.json#external_input_hold_control_mode_4",
 			"label": "External Input S4: Hold Control Mode"
 		},
 		{
 			"#": "45",
-			"$import": "templates/heltun_template.json#external_input_hold_control_mode",
+			"$import": "templates/heltun_template.json#external_input_hold_control_mode_4",
 			"label": "External Input S5: Hold Control Mode"
 		},
 		{

--- a/packages/config/config/devices/0x0344/templates/heltun_template.json
+++ b/packages/config/config/devices/0x0344/templates/heltun_template.json
@@ -94,6 +94,35 @@
 			}
 		]
 	},
+	"external_input_hold_control_mode_4": {
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 4,
+		"defaultValue": 2,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Disable",
+				"value": 0
+			},
+			{
+				"label": "Operate like click (parameter 51)",
+				"value": 1
+			},
+			{
+				"label": "Momentary switch",
+				"value": 2
+			},
+			{
+				"label": "Reversed momentary switch",
+				"value": 3
+			},
+			{
+				"label": "Momentary Toggle Switch",
+				"value": 4
+			}
+		]
+	},
 	"relay_button_number_source": {
 		"valueSize": 1,
 		"minValue": 0,


### PR DESCRIPTION
### Overview

Additions to device configuration files for Heltun Relay Switch Quinto HE-RS01
- Add "Momentary Toggle Switch" to Hold Control Mode parameter options for parameters 41-45.

### Momentary Toggle Switch

Extra template added to `heltun_template.json` for "Hold Control Mode" with additional parameter option of "Momentary Toggle Switch" with value 4. New template suffixed `_4` following the convention in the same file for "Click Control Mode" to differentiate this template from that used by other devices that do not support this control mode.

`he-rs01.json` updated so that parameters 41-45 use this new template.

### Testing

Tested with zwavejs2mqtt 0.33.0 using modified device files in `store` directory.