### PR TITLE
fix(config): correct value for Brightness After Power Failure for LZW31-SN

### DIFF
--- a/packages/config/config/devices/0x031e/lzw31-sn.json
+++ b/packages/config/config/devices/0x031e/lzw31-sn.json
@@ -155,7 +155,7 @@
 			"label": "Brightness After Power Failure",
 			"valueSize": 1,
 			"minValue": 0,
-			"maxValue": 101,
+			"maxValue": 100,
 			"defaultValue": 100,
 			"options": [
 				{
@@ -164,7 +164,7 @@
 				},
 				{
 					"label": "Previous state",
-					"value": 101
+					"value": 100
 				}
 			]
 		},


### PR DESCRIPTION
It turns out that 101 is not a valid value for `Brightness After Power Failure`, based on the discussion here (https://community.inovelli.com/t/cant-choose-option-101-for-parameter-11-7-presses-power-on-state/1392/8). 101 is rejected by the switch.
