### PR TITLE
fix(config): enable Basic Set mapping for Eaton RF9542-Z

### DIFF
--- a/packages/config/config/devices/0x001a/rf9542.json
+++ b/packages/config/config/devices/0x001a/rf9542.json
@@ -122,5 +122,8 @@
 			"defaultValue": 0,
 			"unsigned": true
 		}
-	]
+	],
+	"compat": {
+		"enableBasicSetMapping": true
+	}
 }


### PR DESCRIPTION
enableBasicSetMapping for this device to report manual on/off button presses