### PR TITLE
feat(config): add fingerprint for AU/NZ model of Aeotec NanoMote Quad

### DIFF
--- a/packages/config/config/devices/0x0371/zwa003.json
+++ b/packages/config/config/devices/0x0371/zwa003.json
@@ -15,6 +15,10 @@
 			"zwaveAllianceId": 2817
 		},
 		{
+			"productType": "0x0202",
+			"productId": "0x0003"
+		},
+		{
 			"productType": "0x1c02",
 			"productId": "0x0003",
 			"zwaveAllianceId": 3247


### PR DESCRIPTION
added fingerprint for AU/NZ model of Aeotec ZWA003