### PR TITLE
fix: handle `x.y.z` protocol versions correctly in feature test

### DIFF
--- a/packages/zwave-js/src/lib/controller/Controller.test.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.test.ts
@@ -34,12 +34,10 @@ describe("lib/controller/Controller", () => {
 	describe("getAssociationGroups()", () => {
 		let fakeDriver: Driver;
 		beforeAll(async () => {
-			jest.setTimeout(60000);
-
 			fakeDriver = createEmptyMockDriver() as unknown as Driver;
 			fakeDriver.registerRequestHandler = () => {};
 			await fakeDriver.configManager.loadAll();
-		});
+		}, 60000);
 
 		it("should respect the endpoint definition format when AGI is supported", async () => {
 			const ctrl = new ZWaveController(fakeDriver);

--- a/packages/zwave-js/src/lib/controller/ZWaveSDKVersions.test.ts
+++ b/packages/zwave-js/src/lib/controller/ZWaveSDKVersions.test.ts
@@ -17,4 +17,9 @@ describe("protocolVersionToSDKVersion", () => {
 	it("finds protocol version 6.02", () => {
 		expect(protocolVersionToSDKVersion("6.02")).toBe("6.81.1");
 	});
+
+	it("handles both the legacy x.0y and x.y.z versions", () => {
+		expect(protocolVersionToSDKVersion("6.07")).toBe("6.81.6");
+		expect(protocolVersionToSDKVersion("6.7.0")).toBe("6.81.6");
+	});
 });

--- a/packages/zwave-js/src/lib/controller/ZWaveSDKVersions.ts
+++ b/packages/zwave-js/src/lib/controller/ZWaveSDKVersions.ts
@@ -1,3 +1,5 @@
+import { padStart } from "alcalzone-shared/strings";
+
 // Based on INS13954-13, chapter 7
 const versions = Object.freeze([
 	// Z-Wave 700 uses 7.x SDK versions but also a different NVM format,
@@ -330,6 +332,16 @@ const versions = Object.freeze([
 ]);
 
 /**
+ * Converts versions determined using GetProtocolVersion (x.y.z) into the legacy format
+ * so they can be used to look up the SDK version.
+ */
+function semverToLegacy(version: string): string {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const [major, minor, _patch] = version.split(".", 3);
+	return `${major}.${padStart(minor, 2, "0")}`;
+}
+
+/**
  * Looks up which SDK version is being used for a given protocol version.
  * Defaults to the protocol version itself, which is the case for v7+
  */
@@ -338,9 +350,11 @@ export function protocolVersionToSDKVersion(protocolVersion: string): string {
 		protocolVersion = protocolVersion.substr(7);
 	}
 
+	const normalizedVersion = semverToLegacy(protocolVersion);
 	let ret = versions.find(
-		(v) => v.protocolVersion === protocolVersion,
+		(v) => v.protocolVersion === normalizedVersion,
 	)?.sdkVersion;
+
 	if (!ret) {
 		// Remove leading zeroes and stuff
 		ret = protocolVersion


### PR DESCRIPTION
fixes: #4482