### PR TITLE
feat: request SDK revision if supported

### DIFF
--- a/packages/core/src/capabilities/Protocols.ts
+++ b/packages/core/src/capabilities/Protocols.ts
@@ -20,3 +20,9 @@ export enum RouteProtocolDataRate {
 }
 
 export const protocolDataRateMask = 0b111;
+
+export enum ProtocolType {
+	"Z-Wave" = 0,
+	"Z-Wave AV" = 1,
+	"Z-Wave for IP" = 2,
+}

--- a/packages/zwave-js/src/lib/message/Constants.ts
+++ b/packages/zwave-js/src/lib/message/Constants.ts
@@ -56,7 +56,7 @@ export enum FunctionType {
 
 	SoftReset = 0x08,
 
-	UNKNOWN_FUNC_UNKNOWN_0x09 = 0x09, // ??
+	GetProtocolVersion = 0x09, // Used to request the Z-Wave Protocol version data (700 series)
 	SerialAPIStarted = 0x0a, // Sent by the controller after the serial API has been started (again)
 
 	SerialAPISetup = 0x0b, // Configure the Serial API

--- a/packages/zwave-js/src/lib/serialapi/capability/GetProtocolVersionMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/capability/GetProtocolVersionMessages.ts
@@ -1,0 +1,45 @@
+import type { ProtocolType } from "@zwave-js/core";
+import type { Driver } from "../../driver/Driver";
+import {
+	FunctionType,
+	MessagePriority,
+	MessageType,
+} from "../../message/Constants";
+import {
+	expectedResponse,
+	Message,
+	MessageDeserializationOptions,
+	messageTypes,
+	priority,
+} from "../../message/Message";
+
+@messageTypes(MessageType.Request, FunctionType.GetProtocolVersion)
+@priority(MessagePriority.Controller)
+@expectedResponse(FunctionType.GetProtocolVersion)
+export class GetProtocolVersionRequest extends Message {}
+
+@messageTypes(MessageType.Response, FunctionType.GetProtocolVersion)
+export class GetProtocolVersionResponse extends Message {
+	public constructor(driver: Driver, options: MessageDeserializationOptions) {
+		super(driver, options);
+		this.protocolType = this.payload[0];
+		this.protocolVersion = [
+			this.payload[1],
+			this.payload[2],
+			this.payload[3],
+		].join(".");
+		const appBuild = this.payload.readUInt16BE(4);
+		if (appBuild !== 0) this.applicationFrameworkBuildNumber = appBuild;
+		if (this.payload.length >= 22) {
+			const commitHash = this.payload.slice(6, 22);
+			if (!commitHash.every((b) => b === 0)) {
+				this.gitCommitHash = commitHash.toString("hex");
+			}
+		}
+	}
+
+	public readonly protocolType: ProtocolType;
+	public readonly protocolVersion: string;
+	public readonly applicationFrameworkBuildNumber?: number;
+	public readonly gitCommitHash?: string;
+}


### PR DESCRIPTION
With this PR, we now request the SDK revision if the corresponding command is supported by the Z-Wave module (SDK 7.x+). This means we can now distinguish between `7.17.1` and `7.17.2` for example. The information is stored in the `Controller.sdkVersion` property, the `firmwareVersion` is **not** changed, because third party firmwares could have a different versioning scheme.

fixes: #4351