### PR TITLE
fix(config): add metadata to AEON Labs DSC26

### DIFF
--- a/packages/config/config/devices/0x0086/dsc26.json
+++ b/packages/config/config/devices/0x0086/dsc26.json
@@ -58,5 +58,12 @@
 			"#": "255",
 			"$import": "templates/aeotec_template.json#factory_reset"
 		}
-	]
+	],
+	"metadata": {
+		"wakeup": "Press and release the button which is on Micro Smart Energy Switch G2.",
+		"inclusion": "1. Start by placing the controller into inclusion mode.\n2. While the Micro Smart Energy Switch G2 is powered in a 3-wire system, the external switch/button can be toggled to initiate pairing into the Z-Wave network. Or the internal button can be pushed to initiate pairing into the Z-Wave network if the Micro Smart Energy Switch G2 was not put into in-wall box.",
+		"exclusion": "1. Start by placing the controller into exclusion mode.\n2. While the Micro Smart Energy Switch G2 is powered in a 3-wire system, the external switch/button can be toggled 10 times in quick succession to initiate removing from the Z-Wave network. Or the internal button can be pushed to initiate pairing into the Z-Wave network if Micro Smart Energy Switch G2 was not put into in-wall box.",
+		"reset": "Press and hold the button which is on Micro Smart Energy Switch G2 for 20 seconds",
+		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/1498/D.W.%20Zwave%20Manual%20R1.04.docx"
+	}
 }

--- a/packages/config/config/devices/0x0086/dsc26.json
+++ b/packages/config/config/devices/0x0086/dsc26.json
@@ -64,6 +64,6 @@
 		"inclusion": "1. Start by placing the controller into inclusion mode.\n2. While the Micro Smart Energy Switch G2 is powered in a 3-wire system, the external switch/button can be toggled to initiate pairing into the Z-Wave network. Or the internal button can be pushed to initiate pairing into the Z-Wave network if the Micro Smart Energy Switch G2 was not put into in-wall box.",
 		"exclusion": "1. Start by placing the controller into exclusion mode.\n2. While the Micro Smart Energy Switch G2 is powered in a 3-wire system, the external switch/button can be toggled 10 times in quick succession to initiate removing from the Z-Wave network. Or the internal button can be pushed to initiate pairing into the Z-Wave network if Micro Smart Energy Switch G2 was not put into in-wall box.",
 		"reset": "Press and hold the button which is on Micro Smart Energy Switch G2 for 20 seconds",
-		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/1498/D.W.%20Zwave%20Manual%20R1.04.docx"
+		"manual": "https://help.aeotec.com/support/solutions/articles/6000165733-micro-switch-g2-user-guide-"
 	}
 }


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

I couldn't find a download link in a canonical source for the manual.  The link in the JSON goes to the manufacturer support page.  Z-Wave Alliance product page does not have a manual available: https://products.z-wavealliance.org/products/709?selectedFrequencyId=-1
