### PR TITLE
fix(serial): continue listening for the serial `close` event

### DIFF
--- a/packages/serial/src/ZWaveSerialPort.ts
+++ b/packages/serial/src/ZWaveSerialPort.ts
@@ -19,6 +19,8 @@ export class ZWaveSerialPort extends ZWaveSerialPortBase {
 		loggers: ZWaveLogContainer,
 		Binding: typeof SerialPort = SerialPort,
 	) {
+		let removeListeners: (removeOnClose: boolean) => void;
+
 		super(
 			{
 				create: () =>
@@ -32,12 +34,10 @@ export class ZWaveSerialPort extends ZWaveSerialPortBase {
 					}),
 				open: (serial: SerialPort) =>
 					new Promise((resolve, reject) => {
-						// eslint-disable-next-line prefer-const
-						let removeListeners: () => void;
 						const onClose = (err?: DisconnectError) => {
 							// detect serial disconnection errors
 							if (err?.disconnected === true) {
-								removeListeners();
+								removeListeners(true);
 								this.emit(
 									"error",
 									new ZWaveError(
@@ -48,19 +48,20 @@ export class ZWaveSerialPort extends ZWaveSerialPortBase {
 							}
 						};
 						const onError = (err: Error) => {
-							removeListeners();
+							removeListeners(true);
 							reject(err);
 						};
 						const onOpen = () => {
-							removeListeners();
+							removeListeners(false);
 							resolve();
 						};
 
 						// We need to remove the listeners again no matter which of the handlers is called
 						// Otherwise this would cause an EventEmitter leak.
 						// Hence this somewhat ugly construct
-						removeListeners = () => {
-							serial.removeListener("close", onClose);
+						removeListeners = (removeOnClose: boolean) => {
+							if (removeOnClose)
+								serial.removeListener("close", onClose);
 							serial.removeListener("error", onError);
 							serial.removeListener("open", onOpen);
 						};
@@ -71,6 +72,7 @@ export class ZWaveSerialPort extends ZWaveSerialPortBase {
 					}),
 				close: (serial: SerialPort) =>
 					new Promise((resolve) => {
+						removeListeners(true);
 						serial.once("close", resolve).close();
 					}),
 			},


### PR DESCRIPTION
The `"close"` event also gets called during normal operation when the USB stick gets disconnected. We need to continue monitoring it to detect serial disconnection and destroy the driver in that case.