### PR TITLE
fix(config): add `treatMultilevelSwitchSetAsEvent` compat flag to Aeotec ZW111

### DIFF
--- a/packages/config/config/devices/0x0086/zw111.json
+++ b/packages/config/config/devices/0x0086/zw111.json
@@ -491,7 +491,8 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"treatBasicSetAsEvent": true,
+		"treatMultilevelSwitchSetAsEvent": true
 	},
 	"metadata": {
 		"inclusion": "Turn the primary controller of Z-Wave network into inclusion mode, short press the product’s Action button that you can find on the product's housing",


### PR DESCRIPTION
Add new "treatMultilevelSwitchSetAsEvent" compat flag to ZW111 to allow controller to process multilevel CCs sent when ZW111 is associated with the controller and external switch used.
