### PR TITLE
feat(config): add config for Keemple KP-SO-02 Smart Socket

### DIFF
--- a/packages/config/config/devices/0x041a/kp-so-02.json
+++ b/packages/config/config/devices/0x041a/kp-so-02.json
@@ -1,0 +1,101 @@
+{
+	// Device is rebranded Shenzhen Neo NAS-WR01ZE
+	"manufacturer": "Keemple",
+	"manufacturerId": "0x041a",
+	"label": "KP-SO-02",
+	"description": "Smart Socket",
+	"devices": [
+		{
+			"productType": "0x0200",
+			"productId": "0x0008"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev"
+		},
+		{
+			"#": "2",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Button",
+			"defaultValue": 1
+		},
+		{
+			"#": "3",
+			"$import": "~/templates/master_template.json#enable_led_indicator",
+			"defaultValue": 1
+		},
+		{
+			"#": "4",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Auto-Off Timer"
+		},
+		{
+			"#": "5",
+			"label": "Auto-Off Delay",
+			"description": "Delay time after the plug is switched off",
+			"unit": "minutes",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 32767,
+			"defaultValue": 120,
+			"unsigned": true
+		},
+		{
+			"#": "6",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Send Meter Reports"
+		},
+		{
+			"#": "7",
+			"label": "Meter Report Interval",
+			"unit": "seconds",
+			"valueSize": 2,
+			"minValue": 30,
+			"maxValue": 32767,
+			"defaultValue": 300,
+			"unsigned": true
+		},
+		{
+			"#": "8",
+			"label": "Overcurrent Protection Threshold",
+			"description": "Threshold at which the plug enters overcurrent protection mode",
+			"unit": "A",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 16,
+			"defaultValue": 16
+		},
+		{
+			"#": "9",
+			"label": "Current Report Threshold",
+			"description": "Change in current consumption that triggers a report",
+			"unit": "0.01 A",
+			"valueSize": 2,
+			"minValue": 1,
+			"maxValue": 1600,
+			"defaultValue": 50
+		},
+		{
+			"#": "10",
+			"label": "Overcurrent Alarm Threshold",
+			"description": "Threshold at which the plug sends an overcurrent notification",
+			"unit": "A",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 16,
+			"defaultValue": 13
+		}
+	],
+	"metadata": {
+		"comments": {
+			"level": "warning",
+			"text": "This device is buggy and sends large negative Meter Reports from time to time."
+		}
+	}
+}

--- a/packages/config/config/devices/0x041a/kp-so-02.json
+++ b/packages/config/config/devices/0x041a/kp-so-02.json
@@ -33,7 +33,7 @@
 		{
 			"#": "4",
 			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Auto-Off Timer"
+			"label": "Auto-Off"
 		},
 		{
 			"#": "5",


### PR DESCRIPTION
This device is an exact match with the Shenzhen Neo NAS-WR01ZE.~~I've imported its config from the respective device config file and overridden only the brand-specific fields.~~

*Source: I've several NAS-WR01ZE devices from a Chinese dealer that accidentally provided me unbranded units with firmware configured for Keemple resale*

~~I'm not sure if this is the recommended way of handling rebranded devices that report a different manufacturerId, but if the maintainers agree, maybe we can add a config-files documentation entry describing this use-case.~~

Device configuration parameters are identical to the updated Shenzhen Neo NAS-WR01ZE in #4186.

Closes: #3882