### PR TITLE
fix(config): add metadata to 0x0258: Shenzhen Neo Siren Alarm

### DIFF
--- a/packages/config/config/devices/0x0118/tz06.json
+++ b/packages/config/config/devices/0x0118/tz06.json
@@ -152,5 +152,8 @@
 				}
 			]
 		}
+	},
+	"compat": {
+		"mapRootReportsToEndpoint": 1
 	}
 }


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

PR description here
[0x0258 - Shenzhen Neo Siren Alarm.txt](https://github.com/zwave-js/node-zwave-js/files/8307701/0x0258.-.Shenzhen.Neo.Siren.Alarm.txt)
Adds values for Alarm and Doorbell Sound Selection
