### PR TITLE
fix(config): correct valueSize for param 15 on GE/Jasco 26931 / ZW4006

### DIFF
--- a/packages/config/config/devices/0x0063/26931_zw4006.json
+++ b/packages/config/config/devices/0x0063/26931_zw4006.json
@@ -212,6 +212,7 @@
 		{
 			"#": "15",
 			"label": "Reset Cycle",
+			"description": "Values 5 to 109 are 15 second intervals, starting at 60 seconds",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 110,
@@ -238,11 +239,10 @@
 					"value": 4
 				},
 				{
-					"label": "27 mins",
+					"label": "27 mins, 15 seconds",
 					"value": 110
 				}
-			],
-			"description": "Steps of 15 seconds for value 5 through 109"
+			]
 		},
 		{
 			"#": "19",

--- a/packages/config/config/devices/0x0063/26931_zw4006.json
+++ b/packages/config/config/devices/0x0063/26931_zw4006.json
@@ -212,11 +212,10 @@
 		{
 			"#": "15",
 			"label": "Reset Cycle",
-			"valueSize": 1,
+			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 110,
 			"defaultValue": 2,
-			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",
@@ -242,7 +241,8 @@
 					"label": "27 mins",
 					"value": 110
 				}
-			]
+			],
+			"description": "Steps of 15 seconds for value 5 through 109"
 		},
 		{
 			"#": "19",

--- a/packages/config/config/devices/0x0063/26931_zw4006.json
+++ b/packages/config/config/devices/0x0063/26931_zw4006.json
@@ -212,7 +212,7 @@
 		{
 			"#": "15",
 			"label": "Reset Cycle",
-			"description": "Values 5 to 109 are 15 second intervals, starting at 60 seconds",
+			"description": "15 second intervals, starting from 60 seconds: Duration = (value-1) · 15s.",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 110,
@@ -223,23 +223,23 @@
 					"value": 0
 				},
 				{
-					"label": "10 secs",
+					"label": "10 seconds",
 					"value": 1
 				},
 				{
-					"label": "20 secs",
+					"label": "20 seconds",
 					"value": 2
 				},
 				{
-					"label": "30 secs",
+					"label": "30 seconds",
 					"value": 3
 				},
 				{
-					"label": "45 secs",
+					"label": "45 seconds",
 					"value": 4
 				},
 				{
-					"label": "27 mins, 15 seconds",
+					"label": "27 minutes, 15 seconds",
 					"value": 110
 				}
 			]


### PR DESCRIPTION
I have 3 of these switches (I don't have any of the dimmer type). The motion timeout setting has not been working, finally realized this should be a valueSize of 2. Additionally it accepts values outside of the options, so I've removed the limit on manual entry and added a description. Tested and working well for my 3 of these devices.
