### PR TITLE
chore: revert and prevent ESBuild updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,5 +26,5 @@
 			"automerge": true
 		}
 	],
-	"ignoreDeps": ["node"]
+	"ignoreDeps": ["node", "esbuild"]
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "commitizen": "^4.2.4",
     "coveralls": "^3.1.1",
     "cz-conventional-changelog": "^3.3.0",
-    "esbuild": "0.14.16",
+    "esbuild": "0.14.15",
     "esbuild-register": "^3.3.2",
     "eslint": "^8.8.0",
     "eslint-config-prettier": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "commitizen": "^4.2.4",
     "coveralls": "^3.1.1",
     "cz-conventional-changelog": "^3.3.0",
-    "esbuild": "0.14.15",
+    "esbuild": "0.14.1",
     "esbuild-register": "^3.3.2",
     "eslint": "^8.8.0",
     "eslint-config-prettier": "^8.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4423,7 +4423,7 @@ __metadata:
     commitizen: ^4.2.4
     coveralls: ^3.1.1
     cz-conventional-changelog: ^3.3.0
-    esbuild: 0.14.16
+    esbuild: 0.14.15
     esbuild-register: ^3.3.2
     eslint: ^8.8.0
     eslint-config-prettier: ^8.3.0
@@ -6654,9 +6654,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-android-arm64@npm:0.14.16":
-  version: 0.14.16
-  resolution: "esbuild-android-arm64@npm:0.14.16"
+"esbuild-android-arm64@npm:0.14.15":
+  version: 0.14.15
+  resolution: "esbuild-android-arm64@npm:0.14.15"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -6668,9 +6668,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-darwin-64@npm:0.14.16":
-  version: 0.14.16
-  resolution: "esbuild-darwin-64@npm:0.14.16"
+"esbuild-darwin-64@npm:0.14.15":
+  version: 0.14.15
+  resolution: "esbuild-darwin-64@npm:0.14.15"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -6682,9 +6682,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-darwin-arm64@npm:0.14.16":
-  version: 0.14.16
-  resolution: "esbuild-darwin-arm64@npm:0.14.16"
+"esbuild-darwin-arm64@npm:0.14.15":
+  version: 0.14.15
+  resolution: "esbuild-darwin-arm64@npm:0.14.15"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -6696,9 +6696,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-freebsd-64@npm:0.14.16":
-  version: 0.14.16
-  resolution: "esbuild-freebsd-64@npm:0.14.16"
+"esbuild-freebsd-64@npm:0.14.15":
+  version: 0.14.15
+  resolution: "esbuild-freebsd-64@npm:0.14.15"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -6710,9 +6710,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-freebsd-arm64@npm:0.14.16":
-  version: 0.14.16
-  resolution: "esbuild-freebsd-arm64@npm:0.14.16"
+"esbuild-freebsd-arm64@npm:0.14.15":
+  version: 0.14.15
+  resolution: "esbuild-freebsd-arm64@npm:0.14.15"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -6724,9 +6724,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-32@npm:0.14.16":
-  version: 0.14.16
-  resolution: "esbuild-linux-32@npm:0.14.16"
+"esbuild-linux-32@npm:0.14.15":
+  version: 0.14.15
+  resolution: "esbuild-linux-32@npm:0.14.15"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
@@ -6738,9 +6738,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-64@npm:0.14.16":
-  version: 0.14.16
-  resolution: "esbuild-linux-64@npm:0.14.16"
+"esbuild-linux-64@npm:0.14.15":
+  version: 0.14.15
+  resolution: "esbuild-linux-64@npm:0.14.15"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
@@ -6752,9 +6752,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-arm64@npm:0.14.16":
-  version: 0.14.16
-  resolution: "esbuild-linux-arm64@npm:0.14.16"
+"esbuild-linux-arm64@npm:0.14.15":
+  version: 0.14.15
+  resolution: "esbuild-linux-arm64@npm:0.14.15"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
@@ -6766,9 +6766,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-arm@npm:0.14.16":
-  version: 0.14.16
-  resolution: "esbuild-linux-arm@npm:0.14.16"
+"esbuild-linux-arm@npm:0.14.15":
+  version: 0.14.15
+  resolution: "esbuild-linux-arm@npm:0.14.15"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -6780,9 +6780,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-mips64le@npm:0.14.16":
-  version: 0.14.16
-  resolution: "esbuild-linux-mips64le@npm:0.14.16"
+"esbuild-linux-mips64le@npm:0.14.15":
+  version: 0.14.15
+  resolution: "esbuild-linux-mips64le@npm:0.14.15"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
@@ -6794,23 +6794,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-ppc64le@npm:0.14.16":
-  version: 0.14.16
-  resolution: "esbuild-linux-ppc64le@npm:0.14.16"
+"esbuild-linux-ppc64le@npm:0.14.15":
+  version: 0.14.15
+  resolution: "esbuild-linux-ppc64le@npm:0.14.15"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
 
