### PR TITLE
fix: treat `undefined` object properties the same way as missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@
 <!--
 	Add placeholder for next release with `wip` snippet
 -->
-## 9.0.0 (2022-04-03) · _„You had my curiosity. But now you have my attention.”_
+## __WORK IN PROGRESS__
+### Bugfixes
+* The auto-generated argument validation now considers `{ prop1: undefined }` and `{}` to be equivalent.
 
+## 9.0.0 (2022-04-03) · _„You had my curiosity. But now you have my attention.”_
 Roughly nine months after the [last major release](https://github.com/zwave-js/node-zwave-js/releases/tag/v8.0.1), we've reached a new milestone.
 Z-Wave JS is now 4 years old, its usage has more than doubled over the course of the `v8.x` release line and it is still growing steadily. There are many exciting things yet to come, so stay tuned!
 

--- a/packages/transformers/src/validateArgs/visitor-type-check.ts
+++ b/packages/transformers/src/validateArgs/visitor-type-check.ts
@@ -551,9 +551,29 @@ function visitRegularObjectType(
 						return [
 							f.createIfStatement(
 								f.createBinaryExpression(
-									f.createStringLiteral(propertyInfo.name),
-									ts.SyntaxKind.InKeyword,
-									VisitorUtils.objectIdentifier,
+									f.createBinaryExpression(
+										f.createStringLiteral(
+											propertyInfo.name,
+										),
+										ts.SyntaxKind.InKeyword,
+										VisitorUtils.objectIdentifier,
+									),
+									f.createToken(
+										ts.SyntaxKind.AmpersandAmpersandToken,
+									),
+									f.createBinaryExpression(
+										f.createElementAccessExpression(
+											VisitorUtils.objectIdentifier,
+											f.createStringLiteral(
+												propertyInfo.name,
+											),
+										),
+										f.createToken(
+											ts.SyntaxKind
+												.ExclamationEqualsEqualsToken,
+										),
+										f.createIdentifier("undefined"),
+									),
 								),
 								VisitorUtils.createBlock(
 									f,

--- a/packages/transformers/test/fixtures/testOptionalProperty.ts
+++ b/packages/transformers/test/fixtures/testOptionalProperty.ts
@@ -1,0 +1,28 @@
+import { validateArgs } from "@zwave-js/transformers";
+import assert from "assert";
+
+interface Foo {
+	p1: number;
+	p2?: string;
+}
+
+class Test {
+	@validateArgs()
+	foo(arg1: Foo): void {
+		arg1;
+		return void 0;
+	}
+}
+
+const test = new Test();
+// These should not throw
+test.foo({ p1: 1 });
+test.foo({ p1: 1, p2: "a string" });
+test.foo({ p1: 1, p2: undefined });
+
+// These should throw
+assert.throws(
+	// @ts-expect-error
+	() => test.foo({ p2: "a string" }),
+	/arg1 is not a Foo/,
+);


### PR DESCRIPTION
fixes: #4439 