### PR TITLE
feat(config): add fingerprint to Fibaro FGD212

### DIFF
--- a/packages/config/config/devices/0x010f/fgd212.json
+++ b/packages/config/config/devices/0x010f/fgd212.json
@@ -10,6 +10,10 @@
 		},
 		{
 			"productType": "0x0102",
+			"productId": "0x1001"
+		},
+		{
+			"productType": "0x0102",
 			"productId": "0x2000"
 		},
 		{


### PR DESCRIPTION
This PR adds a new Product Identifier for the Fibaro FGD212 aka "Dimmer 2",  I don't know if it's the default PID for all the new FGD212 but I've bought some that have been manufactured 19th of November 2021 and they all have this new PID, the previous one that I've bought earlier last year were tagged with PID `1000`.