### PR TITLE
docs: use relative paths in CC index 

### DIFF
--- a/docs/api/CCs/index.md
+++ b/docs/api/CCs/index.md
@@ -10,60 +10,60 @@ The **Command Classes API** provides a high-to-mid level entrypoint which allows
 
 <!-- AUTO-GENERATE: CC List -->
 
--   [Alarm Sensor CC](AlarmSensor.md) · `0x9c`
--   [Association CC](Association.md) · `0x85`
--   [Association Group Information CC](AssociationGroupInfo.md) · `0x59`
--   [Barrier Operator CC](BarrierOperator.md) · `0x66`
--   [Basic CC](Basic.md) · `0x20`
--   [Battery CC](Battery.md) · `0x80`
--   [Binary Sensor CC](BinarySensor.md) · `0x30`
--   [Binary Switch CC](BinarySwitch.md) · `0x25`
--   [Central Scene CC](CentralScene.md) · `0x5b`
--   [Climate Control Schedule CC](ClimateControlSchedule.md) · `0x46`
--   [Clock CC](Clock.md) · `0x81`
--   [Color Switch CC](ColorSwitch.md) · `0x33`
--   [Configuration CC](Configuration.md) · `0x70`
--   [CRC-16 Encapsulation CC](CRC16.md) · `0x56`
--   [Door Lock CC](DoorLock.md) · `0x62`
--   [Door Lock Logging CC](DoorLockLogging.md) · `0x4c`
--   [Entry Control CC](EntryControl.md) · `0x6f`
--   [Firmware Update Meta Data CC](FirmwareUpdateMetaData.md) · `0x7a`
--   [Humidity Control Mode CC](HumidityControlMode.md) · `0x6d`
--   [Humidity Control Operating State CC](HumidityControlOperatingState.md) · `0x6e`
--   [Humidity Control Setpoint CC](HumidityControlSetpoint.md) · `0x64`
--   [Indicator CC](Indicator.md) · `0x87`
--   [Irrigation CC](Irrigation.md) · `0x6b`
--   [Language CC](Language.md) · `0x89`
--   [Lock CC](Lock.md) · `0x76`
--   [Manufacturer Proprietary CC](ManufacturerProprietary.md) · `0x91`
--   [Manufacturer Specific CC](ManufacturerSpecific.md) · `0x72`
--   [Meter CC](Meter.md) · `0x32`
--   [Multi Channel Association CC](MultiChannelAssociation.md) · `0x8e`
--   [Multi Channel CC](MultiChannel.md) · `0x60`
--   [Multi Command CC](MultiCommand.md) · `0x8f`
--   [Multilevel Sensor CC](MultilevelSensor.md) · `0x31`
--   [Multilevel Switch CC](MultilevelSwitch.md) · `0x26`
--   [Node Naming and Location CC](NodeNamingAndLocation.md) · `0x77`
--   [No Operation CC](NoOperation.md) · `0x00`
--   [Notification CC](Notification.md) · `0x71`
--   [Powerlevel CC](Powerlevel.md) · `0x73`
--   [Protection CC](Protection.md) · `0x75`
--   [Scene Activation CC](SceneActivation.md) · `0x2b`
--   [Scene Actuator Configuration CC](SceneActuatorConfiguration.md) · `0x2c`
--   [Scene Controller Configuration CC](SceneControllerConfiguration.md) · `0x2d`
--   [Security 2 CC](Security2.md) · `0x9f`
--   [Security CC](Security.md) · `0x98`
--   [Sound Switch CC](SoundSwitch.md) · `0x79`
--   [Supervision CC](Supervision.md) · `0x6c`
--   [Thermostat Fan Mode CC](ThermostatFanMode.md) · `0x44`
--   [Thermostat Fan State CC](ThermostatFanState.md) · `0x45`
--   [Thermostat Mode CC](ThermostatMode.md) · `0x40`
--   [Thermostat Operating State CC](ThermostatOperatingState.md) · `0x42`
--   [Thermostat Setback CC](ThermostatSetback.md) · `0x47`
--   [Thermostat Setpoint CC](ThermostatSetpoint.md) · `0x43`
--   [Time CC](Time.md) · `0x8a`
--   [Time Parameters CC](TimeParameters.md) · `0x8b`
--   [User Code CC](UserCode.md) · `0x63`
--   [Version CC](Version.md) · `0x86`
--   [Wake Up CC](WakeUp.md) · `0x84`
--   [Z-Wave Plus Info CC](ZWavePlus.md) · `0x5e`
+-   [Alarm Sensor CC](./AlarmSensor.md) · `0x9c`
+-   [Association CC](./Association.md) · `0x85`
+-   [Association Group Information CC](./AssociationGroupInfo.md) · `0x59`
+-   [Barrier Operator CC](./BarrierOperator.md) · `0x66`
+-   [Basic CC](./Basic.md) · `0x20`
+-   [Battery CC](./Battery.md) · `0x80`
+-   [Binary Sensor CC](./BinarySensor.md) · `0x30`
+-   [Binary Switch CC](./BinarySwitch.md) · `0x25`
+-   [Central Scene CC](./CentralScene.md) · `0x5b`
+-   [Climate Control Schedule CC](./ClimateControlSchedule.md) · `0x46`
+-   [Clock CC](./Clock.md) · `0x81`
+-   [Color Switch CC](./ColorSwitch.md) · `0x33`
+-   [Configuration CC](./Configuration.md) · `0x70`
+-   [CRC-16 Encapsulation CC](./CRC16.md) · `0x56`
+-   [Door Lock CC](./DoorLock.md) · `0x62`
+-   [Door Lock Logging CC](./DoorLockLogging.md) · `0x4c`
+-   [Entry Control CC](./EntryControl.md) · `0x6f`
+-   [Firmware Update Meta Data CC](./FirmwareUpdateMetaData.md) · `0x7a`
+-   [Humidity Control Mode CC](./HumidityControlMode.md) · `0x6d`
+-   [Humidity Control Operating State CC](./HumidityControlOperatingState.md) · `0x6e`
+-   [Humidity Control Setpoint CC](./HumidityControlSetpoint.md) · `0x64`
+-   [Indicator CC](./Indicator.md) · `0x87`
+-   [Irrigation CC](./Irrigation.md) · `0x6b`
+-   [Language CC](./Language.md) · `0x89`
+-   [Lock CC](./Lock.md) · `0x76`
+-   [Manufacturer Proprietary CC](./ManufacturerProprietary.md) · `0x91`
+-   [Manufacturer Specific CC](./ManufacturerSpecific.md) · `0x72`
+-   [Meter CC](./Meter.md) · `0x32`
+-   [Multi Channel Association CC](./MultiChannelAssociation.md) · `0x8e`
+-   [Multi Channel CC](./MultiChannel.md) · `0x60`
+-   [Multi Command CC](./MultiCommand.md) · `0x8f`
+-   [Multilevel Sensor CC](./MultilevelSensor.md) · `0x31`
+-   [Multilevel Switch CC](./MultilevelSwitch.md) · `0x26`
+-   [Node Naming and Location CC](./NodeNamingAndLocation.md) · `0x77`
+-   [No Operation CC](./NoOperation.md) · `0x00`
+-   [Notification CC](./Notification.md) · `0x71`
+-   [Powerlevel CC](./Powerlevel.md) · `0x73`
+-   [Protection CC](./Protection.md) · `0x75`
+-   [Scene Activation CC](./SceneActivation.md) · `0x2b`
+-   [Scene Actuator Configuration CC](./SceneActuatorConfiguration.md) · `0x2c`
+-   [Scene Controller Configuration CC](./SceneControllerConfiguration.md) · `0x2d`
+-   [Security 2 CC](./Security2.md) · `0x9f`
+-   [Security CC](./Security.md) · `0x98`
+-   [Sound Switch CC](./SoundSwitch.md) · `0x79`
+-   [Supervision CC](./Supervision.md) · `0x6c`
+-   [Thermostat Fan Mode CC](./ThermostatFanMode.md) · `0x44`
+-   [Thermostat Fan State CC](./ThermostatFanState.md) · `0x45`
+-   [Thermostat Mode CC](./ThermostatMode.md) · `0x40`
+-   [Thermostat Operating State CC](./ThermostatOperatingState.md) · `0x42`
+-   [Thermostat Setback CC](./ThermostatSetback.md) · `0x47`
+-   [Thermostat Setpoint CC](./ThermostatSetpoint.md) · `0x43`
+-   [Time CC](./Time.md) · `0x8a`
+-   [Time Parameters CC](./TimeParameters.md) · `0x8b`
+-   [User Code CC](./UserCode.md) · `0x63`
+-   [Version CC](./Version.md) · `0x86`
+-   [Wake Up CC](./WakeUp.md) · `0x84`
+-   [Z-Wave Plus Info CC](./ZWavePlus.md) · `0x5e`

