### PR TITLE
feat(config): add parameter 10 (all on, all off) to Qubino SmartMeter ZMNHTD

### DIFF
--- a/packages/config/config/devices/0x0159/zmnhtd.json
+++ b/packages/config/config/devices/0x0159/zmnhtd.json
@@ -47,6 +47,33 @@
 			]
 		},
 		{
+			"#": "10",
+			"label": "Activate / Desactivate function ALL ON / ALL OFF",
+			"unit": "seconds",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 32535,
+			"defaultValue": 255,
+			"options": [
+				{
+					"label": "ALL ON is not active, ALL OFF is not active",
+					"value": 0
+				},
+				{
+					"label": "ALL ON is not active, ALL OFF active",
+					"value": 1
+				},
+				{
+					"label": "ALL ON active, ALL OFF is not active",
+					"value": 2
+				},
+				{
+					"label": "255 - ALL ON active, ALL OFF active",
+					"value": 2
+				}
+			]
+		},
+		{
 			"#": "11",
 			"label": "Timer turning off IR external relay",
 			"unit": "seconds",

--- a/packages/config/config/devices/0x0159/zmnhtd.json
+++ b/packages/config/config/devices/0x0159/zmnhtd.json
@@ -48,26 +48,27 @@
 		},
 		{
 			"#": "10",
-			"label": "Activate / Desactivate function ALL ON / ALL OFF",
+			"label": "All On / All Off Function",
 			"valueSize": 2,
 			"minValue": 0,
-			"maxValue": 32535,
+			"maxValue": 255,
 			"defaultValue": 255,
+			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "ALL ON is not active, ALL OFF is not active",
+					"label": "Disable both",
 					"value": 0
 				},
 				{
-					"label": "ALL ON is not active, ALL OFF active",
+					"label": "Disable All On, Enable All Off",
 					"value": 1
 				},
 				{
-					"label": "ALL ON active, ALL OFF is not active",
+					"label": "Enable All On, Disable All Off",
 					"value": 2
 				},
 				{
-					"label": "255 - ALL ON active, ALL OFF active",
+					"label": "Enable both",
 					"value": 255
 				}
 			]

--- a/packages/config/config/devices/0x0159/zmnhtd.json
+++ b/packages/config/config/devices/0x0159/zmnhtd.json
@@ -69,7 +69,7 @@
 				},
 				{
 					"label": "255 - ALL ON active, ALL OFF active",
-					"value": 2
+					"value": 255
 				}
 			]
 		},

--- a/packages/config/config/devices/0x0159/zmnhtd.json
+++ b/packages/config/config/devices/0x0159/zmnhtd.json
@@ -49,7 +49,6 @@
 		{
 			"#": "10",
 			"label": "Activate / Desactivate function ALL ON / ALL OFF",
-			"unit": "seconds",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 32535,


### PR DESCRIPTION
Hello,

I think one parameter - 10 - is missing as described in the manual:

Parameter no. 10 - Activate / deactivate functions ALL ON / ALL OFF
Available config. parameters (data type is 2 Byte DEC):
default value 255
255 - ALL ON active, ALL OFF active.
0 - ALL ON is not active, ALL OFF is not active
1 - ALL ON is not active, ALL OFF active
2 - ALL ON active, ALL OFF is not active
Smart meter module responds to commands ALL ON/ ALL OFF that may be sent by the main controller or by other controller belonging to the system

Best Regards,
Stéphane

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

PR description here

Add Parameter no. 10 - Activate / deactivate functions ALL ON / ALL OFF
