### PR TITLE
fix(config): update GE/Jasco ZW3012 Configuration to correct LED status

### DIFF
--- a/packages/config/config/devices/0x0063/52252_52253_zw3012.json
+++ b/packages/config/config/devices/0x0063/52252_52253_zw3012.json
@@ -51,11 +51,11 @@
 					"value": 1
 				},
 				{
-					"label": "LED always ON",
+					"label": "LED always OFF",
 					"value": 2
 				},
 				{
-					"label": "LED always OFF",
+					"label": "LED always ON",
 					"value": 3
 				}
 			]


### PR DESCRIPTION
The linked user manual in this config file at https://products.z-wavealliance.org/ProductManual/File?folder=&filename=product_documents/3987/52252_QSG_v1[1].pdf notes that for "Cycle LED Light"

> Cycle LED light
> The LED below the dimmer acts as a guide light or status indicator.
> How to cycle through options: Press up three times and down once quickly.
> 1. LED is ON when the load is OFF (guide light in the dark) (default)
> 2. LED is ON when the load is ON (indicates the dimmer is ON)
> 3. LED is always OFF
> 4. LED is always ON (illuminates dimmer in the dark)

However, the config file prior to this PR has 3 and 4 inverted -- it claims that the third option (setting the value to 2, assuming zero-indexing) is "always ON" and the fourth option (setting the value to 3, assuming zero-indexing) is "always OFF'.

I verified on my switch that the manual is correct -- setting the value to 2 turns the LED always off as the manual indicates. https://ezzwave.com/support/advanced-configuration also suggests that "To turn the LED OFF at all times, change parameter 3’s value to 2," which matches the manual and observed behavior.

So this PR updates the config file to match both the manual and the observed behavior.