### PR TITLE
fix: rebuild cache-backed maps after cache migration

### DIFF
--- a/packages/core/src/values/CacheBackedMap.ts
+++ b/packages/core/src/values/CacheBackedMap.ts
@@ -16,15 +16,8 @@ export class CacheBackedMap<K extends string | number, V> implements Map<K, V> {
 		private readonly cacheKeys: CacheBackedMapKeys<K>,
 	) {
 		this.map = new Map();
-		for (const [key, value] of this.cache.entries()) {
-			if (key.startsWith(this.cacheKeys.prefix)) {
-				const suffix = key.substring(this.cacheKeys.prefix.length);
-				const suffixKey = this.cacheKeys.suffixDeserializer(suffix);
-				if (suffixKey !== undefined) {
-					this.map.set(suffixKey, value);
-				}
-			}
-		}
+		this.rebuild();
+
 		// Bind all map properties we can use directly
 		this.forEach = this.map.forEach.bind(this.map);
 		this.get = this.map.get.bind(this.map);
@@ -38,6 +31,22 @@ export class CacheBackedMap<K extends string | number, V> implements Map<K, V> {
 	private map: Map<K, V>;
 	private keyToCacheKey(key: K): string {
 		return this.cacheKeys.prefix + this.cacheKeys.suffixSerializer(key);
+	}
+
+	/**
+	 * Discards the locally-cached entries and rebuilds the map with up-to-date information from the cache
+	 */
+	rebuild(): void {
+		this.map.clear();
+		for (const [key, value] of this.cache.entries()) {
+			if (key.startsWith(this.cacheKeys.prefix)) {
+				const suffix = key.substring(this.cacheKeys.prefix.length);
+				const suffixKey = this.cacheKeys.suffixDeserializer(suffix);
+				if (suffixKey !== undefined) {
+					this.map.set(suffixKey, value);
+				}
+			}
+		}
 	}
 
 	clear(): void {

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -2,6 +2,7 @@ import { JsonlDB, JsonlDBOptions } from "@alcalzone/jsonl-db";
 import * as Sentry from "@sentry/node";
 import { ConfigManager, externalConfigDir } from "@zwave-js/config";
 import {
+	CacheBackedMap,
 	CommandClasses,
 	deserializeCacheValue,
 	dskFromString,
@@ -3964,6 +3965,21 @@ ${handlers.length} left`,
 						continue;
 					}
 					this._valueDB.delete(key);
+				}
+
+				// Re-create cache-backed maps which are operating on outdated information now
+				for (const node of this.controller.nodes.values()) {
+					(
+						node.securityClasses as CacheBackedMap<any, any>
+					).rebuild();
+					for (const ep of node.getAllEndpoints()) {
+						(
+							ep.implementedCommandClasses as CacheBackedMap<
+								any,
+								any
+							>
+						).rebuild();
+					}
 				}
 			} catch (e) {
 				const message = `Migrating the legacy cache file to jsonl failed: ${getErrorMessage(


### PR DESCRIPTION
Prior to this PR, a cache migration from v8 to v9 would leave the internal `CacheBackedMap`s in node and enpoint instances empty, because they were created when the cache was still empty. This lead to empty responses for security classes and defined value IDs.