-"esbuild-linux-s390x@npm:0.14.16":
-  version: 0.14.16
-  resolution: "esbuild-linux-s390x@npm:0.14.16"
+"esbuild-linux-s390x@npm:0.14.15":
+  version: 0.14.15
+  resolution: "esbuild-linux-s390x@npm:0.14.15"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
 
-"esbuild-netbsd-64@npm:0.14.16":
-  version: 0.14.16
-  resolution: "esbuild-netbsd-64@npm:0.14.16"
+"esbuild-netbsd-64@npm:0.14.15":
+  version: 0.14.15
+  resolution: "esbuild-netbsd-64@npm:0.14.15"
   conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -6822,9 +6822,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-openbsd-64@npm:0.14.16":
-  version: 0.14.16
-  resolution: "esbuild-openbsd-64@npm:0.14.16"
+"esbuild-openbsd-64@npm:0.14.15":
+  version: 0.14.15
+  resolution: "esbuild-openbsd-64@npm:0.14.15"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -6845,9 +6845,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-sunos-64@npm:0.14.16":
-  version: 0.14.16
-  resolution: "esbuild-sunos-64@npm:0.14.16"
+"esbuild-sunos-64@npm:0.14.15":
+  version: 0.14.15
+  resolution: "esbuild-sunos-64@npm:0.14.15"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
@@ -6859,9 +6859,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-windows-32@npm:0.14.16":
-  version: 0.14.16
-  resolution: "esbuild-windows-32@npm:0.14.16"
+"esbuild-windows-32@npm:0.14.15":
+  version: 0.14.15
+  resolution: "esbuild-windows-32@npm:0.14.15"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
@@ -6873,9 +6873,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-windows-64@npm:0.14.16":
-  version: 0.14.16
-  resolution: "esbuild-windows-64@npm:0.14.16"
+"esbuild-windows-64@npm:0.14.15":
+  version: 0.14.15
+  resolution: "esbuild-windows-64@npm:0.14.15"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -6887,9 +6887,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-windows-arm64@npm:0.14.16":
-  version: 0.14.16
-  resolution: "esbuild-windows-arm64@npm:0.14.16"
+"esbuild-windows-arm64@npm:0.14.15":
+  version: 0.14.15
+  resolution: "esbuild-windows-arm64@npm:0.14.15"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -6953,28 +6953,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:0.14.16":
-  version: 0.14.16
-  resolution: "esbuild@npm:0.14.16"
+"esbuild@npm:0.14.15":
+  version: 0.14.15
+  resolution: "esbuild@npm:0.14.15"
   dependencies:
