### PR TITLE
feat: export LogContext types

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -2,6 +2,7 @@ export * from "./ConfigManager";
 export * from "./DeviceClasses";
 export * from "./Devices";
 export * from "./Indicators";
+export { ConfigLogContext } from "./Logger";
 export * from "./Manufacturers";
 export * from "./Meters";
 export * from "./Notifications";

--- a/packages/serial/src/index.ts
+++ b/packages/serial/src/index.ts
@@ -1,3 +1,4 @@
+export { SerialLogContext } from "./Logger";
 export * from "./MessageHeaders";
 export * from "./MockSerialPort";
 export * from "./SerialAPIParser";

--- a/packages/zwave-js/src/Controller.ts
+++ b/packages/zwave-js/src/Controller.ts
@@ -14,4 +14,9 @@ export {
 	TXReport,
 } from "./lib/controller/SendDataShared";
 export type { ZWaveLibraryTypes } from "./lib/controller/ZWaveLibraryTypes";
+export {
+	ControllerLogContext,
+	ControllerNodeLogContext,
+	ControllerValueLogContext,
+} from "./lib/log/Controller";
 export { RFRegion } from "./lib/serialapi/misc/SerialAPISetupMessages";

--- a/packages/zwave-js/src/Controller.ts
+++ b/packages/zwave-js/src/Controller.ts
@@ -17,6 +17,7 @@ export type { ZWaveLibraryTypes } from "./lib/controller/ZWaveLibraryTypes";
 export {
 	ControllerLogContext,
 	ControllerNodeLogContext,
+	ControllerSelfLogContext,
 	ControllerValueLogContext,
 } from "./lib/log/Controller";
 export { RFRegion } from "./lib/serialapi/misc/SerialAPISetupMessages";

--- a/packages/zwave-js/src/Driver.ts
+++ b/packages/zwave-js/src/Driver.ts
@@ -2,6 +2,7 @@ export { Driver, libName, libVersion } from "./lib/driver/Driver";
 export type { SendMessageOptions } from "./lib/driver/Driver";
 export type { FileSystem } from "./lib/driver/FileSystem";
 export type { ZWaveOptions } from "./lib/driver/ZWaveOptions";
+export { DriverLogContext } from "./lib/log/Driver";
 export {
 	FunctionType,
 	MessagePriority,

--- a/packages/zwave-js/src/lib/log/Controller.ts
+++ b/packages/zwave-js/src/lib/log/Controller.ts
@@ -30,19 +30,24 @@ interface LogNodeOptions {
 	endpoint?: number;
 }
 
-export interface ControllerLogContext extends LogContext<"controller"> {
-	type?: "controller" | "node" | "value";
-}
-
-export type ControllerNodeLogContext = ControllerLogContext &
+export type ControllerNodeLogContext = LogContext<"controller"> &
 	NodeLogContext & { endpoint?: number; direction: string };
 
-export type ControllerValueLogContext = ControllerLogContext &
+export type ControllerValueLogContext = LogContext<"controller"> &
 	ValueLogContext & {
 		direction?: string;
 		change?: "added" | "updated" | "removed" | "notification";
 		internal?: boolean;
 	};
+
+export type ControllerSelfLogContext = LogContext<"controller"> & {
+	type: "controller";
+};
+
+export type ControllerLogContext =
+	| ControllerSelfLogContext
+	| ControllerNodeLogContext
+	| ControllerValueLogContext;
 
 export type LogValueArgs<T> = T & { nodeId: number; internal?: boolean };
 
@@ -61,7 +66,7 @@ export class ControllerLogger extends ZWaveLoggerBase<ControllerLogContext> {
 
 	/**
 	 * Logs a message
-	 * @param msg The message to output
+	 * @param message The message to output
 	 */
 	public print(message: string, level?: "verbose" | "warn" | "error"): void {
 		const actualLevel = level || CONTROLLER_LOGLEVEL;

--- a/packages/zwave-js/src/lib/log/Controller.ts
+++ b/packages/zwave-js/src/lib/log/Controller.ts
@@ -30,7 +30,9 @@ interface LogNodeOptions {
 	endpoint?: number;
 }
 
-export type ControllerLogContext = LogContext<"controller">;
+export interface ControllerLogContext extends LogContext<"controller"> {
+	type?: "controller" | "node" | "value";
+}
 
 export type ControllerNodeLogContext = ControllerLogContext &
 	NodeLogContext & { endpoint?: number; direction: string };


### PR DESCRIPTION
I want to add log filtering to the websocket log transport in `zwave-js-server` but I need to access more of the LogContext types