### PR TITLE
fix(config): add AU/NZ fingerprint to Aeotec Home Energy Meter - Gen5

### DIFF
--- a/packages/config/config/devices/0x0086/zw095.json
+++ b/packages/config/config/devices/0x0086/zw095.json
@@ -13,6 +13,11 @@
 			"productType": "0x0102",
 			"productId": "0x005f",
 			"zwaveAllianceId": 1289
+		},
+		{
+			"productType": "0x0202",
+			"productId": "0x005f",
+			"zwaveAllianceId": 1289
 		}
 	],
 	"firmwareVersion": {

--- a/packages/config/config/devices/0x0086/zw095.json
+++ b/packages/config/config/devices/0x0086/zw095.json
@@ -16,8 +16,7 @@
 		},
 		{
 			"productType": "0x0202",
-			"productId": "0x005f",
-			"zwaveAllianceId": 1289
+			"productId": "0x005f"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
"productType": "0x0202" added as Australia New Zealand version

not sure what the "zwaveAllianceId":  should be?

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

PR description here
