### PR TITLE
feat(config): add param 92 (Battery Calibration Check) to aërQ v2.01

### DIFF
--- a/packages/config/config/devices/0x0371/zwa039.json
+++ b/packages/config/config/devices/0x0371/zwa039.json
@@ -278,18 +278,12 @@
 			"#": "92",
 			"$if": "firmwareVersion >= 2.1",
 			"label": "Battery Calibration Check",
-			"description": "To determine the battery calibration value, you must set each step in order",
+			"description": "To determine the battery calibration value, set each step in order and wait for the value to update. If the returned values are NOT 0, the battery is still calibrated.",
 			"unsigned": true,
 			"valueSize": 4,
-			"minValue": 0,
-			"maxValue": 4294967295,
-			"allowManualEntry": false,
 			"defaultValue": 83951616,
+			"allowManualEntry": false,
 			"options": [
-				{
-					"label": "Idle",
-					"value": 0
-				},
 				{
 					"label": "Step 1",
 					"value": 83951616

--- a/packages/config/config/devices/0x0371/zwa039.json
+++ b/packages/config/config/devices/0x0371/zwa039.json
@@ -281,7 +281,8 @@
 			"description": "To determine the battery calibration value, you must set each step in order",
 			"unsigned": true,
 			"valueSize": 4,
-			"defaultValue": 43200,
+			"allowManualEntry": false,
+			"defaultValue": 83951616,
 			"options": [
 				{
 					"label": "Step 1",

--- a/packages/config/config/devices/0x0371/zwa039.json
+++ b/packages/config/config/devices/0x0371/zwa039.json
@@ -281,9 +281,15 @@
 			"description": "To determine the battery calibration value, you must set each step in order",
 			"unsigned": true,
 			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 4294967295,
 			"allowManualEntry": false,
 			"defaultValue": 83951616,
 			"options": [
+				{
+					"label": "Idle",
+					"value": 0
+				},
 				{
 					"label": "Step 1",
 					"value": 83951616

--- a/packages/config/config/devices/0x0371/zwa039.json
+++ b/packages/config/config/devices/0x0371/zwa039.json
@@ -275,6 +275,29 @@
 			"valueSize": 1
 		},
 		{
+			"#": "92",
+			"$if": "firmwareVersion >= 2.1",
+			"label": "Battery Calibration Check",
+			"description": "To determine the battery calibration value, you must set each step in order",
+			"unsigned": true,
+			"valueSize": 4,
+			"defaultValue": 43200,
+			"options": [
+				{
+					"label": "Step 1",
+					"value": 83951616
+				},
+				{
+					"label": "Step 2",
+					"value": 84017152
+				},
+				{
+					"label": "Step 3",
+					"value": 84082688
+				}
+			]
+		},
+		{
 			"#": "255",
 			"$import": "~/0x0086/templates/aeotec_template.json#factory_reset_complete"
 		}


### PR DESCRIPTION
Adding param 92 per Aeotec support:

In V2.01 of the new aerQ Sensor, there is a new battery calibration check parameter setting. There are only 3 different setting inputs:

 

1. Parameter 92 [4 byte] = 0x05010000 (83951616)

Example checked value returned (0x0B5B0B54 = 190516052 )

 

2. Parameter 92 [4 byte] = 0x05020000 (84017152)

Example checked value returned (0x0AF70AEC = 183962348 )

 

3. Parameter 92 [4 byte] = 0x05030000 (84082688)

Example checked value returned (0x0A2F0A28 = 170854952 )