### PR TITLE
build: avoid doing duplicate work

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,8 +80,9 @@
   },
   "scripts": {
     "foreach": "yarn workspaces foreach -pvi --exclude @zwave-js/repo",
-    "build": "yarn foreach -t run build",
-    "watch": "yarn foreach -t --exclude zwave-js run build && yarn workspace zwave-js run watch",
+    "prebuild": "yarn workspace @zwave-js/maintenance run build",
+    "build": "yarn prebuild && yarn workspace zwave-js run build",
+    "watch": "yarn prebuild && yarn workspace zwave-js run watch",
     "test:reset": "jest --clear-cache",
     "test:ts": "jest",
     "test:ci": "yarn run test:ts --runInBand",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,7 @@
     "node": ">=12.22.2 <13 || >=14.13.0 <15 || >= 16 <16.9.0 || >16.9.0"
   },
   "scripts": {
-    "build": "tsc -b tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json --verbose",
     "clean": "yarn run build --clean",
     "watch": "yarn run build --watch --pretty"
   },

--- a/packages/maintenance/package.json
+++ b/packages/maintenance/package.json
@@ -29,7 +29,7 @@
     "node": ">=12.22.2 <13 || >=14.13.0 <15 || >= 16 <16.9.0 || >16.9.0"
   },
   "scripts": {
-    "build": "tsc -b tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json --verbose",
     "clean": "yarn run build --clean",
     "watch": "yarn run build --watch --pretty"
   },

--- a/packages/nvmedit/package.json
+++ b/packages/nvmedit/package.json
@@ -42,7 +42,7 @@
     "yargs": "^17.3.1"
   },
   "scripts": {
-    "build": "tsc -b tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json --verbose",
     "clean": "yarn run build --clean",
     "watch": "yarn run build --watch --pretty"
   },

--- a/packages/serial/package.json
+++ b/packages/serial/package.json
@@ -31,7 +31,7 @@
     "node": ">=12.22.2 <13 || >=14.13.0 <15 || >= 16 <16.9.0 || >16.9.0"
   },
   "scripts": {
-    "build": "tsc -b tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json --verbose",
     "clean": "yarn run build --clean",
     "watch": "yarn run build --watch --pretty"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -35,7 +35,7 @@
     "fs-extra": "^10.0.1"
   },
   "scripts": {
-    "build": "tsc -b tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json --verbose",
     "clean": "yarn run build --clean",
     "watch": "yarn run build --watch --pretty"
   },

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -29,7 +29,7 @@
     "node": ">=12.22.2 <13 || >=14.13.0 <15 || >= 16 <16.9.0 || >16.9.0"
   },
   "scripts": {
-    "build": "tsc -b tsconfig.build.json",
+    "build": "tsc -b tsconfig.build.json --verbose",
     "clean": "yarn run build --clean",
     "watch": "yarn run build --watch --pretty"
   },

--- a/packages/zwave-js/package.json
+++ b/packages/zwave-js/package.json
@@ -44,9 +44,8 @@
   },
   "scripts": {
     "b": "yarn ts maintenance/_build.ts",
-    "deprecated": "node -p '\\\"\\\\n \\\\n \\\\033[31;1;4mThe \\\\\"build:full\\\\\" script has been deprecated. Use \\\\\"build\\\\\" instead!\\\\033[0m\\\\n \\\\n\\\"'",
-    "build_full": "yarn run deprecated && yarn run build",
-    "build": "yarn b prebuild && tsc -b tsconfig.build.json",
+    "build": "yarn b prebuild && tsc -b tsconfig.build.json --verbose",
+    "build_deps": "tsc -b tsconfig.build.json --verbose",
     "clean": "tsc -b tsconfig.build.json --clean",
     "watch": "yarn b prebuild && tsc -b tsconfig.build.json --watch --pretty",
     "lint_zwave": "yarn b lint",

--- a/packages/zwave-js/package.json
+++ b/packages/zwave-js/package.json
@@ -45,7 +45,6 @@
   "scripts": {
     "b": "yarn ts maintenance/_build.ts",
     "build": "yarn b prebuild && tsc -b tsconfig.build.json --verbose",
-    "build_deps": "tsc -b tsconfig.build.json --verbose",
     "clean": "tsc -b tsconfig.build.json --clean",
     "watch": "yarn b prebuild && tsc -b tsconfig.build.json --watch --pretty",
     "lint_zwave": "yarn b lint",


### PR DESCRIPTION
For some reason, these optimizations got lost when switching to yarn v3 workspaces. Now we make sure that `yarn run build` only does the necessary work for a compilation, and only once.

Build times are down to:
- 26s on a cold build (from 31s)
- 10s for incremental builds (from 25s)