### PR TITLE
feat(config): add new product id to Shenzhen Neo NAS-PD07ZU1

### DIFF
--- a/packages/config/config/devices/0x0258/nas-pd07u1.json
+++ b/packages/config/config/devices/0x0258/nas-pd07u1.json
@@ -7,6 +7,10 @@
 		{
 			"productType": "0x0020",
 			"productId": "0x0718"
+		},
+		{
+			"productType": "0x0020",
+			"productId": "0x0720"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
Added newer product ID (0x0720) that visually appears the same, has the same manual and seems to be working locally with the same config json.

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

I ordered 4 devices and one has an updated/different ProductID.  by locally editing this json file I was able to get zwave-js to recognize this new ID and configure it.  This PR is to add this new ID to the existing file and share my findings.
