### PR TITLE
fix: wait for node to wake up before starting lifeline healthcheck

### DIFF
--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3955,6 +3955,15 @@ protocol version:      ${this.protocolVersion}`;
 			})...`,
 		);
 
+		if (this.canSleep && this.status !== NodeStatus.Awake) {
+			// Wait for node to wake up to avoid incorrectly long delays in the first health check round
+			this.driver.controllerLog.logNode(
+				this.id,
+				`waiting for node to wake up...`,
+			);
+			await this.waitForWakeup();
+		}
+
 		const results: LifelineHealthCheckResult[] = [];
 		for (let round = 1; round <= rounds; round++) {
 			// Determine the number of repeating neighbors
@@ -3975,6 +3984,7 @@ protocol version:      ${this.protocolVersion}`;
 					txReport = report;
 				},
 			});
+
 			for (let i = 1; i <= healthCheckTestFrameCount; i++) {
 				const start = Date.now();
 				const pingResult = await pingAPI.send().then(


### PR DESCRIPTION
For https://github.com/zwave-js/node-zwave-js/issues/4075

Previously the first health check round would include the time until a sleeping node wakes up as part of the round trip time, which made no sense. Now we wait until the node wakes up and then start the checks.