### PR TITLE
fix: parsing of GetProtocolVersionResponse

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -58,7 +58,8 @@
 			],
 			"console": "integratedTerminal",
 			"skipFiles": ["<node_internals>/**"],
-			"sourceMaps": true
+			"sourceMaps": true,
+			"preLaunchTask": "npm: build"
 		},
 		{
 			"type": "node",

--- a/packages/zwave-js/src/lib/serialapi/capability/GetProtocolVersionMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/capability/GetProtocolVersionMessages.ts
@@ -28,8 +28,10 @@ export class GetProtocolVersionResponse extends Message {
 			this.payload[2],
 			this.payload[3],
 		].join(".");
-		const appBuild = this.payload.readUInt16BE(4);
-		if (appBuild !== 0) this.applicationFrameworkBuildNumber = appBuild;
+		if (this.payload.length >= 6) {
+			const appBuild = this.payload.readUInt16BE(4);
+			if (appBuild !== 0) this.applicationFrameworkBuildNumber = appBuild;
+		}
 		if (this.payload.length >= 22) {
 			const commitHash = this.payload.slice(6, 22);
 			if (!commitHash.every((b) => b === 0)) {


### PR DESCRIPTION
It seems like there was an older version of GetProtocolVersionResponse with just 4 bytes we didn't consider.

fixes: #4390