### PR TITLE
feat(config): add support for paddle programming on Zooz 700 Dimmers

### DIFF
--- a/packages/config/config/devices/0x027a/templates/zooz_template.json
+++ b/packages/config/config/devices/0x027a/templates/zooz_template.json
@@ -251,5 +251,24 @@
 				"value": 0
 			}
 		]
+	},
+	"paddle_programming": {
+		"label": "Paddle Programming",
+		"description": "Disables inclusion/exclusion commands on paddle for use with scene controls.",
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 1,
+		"defaultValue": 0,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Enable",
+				"value": 0
+			},
+			{
+				"label": "Disable",
+				"value": 1
+			}
+		]
 	}
 }

--- a/packages/config/config/devices/0x027a/zen72.json
+++ b/packages/config/config/devices/0x027a/zen72.json
@@ -147,6 +147,11 @@
 		{
 			"#": "22",
 			"$import": "templates/zooz_template.json#night_light_mode"
+		},
+		{
+			"#": "26",
+			"$if": "firmwareVersion >= 10.0",
+			"$import": "templates/zooz_template.json#paddle_programming"
 		}
 	],
 	"metadata": {

--- a/packages/config/config/devices/0x027a/zen74.json
+++ b/packages/config/config/devices/0x027a/zen74.json
@@ -93,6 +93,11 @@
 		{
 			"#": "22",
 			"$import": "templates/zooz_template.json#night_light_mode"
+		},
+		{
+			"#": "26",
+			"$if": "firmwareVersion >= 10.0",
+			"$import": "templates/zooz_template.json#paddle_programming"
 		}
 	],
 	"metadata": {

--- a/packages/config/config/devices/0x027a/zen77.json
+++ b/packages/config/config/devices/0x027a/zen77.json
@@ -129,6 +129,11 @@
 		{
 			"#": "22",
 			"$import": "templates/zooz_template.json#night_light_mode"
+		},
+		{
+			"#": "26",
+			"$if": "firmwareVersion >= 10.0",
+			"$import": "templates/zooz_template.json#paddle_programming"
 		}
 	],
 	"metadata": {


### PR DESCRIPTION
This adds a new parameter that was added to Zooz dimmer switches that lets you disable the triple-tap up/down to enter inclusion/exclusion mode in firmware v10.0.  Some users will want to disable this so that those triple-tap gestures can be used for scene control instead.  I have many ZEN74 switches in my home but according to Zooz docs it should be the same on the ZEN72 and ZEN77 as well so I went ahead and included those. 

https://www.support.getzooz.com/kb/article/850-zen77-700-series-s2-dimmer-change-log/