-    esbuild-android-arm64: 0.14.16
-    esbuild-darwin-64: 0.14.16
-    esbuild-darwin-arm64: 0.14.16
-    esbuild-freebsd-64: 0.14.16
-    esbuild-freebsd-arm64: 0.14.16
-    esbuild-linux-32: 0.14.16
-    esbuild-linux-64: 0.14.16
-    esbuild-linux-arm: 0.14.16
-    esbuild-linux-arm64: 0.14.16
-    esbuild-linux-mips64le: 0.14.16
-    esbuild-linux-ppc64le: 0.14.16
-    esbuild-linux-s390x: 0.14.16
-    esbuild-netbsd-64: 0.14.16
-    esbuild-openbsd-64: 0.14.16
-    esbuild-sunos-64: 0.14.16
-    esbuild-windows-32: 0.14.16
-    esbuild-windows-64: 0.14.16
-    esbuild-windows-arm64: 0.14.16
+    esbuild-android-arm64: 0.14.15
+    esbuild-darwin-64: 0.14.15
+    esbuild-darwin-arm64: 0.14.15
+    esbuild-freebsd-64: 0.14.15
+    esbuild-freebsd-arm64: 0.14.15
+    esbuild-linux-32: 0.14.15
+    esbuild-linux-64: 0.14.15
+    esbuild-linux-arm: 0.14.15
+    esbuild-linux-arm64: 0.14.15
+    esbuild-linux-mips64le: 0.14.15
+    esbuild-linux-ppc64le: 0.14.15
+    esbuild-linux-s390x: 0.14.15
+    esbuild-netbsd-64: 0.14.15
+    esbuild-openbsd-64: 0.14.15
+    esbuild-sunos-64: 0.14.15
+    esbuild-windows-32: 0.14.15
+    esbuild-windows-64: 0.14.15
+    esbuild-windows-arm64: 0.14.15
   dependenciesMeta:
     esbuild-android-arm64:
       optional: true
@@ -7014,7 +7014,7 @@ __metadata:
       optional: true
   bin:
     esbuild: bin/esbuild
-  checksum: 8320502b9e9d3278120fb14d2556c7f706a2503bb4e4a244ba8d8036973417bcf33d49738477d3f5c7a1c3c8ef1d6d28d12abf1c6d0816181e09ad2d2292996d
+  checksum: 4ab0532fdf483723d667619d60b011b0ca057acb924fac2afdb2fb4a51320b1ad6cc33ab94d873cfff025b4eb1b492c2f66db7653854a9c98ff9bfe30be56294
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4423,7 +4423,7 @@ __metadata:
     commitizen: ^4.2.4
     coveralls: ^3.1.1
     cz-conventional-changelog: ^3.3.0
-    esbuild: 0.14.15
+    esbuild: 0.14.1
     esbuild-register: ^3.3.2
     eslint: ^8.8.0
     eslint-config-prettier: ^8.3.0
