### PR TITLE
refactor: migrate hacky value ID for hasSUCReturnRoute to network cache

### DIFF
--- a/packages/core/src/capabilities/CommandClasses.ts
+++ b/packages/core/src/capabilities/CommandClasses.ts
@@ -128,9 +128,6 @@ export enum CommandClasses {
 	"Z/IP ND" = 0x58,
 	"Z/IP Portal" = 0x61,
 	"Z-Wave Plus Info" = 0x5e,
-
-	// Used to designate values that don't belong to any CC
-	"_NONE" = -1,
 }
 
 export function getCCName(cc: number): string {

--- a/packages/core/src/values/ValueDB.ts
+++ b/packages/core/src/values/ValueDB.ts
@@ -1,6 +1,6 @@
 import type { JsonlDB } from "@alcalzone/jsonl-db";
 import { TypedEventEmitter } from "@zwave-js/shared";
-import { CommandClasses } from "../capabilities/CommandClasses";
+import type { CommandClasses } from "../capabilities/CommandClasses";
 import { isZWaveError, ZWaveError, ZWaveErrorCodes } from "../error/ZWaveError";
 import type { ValueMetadata } from "../values/Metadata";
 
@@ -119,14 +119,6 @@ export function valueIdToString(valueID: ValueID): string {
 	return JSON.stringify(normalizeValueID(valueID));
 }
 
-/** Returns a Value ID that can be used to store node specific data without relating it to a CC */
-export function getNodeMetaValueID(property: string): ValueID {
-	return {
-		commandClass: CommandClasses._NONE,
-		property,
-	};
-}
-
 export interface SetValueOptions {
 	/** When this is true, no event will be emitted for the value change */
 	noEvent?: boolean;
@@ -240,13 +232,10 @@ export class ValueDB extends TypedEventEmitter<ValueDBEventCallbacks> {
 
 			this._index.add(dbKey);
 			this._db.set(dbKey, value);
-			if (
-				valueId.commandClass !== CommandClasses._NONE &&
-				options.noEvent !== true
-			) {
+			if (valueId.commandClass >= 0 && options.noEvent !== true) {
 				this.emit(event, cbArg);
 			}
-		} else if (valueId.commandClass !== CommandClasses._NONE) {
+		} else if (valueId.commandClass >= 0) {
 			// For non-stateful values just emit a notification
 			this.emit("value notification", {
 				...valueId,
@@ -270,10 +259,7 @@ export class ValueDB extends TypedEventEmitter<ValueDBEventCallbacks> {
 			const prevValue = this._db.get(dbKey);
 			this._db.delete(dbKey);
 
-			if (
-				valueId.commandClass !== CommandClasses._NONE &&
-				options.noEvent !== true
-			) {
+			if (valueId.commandClass >= 0 && options.noEvent !== true) {
 				const cbArg: ValueRemovedArgs = {
 					...valueId,
 					prevValue,
@@ -341,10 +327,7 @@ export class ValueDB extends TypedEventEmitter<ValueDBEventCallbacks> {
 				const prevValue = this._db.get(key);
 				this._db.delete(key);
 
-				if (
-					valueId.commandClass !== CommandClasses._NONE &&
-					options.noEvent !== true
-				) {
+				if (valueId.commandClass >= 0 && options.noEvent !== true) {
 					const cbArg: ValueRemovedArgs = {
 						...valueId,
 						prevValue,
@@ -355,10 +338,7 @@ export class ValueDB extends TypedEventEmitter<ValueDBEventCallbacks> {
 			if (this._metadata.has(key)) {
 				this._metadata.delete(key);
 
-				if (
-					valueId.commandClass !== CommandClasses._NONE &&
-					options.noEvent !== true
-				) {
+				if (valueId.commandClass >= 0 && options.noEvent !== true) {
 					const cbArg: MetadataUpdatedArgs = {
 						...valueId,
 						metadata: undefined,
@@ -407,10 +387,7 @@ export class ValueDB extends TypedEventEmitter<ValueDBEventCallbacks> {
 			...valueId,
 			metadata,
 		};
-		if (
-			valueId.commandClass !== CommandClasses._NONE &&
-			options.noEvent !== true
-		) {
+		if (valueId.commandClass >= 0 && options.noEvent !== true) {
 			this.emit("metadata updated", cbArg);
 		}
 	}

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -12,7 +12,6 @@ import {
 	DataRate,
 	FLiRS,
 	getCCName,
-	getNodeMetaValueID,
 	isTransmissionError,
 	isZWaveError,
 	Maybe,
@@ -739,12 +738,12 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner {
 
 	/** Whether a SUC return route was configured for this node */
 	public get hasSUCReturnRoute(): boolean {
-		return !!this.valueDB.getValue<boolean>(
-			getNodeMetaValueID("hasSUCReturnRoute"),
+		return !!this.driver.cacheGet(
+			cacheKeys.node(this.id).hasSUCReturnRoute,
 		);
 	}
 	public set hasSUCReturnRoute(value: boolean) {
-		this.valueDB.setValue(getNodeMetaValueID("hasSUCReturnRoute"), value);
+		this.driver.cacheSet(cacheKeys.node(this.id).hasSUCReturnRoute, value);
 	}
 
 	private _deviceConfig: DeviceConfig | undefined;


### PR DESCRIPTION
This was never a good solution but it was the best at the time. Now with the jsonl network cache, we can finally get rid of the CC -1.