### PR TITLE
fix(config): add association to Leviton DZ15S switch

### DIFF
--- a/packages/config/config/devices/0x001d/dz15s.json
+++ b/packages/config/config/devices/0x001d/dz15s.json
@@ -13,6 +13,13 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
+	"associations": {
+		"1": {
+			"label": "Group 1",
+			"maxNodes": 5,
+			"isLifeline": true
+		}
+	},
 	"paramInformation": [
 		{
 			"#": "7",

--- a/packages/config/config/devices/0x001d/dz15s.json
+++ b/packages/config/config/devices/0x001d/dz15s.json
@@ -15,7 +15,7 @@
 	},
 	"associations": {
 		"1": {
-			"label": "Group 1",
+			"label": "Lifeline",
 			"maxNodes": 5,
 			"isLifeline": true
 		}


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

I have many of these switches at home and it seems like the association group is missing, I only have a Lifeline group which doesn't seem to work for grouping switches together. I checked other configuration files and this seems to be the way to define an association group (please confirm!). This is what the [DZ15S manual](https://www.leviton.com/en/docs/DI-000-DZ15S-02A-W.pdf) says:

![Screenshot from 2022-01-18 13-16-36](https://user-images.githubusercontent.com/2053039/149995767-6cbedb2c-9877-4743-a0fc-be6c797e6cab.png)