@@ -6654,9 +6654,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-android-arm64@npm:0.14.15":
-  version: 0.14.15
-  resolution: "esbuild-android-arm64@npm:0.14.15"
+"esbuild-android-arm64@npm:0.14.1":
+  version: 0.14.1
+  resolution: "esbuild-android-arm64@npm:0.14.1"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -6668,9 +6668,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-darwin-64@npm:0.14.15":
-  version: 0.14.15
-  resolution: "esbuild-darwin-64@npm:0.14.15"
+"esbuild-darwin-64@npm:0.14.1":
+  version: 0.14.1
+  resolution: "esbuild-darwin-64@npm:0.14.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -6682,9 +6682,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-darwin-arm64@npm:0.14.15":
-  version: 0.14.15
-  resolution: "esbuild-darwin-arm64@npm:0.14.15"
+"esbuild-darwin-arm64@npm:0.14.1":
+  version: 0.14.1
+  resolution: "esbuild-darwin-arm64@npm:0.14.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -6696,9 +6696,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-freebsd-64@npm:0.14.15":
-  version: 0.14.15
-  resolution: "esbuild-freebsd-64@npm:0.14.15"
+"esbuild-freebsd-64@npm:0.14.1":
+  version: 0.14.1
+  resolution: "esbuild-freebsd-64@npm:0.14.1"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -6710,9 +6710,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-freebsd-arm64@npm:0.14.15":
-  version: 0.14.15
-  resolution: "esbuild-freebsd-arm64@npm:0.14.15"
+"esbuild-freebsd-arm64@npm:0.14.1":
+  version: 0.14.1
+  resolution: "esbuild-freebsd-arm64@npm:0.14.1"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -6724,9 +6724,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-32@npm:0.14.15":
-  version: 0.14.15
-  resolution: "esbuild-linux-32@npm:0.14.15"
+"esbuild-linux-32@npm:0.14.1":
+  version: 0.14.1
+  resolution: "esbuild-linux-32@npm:0.14.1"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
@@ -6738,9 +6738,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-64@npm:0.14.15":
-  version: 0.14.15
-  resolution: "esbuild-linux-64@npm:0.14.15"
+"esbuild-linux-64@npm:0.14.1":
+  version: 0.14.1
+  resolution: "esbuild-linux-64@npm:0.14.1"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
@@ -6752,9 +6752,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-arm64@npm:0.14.15":
-  version: 0.14.15
-  resolution: "esbuild-linux-arm64@npm:0.14.15"
+"esbuild-linux-arm64@npm:0.14.1":
+  version: 0.14.1
+  resolution: "esbuild-linux-arm64@npm:0.14.1"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
@@ -6766,9 +6766,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-arm@npm:0.14.15":
-  version: 0.14.15
-  resolution: "esbuild-linux-arm@npm:0.14.15"
+"esbuild-linux-arm@npm:0.14.1":
+  version: 0.14.1
+  resolution: "esbuild-linux-arm@npm:0.14.1"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -6780,9 +6780,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-mips64le@npm:0.14.15":
-  version: 0.14.15
-  resolution: "esbuild-linux-mips64le@npm:0.14.15"
+"esbuild-linux-mips64le@npm:0.14.1":
+  version: 0.14.1
+  resolution: "esbuild-linux-mips64le@npm:0.14.1"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
@@ -6794,23 +6794,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-ppc64le@npm:0.14.15":
-  version: 0.14.15
-  resolution: "esbuild-linux-ppc64le@npm:0.14.15"
+"esbuild-linux-ppc64le@npm:0.14.1":
+  version: 0.14.1
+  resolution: "esbuild-linux-ppc64le@npm:0.14.1"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
 
-"esbuild-linux-s390x@npm:0.14.15":
-  version: 0.14.15
-  resolution: "esbuild-linux-s390x@npm:0.14.15"
-  conditions: os=linux & cpu=s390x
-  languageName: node
-  linkType: hard
-
-"esbuild-netbsd-64@npm:0.14.15":
-  version: 0.14.15
-  resolution: "esbuild-netbsd-64@npm:0.14.15"
+"esbuild-netbsd-64@npm:0.14.1":
+  version: 0.14.1
+  resolution: "esbuild-netbsd-64@npm:0.14.1"
   conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -6822,9 +6815,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-openbsd-64@npm:0.14.15":
