### PR TITLE
fix(config): added inclusion, exclusion and reset instructions to Danfoss MT02650

### DIFF
--- a/packages/config/config/devices/0x0002/mt02650.json
+++ b/packages/config/config/devices/0x0002/mt02650.json
@@ -32,5 +32,11 @@
 			["Battery", "get"],
 			["Thermostat Setpoint", "get", 1]
 		]
+	},
+	"metadata": {
+		"inclusion": "In order to include (add) a Z-Wave device to a network it must be in factory default state./nClick on the middle button will confirm inclusion or exclusion and wakeup the device for wireless communication./nA long push for 3 seconds on the middle buttons enters and leaves the management mode indicated by a 'M'.",
+		"exclusion": "Click on the middle button will confirm inclusion or exclusion and wakeup the device for wireless communication./nA long push for 3 seconds on the middle buttons enters and leaves the management mode indicated by a 'M'.",
+		"reset": "Remove the batteries and keep the function button '*' pressed for 5 seconds after the batteries are inserted back.\nThis procedure should only be used when the primary controller is inoperable.",
+		"manual": "http://manuals-backend.z-wave.info/make.php?lang=en&sku=DEVE9356&cert=ZC08-15020003"
 	}
 }

--- a/packages/config/config/devices/0x0002/mt02650.json
+++ b/packages/config/config/devices/0x0002/mt02650.json
@@ -34,8 +34,8 @@
 		]
 	},
 	"metadata": {
-		"inclusion": "In order to include (add) a Z-Wave device to a network it must be in factory default state./nClick on the middle button will confirm inclusion or exclusion and wakeup the device for wireless communication./nA long push for 3 seconds on the middle buttons enters and leaves the management mode indicated by a 'M'.",
-		"exclusion": "Click on the middle button will confirm inclusion or exclusion and wakeup the device for wireless communication./nA long push for 3 seconds on the middle buttons enters and leaves the management mode indicated by a 'M'.",
+		"inclusion": "In order to include (add) a Z-Wave device to a network it must be in factory default state.\nClick on the middle button will confirm inclusion or exclusion and wakeup the device for wireless communication.\nA long push for 3 seconds on the middle buttons enters and leaves the management mode indicated by a 'M'.",
+		"exclusion": "Click on the middle button will confirm inclusion or exclusion and wakeup the device for wireless communication.\nA long push for 3 seconds on the middle buttons enters and leaves the management mode indicated by a 'M'.",
 		"reset": "Remove the batteries and keep the function button '*' pressed for 5 seconds after the batteries are inserted back.\nThis procedure should only be used when the primary controller is inoperable.",
 		"manual": "http://manuals-backend.z-wave.info/make.php?lang=en&sku=DEVE9356&cert=ZC08-15020003"
 	}


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->
added inclusion, excelusion and reset instructions from http://manuals-backend.z-wave.info/make.php?lang=en&sku=DEVE9356&cert=ZC08-15020003
