### PR TITLE
fix: use linear search to determine the highest possible power reduction

### DIFF
--- a/packages/shared/src/misc.test.ts
+++ b/packages/shared/src/misc.test.ts
@@ -1,4 +1,9 @@
-import { cloneDeep, discreteBinarySearch, throttle } from "./misc";
+import {
+	cloneDeep,
+	discreteBinarySearch,
+	discreteLinearSearch,
+	throttle,
+} from "./misc";
 
 describe("throttle()", () => {
 	const originalDateNow = Date.now;
@@ -153,6 +158,80 @@ describe("discreteBinarySearch()", () => {
 		const values: number[] = [];
 		expect(
 			await discreteBinarySearch(
+				rangeMin,
+				rangeMax,
+				(i) => values[i] === 0,
+			),
+		).toBe(undefined);
+	});
+});
+
+describe("discreteLinearSearch()", () => {
+	it("test case 1", async () => {
+		const [rangeMin, rangeMax] = [0, 9];
+		const values = [0, 0, 0, 0, 0, 1, 1, 1, 1, 1];
+		expect(
+			await discreteLinearSearch(
+				rangeMin,
+				rangeMax,
+				(i) => values[i] === 0,
+			),
+		).toBe(4);
+	});
+
+	it("test case 2", async () => {
+		const [rangeMin, rangeMax] = [0, 9];
+		const values = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+		expect(
+			await discreteLinearSearch(
+				rangeMin,
+				rangeMax,
+				(i) => values[i] === 0,
+			),
+		).toBe(9);
+	});
+
+	it("test case 3", async () => {
+		const [rangeMin, rangeMax] = [0, 6];
+		const values = [0, 1, 1, 1, 1, 1, 1];
+		expect(
+			await discreteLinearSearch(
+				rangeMin,
+				rangeMax,
+				(i) => values[i] === 0,
+			),
+		).toBe(0);
+	});
+
+	it("test case 4", async () => {
+		const [rangeMin, rangeMax] = [0, 6];
+		const values = [1, 1, 1, 1, 1, 1, 1];
+		expect(
+			await discreteLinearSearch(
+				rangeMin,
+				rangeMax,
+				(i) => values[i] === 0,
+			),
+		).toBe(undefined);
+	});
+
+	it("test case 5", async () => {
+		const [rangeMin, rangeMax] = [0, 0];
+		const values = [0];
+		expect(
+			await discreteLinearSearch(
+				rangeMin,
+				rangeMax,
+				(i) => values[i] === 0,
+			),
+		).toBe(0);
+	});
+
+	it("test case 6", async () => {
+		const [rangeMin, rangeMax] = [1, -1];
+		const values: number[] = [];
+		expect(
+			await discreteLinearSearch(
 				rangeMin,
 				rangeMax,
 				(i) => values[i] === 0,

--- a/packages/shared/src/misc.ts
+++ b/packages/shared/src/misc.ts
@@ -146,7 +146,10 @@ export function padVersion(version: string): string {
 	return version + ".0";
 }
 
-/** Finds the highest discrete value in [rangeMin...rangeMax] where executor returns true. */
+/**
+ * Using a binary search, this finds the highest discrete value in [rangeMin...rangeMax] where executor returns true, assuming that
+ * increasing the value will at some point cause the executor to return false.
+ */
 export async function discreteBinarySearch(
 	rangeMin: number,
 	rangeMax: number,
@@ -171,6 +174,35 @@ export async function discreteBinarySearch(
 		if (!result) return undefined;
 	}
 	return min;
+}
+
+/**
+ * Using a linear search, this finds the highest discrete value in [rangeMin...rangeMax] where executor returns true, assuming that
+ * increasing the value will at some point cause the executor to return false.
+ */
+export async function discreteLinearSearch(
+	rangeMin: number,
+	rangeMax: number,
+	executor: (value: number) => boolean | PromiseLike<boolean>,
+): Promise<number | undefined> {
+	for (let val = rangeMin; val <= rangeMax; val++) {
+		const result = await executor(val);
+		if (!result) {
+			// Found the first value where it no longer returns true
+			if (val === rangeMin) {
+				// No success at all
+				break;
+			} else {
+				// The previous test was successful
+				return val - 1;
+			}
+		} else {
+			if (val === rangeMax) {
+				// Everything was successful
+				return rangeMax;
+			}
+		}
+	}
 }
 
 export function sum(values: number[]): number {

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -40,7 +40,7 @@ import {
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
 import {
-	discreteBinarySearch,
+	discreteLinearSearch,
 	formatId,
 	getEnumMemberName,
 	getErrorMessage,
@@ -4068,7 +4068,7 @@ protocol version:      ${this.protocolVersion}`;
 					return failedPingsController === 0;
 				};
 				try {
-					const powerlevel = await discreteBinarySearch(
+					const powerlevel = await discreteLinearSearch(
 						Powerlevel["Normal Power"], // minimum reduction
 						Powerlevel["-9 dBm"], // maximum reduction
 						executor,
@@ -4244,7 +4244,10 @@ ${formatLifelineHealthCheckSummary(summary)}`,
 			// Now instruct this node to ping the other one, figuring out the minimum powerlevel
 			if (this.supportsCC(CommandClasses.Powerlevel)) {
 				try {
-					const powerlevel = await discreteBinarySearch(
+					// We have to start with the maximum powerlevel and work our way down
+					// Otherwise some nodes get stuck trying to complete the check at a bad powerlevel
+					// causing the following measurements to fail.
+					const powerlevel = await discreteLinearSearch(
 						Powerlevel["Normal Power"], // minimum reduction
 						Powerlevel["-9 dBm"], // maximum reduction
 						executor(this, otherNode),
@@ -4277,7 +4280,7 @@ ${formatLifelineHealthCheckSummary(summary)}`,
 				otherNode.supportsCC(CommandClasses.Powerlevel)
 			) {
 				try {
-					const powerlevel = await discreteBinarySearch(
+					const powerlevel = await discreteLinearSearch(
 						Powerlevel["Normal Power"], // minimum reduction
 						Powerlevel["-9 dBm"], // maximum reduction
 						executor(otherNode, this),


### PR DESCRIPTION
Using a binary search reduces the test time for nodes with a good link, but some get stuck in a never-ending test if the powerlevel is too low, and fail all subsequent tests. Using a linear search from normal power to -9 dBm, we should be able to avoid this situation.

fixes: #4471