-  version: 0.14.15
-  resolution: "esbuild-openbsd-64@npm:0.14.15"
+"esbuild-openbsd-64@npm:0.14.1":
+  version: 0.14.1
+  resolution: "esbuild-openbsd-64@npm:0.14.1"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -6845,9 +6838,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-sunos-64@npm:0.14.15":
-  version: 0.14.15
-  resolution: "esbuild-sunos-64@npm:0.14.15"
+"esbuild-sunos-64@npm:0.14.1":
+  version: 0.14.1
+  resolution: "esbuild-sunos-64@npm:0.14.1"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
@@ -6859,9 +6852,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-windows-32@npm:0.14.15":
-  version: 0.14.15
-  resolution: "esbuild-windows-32@npm:0.14.15"
+"esbuild-windows-32@npm:0.14.1":
+  version: 0.14.1
+  resolution: "esbuild-windows-32@npm:0.14.1"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
@@ -6873,9 +6866,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-windows-64@npm:0.14.15":
-  version: 0.14.15
-  resolution: "esbuild-windows-64@npm:0.14.15"
+"esbuild-windows-64@npm:0.14.1":
+  version: 0.14.1
+  resolution: "esbuild-windows-64@npm:0.14.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -6887,9 +6880,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-windows-arm64@npm:0.14.15":
-  version: 0.14.15
-  resolution: "esbuild-windows-arm64@npm:0.14.15"
+"esbuild-windows-arm64@npm:0.14.1":
+  version: 0.14.1
+  resolution: "esbuild-windows-arm64@npm:0.14.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -6953,28 +6946,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:0.14.15":
-  version: 0.14.15
-  resolution: "esbuild@npm:0.14.15"
+"esbuild@npm:0.14.1":
+  version: 0.14.1
+  resolution: "esbuild@npm:0.14.1"
   dependencies:
-    esbuild-android-arm64: 0.14.15
-    esbuild-darwin-64: 0.14.15
-    esbuild-darwin-arm64: 0.14.15
-    esbuild-freebsd-64: 0.14.15
-    esbuild-freebsd-arm64: 0.14.15
-    esbuild-linux-32: 0.14.15
-    esbuild-linux-64: 0.14.15
-    esbuild-linux-arm: 0.14.15
-    esbuild-linux-arm64: 0.14.15
-    esbuild-linux-mips64le: 0.14.15
-    esbuild-linux-ppc64le: 0.14.15
-    esbuild-linux-s390x: 0.14.15
-    esbuild-netbsd-64: 0.14.15
-    esbuild-openbsd-64: 0.14.15
-    esbuild-sunos-64: 0.14.15
-    esbuild-windows-32: 0.14.15
-    esbuild-windows-64: 0.14.15
-    esbuild-windows-arm64: 0.14.15
+    esbuild-android-arm64: 0.14.1
+    esbuild-darwin-64: 0.14.1
+    esbuild-darwin-arm64: 0.14.1
+    esbuild-freebsd-64: 0.14.1
+    esbuild-freebsd-arm64: 0.14.1
+    esbuild-linux-32: 0.14.1
+    esbuild-linux-64: 0.14.1
+    esbuild-linux-arm: 0.14.1
+    esbuild-linux-arm64: 0.14.1
+    esbuild-linux-mips64le: 0.14.1
+    esbuild-linux-ppc64le: 0.14.1
+    esbuild-netbsd-64: 0.14.1
+    esbuild-openbsd-64: 0.14.1
+    esbuild-sunos-64: 0.14.1
+    esbuild-windows-32: 0.14.1
+    esbuild-windows-64: 0.14.1
+    esbuild-windows-arm64: 0.14.1
   dependenciesMeta:
     esbuild-android-arm64:
       optional: true
@@ -6998,8 +6990,6 @@ __metadata:
       optional: true
     esbuild-linux-ppc64le:
       optional: true
-    esbuild-linux-s390x:
-      optional: true
     esbuild-netbsd-64:
       optional: true
     esbuild-openbsd-64:
@@ -7014,7 +7004,7 @@ __metadata:
       optional: true
   bin:
     esbuild: bin/esbuild
-  checksum: 4ab0532fdf483723d667619d60b011b0ca057acb924fac2afdb2fb4a51320b1ad6cc33ab94d873cfff025b4eb1b492c2f66db7653854a9c98ff9bfe30be56294
+  checksum: ca4df1d0c7d820a11a240526a91f0e186ccf8b976dce38eda7c40a401a68e33a06a90ff2d08c562324daea3b999a6317f0c8b5fbc7be38941c56fd57b19f6962
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Until #4179 is solved, we can't update ESBuild. This PR goes back to a working version and prevents further updates.