### PR TITLE
feat: migrate network cache to .jsonl, update deserialization routine

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -128,6 +128,7 @@ module.exports = {
 				"@typescript-eslint/require-await": "off",
 				"@typescript-eslint/unbound-method": "off",
 				"@typescript-eslint/no-unused-vars": "warn",
+				"@typescript-eslint/dot-notation": "off",
 			},
 		},
 		{

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -90,7 +90,10 @@
 			"disableOptimisticBPs": true,
 			"cwd": "${workspaceFolder}",
 			"runtimeExecutable": "yarn",
-			"args": ["run", "test:ts", "--runInBand", "--watchAll=false"]
+			"args": ["run", "test:ts", "--runInBand", "--watchAll=false"],
+			// https://github.com/microsoft/vscode/issues/142830#issuecomment-1048240356 🤷🏻‍♂️
+			"outFiles": [],
+			"resolveSourceMapLocations": null
 		}
 	]
 }

--- a/docs/getting-started/migrating-to-v9.md
+++ b/docs/getting-started/migrating-to-v9.md
@@ -37,3 +37,12 @@ The `serialport` library was upgraded to version 10.x. It is now built using N-A
 It was found that the global `unhandledRejection` event handler which Sentry registers, has an influence how the application will behave in case of an unhandled rejection. This can affect applications on Node.js before `v15`, which are going to crash instead of logging a warning. While we do believe no rejection should be silently unhandled, we don't want to break existing applications.
 
 Therefore, error reporting is now opt-in using `driver.enableErrorReporting()`. We kindly ask you to do so in production environments, so unhandled errors in the library can be discovered more quickly.
+
+## Migrated the `<homeid>.json` network cache file to `<homeid>.jsonl`
+
+Many centuries (or maybe months) ago, the the value and metadata DBs were migrated to append-only `.jsonl` files, which are resistant against data loss during crashes. However the main network cache file was still a `.json` file, which could lead to the driver "forgetting" the security status of devices.
+
+In version 9, the network cache is now also a `.jsonl` file. This has several implications:
+
+1. If you're backing up the network cache files, make sure to backup the `.jsonl` files. The network cache is automatically migrated from `.json` to `.jsonl` when the driver starts up, so make sure to still have the `.json` file for the first startup after upgrading.
+2. Support for legacy versions of the `.json` cache file from before `v8.1.0` has been removed. When upgrading from older versions, the upgrade must be done in two steps. First upgrade to the latest available `8.x` version, then upgrade to v9.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export * from "./util/firmware";
 export * from "./util/graph";
 export * from "./util/misc";
 export * from "./values/Cache";
+export * from "./values/CacheBackedMap";
 export * from "./values/Duration";
 export * from "./values/Metadata";
 export * from "./values/Primitive";

--- a/packages/core/src/values/CacheBackedMap.ts
+++ b/packages/core/src/values/CacheBackedMap.ts
@@ -1,0 +1,70 @@
+import type { JsonlDB } from "@alcalzone/jsonl-db";
+
+export class CacheBackedMap<K extends string | number, V> implements Map<K, V> {
+	constructor(
+		private readonly cache: JsonlDB<any>,
+		private readonly cacheKey: string,
+		readonly numericKeys: boolean = false,
+	) {
+		const obj = this.cache.get(this.cacheKey) ?? {};
+		let entries = Object.entries(obj) as unknown as [K, V][];
+		if (numericKeys) {
+			entries = entries.map(([key, value]) => [
+				Number(key) as unknown as K,
+				value,
+			]);
+		}
+		this.map = new Map(entries);
+		// Bind all map properties we can use directly
+		this.forEach = this.map.forEach.bind(this.map);
+		this.get = this.map.get.bind(this.map);
+		this.has = this.map.has.bind(this.map);
+		this.entries = this.map.entries.bind(this.map);
+		this.keys = this.map.keys.bind(this.map);
+		this.values = this.map.values.bind(this.map);
+		this[Symbol.iterator] = this.map[Symbol.iterator].bind(this.map);
+	}
+
+	private map: Map<K, V>;
+
+	private save(): void {
+		const obj = {} as Record<K, V>;
+		this.map.forEach((value, key) => {
+			obj[key] = value;
+		});
+		this.cache.set(this.cacheKey, obj);
+	}
+
+	clear(): void {
+		this.map.clear();
+		this.save();
+	}
+	delete(key: K): boolean {
+		const ret = this.map.delete(key);
+		if (ret) this.save();
+		return ret;
+	}
+	set(key: K, value: V): this {
+		this.map.set(key, value);
+		this.save();
+		return this;
+	}
+	get size(): number {
+		return this.map.size;
+	}
+
+	get [Symbol.toStringTag](): string {
+		return "Map";
+	}
+
+	declare forEach: (
+		callbackfn: (value: V, key: K, map: Map<K, V>) => void,
+		thisArg?: any,
+	) => void;
+	declare get: (key: K) => V | undefined;
+	declare has: (key: K) => boolean;
+	declare entries: () => IterableIterator<[K, V]>;
+	declare keys: () => IterableIterator<K>;
+	declare values: () => IterableIterator<V>;
+	declare [Symbol.iterator]: () => IterableIterator<[K, V]>;
+}

--- a/packages/core/src/values/CacheBackedMap.ts
+++ b/packages/core/src/values/CacheBackedMap.ts
@@ -1,5 +1,6 @@
 import type { JsonlDB } from "@alcalzone/jsonl-db";
 
