### PR TITLE
fix: correctly check min/max/default values for signed partial parameters

### DIFF
--- a/packages/config/config/devices/0x0086/templates/aeotec_template.json
+++ b/packages/config/config/devices/0x0086/templates/aeotec_template.json
@@ -1757,7 +1757,8 @@
 		"minValue": 0,
 		"maxValue": 255,
 		"defaultValue": 0,
-		"writeOnly": true
+		"writeOnly": true,
+		"unsigned": true
 	},
 	"blink_length": {
 		"label": "LED Blink Cycle Length",
@@ -1767,7 +1768,8 @@
 		"minValue": 0,
 		"maxValue": 255,
 		"defaultValue": 0,
-		"writeOnly": true
+		"writeOnly": true,
+		"unsigned": true
 	},
 	"motion_timeout": {
 		"label": "Motion Sensor Timeout",

--- a/packages/config/config/devices/0x0086/zw098.json
+++ b/packages/config/config/devices/0x0086/zw098.json
@@ -96,6 +96,7 @@
 			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Blue Color Value",
 			"valueSize": 4,
+			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false
 		},
@@ -104,6 +105,7 @@
 			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Green Color Value",
 			"valueSize": 4,
+			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false
 		},
@@ -112,6 +114,7 @@
 			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Red Color Value",
 			"valueSize": 4,
+			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false
 		},
@@ -161,6 +164,7 @@
 			"minValue": 0,
 			"maxValue": 2,
 			"defaultValue": 0,
+			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -185,6 +189,7 @@
 			"minValue": 0,
 			"maxValue": 31,
 			"defaultValue": 0,
