### PR TITLE
fix(config): force scene count of Leviton VRCS2 to 4

### DIFF
--- a/packages/config/config/devices/0x001d/vrcs2.json
+++ b/packages/config/config/devices/0x001d/vrcs2.json
@@ -20,5 +20,9 @@
 	"firmwareVersion": {
 		"min": "0.0",
 		"max": "255.255"
+	},
+	"compat": {
+		// This device has 2 association groups, but 4 scenes
+		"forceSceneControllerGroupCount": 4
 	}
 }


### PR DESCRIPTION
The Leviton VRCS2 scene controller has 2 buttons each of which has two associated scenes for a total of 4.  Scenes 1-2 are sent when Buttons 1-2 are activated.  Scenes 3-4 are sent when Buttons 1-2 are deactivated.  This behavior is similar to the VRCS4 and VRCZ4 which have 4 buttons and 8 scenes.

I confirmed there are 4 scenes by using the Zwave PC controller to send SCENE_CONTROLLER_CONF_GET messages to the node for each scene.