### PR TITLE
fix(config): add Relay Load Power for Heltun HE-RS01

### DIFF
--- a/packages/config/config/devices/0x0344/he-rs01.json
+++ b/packages/config/config/devices/0x0344/he-rs01.json
@@ -54,27 +54,27 @@
 		{
 			"#": "12",
 			"$import": "templates/heltun_template.json#relay_load_power",
-			"label": "Relay 1: Relay 1 load Power"
+			"label": "Relay 1: Load Power"
 		},
 		{
 			"#": "13",
 			"$import": "templates/heltun_template.json#relay_load_power",
-			"label": "Relay 2: Relay 1 load Power"
+			"label": "Relay 2: Load Power"
 		},
 		{
 			"#": "14",
 			"$import": "templates/heltun_template.json#relay_load_power",
-			"label": "Relay 3: Relay 1 load Power"
+			"label": "Relay 3: Load Power"
 		},
 		{
 			"#": "15",
 			"$import": "templates/heltun_template.json#relay_load_power",
-			"label": "Relay 4: Relay 1 load Power"
+			"label": "Relay 4: Load Power"
 		},
 		{
 			"#": "16",
 			"$import": "templates/heltun_template.json#relay_load_power",
-			"label": "Relay 5: Relay 1 load Power"
+			"label": "Relay 5: Load Power"
 		},
 		{
 			"#": "19",

--- a/packages/config/config/devices/0x0344/he-rs01.json
+++ b/packages/config/config/devices/0x0344/he-rs01.json
@@ -52,6 +52,31 @@
 			"label": "Relay 5: Output Mode"
 		},
 		{
+			"#": "12",
+			"$import": "templates/heltun_template.json#relay_load_power",
+			"label": "Relay 1: Relay 1 load Power"
+		},
+		{
+			"#": "13",
+			"$import": "templates/heltun_template.json#relay_load_power",
+			"label": "Relay 2: Relay 1 load Power"
+		},
+		{
+			"#": "14",
+			"$import": "templates/heltun_template.json#relay_load_power",
+			"label": "Relay 3: Relay 1 load Power"
+		},
+		{
+			"#": "15",
+			"$import": "templates/heltun_template.json#relay_load_power",
+			"label": "Relay 4: Relay 1 load Power"
+		},
+		{
+			"#": "16",
+			"$import": "templates/heltun_template.json#relay_load_power",
+			"label": "Relay 5: Relay 1 load Power"
+		},
+		{
 			"#": "19",
 			"$import": "templates/heltun_template.json#controller_time_correction"
 		},

--- a/packages/config/config/devices/0x0344/templates/heltun_template.json
+++ b/packages/config/config/devices/0x0344/templates/heltun_template.json
@@ -218,6 +218,14 @@
 			}
 		]
 	},
+	"relay_load_power": {
+		"description": "Power of the relay load. Used to calculate energy consumption.",
+		"unit": "W",
+		"valueSize": 2,
+		"minValue": 0,
+		"maxValue": 1100,
+		"defaultValue": 0
+	},
 	"relay_timer_mode_duration": {
 		"description": "Used to open/close garage doors, blinds, curtains, etc. or to turn attached devices like door lock or security OFF for a short time",
 		"unit": "seconds",


### PR DESCRIPTION
### Add Relay Load Power for Heltun HE-RS01

Adds parameters 12-16 corresponding to the load power in watts for corresponding to relays 1-5. These parameters are set by the user in order to allow the device to calculate power consumption for the metering feature.

Tested using custom device configuration files with zwavejs2mqtt 0.33.0 and Home Assistant.

<img width="841" alt="HeltunHE-RS01Manual" src="https://user-images.githubusercontent.com/1502398/150403302-4804f6ae-b15a-45c0-918c-d689272e9a2f.png">

Fixes #4115 
