### PR TITLE
fix(config): add missing parameters to Zooz ZEN32

### DIFF
--- a/packages/config/config/devices/0x027a/zen32.json
+++ b/packages/config/config/devices/0x027a/zen32.json
@@ -519,6 +519,46 @@
 					"value": 1
 				}
 			]
+		},
+		{
+			"#": "22",
+			"$if": "firmwareVersion >= 10.0",
+			"label": "Programming through Relay Button",
+			"description": "Controls whether certain features (inclusion, exclusion, LED indicator modes) can be programmed through the relay button. Disabling this frees up the triple tap action for scene control. Factory reset will always work regardless of this setting.",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Enable",
+					"value": 0
+				},
+				{
+					"label": "Disable",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "23",
+			"$if": "firmwareVersion >= 10.20",
+			"label": "LED Settings Indicator",
+			"description": "When enabled, the relay button LED indicator will flash to confirm the receipt of settings.",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Enable",
+					"value": 0
+				},
+				{
+					"label": "Disable",
+					"value": 1
+				}
+			]
 		}
 	],
 	"metadata": {


### PR DESCRIPTION
This adds two parameters:
1. ability to disable programming function from the button (Parameter 22)
2. control LED indicator flashing during a setting change (Parameter 23)

The [official documentation](https://www.support.getzooz.com/kb/article/608-zen32-scene-controller-advanced-settings/) on Parameter 23 is incorrect. It accepts values 0 (Enabled, default) and 1 (Disabled).

Verified this on my ZEN32 devices.