+/** Wrapper class which allows storing a Map as an object in a JsonlDB */
 export class CacheBackedMap<K extends string | number, V> implements Map<K, V> {
 	constructor(
 		private readonly cache: JsonlDB<any>,
@@ -49,6 +50,87 @@ export class CacheBackedMap<K extends string | number, V> implements Map<K, V> {
 		this.save();
 		return this;
 	}
+	get size(): number {
+		return this.map.size;
+	}
+
+	get [Symbol.toStringTag](): string {
+		return "Map";
+	}
+
+	declare forEach: (
+		callbackfn: (value: V, key: K, map: Map<K, V>) => void,
+		thisArg?: any,
+	) => void;
+	declare get: (key: K) => V | undefined;
+	declare has: (key: K) => boolean;
+	declare entries: () => IterableIterator<[K, V]>;
+	declare keys: () => IterableIterator<K>;
+	declare values: () => IterableIterator<V>;
+	declare [Symbol.iterator]: () => IterableIterator<[K, V]>;
+}
+
+export interface FlatCacheBackedMapKeys<K extends string | number> {
+	/** The common prefix all keys start with */
+	prefix: string;
+	/** Converts the internal key suffix to a string used in the underlying map */
+	suffixSerializer: (suffix: K) => string;
+	/** Converts the key suffix from the underlying map to the one used internally. Returns undefined if the suffix does not match a valid key. */
+	suffixDeserializer: (suffix: string) => K | undefined;
+}
+
+/** Version of {@link CacheBackedMap} where each entry maps to a single cache entry */
+export class FlatCacheBackedMap<K extends string | number, V>
+	implements Map<K, V>
+{
+	constructor(
+		private readonly cache: JsonlDB<any>,
+		private readonly cacheKeys: FlatCacheBackedMapKeys<K>,
+	) {
+		this.map = new Map();
+		for (const [key, value] of this.cache.entries()) {
+			if (key.startsWith(this.cacheKeys.prefix)) {
+				const suffix = key.substring(this.cacheKeys.prefix.length);
+				const suffixKey = this.cacheKeys.suffixDeserializer(suffix);
+				if (suffixKey !== undefined) {
+					this.map.set(suffixKey, value);
+				}
+			}
+		}
+		// Bind all map properties we can use directly
+		this.forEach = this.map.forEach.bind(this.map);
+		this.get = this.map.get.bind(this.map);
+		this.has = this.map.has.bind(this.map);
+		this.entries = this.map.entries.bind(this.map);
+		this.keys = this.map.keys.bind(this.map);
+		this.values = this.map.values.bind(this.map);
+		this[Symbol.iterator] = this.map[Symbol.iterator].bind(this.map);
+	}
+
+	private map: Map<K, V>;
+	private keyToCacheKey(key: K): string {
+		return this.cacheKeys.prefix + this.cacheKeys.suffixSerializer(key);
+	}
+
+	clear(): void {
+		for (const key of this.map.keys()) {
+			this.cache.delete(this.keyToCacheKey(key));
+		}
+		this.map.clear();
+	}
+
+	delete(key: K): boolean {
+		const ret = this.map.delete(key);
+		if (ret) this.cache.delete(this.keyToCacheKey(key));
+		return ret;
+	}
+
+	set(key: K, value: V): this {
+		this.map.set(key, value);
+		this.cache.set(this.keyToCacheKey(key), value);
+		return this;
+	}
+
 	get size(): number {
 		return this.map.size;
 	}

--- a/packages/core/src/values/CacheBackedMap.ts
+++ b/packages/core/src/values/CacheBackedMap.ts
@@ -1,76 +1,6 @@
 import type { JsonlDB } from "@alcalzone/jsonl-db";
 
-/** Wrapper class which allows storing a Map as an object in a JsonlDB */
-export class CacheBackedMap<K extends string | number, V> implements Map<K, V> {
-	constructor(
-		private readonly cache: JsonlDB<any>,
-		private readonly cacheKey: string,
-		readonly numericKeys: boolean = false,
-	) {
-		const obj = this.cache.get(this.cacheKey) ?? {};
-		let entries = Object.entries(obj) as unknown as [K, V][];
-		if (numericKeys) {
-			entries = entries.map(([key, value]) => [
-				Number(key) as unknown as K,
-				value,
-			]);
-		}
-		this.map = new Map(entries);
-		// Bind all map properties we can use directly
-		this.forEach = this.map.forEach.bind(this.map);
-		this.get = this.map.get.bind(this.map);
-		this.has = this.map.has.bind(this.map);
-		this.entries = this.map.entries.bind(this.map);
-		this.keys = this.map.keys.bind(this.map);
-		this.values = this.map.values.bind(this.map);
-		this[Symbol.iterator] = this.map[Symbol.iterator].bind(this.map);
-	}
-
-	private map: Map<K, V>;
-
-	private save(): void {
-		const obj = {} as Record<K, V>;
-		this.map.forEach((value, key) => {
-			obj[key] = value;
-		});
-		this.cache.set(this.cacheKey, obj);
-	}
-
-	clear(): void {
-		this.map.clear();
-		this.save();
-	}
-	delete(key: K): boolean {
-		const ret = this.map.delete(key);
-		if (ret) this.save();
-		return ret;
-	}
-	set(key: K, value: V): this {
-		this.map.set(key, value);
-		this.save();
-		return this;
-	}
-	get size(): number {
-		return this.map.size;
-	}
-
-	get [Symbol.toStringTag](): string {
-		return "Map";
-	}
-
-	declare forEach: (
-		callbackfn: (value: V, key: K, map: Map<K, V>) => void,
-		thisArg?: any,
-	) => void;
-	declare get: (key: K) => V | undefined;
-	declare has: (key: K) => boolean;
-	declare entries: () => IterableIterator<[K, V]>;
-	declare keys: () => IterableIterator<K>;
-	declare values: () => IterableIterator<V>;
-	declare [Symbol.iterator]: () => IterableIterator<[K, V]>;
-}
-
-export interface FlatCacheBackedMapKeys<K extends string | number> {
+export interface CacheBackedMapKeys<K extends string | number> {
 	/** The common prefix all keys start with */
 	prefix: string;
 	/** Converts the internal key suffix to a string used in the underlying map */
@@ -79,13 +9,11 @@ export interface FlatCacheBackedMapKeys<K extends string | number> {
 	suffixDeserializer: (suffix: string) => K | undefined;
 }
 
-/** Version of {@link CacheBackedMap} where each entry maps to a single cache entry */
-export class FlatCacheBackedMap<K extends string | number, V>
-	implements Map<K, V>
-{
+/** Wrapper class which allows storing a Map as a subset of a JsonlDB */
+export class CacheBackedMap<K extends string | number, V> implements Map<K, V> {
 	constructor(
 		private readonly cache: JsonlDB<any>,
-		private readonly cacheKeys: FlatCacheBackedMapKeys<K>,
+		private readonly cacheKeys: CacheBackedMapKeys<K>,
 	) {
 		this.map = new Map();
 		for (const [key, value] of this.cache.entries()) {

--- a/packages/shared/src/misc.ts
+++ b/packages/shared/src/misc.ts
@@ -18,6 +18,34 @@ export function pick<T extends Record<any, any>, K extends keyof T>(
 	return ret;
 }
 
+/**
+ * Traverses an object and returns the property identified by the given path. For example, picking from
+ * ```json
+ * {
+ *  "foo": {
+ *   "bar": [
+ *     1, 2, 3
+ *   ]
+ * }
+ * ```
+ * with path `foo.bar.1` will return `2`.
+ */
+export function pickDeep<T = unknown>(
+	object: Record<string, any>,
+	path: string,
+): T {
+	function _pickDeep(obj: Record<string, any>, pathArr: string[]): unknown {
+		// are we there yet? then return obj
+		if (!pathArr.length) return obj;
+		// are we not looking at an object or array? Then bail
+		if (!isObject(obj) && !isArray(obj)) return undefined;
+		// go deeper
+		const propName = pathArr.shift()!;
+		return _pickDeep(obj[propName], pathArr);
+	}
+	return _pickDeep(object, path.split(".")) as T;
+}
+
 /** Calls the map function of the given array and flattens the result by one level */
 export function flatMap<U, T extends any[]>(
 	array: T[],

--- a/packages/zwave-js/src/lib/commandclass/WakeUpCC.test.ts
+++ b/packages/zwave-js/src/lib/commandclass/WakeUpCC.test.ts
@@ -76,10 +76,10 @@ describe("lib/commandclass/WakeUpCC => ", () => {
 
 		it("should not send anything if the node is frequent listening", async () => {
 			// Temporarily make this node frequent listening
-			(node as any)._isFrequentListening = true;
+			(node as any)["isFrequentListening"] = true;
 			await cc.interview();
 			expect(fakeDriver.sendMessage).not.toBeCalled();
-			(node as any)._isFrequentListening = false;
+			(node as any)["isFrequentListening"] = false;
 		});
 
 		it.skip("if the node is V2+, it should send a WakeUpCCIntervalCapabilitiesGet", async () => {

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -503,7 +503,7 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 	public get supportsSoftReset(): boolean | undefined {
 		return this.driver.networkCache.get(
 			cacheKeys.controller.supportsSoftReset,
-		) as any;
+		);
 	}
 	/** @internal */
 	public set supportsSoftReset(value: boolean | undefined) {
@@ -563,7 +563,7 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 	public get provisioningList(): readonly SmartStartProvisioningEntry[] {
 		return this.driver.networkCache.get(
 			cacheKeys.controller.provisioningList,
-		) as any;
+		);
 	}
 	private set provisioningList(
 		value: readonly SmartStartProvisioningEntry[],
@@ -4291,6 +4291,7 @@ ${associatedNodes.join(", ")}`,
 		}
 
 		// Remove nodes which no longer exist from the cache
+		// TODO: Do the same when removing a node
 		for (const cacheKey of cache.keys()) {
 			const nodeId = cacheKeyUtils.nodeIdFromKey(cacheKey);
 			if (nodeId && !this.nodes.has(nodeId)) {

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -26,7 +26,6 @@ import {
 	flatMap,
 	getEnumMemberName,
 	getErrorMessage,
-	JSONObject,
 	Mixin,
 	num2hex,
 	ObjectKeyMap,
@@ -41,7 +40,6 @@ import {
 	createDeferredPromise,
 	DeferredPromise,
 } from "alcalzone-shared/deferred-promise";
-import { composeObject } from "alcalzone-shared/objects";
 import crypto from "crypto";
 import semver from "semver";
 import util from "util";
@@ -4224,41 +4222,6 @@ ${associatedNodes.join(", ")}`,
 			});
 		}
 		return ret;
-	}
-
-	/**
-	 * @internal
-	 * Serializes the controller information and all nodes to store them in a cache.
-	 */
-	public serialize(): JSONObject {
-		return {
-			controller: {
-				supportsSoftReset: this.supportsSoftReset,
-				provisioningList: this.provisioningList.map((e) => {
-					const {
-						dsk,
-						securityClasses,
-						// Node ID is not saved - we update it when deserializing nodes
-						nodeId,
-						...rest
-					} = e;
-					return {
-						dsk,
-						securityClasses: securityClasses.map(
-							(s) => SecurityClass[s],
-						),
-						// The user-defined properties are saved as-is
-						...rest,
-					};
-				}),
-			},
-			nodes: composeObject(
-				[...this.nodes.entries()].map(
-					([id, node]) =>
-						[id.toString(), node.serialize()] as [string, unknown],
-				),
-			),
-		};
 	}
 
 	/**

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -501,22 +501,11 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 
 	/** Whether the controller is known to support soft reset */
 	public get supportsSoftReset(): boolean | undefined {
-		return this.driver.networkCache.get(
-			cacheKeys.controller.supportsSoftReset,
-		);
+		return this.driver.cacheGet(cacheKeys.controller.supportsSoftReset);
 	}
 	/** @internal */
 	public set supportsSoftReset(value: boolean | undefined) {
-		if (value === undefined) {
-			this.driver.networkCache.delete(
-				cacheKeys.controller.supportsSoftReset,
-			);
-		} else {
-			this.driver.networkCache.set(
-				cacheKeys.controller.supportsSoftReset,
-				value,
-			);
-		}
+		this.driver.cacheSet(cacheKeys.controller.supportsSoftReset, value);
 	}
 
 	private _nodes: ThrowingMap<number, ZWaveNode>;
@@ -561,17 +550,14 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 
 	/** @internal */
 	public get provisioningList(): readonly SmartStartProvisioningEntry[] {
-		return this.driver.networkCache.get(
-			cacheKeys.controller.provisioningList,
+		return (
+			this.driver.cacheGet(cacheKeys.controller.provisioningList) ?? []
 		);
 	}
 	private set provisioningList(
 		value: readonly SmartStartProvisioningEntry[],
 	) {
-		this.driver.networkCache.set(
-			cacheKeys.controller.provisioningList,
-			value,
-		);
+		this.driver.cacheSet(cacheKeys.controller.provisioningList, value);
 	}
 
 	/** Adds the given entry (DSK and security classes) to the controller's SmartStart provisioning list or replaces an existing entry */
@@ -590,7 +576,6 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 		this.provisioningList = provisioningList;
 
 		this.autoProvisionSmartStart();
-		void this.driver.saveNetworkToCache();
 	}
 
 	/**
@@ -611,7 +596,6 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 		if (index >= 0) {
 			provisioningList.splice(index, 1);
 			this.autoProvisionSmartStart();
-			void this.driver.saveNetworkToCache();
 			this.provisioningList = provisioningList;
 		}
 	}
@@ -4690,7 +4674,6 @@ ${associatedNodes.join(", ")}`,
 		// Also, we could be talking to different nodes than the cache file contains.
 		// Reset all info about all nodes, so they get re-interviewed.
 		this._nodes.clear();
-		await this.driver.saveNetworkToCache();
 
 		// Normally we'd only need to soft reset the stick, but we also need to re-interview the controller and potentially all nodes.
 		// Just forcing a restart of the driver seems easier.

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -3944,6 +3944,7 @@ ${handlers.length} left`,
 
 			try {
 				await migrateLegacyNetworkCache(
+					this,
 					this.controller.homeId,
 					this._networkCache,
 					this.options.storage.driver,

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -151,6 +151,7 @@ import {
 	sendStatistics,
 } from "../telemetry/statistics";
 import { createMessageGenerator } from "./MessageGenerators";
+import { migrateLegacyNetworkCache } from "./NetworkCache";
 import {
 	createSendThreadMachine,
 	SendThreadInterpreter,
@@ -643,6 +644,11 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> {
 	public get metadataDB(): JsonlDB<ValueMetadata> | undefined {
 		return this._metadataDB;
 	}
+	private _networkCache: JsonlDB | undefined;
+	/** @internal */
+	public get networkCache(): JsonlDB | undefined {
+		return this._networkCache;
+	}
 
 	public readonly configManager: ConfigManager;
 	public get configVersion(): string {
@@ -921,14 +927,22 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> {
 	}
 
 	private async initValueDBs(homeId: number): Promise<void> {
-		// Always start the value and metadata databases
 		const options: JsonlDBOptions<any> = {
 			ignoreReadErrors: true,
 			...throttlePresets[this.options.storage.throttle],
 		};
 		if (this.options.storage.lockDir) {
-			options.lockfileDirectory = this.options.storage.lockDir;
+			options.lockfile = {
+				directory: this.options.storage.lockDir,
+			};
 		}
+
+		const networkCacheFile = path.join(
+			this.cacheDir,
+			`${homeId.toString(16)}.jsonl`,
+		);
+		this._networkCache = new JsonlDB(networkCacheFile, options);
+		await this._networkCache.open();
 
 		const valueDBFile = path.join(
 			this.cacheDir,
@@ -949,8 +963,9 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> {
 		await this._metadataDB.open();
 
 		if (process.env.NO_CACHE === "true") {
-			// Since value/metadata DBs are append-only, we need to clear them
-			// if the cache should be ignored
+			// Since cache and value/metadata DBs are append-only, we need to
+			// clear them if the cache should be ignored
+			this._networkCache.clear();
 			this._valueDB.clear();
 			this._metadataDB.clear();
 		}
@@ -3953,13 +3968,35 @@ ${handlers.length} left`,
 	 * Restores a previously stored Z-Wave network state from cache to speed up the startup process
 	 */
 	public async restoreNetworkStructureFromCache(): Promise<void> {
-		if (!this._controller || !this.controller.homeId) return;
+		if (!this._controller || !this.controller.homeId || !this._networkCache)
+			return;
 
-		const cacheFile = path.join(
-			this.cacheDir,
-			`${this.controller.homeId.toString(16)}.json`,
-		);
-		if (!(await this.options.storage.driver.pathExists(cacheFile))) return;
+		// In v9, the network cache was switched from a json file to use a Jsonl-DB
+		// Therefore the legacy cache file must be migrated to the new format
+		if (this._networkCache.size === 0) {
+			// version the cache format, so migrations in the future are easier
+			this._networkCache.set("cacheFormat", 1);
+
+			try {
+				await migrateLegacyNetworkCache(
+					this.controller.homeId,
+					this._networkCache,
+					this.options.storage.driver,
+					this.cacheDir,
+				);
+			} catch (e) {
+				const message = `Migrating the legacy cache file to jsonl failed: ${getErrorMessage(
+					e,
+					true,
+				)}`;
+				this.driverLog.print(message, "error");
+			}
+		}
+
+		if (this._networkCache.size <= 1) {
+			// If the size is 0 or 1, the cache is empty, so we cannot restore it
+			return;
+		}
 
 		try {
 			this.driverLog.print(
@@ -3967,11 +4004,7 @@ ${handlers.length} left`,
 					this.controller.homeId,
 				)} found, attempting to restore the network from cache...`,
 			);
-			const cacheString = await this.options.storage.driver.readFile(
-				cacheFile,
-				"utf8",
-			);
-			await this.controller.deserialize(JSON.parse(cacheString));
+			await this.controller.deserialize();
 			this.driverLog.print(
 				`Restoring the network from cache was successful!`,
 			);

--- a/packages/zwave-js/src/lib/driver/NetworkCache.ts
+++ b/packages/zwave-js/src/lib/driver/NetworkCache.ts
@@ -1,0 +1,213 @@
+import type { JsonlDB } from "@alcalzone/jsonl-db";
+import type { CommandClasses } from "@zwave-js/core";
+import { num2hex, pickDeep } from "@zwave-js/shared";
+import { isObject } from "alcalzone-shared/typeguards";
+import path from "path";
+import type { FileSystem } from "./FileSystem";
+
+/**
+ * Defines the keys that are used to store certain properties in the network cache.
+ */
+export const cacheKeys = {
+	controller: {
+		provisioningList: "controller.provisioningList",
+		supportsSoftReset: "controller.supportsSoftReset",
+	},
+	node: (nodeId: number) => ({
+		_baseKey: `node.${nodeId}`,
+		interviewStage: `node.${nodeId}.interviewStage`,
+		deviceClass: `node.${nodeId}.deviceClass`,
+		isListening: `node.${nodeId}.isListening`,
+		isFrequentListening: `node.${nodeId}.isFrequentListening`,
+		isRouting: `node.${nodeId}.isRouting`,
+		supportedDataRates: `node.${nodeId}.supportedDataRates`,
+		protocolVersion: `node.${nodeId}.protocolVersion`,
+		nodeType: `node.${nodeId}.nodeType`,
+		supportsSecurity: `node.${nodeId}.supportsSecurity`,
+		supportsBeaming: `node.${nodeId}.supportsBeaming`,
+		securityClasses: `node.${nodeId}.securityClasses`,
+		dsk: `node.${nodeId}.dsk`,
+		commandClass: (ccId: CommandClasses) => {
+			const ccAsHex = num2hex(ccId);
+			const baseKey = `node.${nodeId}.commandClass.${ccAsHex}`;
+			return {
+				_baseKey: baseKey,
+				name: `${baseKey}.name`,
+				endpoint: (index: number) => `${baseKey}.endpoints.${index}`,
+			};
+		},
+	}),
+} as const;
+
+export const cacheKeyUtils = {
+	nodeIdFromKey: (key: string): number | undefined => {
+		const match = /^node\.(?<nodeId>\d+)\./.exec(key);
+		if (match) {
+			return parseInt(match.groups!.nodeId, 10);
+		}
+	},
+	isEndpointKey: (key: string): boolean => {
+		return /endpoints\.(?<index>\d+)$/.test(key);
+	},
+	endpointIndexFromKey: (key: string): number | undefined => {
+		const match = /endpoints\.(?<index>\d+)$/.exec(key);
+		if (match) {
+			return parseInt(match.groups!.index, 10);
+		}
+	},
+} as const;
+
+/** Defines the JSON paths that were used to store certain properties in the legacy network cache */
+const legacyPaths = {
+	// These seem to duplicate the ones in cacheKeys, but this allows us to change
+	// something in the future without breaking migration
+	controller: {
+		provisioningList: "controller.provisioningList",
+		supportsSoftReset: "controller.supportsSoftReset",
+	},
+	node: {
+		// These are relative to the node object
+		interviewStage: `interviewStage`,
+		deviceClass: `deviceClass`,
+		isListening: `isListening`,
+		isFrequentListening: `isFrequentListening`,
+		isRouting: `isRouting`,
+		supportedDataRates: `supportedDataRates`,
+		protocolVersion: `protocolVersion`,
+		nodeType: `nodeType`,
+		supportsSecurity: `supportsSecurity`,
+		supportsBeaming: `supportsBeaming`,
+		securityClasses: `securityClasses`,
+		dsk: `dsk`,
+	},
+	commandClass: {
+		// These are relative to the commandClasses object
+		name: `name`,
+		endpoint: (index: number) => `endpoints.${index}`,
+	},
+} as const;
+
+export async function migrateLegacyNetworkCache(
+	homeId: number,
+	networkCache: JsonlDB,
+	storageDriver: FileSystem,
+	cacheDir: string,
+): Promise<void> {
+	const cacheFile = path.join(cacheDir, `${homeId.toString(16)}.json`);
+	if (!(await storageDriver.pathExists(cacheFile))) return;
+	const legacy = JSON.parse(await storageDriver.readFile(cacheFile, "utf8"));
+
+	const jsonl = networkCache;
+	function tryMigrate(
+		targetKey: string,
+		source: Record<string, any>,
+		sourcePath: string,
+	): void {
+		const val = pickDeep(source, sourcePath);
+		if (val != undefined) jsonl.set(targetKey, val);
+	}
+
+	// Translate all possible entries
+
+	// Controller provisioning list and supportsSoftReset info
+	tryMigrate(
+		cacheKeys.controller.provisioningList,
+		legacy,
+		legacyPaths.controller.provisioningList,
+	);
+	tryMigrate(
+		cacheKeys.controller.supportsSoftReset,
+		legacy,
+		legacyPaths.controller.supportsSoftReset,
+	);
+
+	// All nodes, ...
+	if (isObject(legacy.nodes)) {
+		for (const node of Object.values<any>(legacy.nodes)) {
+			if (!isObject(node) || typeof node.id !== "number") continue;
+			const nodeCacheKeys = cacheKeys.node(node.id);
+
+			// ... their properties
+			tryMigrate(
+				nodeCacheKeys.interviewStage,
+				node,
+				legacyPaths.node.interviewStage,
+			);
+			tryMigrate(
+				nodeCacheKeys.deviceClass,
+				node,
+				legacyPaths.node.deviceClass,
+			);
+			tryMigrate(
+				nodeCacheKeys.isListening,
+				node,
+				legacyPaths.node.isListening,
+			);
+			tryMigrate(
+				nodeCacheKeys.isFrequentListening,
+				node,
+				legacyPaths.node.isFrequentListening,
+			);
+			tryMigrate(
+				nodeCacheKeys.isRouting,
+				node,
+				legacyPaths.node.isRouting,
+			);
+			tryMigrate(
+				nodeCacheKeys.supportedDataRates,
+				node,
+				legacyPaths.node.supportedDataRates,
+			);
+			tryMigrate(
+				nodeCacheKeys.protocolVersion,
+				node,
+				legacyPaths.node.protocolVersion,
+			);
+			tryMigrate(nodeCacheKeys.nodeType, node, legacyPaths.node.nodeType);
+			tryMigrate(
+				nodeCacheKeys.supportsSecurity,
+				node,
+				legacyPaths.node.supportsSecurity,
+			);
+			tryMigrate(
+				nodeCacheKeys.supportsBeaming,
+				node,
+				legacyPaths.node.supportsBeaming,
+			);
+			tryMigrate(
+				nodeCacheKeys.securityClasses,
+				node,
+				legacyPaths.node.securityClasses,
+			);
+			tryMigrate(nodeCacheKeys.dsk, node, legacyPaths.node.dsk);
+
+			// ... and command classes
+			if (isObject(node.commandClasses)) {
+				for (const [ccIdHex, cc] of Object.entries<any>(
+					node.commandClasses,
+				)) {
+					const ccId = parseInt(ccIdHex, 16);
+					const cacheKey = nodeCacheKeys.commandClass(ccId);
+
+					tryMigrate(
+						cacheKey.name,
+						cc,
+						legacyPaths.commandClass.name,
+					);
+					if (isObject(cc.endpoints)) {
+						for (const endpointId of Object.keys(cc.endpoints)) {
+							const endpointIndex = parseInt(endpointId, 10);
+							tryMigrate(
+								cacheKey.endpoint(endpointIndex),
+								cc,
+								legacyPaths.commandClass.endpoint(
+									endpointIndex,
+								),
+							);
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/packages/zwave-js/src/lib/node/Endpoint.test.ts
+++ b/packages/zwave-js/src/lib/node/Endpoint.test.ts
@@ -184,7 +184,7 @@ describe("lib/node/Endpoint", () => {
 			const fakeDriver = createEmptyMockDriver() as unknown as Driver;
 			const node = new ZWaveNode(1, fakeDriver);
 			(fakeDriver.controller.nodes as any).set(1, node);
-			node["_isListening"] = true;
+			node["isListening"] = true;
 			node["applyDeviceClass"](soundSwitch);
 
 			expect(node.supportsCC(CommandClasses.Battery)).toBeFalse();

--- a/packages/zwave-js/src/lib/node/Endpoint.ts
+++ b/packages/zwave-js/src/lib/node/Endpoint.ts
@@ -84,9 +84,7 @@ export class Endpoint {
 		suffixSerializer: (cc: CommandClasses) => num2hex(cc),
 		suffixDeserializer: (key: string) => {
 			const ccId = parseInt(key, 16);
-			if (ccId in CommandClasses) {
-				return (CommandClasses as any)[ccId];
-			}
+			if (ccId in CommandClasses) return ccId;
 		},
 	});
 

--- a/packages/zwave-js/src/lib/node/Node.test.ts
+++ b/packages/zwave-js/src/lib/node/Node.test.ts
@@ -713,8 +713,8 @@ describe("lib/node/Node", () => {
 
 		function makeNode(canSleep: boolean = false): ZWaveNode {
 			const node = new ZWaveNode(2, fakeDriver as unknown as Driver);
-			node["_isListening"] = !canSleep;
-			node["_isFrequentListening"] = false;
+			node["isListening"] = !canSleep;
+			node["isFrequentListening"] = false;
 			// node.addCC(CommandClasses["Wake Up"], { isSupported: true });
 			fakeDriver.controller.nodes.set(node.id, node);
 			return node;
@@ -777,8 +777,8 @@ describe("lib/node/Node", () => {
 
 		function makeNode(): ZWaveNode {
 			const node = new ZWaveNode(2, fakeDriver as unknown as Driver);
-			node["_isListening"] = false;
-			node["_isFrequentListening"] = false;
+			node["isListening"] = false;
+			node["isFrequentListening"] = false;
 			node.addCC(CommandClasses["Wake Up"], { isSupported: true });
 			fakeDriver.controller.nodes.set(node.id, node);
 			return node;
@@ -1010,326 +1010,327 @@ describe("lib/node/Node", () => {
 		});
 	});
 
-	describe("serialize() / deserialize()", () => {
-		const fakeDriver = createEmptyMockDriver() as unknown as Driver;
+	it.todo("serialize() / deserialize()");
+	// describe("serialize() / deserialize()", () => {
+	// 	const fakeDriver = createEmptyMockDriver() as unknown as Driver;
 
-		beforeAll(async () => {
-			// Loading configuration may take a while on CI
-			if (process.env.CI) jest.setTimeout(30000);
-			await fakeDriver.configManager.loadDeviceClasses();
-		});
+	// 	beforeAll(async () => {
+	// 		// Loading configuration may take a while on CI
+	// 		if (process.env.CI) jest.setTimeout(30000);
+	// 		await fakeDriver.configManager.loadDeviceClasses();
+	// 	});
 
-		const serializedTestNode = {
-			id: 1,
-			interviewStage: "NodeInfo",
-			deviceClass: {
-				basic: 2,
-				generic: 2,
-				specific: 1,
-			},
-			isListening: true,
-			isFrequentListening: false,
-			isRouting: false,
-			supportedDataRates: [40000],
-			supportsSecurity: false,
-			supportsBeaming: true,
-			protocolVersion: 3,
-			nodeType: "Controller",
-			securityClasses: {
-				S2_AccessControl: false,
-				S2_Authenticated: true,
-				S2_Unauthenticated: true,
-				S0_Legacy: false,
-			},
-			dsk: "00000-00001-00002-00003-00004-00005-00006-00007",
-			commandClasses: {
-				"0x25": {
-					name: "Binary Switch",
-					endpoints: {
-						0: {
-							isSupported: false,
-							isControlled: true,
-							secure: false,
-							version: 3,
-						},
-					},
-				},
-				"0x26": {
-					name: "Multilevel Switch",
-					endpoints: {
-						0: {
-							isSupported: false,
-							isControlled: true,
-							secure: false,
-							version: 4,
-						},
-					},
-				},
-			},
-		};
+	// 	const serializedTestNode = {
+	// 		id: 1,
+	// 		interviewStage: "NodeInfo",
+	// 		deviceClass: {
+	// 			basic: 2,
+	// 			generic: 2,
+	// 			specific: 1,
+	// 		},
+	// 		isListening: true,
+	// 		isFrequentListening: false,
+	// 		isRouting: false,
+	// 		supportedDataRates: [40000],
+	// 		supportsSecurity: false,
+	// 		supportsBeaming: true,
+	// 		protocolVersion: 3,
+	// 		nodeType: "Controller",
+	// 		securityClasses: {
+	// 			S2_AccessControl: false,
+	// 			S2_Authenticated: true,
+	// 			S2_Unauthenticated: true,
+	// 			S0_Legacy: false,
+	// 		},
+	// 		dsk: "00000-00001-00002-00003-00004-00005-00006-00007",
+	// 		commandClasses: {
+	// 			"0x25": {
+	// 				name: "Binary Switch",
+	// 				endpoints: {
+	// 					0: {
+	// 						isSupported: false,
+	// 						isControlled: true,
+	// 						secure: false,
+	// 						version: 3,
+	// 					},
+	// 				},
+	// 			},
+	// 			"0x26": {
+	// 				name: "Multilevel Switch",
+	// 				endpoints: {
+	// 					0: {
+	// 						isSupported: false,
+	// 						isControlled: true,
+	// 						secure: false,
+	// 						version: 4,
+	// 					},
+	// 				},
+	// 			},
+	// 		},
+	// 	};
 
-		it("serializing a deserialized node should result in the original object", () => {
-			const node = new ZWaveNode(1, fakeDriver);
-			// @ts-ignore We need write access to the map
-			fakeDriver.controller.nodes.set(1, node);
-			node.deserialize(serializedTestNode);
-			expect(node.serialize()).toEqual(serializedTestNode);
-			node.destroy();
-		});
+	// 	it("serializing a deserialized node should result in the original object", () => {
+	// 		const node = new ZWaveNode(1, fakeDriver);
+	// 		// @ts-ignore We need write access to the map
+	// 		fakeDriver.controller.nodes.set(1, node);
+	// 		node.deserialize(serializedTestNode);
+	// 		expect(node.serialize()).toEqual(serializedTestNode);
+	// 		node.destroy();
+	// 	});
 
-		it("deserializing a legacy node object should have the correct properties", () => {
-			const node = new ZWaveNode(1, fakeDriver);
-			// @ts-ignore We need write access to the map
-			fakeDriver.controller.nodes.set(1, node);
-			const legacy = {
-				...serializedTestNode,
-				version: 4, // version 4 -> protocolVersion 3
-				isFrequentListening: true, // --> 1000ms
-				isBeaming: true,
-				maxBaudRate: 40000,
-				isSecure: true, // --> securityClasses.S0_Legacy: true
-			};
-			// @ts-expect-error We want to test this!
-			delete legacy.protocolVersion;
-			// @ts-expect-error We want to test this!
-			delete legacy.securityClasses;
-			node.deserialize(legacy);
-			const expected = {
-				...serializedTestNode,
-				isFrequentListening: "1000ms",
-				securityClasses: {
-					S0_Legacy: true,
-					// S2 classes are not granted when deserializing legacy caches
-					S2_AccessControl: false,
-					S2_Authenticated: false,
-					S2_Unauthenticated: false,
-				},
-			};
-			expect(node.serialize()).toEqual(expected);
-			node.destroy();
-		});
+	// 	it("deserializing a legacy node object should have the correct properties", () => {
+	// 		const node = new ZWaveNode(1, fakeDriver);
+	// 		// @ts-ignore We need write access to the map
+	// 		fakeDriver.controller.nodes.set(1, node);
+	// 		const legacy = {
+	// 			...serializedTestNode,
+	// 			version: 4, // version 4 -> protocolVersion 3
+	// 			isFrequentListening: true, // --> 1000ms
+	// 			isBeaming: true,
+	// 			maxBaudRate: 40000,
+	// 			isSecure: true, // --> securityClasses.S0_Legacy: true
+	// 		};
+	// 		// @ts-expect-error We want to test this!
+	// 		delete legacy.protocolVersion;
+	// 		// @ts-expect-error We want to test this!
+	// 		delete legacy.securityClasses;
+	// 		node.deserialize(legacy);
+	// 		const expected = {
+	// 			...serializedTestNode,
+	// 			isFrequentListening: "1000ms",
+	// 			securityClasses: {
+	// 				S0_Legacy: true,
+	// 				// S2 classes are not granted when deserializing legacy caches
+	// 				S2_AccessControl: false,
+	// 				S2_Authenticated: false,
+	// 				S2_Unauthenticated: false,
+	// 			},
+	// 		};
+	// 		expect(node.serialize()).toEqual(expected);
+	// 		node.destroy();
+	// 	});
 
-		it("a changed interview stage is reflected in the cache", () => {
-			const node = new ZWaveNode(1, fakeDriver);
-			// @ts-ignore We need write access to the map
-			fakeDriver.controller.nodes.set(1, node);
-			node.deserialize(serializedTestNode);
-			node.interviewStage = InterviewStage.Complete;
-			expect(node.serialize().interviewStage).toEqual(
-				InterviewStage[InterviewStage.Complete],
-			);
-			node.destroy();
-		});
+	// 	it("a changed interview stage is reflected in the cache", () => {
+	// 		const node = new ZWaveNode(1, fakeDriver);
+	// 		// @ts-ignore We need write access to the map
+	// 		fakeDriver.controller.nodes.set(1, node);
+	// 		node.deserialize(serializedTestNode);
+	// 		node.interviewStage = InterviewStage.Complete;
+	// 		expect(node.serialize().interviewStage).toEqual(
+	// 			InterviewStage[InterviewStage.Complete],
+	// 		);
+	// 		node.destroy();
+	// 	});
 
-		it("deserialize() should correctly read values and metadata", () => {
-			const input = { ...serializedTestNode };
+	// 	it("deserialize() should correctly read values and metadata", () => {
+	// 		const input = { ...serializedTestNode };
 
-			const valueId1 = {
-				endpoint: 1,
-				property: "targetValue",
-			};
-			const valueId2 = {
-				endpoint: 2,
-				property: "targetValue",
-			};
+	// 		const valueId1 = {
+	// 			endpoint: 1,
+	// 			property: "targetValue",
+	// 		};
+	// 		const valueId2 = {
+	// 			endpoint: 2,
+	// 			property: "targetValue",
+	// 		};
 
-			(input.commandClasses as any)["0x20"] = {
-				name: "Basic",
-				isSupported: false,
-				isControlled: true,
-				version: 1,
-				values: [{ ...valueId1, value: 12 }],
-				metadata: [
-					{
-						...valueId2,
-						metadata: ValueMetadata.ReadOnlyInt32,
-					},
-				],
-			};
+	// 		(input.commandClasses as any)["0x20"] = {
+	// 			name: "Basic",
+	// 			isSupported: false,
+	// 			isControlled: true,
+	// 			version: 1,
+	// 			values: [{ ...valueId1, value: 12 }],
+	// 			metadata: [
+	// 				{
+	// 					...valueId2,
+	// 					metadata: ValueMetadata.ReadOnlyInt32,
+	// 				},
+	// 			],
+	// 		};
 
-			const node = new ZWaveNode(1, fakeDriver);
-			// @ts-ignore We need write access to the map
-			fakeDriver.controller.nodes.set(1, node);
-			node.deserialize(input);
+	// 		const node = new ZWaveNode(1, fakeDriver);
+	// 		// @ts-ignore We need write access to the map
+	// 		fakeDriver.controller.nodes.set(1, node);
+	// 		node.deserialize(input);
 
-			expect(
-				node.valueDB.getValue({
-					...valueId1,
-					commandClass: CommandClasses.Basic,
-				}),
-			).toBe(12);
-			expect(
-				node.valueDB.getMetadata({
-					...valueId2,
-					commandClass: CommandClasses.Basic,
-				}),
-			).toBe(ValueMetadata.ReadOnlyInt32);
-			node.destroy();
-		});
+	// 		expect(
+	// 			node.valueDB.getValue({
+	// 				...valueId1,
+	// 				commandClass: CommandClasses.Basic,
+	// 			}),
+	// 		).toBe(12);
+	// 		expect(
+	// 			node.valueDB.getMetadata({
+	// 				...valueId2,
+	// 				commandClass: CommandClasses.Basic,
+	// 			}),
+	// 		).toBe(ValueMetadata.ReadOnlyInt32);
+	// 		node.destroy();
+	// 	});
 
-		it("deserialize() should also accept numbers for the interview stage", () => {
-			const input = {
-				...serializedTestNode,
-				interviewStage: InterviewStage.Complete,
-			};
-			const node = new ZWaveNode(1, fakeDriver);
-			node.deserialize(input);
-			expect(node.interviewStage).toBe(InterviewStage.Complete);
-			node.destroy();
-		});
+	// 	it("deserialize() should also accept numbers for the interview stage", () => {
+	// 		const input = {
+	// 			...serializedTestNode,
+	// 			interviewStage: InterviewStage.Complete,
+	// 		};
+	// 		const node = new ZWaveNode(1, fakeDriver);
+	// 		node.deserialize(input);
+	// 		expect(node.interviewStage).toBe(InterviewStage.Complete);
+	// 		node.destroy();
+	// 	});
 
-		it("deserialize() should skip the deviceClass if it is malformed", () => {
-			const node = new ZWaveNode(1, fakeDriver);
-			const brokenDeviceClasses = [
-				// not an object
-				undefined,
-				1,
-				"foo",
-				// incomplete
-				{},
-				{ basic: 1 },
-				{ generic: 2 },
-				{ specific: 3 },
-				{ basic: 1, generic: 2 },
-				{ basic: 1, specific: 3 },
-				{ generic: 2, specific: 3 },
-				// wrong type
-				{ basic: "1", generic: 2, specific: 3 },
-				{ basic: 1, generic: true, specific: 3 },
-				{ basic: 1, generic: 2, specific: {} },
-			];
-			for (const dc of brokenDeviceClasses) {
-				const input = {
-					...serializedTestNode,
-					deviceClass: dc,
-				};
-				(node as any)._deviceClass = undefined;
-				node.deserialize(input);
-				expect(node.deviceClass).toBeUndefined();
-			}
-			node.destroy();
-		});
+	// 	it("deserialize() should skip the deviceClass if it is malformed", () => {
+	// 		const node = new ZWaveNode(1, fakeDriver);
+	// 		const brokenDeviceClasses = [
+	// 			// not an object
+	// 			undefined,
+	// 			1,
+	// 			"foo",
+	// 			// incomplete
+	// 			{},
+	// 			{ basic: 1 },
+	// 			{ generic: 2 },
+	// 			{ specific: 3 },
+	// 			{ basic: 1, generic: 2 },
+	// 			{ basic: 1, specific: 3 },
+	// 			{ generic: 2, specific: 3 },
+	// 			// wrong type
+	// 			{ basic: "1", generic: 2, specific: 3 },
+	// 			{ basic: 1, generic: true, specific: 3 },
+	// 			{ basic: 1, generic: 2, specific: {} },
+	// 		];
+	// 		for (const dc of brokenDeviceClasses) {
+	// 			const input = {
+	// 				...serializedTestNode,
+	// 				deviceClass: dc,
+	// 			};
+	// 			(node as any)._deviceClass = undefined;
+	// 			node.deserialize(input);
+	// 			expect(node.deviceClass).toBeUndefined();
+	// 		}
+	// 		node.destroy();
+	// 	});
 
-		it("deserialize() should skip any primitive properties that have the wrong type or format", () => {
-			const node = new ZWaveNode(1, fakeDriver);
-			const wrongInputs: [string, any][] = [
-				["isListening", 1],
-				["isFrequentListening", 2],
-				["isRouting", {}],
-				["supportedDataRates", true],
-				["supportsSecurity", 3],
-				["supportsSecurity", "3"],
-				["protocolVersion", false],
-				["dsk", "foo"],
-			];
-			for (const [prop, val] of wrongInputs) {
-				const input = {
-					...serializedTestNode,
-					[prop]: val,
-				};
-				(node as any)["_" + prop] = undefined;
-				node.deserialize(input);
-				expect((node as any)[prop]).toBeUndefined();
-			}
-			node.destroy();
-		});
+	// 	it("deserialize() should skip any primitive properties that have the wrong type or format", () => {
+	// 		const node = new ZWaveNode(1, fakeDriver);
+	// 		const wrongInputs: [string, any][] = [
+	// 			["isListening", 1],
+	// 			["isFrequentListening", 2],
+	// 			["isRouting", {}],
+	// 			["supportedDataRates", true],
+	// 			["supportsSecurity", 3],
+	// 			["supportsSecurity", "3"],
+	// 			["protocolVersion", false],
+	// 			["dsk", "foo"],
+	// 		];
+	// 		for (const [prop, val] of wrongInputs) {
+	// 			const input = {
+	// 				...serializedTestNode,
+	// 				[prop]: val,
+	// 			};
+	// 			(node as any)["_" + prop] = undefined;
+	// 			node.deserialize(input);
+	// 			expect((node as any)[prop]).toBeUndefined();
+	// 		}
+	// 		node.destroy();
+	// 	});
 
-		it("deserialize() should skip command classes that don't have a HEX key", () => {
-			const node = new ZWaveNode(1, fakeDriver);
-			const input = {
-				...serializedTestNode,
-				commandClasses: {
-					"Binary Switch": {
-						name: "Binary Switch",
-						isSupported: false,
-						isControlled: true,
-						version: 3,
-					},
-				},
-			};
-			node.deserialize(input);
-			expect(node.implementedCommandClasses.size).toBe(0);
-			node.destroy();
-		});
+	// 	it("deserialize() should skip command classes that don't have a HEX key", () => {
+	// 		const node = new ZWaveNode(1, fakeDriver);
+	// 		const input = {
+	// 			...serializedTestNode,
+	// 			commandClasses: {
+	// 				"Binary Switch": {
+	// 					name: "Binary Switch",
+	// 					isSupported: false,
+	// 					isControlled: true,
+	// 					version: 3,
+	// 				},
+	// 			},
+	// 		};
+	// 		node.deserialize(input);
+	// 		expect(node.implementedCommandClasses.size).toBe(0);
+	// 		node.destroy();
+	// 	});
 
-		it("deserialize() should skip command classes that are not known to this library", () => {
-			const node = new ZWaveNode(1, fakeDriver);
-			const input = {
-				...serializedTestNode,
-				commandClasses: {
-					"0x001122ff": {
-						name: "Binary Switch",
-						isSupported: false,
-						isControlled: true,
-						version: 3,
-					},
-				},
-			};
-			node.deserialize(input);
-			expect(node.implementedCommandClasses.size).toBe(0);
-			node.destroy();
-		});
+	// 	it("deserialize() should skip command classes that are not known to this library", () => {
+	// 		const node = new ZWaveNode(1, fakeDriver);
+	// 		const input = {
+	// 			...serializedTestNode,
+	// 			commandClasses: {
+	// 				"0x001122ff": {
+	// 					name: "Binary Switch",
+	// 					isSupported: false,
+	// 					isControlled: true,
+	// 					version: 3,
+	// 				},
+	// 			},
+	// 		};
+	// 		node.deserialize(input);
+	// 		expect(node.implementedCommandClasses.size).toBe(0);
+	// 		node.destroy();
+	// 	});
 
-		it("deserialize() should not parse any malformed CC properties", () => {
-			const node = new ZWaveNode(1, fakeDriver);
-			const input = {
-				...serializedTestNode,
-				commandClasses: {
-					"0x25": {
-						isSupported: 1,
-					},
-					"0x26": {
-						isControlled: "",
-					},
-					"0x27": {
-						isSupported: true,
-						version: "5",
-					},
-				},
-			};
-			node.deserialize(input);
-			expect(node.supportsCC(0x25)).toBeFalse();
-			expect(node.controlsCC(0x26)).toBeFalse();
-			expect(node.getCCVersion(0x27)).toBe(0);
-			node.destroy();
-		});
+	// 	it("deserialize() should not parse any malformed CC properties", () => {
+	// 		const node = new ZWaveNode(1, fakeDriver);
+	// 		const input = {
+	// 			...serializedTestNode,
+	// 			commandClasses: {
+	// 				"0x25": {
+	// 					isSupported: 1,
+	// 				},
+	// 				"0x26": {
+	// 					isControlled: "",
+	// 				},
+	// 				"0x27": {
+	// 					isSupported: true,
+	// 					version: "5",
+	// 				},
+	// 			},
+	// 		};
+	// 		node.deserialize(input);
+	// 		expect(node.supportsCC(0x25)).toBeFalse();
+	// 		expect(node.controlsCC(0x26)).toBeFalse();
+	// 		expect(node.getCCVersion(0x27)).toBe(0);
+	// 		node.destroy();
+	// 	});
 
-		it("deserialize() should set the node status to Unknown if the node can sleep", () => {
-			const input = {
-				...serializedTestNode,
-				isListening: false,
-				isFrequentListening: false,
-			};
-			const node = new ZWaveNode(1, fakeDriver);
-			node.deserialize(input);
-			expect(node.status).toBe(NodeStatus.Unknown);
-			node.destroy();
-		});
+	// 	it("deserialize() should set the node status to Unknown if the node can sleep", () => {
+	// 		const input = {
+	// 			...serializedTestNode,
+	// 			isListening: false,
+	// 			isFrequentListening: false,
+	// 		};
+	// 		const node = new ZWaveNode(1, fakeDriver);
+	// 		node.deserialize(input);
+	// 		expect(node.status).toBe(NodeStatus.Unknown);
+	// 		node.destroy();
+	// 	});
 
-		it("deserialize() should set the node status to Unknown if the node is a listening node", () => {
-			const input = {
-				...serializedTestNode,
-				isListening: true,
-				isFrequentListening: false,
-			};
-			const node = new ZWaveNode(1, fakeDriver);
-			node.deserialize(input);
-			expect(node.status).toBe(NodeStatus.Unknown);
-			node.destroy();
-		});
+	// 	it("deserialize() should set the node status to Unknown if the node is a listening node", () => {
+	// 		const input = {
+	// 			...serializedTestNode,
+	// 			isListening: true,
+	// 			isFrequentListening: false,
+	// 		};
+	// 		const node = new ZWaveNode(1, fakeDriver);
+	// 		node.deserialize(input);
+	// 		expect(node.status).toBe(NodeStatus.Unknown);
+	// 		node.destroy();
+	// 	});
 
-		it("deserialize() should set the node status to Unknown if the node is a frequent listening node", () => {
-			const input = {
-				...serializedTestNode,
-				isListening: false,
-				isFrequentListening: true,
-			};
-			const node = new ZWaveNode(1, fakeDriver);
-			node.deserialize(input);
-			expect(node.status).toBe(NodeStatus.Unknown);
-			node.destroy();
-		});
-	});
+	// 	it("deserialize() should set the node status to Unknown if the node is a frequent listening node", () => {
+	// 		const input = {
+	// 			...serializedTestNode,
+	// 			isListening: false,
+	// 			isFrequentListening: true,
+	// 		};
+	// 		const node = new ZWaveNode(1, fakeDriver);
+	// 		node.deserialize(input);
+	// 		expect(node.status).toBe(NodeStatus.Unknown);
+	// 		node.destroy();
+	// 	});
+	// });
 
 	describe("the emitted events", () => {
 		let node: ZWaveNode;
@@ -1711,8 +1712,8 @@ describe("lib/node/Node", () => {
 
 		function makeNode(canSleep: boolean = false): ZWaveNode {
 			const node = new ZWaveNode(2, fakeDriver as unknown as Driver);
-			node["_isListening"] = !canSleep;
-			node["_isFrequentListening"] = false;
+			node["isListening"] = !canSleep;
+			node["isFrequentListening"] = false;
 			if (canSleep)
 				node.addCC(CommandClasses["Wake Up"], { isSupported: true });
 			fakeDriver.controller.nodes.set(node.id, node);

--- a/packages/zwave-js/src/lib/node/Node.test.ts
+++ b/packages/zwave-js/src/lib/node/Node.test.ts
@@ -392,7 +392,10 @@ describe("lib/node/Node", () => {
 					Promise.resolve(),
 				),
 			);
-			beforeEach(() => fakeDriver.sendMessage.mockClear());
+			beforeEach(() => {
+				fakeDriver.sendMessage.mockClear();
+				fakeDriver.networkCache.clear();
+			});
 
 			it.todo("test that the CC interview methods are called");
 
@@ -715,6 +718,11 @@ describe("lib/node/Node", () => {
 			const node = new ZWaveNode(2, fakeDriver as unknown as Driver);
 			node["isListening"] = !canSleep;
 			node["isFrequentListening"] = false;
+			// If the node doesn't support Z-Wave+ Info CC, the node instance
+			// will try to poll the device for changes. We don't want this to happen in tests.
+			node.addCC(CommandClasses["Z-Wave Plus Info"], {
+				isSupported: true,
+			});
 			// node.addCC(CommandClasses["Wake Up"], { isSupported: true });
 			fakeDriver.controller.nodes.set(node.id, node);
 			return node;
@@ -724,6 +732,10 @@ describe("lib/node/Node", () => {
 			supportedCCs: [],
 			controlledCCs: [],
 		};
+
+		beforeEach(() => {
+			fakeDriver.networkCache.clear();
+		});
 
 		it("marks a sleeping node as awake", () => {
 			const node = makeNode(true);

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -254,11 +254,19 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner {
 			);
 		}
 
-		this.securityClasses = new CacheBackedMap(
-			this.driver.networkCache,
-			cacheKeys.node(this.id).securityClasses,
-			true,
-		);
+		this.securityClasses = new CacheBackedMap(this.driver.networkCache, {
+			prefix: cacheKeys.node(this.id)._securityClassBaseKey + ".",
+			suffixSerializer: (value: SecurityClass) =>
+				getEnumMemberName(SecurityClass, value),
+			suffixDeserializer: (key: string) => {
+				if (
+					key in SecurityClass &&
+					typeof (SecurityClass as any)[key] === "number"
+				) {
+					return (SecurityClass as any)[key];
+				}
+			},
+		});
 
 		// Add optional controlled CCs - endpoints don't have this
 		for (const cc of controlledCCs) this.addCC(cc, { isControlled: true });

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1402,7 +1402,7 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner {
 			if (this.interviewStage === InterviewStage.NodeInfo) {
 				// Only advance the interview if it was completed, otherwise abort
 				if (await this.interviewCCs()) {
-					await this.setInterviewStage(InterviewStage.CommandClasses);
+					this.setInterviewStage(InterviewStage.CommandClasses);
 				} else {
 					return false;
 				}
@@ -1419,7 +1419,7 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner {
 			await this.overwriteConfig();
 		}
 
-		await this.setInterviewStage(InterviewStage.Complete);
+		this.setInterviewStage(InterviewStage.Complete);
 		this.readyMachine.send("INTERVIEW_DONE");
 
 		// Tell listeners that the interview is completed
@@ -1429,9 +1429,7 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner {
 	}
 
 	/** Updates this node's interview stage and saves to cache when appropriate */
-	private async setInterviewStage(
-		completedStage: InterviewStage,
-	): Promise<void> {
+	private setInterviewStage(completedStage: InterviewStage): void {
 		this.interviewStage = completedStage;
 		this.emit(
 			"interview stage completed",
@@ -1491,7 +1489,7 @@ protocol version:      ${this.protocolVersion}`;
 			}
 		}
 
-		await this.setInterviewStage(InterviewStage.ProtocolInfo);
+		this.setInterviewStage(InterviewStage.ProtocolInfo);
 	}
 
 	/** Node interview: pings the node to see if it responds */
@@ -1588,7 +1586,7 @@ protocol version:      ${this.protocolVersion}`;
 			});
 			this.updateNodeInfo(resp.nodeInformation);
 		}
-		await this.setInterviewStage(InterviewStage.NodeInfo);
+		this.setInterviewStage(InterviewStage.NodeInfo);
 	}
 
 	/**
@@ -2231,7 +2229,7 @@ protocol version:      ${this.protocolVersion}`;
 			}
 		}
 
-		await this.setInterviewStage(InterviewStage.OverwriteConfig);
+		this.setInterviewStage(InterviewStage.OverwriteConfig);
 	}
 
 	/**

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepBlockNonceReport.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepBlockNonceReport.test.ts
@@ -50,8 +50,8 @@ describe("regression tests", () => {
 		}
 		driver["lastCallbackId"] = 2;
 
-		node44["_isListening"] = false;
-		node44["_isFrequentListening"] = false;
+		node44["isListening"] = false;
+		node44["isFrequentListening"] = false;
 		node44.addCC(CommandClasses.Security, { isSupported: true });
 		node44.markAsAsleep();
 		expect(node44.status).toBe(NodeStatus.Asleep);

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepMessageOrder.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepMessageOrder.test.ts
@@ -43,8 +43,8 @@ describe("regression tests", () => {
 			driver["addNodeEventHandlers"](node);
 		}
 
-		node10["_isListening"] = false;
-		node10["_isFrequentListening"] = false;
+		node10["isListening"] = false;
+		node10["isFrequentListening"] = false;
 		node10.markAsAwake();
 		expect(node10.status).toBe(NodeStatus.Awake);
 

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepNoReject.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepNoReject.test.ts
@@ -41,8 +41,8 @@ describe("regression tests", () => {
 			driver["addNodeEventHandlers"](node);
 		}
 
-		node2["_isListening"] = false;
-		node2["_isFrequentListening"] = false;
+		node2["isListening"] = false;
+		node2["isFrequentListening"] = false;
 		node2.markAsAwake();
 		expect(node2.status).toBe(NodeStatus.Awake);
 

--- a/packages/zwave-js/src/lib/test/driver/successfulPingChangeNodeStatus.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/successfulPingChangeNodeStatus.test.ts
@@ -74,11 +74,11 @@ describe("When a ping succeeds, the node should be marked awake/alive", () => {
 				}
 
 				if (canSleep) {
-					node4["_isListening"] = false;
-					node4["_isFrequentListening"] = false;
+					node4["isListening"] = false;
+					node4["isFrequentListening"] = false;
 				} else {
-					node4["_isListening"] = true;
-					node4["_isFrequentListening"] = false;
+					node4["isListening"] = true;
+					node4["isFrequentListening"] = false;
 				}
 
 				if (initialStatus === NodeStatus.Asleep) {

--- a/packages/zwave-js/src/lib/test/utils.ts
+++ b/packages/zwave-js/src/lib/test/utils.ts
@@ -53,6 +53,8 @@ export async function createAndStartDriver(
 	driver["_valueDB"]!.close = () => Promise.resolve();
 	driver["_metadataDB"] = new Map() as any;
 	driver["_metadataDB"]!.close = () => Promise.resolve();
+	driver["_networkCache"] = new Map() as any;
+	driver["_networkCache"]!.close = () => Promise.resolve();
 
 	// Mock the controller as it will not be initialized with skipInterview: true
 	driver["_controller"] = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4530,24 +4530,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001219":
-  version: 1.0.30001242
-  resolution: "caniuse-lite@npm:1.0.30001242"
-  checksum: d8ceec73bbd2547d6e5107f8dbbf48ed0eeea3cd0afdefbffa22697514371e4c20a82ce4a15112f8d9035974cf309ba6af95656f21c828d94de389d534aebffb
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001271":
-  version: 1.0.30001274
-  resolution: "caniuse-lite@npm:1.0.30001274"
-  checksum: 75790d021edbc68dbb36c0bc63255fad1e7aa3986039e685d10340e7e9a37147b0ddedaba22cf6c52b3657cca794ed41af88045ad5cce79084e9361e95f1c5d4
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001286":
-  version: 1.0.30001304
-  resolution: "caniuse-lite@npm:1.0.30001304"
-  checksum: 63092ec6c65346f57026d9c7bee0548b77fd606819ca205ee3d99c948e4701b8820c365c00b79d4a4b96f3f0045bc0be767149b8edb74f7223d16cb30630f81e
+"caniuse-lite@npm:^1.0.30001219, caniuse-lite@npm:^1.0.30001271, caniuse-lite@npm:^1.0.30001286":
+  version: 1.0.30001312
+  resolution: "caniuse-lite@npm:1.0.30001312"
+  checksum: 753fb9ea1e02e999430b323a71b5acab5120f3b5fc0161b01669f54a3ef5c5296240b6ae9b79b12a3742e3aed216aa9ee3d5398a23c16d08625ccd376b79545d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
With this PR, we no longer write a monolithic JSON file every couple of milliseconds, but rather use a .jsonl DB for the relatively "static" network cache part. Hopefully this prevents this last part of the cache from breaking when Docker does weird shit.

fixes: #3091