### PR TITLE
fix(config): fix parameter 155 unit (W instead of seconds) for FGR223

### DIFF
--- a/packages/config/config/devices/0x010f/fgr223.json
+++ b/packages/config/config/devices/0x010f/fgr223.json
@@ -313,7 +313,7 @@
 			"#": "155",
 			"label": "Motor operation detection",
 			"description": "Power threshold to be interpreted as reaching a limit switch",
-			"unit": "1/10 sec",
+			"unit": "Watts",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 255,

--- a/packages/config/config/devices/0x010f/fgr223.json
+++ b/packages/config/config/devices/0x010f/fgr223.json
@@ -313,7 +313,7 @@
 			"#": "155",
 			"label": "Motor operation detection",
 			"description": "Power threshold to be interpreted as reaching a limit switch",
-			"unit": "Watts",
+			"unit": "W",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 255,


### PR DESCRIPTION
Fixes the unit for the parameter 155 description of Fibaro FGR233: watts instead of 1/10 seconds.