### PR TITLE
fix(nvmedit): set proper defaults for 700 series `rfConfig`

### DIFF
--- a/packages/nvmedit/src/convert.ts
+++ b/packages/nvmedit/src/convert.ts
@@ -781,6 +781,23 @@ export function jsonToNVMObjects_v1_to_v4(
 	});
 	addApplicationObjects(applVersionFile.serialize());
 
+	// When converting it can be that the rfConfig doesn't exist. Make sure
+	// that it is initialized with proper defaults.
+	target.controller.rfConfig ??= {
+		rfRegion: 0xff, // default
+		txPower: 0.0,
+		measured0dBm: +3.3,
+		enablePTI: null,
+		maxTXPower: null,
+	};
+
+	// For v3+ targets, the enablePTI and maxTxPower must be set in the rfConfig
+	// or the controller will ignore the file and not accept any changes to the RF config
+	if (format >= 3) {
+		target.controller.rfConfig.enablePTI ??= 0;
+		target.controller.rfConfig.maxTXPower ??= 14.0;
+	}
+
 	addApplicationObjects(...serializeCommonApplicationObjects(target));
 
 	// Protocol files


### PR DESCRIPTION
It turns out that 7.15.3 and later protocol version require the `enablePTI` and `maxTxPower` properties for the `rfConfig` to be set. Otherwise the whole NVM file gets ignored, leading to garbage responses to the RF configuration messages and the stick not accepting new settings.

fixes: https://github.com/zwave-js/node-zwave-js/issues/4367