--- a/docs/api/CCs/index.md
+++ b/docs/api/CCs/index.md
@@ -10,60 +10,60 @@ The **Command Classes API** provides a high-to-mid level entrypoint which allows
 
 <!-- AUTO-GENERATE: CC List -->
 
--   [Alarm Sensor CC](api/CCs/AlarmSensor.md) · `0x9c`
--   [Association CC](api/CCs/Association.md) · `0x85`
--   [Association Group Information CC](api/CCs/AssociationGroupInfo.md) · `0x59`
--   [Barrier Operator CC](api/CCs/BarrierOperator.md) · `0x66`
--   [Basic CC](api/CCs/Basic.md) · `0x20`
--   [Battery CC](api/CCs/Battery.md) · `0x80`
--   [Binary Sensor CC](api/CCs/BinarySensor.md) · `0x30`
--   [Binary Switch CC](api/CCs/BinarySwitch.md) · `0x25`
--   [Central Scene CC](api/CCs/CentralScene.md) · `0x5b`
--   [Climate Control Schedule CC](api/CCs/ClimateControlSchedule.md) · `0x46`
--   [Clock CC](api/CCs/Clock.md) · `0x81`
--   [Color Switch CC](api/CCs/ColorSwitch.md) · `0x33`
--   [Configuration CC](api/CCs/Configuration.md) · `0x70`
--   [CRC-16 Encapsulation CC](api/CCs/CRC16.md) · `0x56`
--   [Door Lock CC](api/CCs/DoorLock.md) · `0x62`
--   [Door Lock Logging CC](api/CCs/DoorLockLogging.md) · `0x4c`
--   [Entry Control CC](api/CCs/EntryControl.md) · `0x6f`
--   [Firmware Update Meta Data CC](api/CCs/FirmwareUpdateMetaData.md) · `0x7a`
--   [Humidity Control Mode CC](api/CCs/HumidityControlMode.md) · `0x6d`
--   [Humidity Control Operating State CC](api/CCs/HumidityControlOperatingState.md) · `0x6e`
--   [Humidity Control Setpoint CC](api/CCs/HumidityControlSetpoint.md) · `0x64`
--   [Indicator CC](api/CCs/Indicator.md) · `0x87`
--   [Irrigation CC](api/CCs/Irrigation.md) · `0x6b`
--   [Language CC](api/CCs/Language.md) · `0x89`
--   [Lock CC](api/CCs/Lock.md) · `0x76`
--   [Manufacturer Proprietary CC](api/CCs/ManufacturerProprietary.md) · `0x91`
--   [Manufacturer Specific CC](api/CCs/ManufacturerSpecific.md) · `0x72`
--   [Meter CC](api/CCs/Meter.md) · `0x32`
--   [Multi Channel Association CC](api/CCs/MultiChannelAssociation.md) · `0x8e`
--   [Multi Channel CC](api/CCs/MultiChannel.md) · `0x60`
--   [Multi Command CC](api/CCs/MultiCommand.md) · `0x8f`
--   [Multilevel Sensor CC](api/CCs/MultilevelSensor.md) · `0x31`
--   [Multilevel Switch CC](api/CCs/MultilevelSwitch.md) · `0x26`
--   [Node Naming and Location CC](api/CCs/NodeNamingAndLocation.md) · `0x77`
--   [No Operation CC](api/CCs/NoOperation.md) · `0x00`
--   [Notification CC](api/CCs/Notification.md) · `0x71`
--   [Powerlevel CC](api/CCs/Powerlevel.md) · `0x73`
--   [Protection CC](api/CCs/Protection.md) · `0x75`
--   [Scene Activation CC](api/CCs/SceneActivation.md) · `0x2b`
--   [Scene Actuator Configuration CC](api/CCs/SceneActuatorConfiguration.md) · `0x2c`
--   [Scene Controller Configuration CC](api/CCs/SceneControllerConfiguration.md) · `0x2d`
--   [Security 2 CC](api/CCs/Security2.md) · `0x9f`
--   [Security CC](api/CCs/Security.md) · `0x98`
--   [Sound Switch CC](api/CCs/SoundSwitch.md) · `0x79`
--   [Supervision CC](api/CCs/Supervision.md) · `0x6c`
--   [Thermostat Fan Mode CC](api/CCs/ThermostatFanMode.md) · `0x44`
--   [Thermostat Fan State CC](api/CCs/ThermostatFanState.md) · `0x45`
--   [Thermostat Mode CC](api/CCs/ThermostatMode.md) · `0x40`
--   [Thermostat Operating State CC](api/CCs/ThermostatOperatingState.md) · `0x42`
--   [Thermostat Setback CC](api/CCs/ThermostatSetback.md) · `0x47`
--   [Thermostat Setpoint CC](api/CCs/ThermostatSetpoint.md) · `0x43`
--   [Time CC](api/CCs/Time.md) · `0x8a`
--   [Time Parameters CC](api/CCs/TimeParameters.md) · `0x8b`
--   [User Code CC](api/CCs/UserCode.md) · `0x63`
--   [Version CC](api/CCs/Version.md) · `0x86`
--   [Wake Up CC](api/CCs/WakeUp.md) · `0x84`
--   [Z-Wave Plus Info CC](api/CCs/ZWavePlus.md) · `0x5e`
+-   [Alarm Sensor CC](AlarmSensor.md) · `0x9c`
+-   [Association CC](Association.md) · `0x85`
+-   [Association Group Information CC](AssociationGroupInfo.md) · `0x59`
+-   [Barrier Operator CC](BarrierOperator.md) · `0x66`
+-   [Basic CC](Basic.md) · `0x20`
+-   [Battery CC](Battery.md) · `0x80`
+-   [Binary Sensor CC](BinarySensor.md) · `0x30`
+-   [Binary Switch CC](BinarySwitch.md) · `0x25`
+-   [Central Scene CC](CentralScene.md) · `0x5b`
+-   [Climate Control Schedule CC](ClimateControlSchedule.md) · `0x46`
+-   [Clock CC](Clock.md) · `0x81`
+-   [Color Switch CC](ColorSwitch.md) · `0x33`
+-   [Configuration CC](Configuration.md) · `0x70`
+-   [CRC-16 Encapsulation CC](CRC16.md) · `0x56`
+-   [Door Lock CC](DoorLock.md) · `0x62`
+-   [Door Lock Logging CC](DoorLockLogging.md) · `0x4c`
+-   [Entry Control CC](EntryControl.md) · `0x6f`
+-   [Firmware Update Meta Data CC](FirmwareUpdateMetaData.md) · `0x7a`
+-   [Humidity Control Mode CC](HumidityControlMode.md) · `0x6d`
+-   [Humidity Control Operating State CC](HumidityControlOperatingState.md) · `0x6e`
+-   [Humidity Control Setpoint CC](HumidityControlSetpoint.md) · `0x64`
+-   [Indicator CC](Indicator.md) · `0x87`
+-   [Irrigation CC](Irrigation.md) · `0x6b`
+-   [Language CC](Language.md) · `0x89`
+-   [Lock CC](Lock.md) · `0x76`
+-   [Manufacturer Proprietary CC](ManufacturerProprietary.md) · `0x91`
+-   [Manufacturer Specific CC](ManufacturerSpecific.md) · `0x72`
+-   [Meter CC](Meter.md) · `0x32`
+-   [Multi Channel Association CC](MultiChannelAssociation.md) · `0x8e`
+-   [Multi Channel CC](MultiChannel.md) · `0x60`
+-   [Multi Command CC](MultiCommand.md) · `0x8f`
+-   [Multilevel Sensor CC](MultilevelSensor.md) · `0x31`
+-   [Multilevel Switch CC](MultilevelSwitch.md) · `0x26`
+-   [Node Naming and Location CC](NodeNamingAndLocation.md) · `0x77`
+-   [No Operation CC](NoOperation.md) · `0x00`
+-   [Notification CC](Notification.md) · `0x71`
+-   [Powerlevel CC](Powerlevel.md) · `0x73`
+-   [Protection CC](Protection.md) · `0x75`
+-   [Scene Activation CC](SceneActivation.md) · `0x2b`
+-   [Scene Actuator Configuration CC](SceneActuatorConfiguration.md) · `0x2c`
+-   [Scene Controller Configuration CC](SceneControllerConfiguration.md) · `0x2d`
+-   [Security 2 CC](Security2.md) · `0x9f`
+-   [Security CC](Security.md) · `0x98`
+-   [Sound Switch CC](SoundSwitch.md) · `0x79`
+-   [Supervision CC](Supervision.md) · `0x6c`
+-   [Thermostat Fan Mode CC](ThermostatFanMode.md) · `0x44`
+-   [Thermostat Fan State CC](ThermostatFanState.md) · `0x45`
+-   [Thermostat Mode CC](ThermostatMode.md) · `0x40`
+-   [Thermostat Operating State CC](ThermostatOperatingState.md) · `0x42`
+-   [Thermostat Setback CC](ThermostatSetback.md) · `0x47`
+-   [Thermostat Setpoint CC](ThermostatSetpoint.md) · `0x43`
+-   [Time CC](Time.md) · `0x8a`
+-   [Time Parameters CC](TimeParameters.md) · `0x8b`
+-   [User Code CC](UserCode.md) · `0x63`
+-   [Version CC](Version.md) · `0x86`
+-   [Wake Up CC](WakeUp.md) · `0x84`
+-   [Z-Wave Plus Info CC](ZWavePlus.md) · `0x5e`

--- a/packages/maintenance/src/generateTypedDocs.ts
+++ b/packages/maintenance/src/generateTypedDocs.ts
@@ -325,7 +325,7 @@ async function processCCDocFile(
 
 ?> CommandClass ID: \`${num2hex((CommandClasses as any)[ccName])}\`
 `;
-	const generatedIndex = `\n- [${ccName} CC](api/CCs/${filename}) · \`${num2hex(
+	const generatedIndex = `\n- [${ccName} CC](./${filename}) · \`${num2hex(
 		(CommandClasses as any)[ccName],
 	)}\``;
 	const generatedSidebar = `\n\t\t- [${ccName} CC](api/CCs/${filename})`;


### PR DESCRIPTION
Hi, Command Classes links result in 404 due to wrong path structure.

![image](https://user-images.githubusercontent.com/15020561/163716610-470c2fb0-87a1-40fc-9ce3-a3375b3695e2.png)
