### PR TITLE
fix: prebuild zwave-js before running test script

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,6 @@
 			"runtimeArgs": [
 				"node",
 				"--async-stack-traces",
-				"--inspect-brk=9229",
 				"-r",
 				"esbuild-register",
 				"${workspaceFolder}/test/run.ts"
@@ -24,7 +23,8 @@
 			},
 			"console": "integratedTerminal",
 			"skipFiles": ["<node_internals>/**"],
-			"sourceMaps": true
+			"sourceMaps": true,
+			"preLaunchTask": "npm: build"
 		},
 		{
 			"type": "node",

--- a/test/run.ts
+++ b/test/run.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import "reflect-metadata";
-import { Driver } from "../packages/zwave-js/src";
+import { Driver } from "zwave-js";
 
 process.on("unhandledRejection", (_r) => {
 	debugger;


### PR DESCRIPTION
With the recent inclusion of transformers, we cannot rely on esbuild to do the compilation. Instead the debug task now runs `yarn build` first.