### PR TITLE
fix: correct cache load order, bind node device class to cache

### DIFF
--- a/packages/core/src/values/CacheBackedMap.ts
+++ b/packages/core/src/values/CacheBackedMap.ts
@@ -16,7 +16,15 @@ export class CacheBackedMap<K extends string | number, V> implements Map<K, V> {
 		private readonly cacheKeys: CacheBackedMapKeys<K>,
 	) {
 		this.map = new Map();
-		this.rebuild();
+		for (const [key, value] of this.cache.entries()) {
+			if (key.startsWith(this.cacheKeys.prefix)) {
+				const suffix = key.substring(this.cacheKeys.prefix.length);
+				const suffixKey = this.cacheKeys.suffixDeserializer(suffix);
+				if (suffixKey !== undefined) {
+					this.map.set(suffixKey, value);
+				}
+			}
+		}
 
 		// Bind all map properties we can use directly
 		this.forEach = this.map.forEach.bind(this.map);
@@ -31,22 +39,6 @@ export class CacheBackedMap<K extends string | number, V> implements Map<K, V> {
 	private map: Map<K, V>;
 	private keyToCacheKey(key: K): string {
 		return this.cacheKeys.prefix + this.cacheKeys.suffixSerializer(key);
-	}
-
-	/**
-	 * Discards the locally-cached entries and rebuilds the map with up-to-date information from the cache
-	 */
-	rebuild(): void {
-		this.map.clear();
-		for (const [key, value] of this.cache.entries()) {
-			if (key.startsWith(this.cacheKeys.prefix)) {
-				const suffix = key.substring(this.cacheKeys.prefix.length);
-				const suffixKey = this.cacheKeys.suffixDeserializer(suffix);
-				if (suffixKey !== undefined) {
-					this.map.set(suffixKey, value);
-				}
-			}
-		}
 	}
 
 	clear(): void {

--- a/packages/zwave-js/src/lib/node/Endpoint.ts
+++ b/packages/zwave-js/src/lib/node/Endpoint.ts
@@ -65,9 +65,29 @@ export class Endpoint {
 		}
 	}
 
-	protected _deviceClass: DeviceClass | undefined;
+	/**
+	 * Only used for endpoints which store their device class differently than nodes.
+	 * DO NOT ACCESS directly!
+	 */
+	private _deviceClass: DeviceClass | undefined;
 	public get deviceClass(): DeviceClass | undefined {
-		return this._deviceClass;
+		if (this.index > 0) {
+			return this._deviceClass;
+		} else {
+			return this.driver.cacheGet(
+				cacheKeys.node(this.nodeId).deviceClass,
+			);
+		}
+	}
+	protected set deviceClass(deviceClass: DeviceClass | undefined) {
+		if (this.index > 0) {
+			this._deviceClass = deviceClass;
+		} else {
+			this.driver.cacheSet(
+				cacheKeys.node(this.nodeId).deviceClass,
+				deviceClass,
+			);
+		}
 	}
 
 	/** Resets all stored information of this endpoint */
@@ -105,9 +125,9 @@ export class Endpoint {
 	 * **Note:** This does nothing if the device class was already configured
 	 */
 	protected applyDeviceClass(deviceClass?: DeviceClass): void {
-		if (this._deviceClass) return;
+		if (this.deviceClass) return;
 
-		this._deviceClass = deviceClass;
+		this.deviceClass = deviceClass;
 		// Add mandatory CCs
 		if (deviceClass) {
 			for (const cc of deviceClass.mandatorySupportedCCs) {

--- a/packages/zwave-js/src/lib/node/Node.test.ts
+++ b/packages/zwave-js/src/lib/node/Node.test.ts
@@ -1,3 +1,4 @@
+import { ConfigManager } from "@zwave-js/config";
 import {
 	applicationCCs,
 	assertZWaveError,
@@ -79,12 +80,18 @@ describe("lib/node/Node", () => {
 
 	describe("constructor", () => {
 		let fakeDriver: Driver;
+		let configManager: ConfigManager;
 
 		beforeAll(async () => {
-			fakeDriver = createEmptyMockDriver() as unknown as Driver;
 			// Loading configuration may take a while on CI
 			if (process.env.CI) jest.setTimeout(30000);
-			await fakeDriver.configManager.loadDeviceClasses();
+			configManager = new ConfigManager();
+			await configManager.loadDeviceClasses();
+		});
+
+		beforeEach(() => {
+			fakeDriver = createEmptyMockDriver() as unknown as Driver;
+			(fakeDriver as any).configManager = configManager;
 		});
 
 		it("stores the given Node ID", () => {

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1119,16 +1119,16 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner {
 				this.endpointsHaveIdenticalCapabilities ? 1 : index,
 			),
 		);
-		if (deviceClass && this._deviceClass) {
+		if (deviceClass && this.deviceClass) {
 			return new DeviceClass(
 				this.driver.configManager,
-				this._deviceClass.basic.key,
+				this.deviceClass.basic.key,
 				deviceClass.generic,
 				deviceClass.specific,
 			);
 		}
 		// fall back to the node's device class if it is known
-		return this._deviceClass;
+		return this.deviceClass;
 	}
 
 	private getEndpointCCs(index: number): CommandClasses[] | undefined {
@@ -1312,7 +1312,7 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner {
 		this._interviewAttempts = 0;
 		this.interviewStage = InterviewStage.None;
 		this._ready = false;
-		this._deviceClass = undefined;
+		this.deviceClass = undefined;
 		this.isListening = undefined;
 		this.isFrequentListening = undefined;
 		this.isRouting = undefined;


### PR DESCRIPTION
https://github.com/zwave-js/node-zwave-js/pull/4395 was not cutting it. We now perform cache migration before node instances are created and the device class for nodes is now directly bound to the cache, so it gets automatically loaded and stored.