### PR TITLE
fix: set failed pings to 0 if there was a reduced powerlevel w/o errors

### DIFF
--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -4237,6 +4237,7 @@ ${formatLifelineHealthCheckSummary(summary)}`,
 						failedPingsToTarget = failedPings;
 					} else {
 						minPowerlevelSource = powerlevel;
+						failedPingsToTarget = 0;
 					}
 				} catch (e) {
 					if (
@@ -4269,6 +4270,7 @@ ${formatLifelineHealthCheckSummary(summary)}`,
 						failedPingsToSource = failedPings;
 					} else {
 						minPowerlevelTarget = powerlevel;
+						failedPingsToSource = 0;
 					}
 				} catch (e) {
 					if (


### PR DESCRIPTION
For https://github.com/zwave-js/node-zwave-js/issues/4075

If a powerlevel test completed without errors, the failed pings are now set to 0. `undefined` is still possible but means the check wasn't done.