### PR TITLE
fix(config): add manual to GE/Jasco 26932 / 26933 / ZW3008

### DIFF
--- a/packages/config/config/devices/0x0063/26932_26933_zw3008.json
+++ b/packages/config/config/devices/0x0063/26932_26933_zw3008.json
@@ -344,12 +344,12 @@
 			]
 		}
 	],
-	"metadata": {
-		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/2108/26933%20EnFrSp%20QSG%20v1.3%20and%20Parameters.pdf"
-	},
 	// Add compat flag to re-enable basic command events to replicate central scene functionality.
 	// Allows user to detect switch button presses as events when zwave controller is added to Group 2 or 3.
 	"compat": {
 		"treatBasicSetAsEvent": true
+	},
+	"metadata": {
+		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/2108/26933%20EnFrSp%20QSG%20v1.3%20and%20Parameters.pdf"
 	}
 }

--- a/packages/config/config/devices/0x0063/26932_26933_zw3008.json
+++ b/packages/config/config/devices/0x0063/26932_26933_zw3008.json
@@ -344,6 +344,9 @@
 			]
 		}
 	],
+	"metadata": {
+		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/2108/26933%20EnFrSp%20QSG%20v1.3%20and%20Parameters.pdf"
+	},
 	// Add compat flag to re-enable basic command events to replicate central scene functionality.
 	// Allows user to detect switch button presses as events when zwave controller is added to Group 2 or 3.
 	"compat": {


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

PR description here
