### PR TITLE
fix: prevent route health checks to sleeping nodes

### DIFF
--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -4119,23 +4119,20 @@ ${formatLifelineHealthCheckSummary(summary)}`,
 				"Nodes which can sleep are not a valid target for a route health check!",
 				ZWaveErrorCodes.CC_NotSupported,
 			);
-		}
-
-		if (
+		} else if (
+			this.canSleep &&
+			!this.supportsCC(CommandClasses.Powerlevel)
+		) {
+			throw new ZWaveError(
+				"Route health checks require that nodes which can sleep support Powerlevel CC!",
+				ZWaveErrorCodes.CC_NotSupported,
+			);
+		} else if (
 			!this.supportsCC(CommandClasses.Powerlevel) &&
 			!otherNode.supportsCC(CommandClasses.Powerlevel)
 		) {
 			throw new ZWaveError(
 				"For a route health check, at least one of the nodes must support Powerlevel CC!",
-				ZWaveErrorCodes.CC_NotSupported,
-			);
-		} else if (
-			!this.supportsCC(CommandClasses.Powerlevel) &&
-			this.canSleep &&
-			otherNode.supportsCC(CommandClasses.Powerlevel)
-		) {
-			throw new ZWaveError(
-				"Route health checks involving nodes that can sleep require the sleeping node to support Powerlevel CC!",
 				ZWaveErrorCodes.CC_NotSupported,
 			);
 		}


### PR DESCRIPTION
For https://github.com/zwave-js/node-zwave-js/issues/4075

Testing the route health of sleeping nodes only makes sense in the following situations:
- The target node is not a sleeping node
- The sleeping node supports Powerlevel CC, since it will be the one sending commands

We now enforce this and throw for all other route health check attempts