### PR TITLE
chore: upgrade to TS 4.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "reflect-metadata": "^0.1.13",
     "semver": "^7.3.5",
     "source-map-support": "^0.5.21",
-    "typescript": "4.5.5",
+    "typescript": "4.6.1-rc",
     "zwave-js": "workspace:*"
   },
   "scripts": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -69,7 +69,7 @@
     "js-levenshtein": "^1.1.6",
     "pegjs": "^0.10.0",
     "ts-pegjs": "^0.3.1",
-    "typescript": "4.5.5",
+    "typescript": "4.6.1-rc",
     "xml2json": "^0.12.0",
     "yargs": "^17.3.1"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,6 +55,6 @@
     "esbuild": "*",
     "esbuild-register": "^3.3.2",
     "jest-extended": "^0.11.5",
-    "typescript": "4.5.5"
+    "typescript": "4.6.1-rc"
   }
 }

--- a/packages/maintenance/package.json
+++ b/packages/maintenance/package.json
@@ -52,7 +52,7 @@
     "prettier": "^2.5.1",
     "reflect-metadata": "^0.1.13",
     "ts-morph": "^13.0.3",
-    "typescript": "4.5.5",
+    "typescript": "4.6.1-rc",
     "yargs": "^17.3.1"
   }
 }

--- a/packages/nvmedit/package.json
+++ b/packages/nvmedit/package.json
@@ -55,6 +55,6 @@
     "esbuild": "*",
     "esbuild-register": "^3.3.2",
     "jest-extended": "^0.11.5",
-    "typescript": "4.5.5"
+    "typescript": "4.6.1-rc"
   }
 }

--- a/packages/serial/package.json
+++ b/packages/serial/package.json
@@ -53,6 +53,6 @@
     "esbuild": "*",
     "esbuild-register": "^3.3.2",
     "jest-extended": "^0.11.5",
-    "typescript": "4.5.5"
+    "typescript": "4.6.1-rc"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -46,6 +46,6 @@
     "esbuild": "*",
     "esbuild-register": "^3.3.2",
     "jest-extended": "^0.11.5",
-    "typescript": "4.5.5"
+    "typescript": "4.6.1-rc"
   }
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -43,7 +43,7 @@
     "esbuild-register": "^3.3.2",
     "jest-extended": "^0.11.5",
     "triple-beam": "*",
-    "typescript": "4.5.5",
+    "typescript": "4.6.1-rc",
     "winston-transport": "^4.5.0"
   }
 }

--- a/packages/zwave-js/package.json
+++ b/packages/zwave-js/package.json
@@ -90,6 +90,6 @@
     "esbuild-register": "^3.3.2",
     "jest-extended": "^0.11.5",
     "mockdate": "^3.0.5",
-    "typescript": "4.5.5"
+    "typescript": "4.6.1-rc"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4392,7 +4392,7 @@ __metadata:
     pegjs: ^0.10.0
     semver: ^7.3.5
     ts-pegjs: ^0.3.1
-    typescript: 4.5.5
+    typescript: 4.6.1-rc
     winston: ^3.5.1
     xml2json: ^0.12.0
     yargs: ^17.3.1
@@ -4418,7 +4418,7 @@ __metadata:
     logform: ^2.3.2
     nrf-intel-hex: ^1.3.0
     triple-beam: "*"
-    typescript: 4.5.5
+    typescript: 4.6.1-rc
     winston: ^3.5.1
     winston-transport: ^4.5.0
   languageName: unknown
@@ -4455,7 +4455,7 @@ __metadata:
     prettier: ^2.5.1
     reflect-metadata: ^0.1.13
     ts-morph: ^13.0.3
-    typescript: 4.5.5
+    typescript: 4.6.1-rc
     yargs: ^17.3.1
   languageName: unknown
   linkType: soft
@@ -4478,7 +4478,7 @@ __metadata:
     jest-extended: ^0.11.5
     reflect-metadata: ^0.1.13
     semver: ^7.3.5
-    typescript: 4.5.5
+    typescript: 4.6.1-rc
     yargs: ^17.3.1
   bin:
     nvmedit: bin/nvmedit.js
@@ -4538,7 +4538,7 @@ __metadata:
     reflect-metadata: ^0.1.13
     semver: ^7.3.5
     source-map-support: ^0.5.21
-    typescript: 4.5.5
+    typescript: 4.6.1-rc
     zwave-js: "workspace:*"
   languageName: unknown
   linkType: soft
@@ -4561,7 +4561,7 @@ __metadata:
     esbuild-register: ^3.3.2
     jest-extended: ^0.11.5
     serialport: ^9.2.8
-    typescript: 4.5.5
+    typescript: 4.6.1-rc
     winston: ^3.5.1
   languageName: unknown
   linkType: soft
@@ -4578,7 +4578,7 @@ __metadata:
     esbuild-register: ^3.3.2
     fs-extra: ^10.0.0
     jest-extended: ^0.11.5
-    typescript: 4.5.5
+    typescript: 4.6.1-rc
   languageName: unknown
   linkType: soft
 
@@ -4595,7 +4595,7 @@ __metadata:
     esbuild-register: ^3.3.2
     jest-extended: ^0.11.5
     triple-beam: "*"
-    typescript: 4.5.5
+    typescript: 4.6.1-rc
     winston-transport: ^4.5.0
   languageName: unknown
   linkType: soft
@@ -13869,23 +13869,23 @@ typescript@^4.4.3:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.5.5":
-  version: 4.5.5
-  resolution: "typescript@npm:4.5.5"
+"typescript@npm:4.6.1-rc":
+  version: 4.6.1-rc
+  resolution: "typescript@npm:4.6.1-rc"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 506f4c919dc8aeaafa92068c997f1d213b9df4d9756d0fae1a1e7ab66b585ab3498050e236113a1c9e57ee08c21ec6814ca7a7f61378c058d79af50a4b1f5a5e
+  checksum: d456efbc299b3569e049b4cefb92c920b9b631d88f3e85ea9326ee185cb872de98fb02e4ad9e998ae12491e9d5025ee4a85f45f6fe938709cabae9d419c6108b
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@4.5.5#~builtin<compat/typescript>":
-  version: 4.5.5
-  resolution: "typescript@patch:typescript@npm%3A4.5.5#~builtin<compat/typescript>::version=4.5.5&hash=493e53"
+"typescript@patch:typescript@4.6.1-rc#~builtin<compat/typescript>":
+  version: 4.6.1-rc
+  resolution: "typescript@patch:typescript@npm%3A4.6.1-rc#~builtin<compat/typescript>::version=4.6.1-rc&hash=493e53"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: c05c318d79c690f101d7ffb34cd6c7d6bbd884d3af9cefe7749ad0cd6be43c7082f098280982ca945dcba23fde34a08fed9602bb26540936baf8c0520727d3ba
+  checksum: 27bc11254482fa74b50a2a9d4c8114ecbaf02b129ac523de49703dec4efe61831ab8235f5a412fbc8c14d51f2d1c4d7313216ab40e47bfb2524bad6e70bf2243
   languageName: node
   linkType: hard
 
@@ -14663,7 +14663,7 @@ typescript@^4.4.3:
     semver: ^7.3.5
     serialport: ^9.2.8
     source-map-support: ^0.5.21
-    typescript: 4.5.5
+    typescript: 4.6.1-rc
     winston: ^3.5.1
     xstate: ^4.29.0
   languageName: unknown


### PR DESCRIPTION
Currently RC, blocked by:
- [ ] ts-morph update
- [ ] final TS 4.6 release

Doesn't seem to break anything so far