### PR TITLE
feat: export commonly used string formatting utilities

### DIFF
--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -46,3 +46,64 @@ enum QRCodeVersion {
 ```
 
 the this information can be used to either include an S2 capable node via the [conventional inclusion process](api/controller.md#beginInclusion) or add the information of a SmartStart capable node to the [provisioning list](api/controller.md#provisionSmartStartNode).
+
+## String formatting utilities
+
+### `num2hex`
+
+```ts
+num2hex(
+	val: number | undefined | null,
+	uppercase: boolean = false,
+): string
+```
+
+Formats a number as a hexadecimal string, while making sure that the length is a multiple of two digits. `undefined` and `null` get converted to `"undefined"`.
+
+Parameters:
+
+-   `val` - The value to be formatted as hexadecimal
+-   `uppercase` - Whether uppercase letters should be used
+
+### `formatId`
+
+```ts
+formatId(id: number): string
+```
+
+Formats an ID as a 4-digit lowercase hexadecimal string, to guarantee a representation that matches the Z-Wave specs. This is meant to be used to display manufacturer ID, product type and product ID, etc.
+
+### `buffer2hex`
+
+```ts
+buffer2hex(buffer: Buffer, uppercase: boolean = false): string
+```
+
+Formats a buffer as an hexadecimal string, with an even number of digits. Returns `"(empty)"` if the buffer is empty.
+
+Parameters:
+
+-   `buffer` - The value to be formatted as hexadecimal
+-   `uppercase` - Whether uppercase letters should be used
+
+### `getEnumMemberName`
+
+```ts
+getEnumMemberName(enumeration: unknown, value: number): string
+```
+
+Returns a human-readable representation of the given enum value.
+If the given value is not found in the enum object, `"unknown (<value-as-hex>)"` is returned.
+
+Parameters:
+
+-   `enumeration` - The enumeration object the value comes from
+-   `value` - The enum value to be pretty-printed
+
+### `rssiToString`
+
+```ts
+rssiToString(rssi: RSSI): string
+```
+
+Converts an RSSI value to a human readable format, i.e. the measurement including the unit or the corresponding error message.

--- a/packages/shared/src/misc.ts
+++ b/packages/shared/src/misc.ts
@@ -55,6 +55,13 @@ export function flatMap<U, T extends any[]>(
 	return mapped.reduce((acc, cur) => [...acc, ...cur], [] as U[]);
 }
 
+/**
+ * Returns a human-readable representation of the given enum value.
+ * If the given value is not found in the enum object, `"unknown (<value-as-hex>)"` is returned.
+ *
+ * @param enumeration The enumeration object the value comes from
+ * @param value The enum value to be pretty-printed
+ */
 export function getEnumMemberName(enumeration: unknown, value: number): string {
 	return (enumeration as any)[value] || `unknown (${num2hex(value)})`;
 }

--- a/packages/shared/src/strings.ts
+++ b/packages/shared/src/strings.ts
@@ -7,6 +7,13 @@ export function cpp2js(str: string): string {
 	return str.substr(0, nullIndex);
 }
 
+/**
+ * Formats a number as a hexadecimal string, while making sure that the length is a multiple of two digits.
+ * `undefined` and `null` get converted to `"undefined"`.
+ *
+ * @param val The value to be formatted as hexadecimal
+ * @param uppercase Whether uppercase letters should be used
+ */
 export function num2hex(
 	val: number | undefined | null,
 	uppercase: boolean = false,
@@ -18,6 +25,10 @@ export function num2hex(
 	return "0x" + ret;
 }
 
+/**
+ * Formats an ID as a 4-digit lowercase hexadecimal string, to guarantee a representation that matches the Z-Wave specs.
+ * This is meant to be used to display manufacturer ID, product type and product ID, etc.
+ */
 export function formatId(id: number | string): string {
 	id = typeof id === "number" ? id.toString(16) : id;
 	return "0x" + padStart(id, 4, "0").toLowerCase();
@@ -27,11 +38,18 @@ export function stringify(arg: unknown, space: 4 | "\t" = 4): string {
 	return JSON.stringify(arg, null, space);
 }
 
+/**
+ * Formats a buffer as an hexadecimal string, with an even number of digits.
+ * Returns `"(empty)"` if the buffer is empty.
+ *
+ * @param buffer The value to be formatted as hexadecimal
+ * @param uppercase Whether uppercase letters should be used
+ */
 export function buffer2hex(buffer: Buffer, uppercase: boolean = false): string {
 	if (buffer.length === 0) return "(empty)";
-	let ret = `0x${buffer.toString("hex")}`;
+	let ret = buffer.toString("hex");
 	if (uppercase) ret = ret.toUpperCase();
-	return ret;
+	return "0x" + ret;
 }
 
 export function isPrintableASCII(text: string): boolean {

--- a/packages/zwave-js/src/Utils.ts
+++ b/packages/zwave-js/src/Utils.ts
@@ -10,6 +10,12 @@ export type {
 	Protocols,
 	QRProvisioningInformation,
 } from "@zwave-js/core";
+export {
+	buffer2hex,
+	formatId,
+	getEnumMemberName,
+	num2hex,
+} from "@zwave-js/shared";
 export { rssiToString } from "./lib/controller/SendDataShared";
 export {
 	formatLifelineHealthCheckRound,

--- a/packages/zwave-js/src/lib/controller/SendDataShared.ts
+++ b/packages/zwave-js/src/lib/controller/SendDataShared.ts
@@ -112,6 +112,9 @@ export function tryParseRSSI(
 	return parseRSSI(payload, offset);
 }
 
+/**
+ * Converts an RSSI value to a human readable format, i.e. the measurement including the unit or the corresponding error message.
+ */
 export function rssiToString(rssi: RSSI): string {
 	switch (rssi) {
 		case RssiError.NotAvailable:


### PR DESCRIPTION
This PR exports a few commonly used string formatting utilities under the export `zwave-js/Utils`.