+			"unsigned": true,
 			"options": [
 				{
 					"label": "Constant speed",
@@ -203,6 +208,7 @@
 			"description": "Allowable range: 1-254",
 			"valueSize": 4,
 			"defaultValue": 0,
+			"unsigned": true,
 			"options": [
 				{
 					"label": "Unlimited",
@@ -220,6 +226,7 @@
 			"label": "Brightness",
 			"description": "Allowable range: 1-99",
 			"valueSize": 4,
+			"unsigned": true,
 			"options": [
 				{
 					"label": "Inactive",
@@ -234,6 +241,7 @@
 			"minValue": 0,
 			"maxValue": 4,
 			"defaultValue": 0,
+			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -265,6 +273,7 @@
 			"minValue": 0,
 			"maxValue": 0,
 			"defaultValue": 0,
+			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -280,6 +289,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0086/zw099.json
+++ b/packages/config/config/devices/0x0086/zw099.json
@@ -30,11 +30,13 @@
 	"paramInformation": [
 		{
 			"#": "2[0xff]",
-			"$import": "templates/aeotec_template.json#blink_duration"
+			"$import": "templates/aeotec_template.json#blink_duration",
+			"unsigned": true
 		},
 		{
 			"#": "2[0xff00]",
-			"$import": "templates/aeotec_template.json#blink_length"
+			"$import": "templates/aeotec_template.json#blink_length",
+			"unsigned": true
 		},
 		{
 			"#": "3",

--- a/packages/config/config/devices/0x0086/zw121.json
+++ b/packages/config/config/devices/0x0086/zw121.json
@@ -129,6 +129,7 @@
 			"minValue": 0,
 			"maxValue": 2,
 			"defaultValue": 0,
+			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -153,6 +154,7 @@
 			"minValue": 0,
 			"maxValue": 31,
 			"defaultValue": 0,
+			"unsigned": true,
 			"options": [
 				{
 					"label": "Constant speed",
@@ -171,6 +173,7 @@
 			"description": "Allowable range: 1-254",
 			"valueSize": 4,
 			"defaultValue": 0,
+			"unsigned": true,
 			"options": [
 				{
 					"label": "Unlimited",
@@ -188,6 +191,7 @@
 			"label": "Brightness",
 			"description": "Allowable range: 1-99",
 			"valueSize": 4,
+			"unsigned": true,
 			"options": [
 				{
 					"label": "Inactive",
@@ -202,6 +206,7 @@
 			"minValue": 0,
 			"maxValue": 4,
 			"defaultValue": 0,
+			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -233,6 +238,7 @@
 			"minValue": 0,
 			"maxValue": 0,
 			"defaultValue": 0,
+			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -248,6 +254,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0086/zw122.json
+++ b/packages/config/config/devices/0x0086/zw122.json
@@ -87,7 +87,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 10
+			"defaultValue": 10,
+			"unsigned": true
 		},
 		{
 			"#": "10[0xff00]",
@@ -95,7 +96,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 20
+			"defaultValue": 20,
+			"unsigned": true
 		},
 		{
 			"#": "10[0xffff0000]",
@@ -103,7 +105,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 32767,
-			"defaultValue": 120
+			"defaultValue": 120,
+			"unsigned": true
 		},
 		{
 			"#": "39",
@@ -121,7 +124,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 32767,
-			"defaultValue": 4
+			"defaultValue": 4,
+			"unsigned": true
 		},
 		{
 			"#": "49[0xff00]",
@@ -134,7 +138,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 32767,
-			"defaultValue": 1
+			"defaultValue": 1,
+			"unsigned": true
 		},
 		{
 			"#": "50[0xff00]",

--- a/packages/config/config/devices/0x0090/smartcode_888.json
+++ b/packages/config/config/devices/0x0090/smartcode_888.json
@@ -118,6 +118,7 @@
 			"minValue": 30,
 			"maxValue": 180,
 			"defaultValue": 30,
+			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0098/ct101.json
+++ b/packages/config/config/devices/0x0098/ct101.json
@@ -76,6 +76,7 @@
 			"minValue": 1,
 			"maxValue": 2,
 			"defaultValue": 1,
+			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -95,6 +96,7 @@
 			"minValue": 0,
 			"maxValue": 15,
 			"readOnly": true,
+			"unsigned": true,
 			"allowManualEntry": false
 		},
 		{
@@ -104,6 +106,7 @@
 			"minValue": 1,
 			"maxValue": 2,
 			"readOnly": true,
+			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -123,6 +126,7 @@
 			"minValue": 0,
 			"maxValue": 255,
 			"readOnly": true,
+			"unsigned": true,
 			"allowManualEntry": false
 		},
 		{
@@ -132,6 +136,7 @@
 			"minValue": 0,
 			"maxValue": 255,
 			"readOnly": true,
+			"unsigned": true,
 			"allowManualEntry": false
 		},
 		{

--- a/packages/config/config/devices/0x0098/ct110.json
+++ b/packages/config/config/devices/0x0098/ct110.json
@@ -259,6 +259,7 @@
 			"minValue": 1,
 			"maxValue": 2,
 			"defaultValue": 1,
+			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -277,7 +278,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 15,
-			"defaultValue": 0
+			"defaultValue": 0,
+			"unsigned": true
 		},
 		{
 			"#": "2[0xf000]",
@@ -286,6 +288,7 @@
 			"minValue": 1,
 			"maxValue": 2,
 			"defaultValue": 1,
+			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -304,7 +307,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 128,
-			"defaultValue": 0
+			"defaultValue": 0,
+			"unsigned": true
 		},
 		{
 			"#": "2[0x0f000000]",
@@ -312,7 +316,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 15,
-			"defaultValue": 0
+			"defaultValue": 0,
+			"unsigned": true
 		},
 		{
 			"#": "10[0xffff]",
@@ -320,7 +325,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 124,
-			"defaultValue": 124
+			"defaultValue": 124,
+			"unsigned": true
 		},
 		{
 			"#": "10[0x0fff0000]",
@@ -328,7 +334,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 124,
-			"defaultValue": 124
+			"defaultValue": 124,
+			"unsigned": true
 		}
 	]
 }

--- a/packages/config/config/devices/0x010f/fgr223.json
+++ b/packages/config/config/devices/0x010f/fgr223.json
@@ -368,7 +368,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 0
+			"defaultValue": 0,
+			"unsigned": true
 		},
 		{
 			"#": "30[0xff0000]",
@@ -378,6 +379,7 @@
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 0,
+			"unsigned": true,
 			"options": [
 				{
 					"label": "Any",
@@ -392,7 +394,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 0
+			"defaultValue": 0,
+			"unsigned": true
 		},
 		{
 			"#": "31[0xff]",
@@ -402,6 +405,7 @@
 			"minValue": 0,
 			"maxValue": 2,
 			"defaultValue": 0,
+			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -425,7 +429,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 0
+			"defaultValue": 0,
+			"unsigned": true
 		},
 		{
 			"#": "31[0xff0000]",
@@ -435,6 +440,7 @@
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 255,
+			"unsigned": true,
 			"options": [
 				{
 					"label": "Any",
@@ -449,7 +455,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 5 // Water
+			"defaultValue": 5, // Water
+			"unsigned": true
 		},
 		{
 			"#": "32[0xff]",
@@ -459,6 +466,7 @@
 			"minValue": 0,
 			"maxValue": 2,
 			"defaultValue": 0,
+			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -482,7 +490,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 0
+			"defaultValue": 0,
+			"unsigned": true
 		},
 		{
 			"#": "32[0xff0000]",
@@ -492,6 +501,7 @@
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 255,
+			"unsigned": true,
 			"options": [
 				{
 					"label": "Any",
@@ -506,7 +516,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 1 // Smoke
+			"defaultValue": 1, // Smoke
+			"unsigned": true
 		},
 		{
 			"#": "33[0xff]",
@@ -516,6 +527,7 @@
 			"minValue": 0,
 			"maxValue": 2,
 			"defaultValue": 0,
+			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -539,7 +551,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 0
+			"defaultValue": 0,
+			"unsigned": true
 		},
 		{
 			"#": "33[0xff0000]",
@@ -549,6 +562,7 @@
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 255,
+			"unsigned": true,
 			"options": [
 				{
 					"label": "Any",
@@ -563,7 +577,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 2 // CO
+			"defaultValue": 2, // CO
+			"unsigned": true
 		},
 		{
 			"#": "34[0xff]",
@@ -573,6 +588,7 @@
 			"minValue": 0,
 			"maxValue": 2,
 			"defaultValue": 0,
+			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -596,7 +612,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 0
+			"defaultValue": 0,
+			"unsigned": true
 		},
 		{
 			"#": "34[0xff0000]",
@@ -606,6 +623,7 @@
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 255,
+			"unsigned": true,
 			"options": [
 				{
 					"label": "Any",
@@ -620,7 +638,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 4 // Heat
+			"defaultValue": 4, // Heat
+			"unsigned": true
 		}
 	]
 }

--- a/packages/config/config/devices/0x010f/fgrgbw-442.json
+++ b/packages/config/config/devices/0x010f/fgrgbw-442.json
@@ -382,7 +382,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 255
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		{
 			"#": "154[0xff00]",
@@ -390,7 +391,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 255
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		{
 			"#": "154[0xff0000]",
@@ -398,7 +400,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 255
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		{
 			"#": "154[0xff000000]",
@@ -406,7 +409,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 255
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		{
 			"#": "155[0xff]",
@@ -414,7 +418,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 255
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		{
 			"#": "155[0xff00]",
@@ -422,7 +427,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 255
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		{
 			"#": "155[0xff0000]",
@@ -430,7 +436,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 255
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		{
 			"#": "155[0xff000000]",
@@ -438,7 +445,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 255
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		{
 			"#": "156[0xff]",
@@ -446,7 +454,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 255
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		{
 			"#": "156[0xff00]",
@@ -454,7 +463,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 255
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		{
 			"#": "156[0xff0000]",
@@ -462,7 +472,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 255
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		{
 			"#": "156[0xff000000]",
@@ -470,7 +481,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 255
+			"defaultValue": 255,
+			"unsigned": true
 		}
 	]
 }

--- a/packages/config/config/devices/0x016a/ft096.json
+++ b/packages/config/config/devices/0x016a/ft096.json
@@ -373,7 +373,8 @@
 			"valueSize": 3,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 221
+			"defaultValue": 221,
+			"unsigned": true
 		},
 		{
 			"#": "83[0xff00]",
@@ -381,7 +382,8 @@
 			"valueSize": 3,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 160
+			"defaultValue": 160,
+			"unsigned": true
 		},
 		{
 			"#": "83[0xff0000]",
@@ -390,7 +392,8 @@
 			"valueSize": 3,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 221
+			"defaultValue": 221,
+			"unsigned": true
 		},
 		{
 			"#": "84[0xff]",
@@ -399,7 +402,8 @@
 			"valueSize": 3,
 			"minValue": 0,
 			"maxValue": 100,
-			"defaultValue": 50
+			"defaultValue": 50,
+			"unsigned": true
 		},
 		{
 			"#": "84[0xff00]",
@@ -408,7 +412,8 @@
 			"valueSize": 3,
 			"minValue": 0,
 			"maxValue": 100,
-			"defaultValue": 50
+			"defaultValue": 50,
+			"unsigned": true
 		},
 		{
 			"#": "84[0xff0000]",
@@ -417,7 +422,8 @@
 			"valueSize": 3,
 			"minValue": 0,
 			"maxValue": 100,
-			"defaultValue": 50
+			"defaultValue": 50,
+			"unsigned": true
 		}
 	]
 }

--- a/packages/config/config/devices/0x016a/ft121.json
+++ b/packages/config/config/devices/0x016a/ft121.json
@@ -220,6 +220,7 @@
 			"minValue": 0,
 			"maxValue": 30,
 			"defaultValue": 0,
+			"unsigned": true,
 			"options": [
 				{
 					"label": "Constant Speed",
@@ -235,6 +236,7 @@
 			"minValue": 0,
 			"maxValue": 2,
 			"defaultValue": 0,
+			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -258,7 +260,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 254,
-			"defaultValue": 0
+			"defaultValue": 0,
+			"unsigned": true
 		},
 		{
 			"#": "37[0xff0000]",
@@ -277,6 +280,7 @@
 			"minValue": 0,
 			"maxValue": 4,
 			"defaultValue": 1,
+			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -309,6 +313,7 @@
 			"minValue": 0,
 			"maxValue": 2,
 			"defaultValue": 0,
+			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0234/zhc5010.json
+++ b/packages/config/config/devices/0x0234/zhc5010.json
@@ -640,7 +640,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 255
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		{
 			"#": "19[0xff0000]",
@@ -675,7 +676,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 255
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		{
 			"#": "20[0xff0000]",
@@ -710,7 +712,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 255
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		{
 			"#": "21[0xff0000]",
@@ -745,7 +748,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 255
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		{
 			"#": "22[0xff0000]",

--- a/packages/config/config/devices/0x024f/fwc01.json
+++ b/packages/config/config/devices/0x024f/fwc01.json
@@ -146,6 +146,7 @@
 			"minValue": 0,
 			"maxValue": 3,
 			"defaultValue": 0,
+			"unsigned": true,
 			"options": [
 				{
 					"label": "1 Light Zone",

--- a/packages/config/config/devices/0x031e/lzw30-sn.json
+++ b/packages/config/config/devices/0x031e/lzw30-sn.json
@@ -364,6 +364,7 @@
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 0,
+			"unsigned": true,
 			"options": [
 				{
 					"label": "Red",
@@ -461,7 +462,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 255
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		{
 			"#": "8[0x7f000000]",

--- a/packages/config/config/devices/0x031e/lzw31-sn.json
+++ b/packages/config/config/devices/0x031e/lzw31-sn.json
@@ -424,6 +424,7 @@
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 0,
+			"unsigned": true,
 			"options": [
 				{
 					"label": "Red",
@@ -526,7 +527,8 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 255,
-			"defaultValue": 255
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		{
 			"#": "16[0x7f000000]",

--- a/packages/config/config/devices/0x0346/alarm_keypad_gen1.json
+++ b/packages/config/config/devices/0x0346/alarm_keypad_gen1.json
@@ -370,6 +370,7 @@
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 0,
+			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false
 		},
@@ -381,6 +382,7 @@
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 0,
+			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false
 		},
@@ -392,6 +394,7 @@
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 0,
+			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false
 		}

--- a/packages/config/maintenance/importConfig.ts
+++ b/packages/config/maintenance/importConfig.ts
@@ -14,6 +14,7 @@ import {
 	formatId,
 	getErrorMessage,
 	num2hex,
+	padVersion,
 	stringify,
 } from "@zwave-js/shared";
 import { composeObject } from "alcalzone-shared/objects";
@@ -840,9 +841,8 @@ async function parseZWAFiles(): Promise<void> {
 	for (const file of jsonData) {
 		// Lookup the manufacturer
 		const manufacturerId = parseInt(file.ManufacturerId, 16);
-		const manufacturerName = configManager.lookupManufacturer(
-			manufacturerId,
-		);
+		const manufacturerName =
+			configManager.lookupManufacturer(manufacturerId);
 
 		// Add the manufacturer to our manufacturers.json if it is missing
 		if (Number.isNaN(manufacturerId)) {
@@ -1251,8 +1251,9 @@ async function parseZWAProduct(
 	const exclusion = product?.Texts?.find(
 		(document: any) => document.Type === 2,
 	)?.value;
-	const reset = product?.Texts?.find((document: any) => document.Type === 5)
-		?.value;
+	const reset = product?.Texts?.find(
+		(document: any) => document.Type === 5,
+	)?.value;
 	let manual = product?.Documents?.find(
 		(document: any) => document.Type === 1,
 	)?.value;

--- a/packages/core/src/util/misc.test.ts
+++ b/packages/core/src/util/misc.test.ts
@@ -1,6 +1,7 @@
 import { ZWaveErrorCodes } from "../error/ZWaveError";
 import { assertZWaveError } from "../test/assertZWaveError";
 import {
+	getLegalRangeForBitMask,
 	getMinimumShiftForBitMask,
 	isConsecutiveArray,
 	stripUndefined,
@@ -116,6 +117,33 @@ describe("lib/util/misc", () => {
 			];
 			for (const { input, expected } of tests) {
 				expect(getMinimumShiftForBitMask(input)).toBe(expected);
+			}
+		});
+	});
+
+	describe("getLegalRangeForBitMask", () => {
+		it("returns [0,0] if the mask is 0", () => {
+			expect(getLegalRangeForBitMask(0, true)).toEqual([0, 0]);
+			expect(getLegalRangeForBitMask(0, false)).toEqual([0, 0]);
+		});
+
+		it("returns the correct ranges otherwise", () => {
+			const tests = [
+				// 1-bit masks always match [0,1]
+				{ mask: 0b1, expSigned: [0, 1], expUnsigned: [0, 1] },
+				{ mask: 0b10, expSigned: [0, 1], expUnsigned: [0, 1] },
+				{ mask: 0b100, expSigned: [0, 1], expUnsigned: [0, 1] },
+				{ mask: 0b1000, expSigned: [0, 1], expUnsigned: [0, 1] },
+				{ mask: 0b1010, expSigned: [-4, 3], expUnsigned: [0, 7] },
+				{ mask: 0b1100, expSigned: [-2, 1], expUnsigned: [0, 3] },
+				{ mask: 0b1111, expSigned: [-8, 7], expUnsigned: [0, 15] },
+				{ mask: 0b1011, expSigned: [-8, 7], expUnsigned: [0, 15] },
+			];
+			for (const { mask, expSigned, expUnsigned } of tests) {
+				expect(getLegalRangeForBitMask(mask, true)).toEqual(
+					expUnsigned,
+				);
+				expect(getLegalRangeForBitMask(mask, false)).toEqual(expSigned);
 			}
 		});
 	});

--- a/packages/core/src/util/misc.ts
+++ b/packages/core/src/util/misc.ts
@@ -97,3 +97,28 @@ export function getBitMaskWidth(mask: number): number {
 	}
 	return i;
 }
+
+/**
+ * Determines the legal range of values that can be encoded at with the given bit mask
+ * Example:
+ * ```txt
+ *   Mask = 00110000
+ *            ^^---- => 0..3 unsigned OR -2..+1 signed
+ *
+ *   Mask = 00110001
+ *            ^....^ => 0..63 unsigned OR -32..+31 signed (with gaps)
+ * ```
+ */
+export function getLegalRangeForBitMask(
+	mask: number,
+	unsigned: boolean,
+): [min: number, max: number] {
+	if (mask === 0) return [0, 0];
+	const bitMaskWidth = getBitMaskWidth(mask);
+	const min = unsigned || bitMaskWidth == 1 ? 0 : -(2 ** (bitMaskWidth - 1));
+	const max =
+		unsigned || bitMaskWidth == 1
+			? 2 ** bitMaskWidth - 1
+			: 2 ** (bitMaskWidth - 1) - 1;
+	return [min, max];
+}


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

This is extracted from https://github.com/zwave-js/node-zwave-js/pull/4131/files since these changes are unrelated to the new config I'm adding.

This PR fixes the calculation for allowable min and max values when it comes to partial parameters. Currently the calculation is done with a bitmask, which does not work for signed values since node will represent these as two's complement on 4 or 8 bytes which won't fit any smaller bitmasks. For example -1 with a 2-byte bitmask should be represented as 0xFFFF but it does not pass current linter validation:
![image](https://user-images.githubusercontent.com/2053039/151395063-8916fe6f-124d-4f48-9df2-301b8e1dbecc.png)

I changed the linter logic to calculate the allowable min and max value given the size of the bitmask and the expected signedness.  I had to modify all device configs that did not specify `unsigned: true` but specified values out of the signed range.