### PR TITLE
fix(config): regression of bug #1581 (wrong valueSize, param 13 of LZW31-SN)

### DIFF
--- a/packages/config/config/devices/0x031e/lzw31-sn.json
+++ b/packages/config/config/devices/0x031e/lzw31-sn.json
@@ -268,7 +268,7 @@
 			"#": "13",
 			"label": "LED Indicator: Color",
 			"description": "Uses a scaled hue value (realHue / 360 * 255).",
-			"valueSize": 1,
+			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 170,


### PR DESCRIPTION
PR #4110 inadvertently re-introduced an old Inovelli documentation
error (bug #1581), which described parameter 13 (LED indicator color)
as 1 byte when it is actually 2.  This PR leaves the other changes from
PR #4110 but fixes the regression by correcting valueSize to 2.
