### PR TITLE
fix(config): add values for Alarm and Doorbell Sound Selection to Shenzhen Neo Siren Alarm

### DIFF
--- a/packages/config/config/devices/0x0258/nas-ab01z.json
+++ b/packages/config/config/devices/0x0258/nas-ab01z.json
@@ -93,6 +93,8 @@
 			"#": "3",
 			"label": "Doorbell Duration",
 			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
 			"defaultValue": 1,
 			"unsigned": true,
 			"options": [

--- a/packages/config/config/devices/0x0258/nas-ab01z.json
+++ b/packages/config/config/devices/0x0258/nas-ab01z.json
@@ -142,7 +142,7 @@
 					"value": 1
 				},
 				{
-					"label": "Fur Elise",
+					"label": "Für Elise",
 					"value": 2
 				},
 				{
@@ -191,7 +191,7 @@
 					"value": 1
 				},
 				{
-					"label": "Fur Elise",
+					"label": "Für Elise",
 					"value": 2
 				},
 				{

--- a/packages/config/config/devices/0x0258/nas-ab01z.json
+++ b/packages/config/config/devices/0x0258/nas-ab01z.json
@@ -63,9 +63,8 @@
 			"#": "2",
 			"label": "Alarm Duration",
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 3,
 			"defaultValue": 2,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Off",
@@ -134,9 +133,8 @@
 			"#": "5",
 			"label": "Alarm Sound Selection",
 			"valueSize": 1,
-			"minValue": 1,
-			"maxValue": 10,
-			"defaultValue": 9,
+			"defaultValue": 10,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Doorbell",
@@ -184,9 +182,8 @@
 			"#": "6",
 			"label": "Doorbell Sound Selection",
 			"valueSize": 1,
-			"minValue": 1,
-			"maxValue": 10,
-			"defaultValue": 10,
+			"defaultValue": 9,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Doorbell",

--- a/packages/config/config/devices/0x0258/nas-ab01z.json
+++ b/packages/config/config/devices/0x0258/nas-ab01z.json
@@ -82,6 +82,10 @@
 				{
 					"label": "5 minutes",
 					"value": 3
+				},
+				{
+					"label": "Always on",
+					"value": 255
 				}
 			]
 		},
@@ -132,7 +136,49 @@
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 10,
-			"defaultValue": 9
+			"defaultValue": 9,
+			"options": [
+				{
+					"label": "Doorbell",
+					"value": 1
+				},
+				{
+					"label": "Fur Elise",
+					"value": 2
+				},
+				{
+					"label": "Westminster Chimes",
+					"value": 3
+				},
+				{
+					"label": "Ding Dong",
+					"value": 4
+				},
+				{
+					"label": "William Tell",
+					"value": 5
+				},
+				{
+					"label": "Rondo Alla Turca",
+					"value": 6
+				},
+				{
+					"label": "Police Siren",
+					"value": 7
+				},
+				{
+					"label": "Evacuation",
+					"value": 8
+				},
+				{
+					"label": "Beep Beep",
+					"value": 9
+				},
+				{
+					"label": "Beep",
+					"value": 10
+				}
+			]
 		},
 		{
 			"#": "6",
@@ -140,7 +186,49 @@
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 10,
-			"defaultValue": 10
+			"defaultValue": 10,
+			"options": [
+				{
+					"label": "Doorbell",
+					"value": 1
+				},
+				{
+					"label": "Fur Elise",
+					"value": 2
+				},
+				{
+					"label": "Westminster Chimes",
+					"value": 3
+				},
+				{
+					"label": "Ding Dong",
+					"value": 4
+				},
+				{
+					"label": "William Tell",
+					"value": 5
+				},
+				{
+					"label": "Rondo Alla Turca",
+					"value": 6
+				},
+				{
+					"label": "Police Siren",
+					"value": 7
+				},
+				{
+					"label": "Evacuation",
+					"value": 8
+				},
+				{
+					"label": "Beep Beep",
+					"value": 9
+				},
+				{
+					"label": "Beep",
+					"value": 10
+				}
+			]
 		},
 		{
 			"#": "7",

--- a/packages/config/config/devices/0x0258/nas-ab01z.json
+++ b/packages/config/config/devices/0x0258/nas-ab01z.json
@@ -93,8 +93,6 @@
 			"#": "3",
 			"label": "Doorbell Duration",
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
 			"defaultValue": 1,
 			"unsigned": true,
 			"options": [

--- a/packages/config/config/devices/0x0258/nas-ab01z.json
+++ b/packages/config/config/devices/0x0258/nas-ab01z.json
@@ -64,6 +64,7 @@
 			"label": "Alarm Duration",
 			"valueSize": 1,
 			"defaultValue": 2,
+			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

Also added option "Always on" to "Alarm Duration"
