### PR TITLE
feat(config): add bulk config params to inovelli switches

### DIFF
--- a/packages/config/config/devices/0x031e/lzw30-sn.json
+++ b/packages/config/config/devices/0x031e/lzw30-sn.json
@@ -477,6 +477,14 @@
 					"value": 4
 				}
 			]
+		},
+		{
+			"#": "8",
+			"label": "Bulk set Param 8",
+			"valueSize": 4,
+			"defaultValue": 0,
+			"minValue": 0,
+			"maxValue": 100600575
 		}
 	],
 	"metadata": {

--- a/packages/config/config/devices/0x031e/lzw31-sn.json
+++ b/packages/config/config/devices/0x031e/lzw31-sn.json
@@ -466,6 +466,14 @@
 			]
 		},
 		{
+			"#": "16",
+			"label": "Bulk set Param 16",
+			"valueSize": 4,
+			"defaultValue": 0,
+			"minValue": 0,
+			"maxValue": 100600575
+		},		
+		{
 			"#": "17",
 			"label": "LED Indicator: Timeout",
 			"unit": "seconds",

--- a/packages/config/config/devices/0x031e/lzw31-sn.json
+++ b/packages/config/config/devices/0x031e/lzw31-sn.json
@@ -472,7 +472,7 @@
 			"defaultValue": 0,
 			"minValue": 0,
 			"maxValue": 100600575
-		},		
+		},
 		{
 			"#": "17",
 			"label": "LED Indicator: Timeout",

--- a/packages/config/config/devices/0x031e/lzw36.json
+++ b/packages/config/config/devices/0x031e/lzw36.json
@@ -765,7 +765,7 @@
 			"defaultValue": 0,
 			"minValue": 0,
 			"maxValue": 100600575
-		},		
+		},
 		{
 			"#": "25[0x7f000000]",
 			"label": "Fan LED Effect Type",
@@ -915,7 +915,7 @@
 			"defaultValue": 0,
 			"minValue": 0,
 			"maxValue": 100600575
-		},		
+		},
 		{
 			"#": "26",
 			"label": "Light LED Strip Timeout",

--- a/packages/config/config/devices/0x031e/lzw36.json
+++ b/packages/config/config/devices/0x031e/lzw36.json
@@ -759,6 +759,14 @@
 			]
 		},
 		{
+			"#": "24",
+			"label": "Bulk set Param 24",
+			"valueSize": 4,
+			"defaultValue": 0,
+			"minValue": 0,
+			"maxValue": 100600575
+		},		
+		{
 			"#": "25[0x7f000000]",
 			"label": "Fan LED Effect Type",
 			"valueSize": 4,
@@ -900,6 +908,14 @@
 				}
 			]
 		},
+		{
+			"#": "25",
+			"label": "Bulk set Param 25",
+			"valueSize": 4,
+			"defaultValue": 0,
+			"minValue": 0,
+			"maxValue": 100600575
+		},		
 		{
 			"#": "26",
 			"label": "Light LED Strip Timeout",


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

Add bulk configuration parameters to Inovelli devices: lzw30-sn, lzw31-sn, and lzw36 for LED notifications.
