### PR TITLE
fix(config): add missing parameters to Zooz ZEN30

### DIFF
--- a/packages/config/config/devices/0x027a/zen30.json
+++ b/packages/config/config/devices/0x027a/zen30.json
@@ -492,8 +492,7 @@
 		{
 			"#": "29",
 			"$if": "firmwareVersion >= 1.2",
-			"label": "Enable/Disable Scene Control for Relay",
-			"description": "Enable or disable scene control functionality for quick double tap triggers on the relay button.",
+			"label": "Scene Control (Relay)",
 			"valueSize": 1,
 			"defaultValue": 1,
 			"allowManualEntry": false,

--- a/packages/config/config/devices/0x027a/zen30.json
+++ b/packages/config/config/devices/0x027a/zen30.json
@@ -512,7 +512,7 @@
 		{
 			"#": "30",
 			"$if": "firmwareVersion >= 1.2",
-			"$import": "~/templates/zooz_template.json#paddle_programming"
+			"$import": "~/0x027a/templates/zooz_template.json#paddle_programming"
 		}
 	],
 	"metadata": {

--- a/packages/config/config/devices/0x027a/zen30.json
+++ b/packages/config/config/devices/0x027a/zen30.json
@@ -512,21 +512,7 @@
 		{
 			"#": "30",
 			"$if": "firmwareVersion >= 1.2",
-			"label": "Enable/Disable Programming on the Dimmer Paddles",
-			"description": "If this setting is disabled, then inclusion, exclusion, smart bulb mode no longer work when dimmer paddles are activated (factory reset and scene control will still work) - that means you can now use triple-tap triggers on the dimmer for scenes and remote control of other devices.",
-			"valueSize": 1,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Programming enabled",
-					"value": 0
-				},
-				{
-					"label": "Programming disabled",
-					"value": 1
-				}
-			]
+			"$import": "~/templates/zooz_template.json#paddle_programming"
 		}
 	],
 	"metadata": {

--- a/packages/config/config/devices/0x027a/zen30.json
+++ b/packages/config/config/devices/0x027a/zen30.json
@@ -470,6 +470,63 @@
 					"value": 2
 				}
 			]
+		},
+		{
+			"#": "28",
+			"$if": "firmwareVersion >= 2.1",
+			"label": "Enable/Disable Scene Control for Dimmer",
+			"description": "Enable or disable scene control functionality for quick double tap triggers on the dimmer.",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Scene control disabled",
+					"value": 0
+				},
+				{
+					"label": "Scene control enabled",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "29",
+			"$if": "firmwareVersion >= 2.1",
+			"label": "Enable/Disable Scene Control for Relay",
+			"description": "Enable or disable scene control functionality for quick double tap triggers on the relay button.",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Scene control disabled",
+					"value": 0
+				},
+				{
+					"label": "Scene control enabled",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "30",
+			"$if": "firmwareVersion >= 1.2",
+			"label": "Enable/Disable Programming on the Dimmer Paddles",
+			"description": "If this setting is disabled, then inclusion, exclusion, smart bulb mode no longer work when dimmer paddles are activated (factory reset and scene control will still work) - that means you can now use triple-tap triggers on the dimmer for scenes and remote control of other devices.",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Programming enabled",
+					"value": 0
+				},
+				{
+					"label": "Programming disabled",
+					"value": 1
+				}
+			]
 		}
 	],
 	"metadata": {

--- a/packages/config/config/devices/0x027a/zen30.json
+++ b/packages/config/config/devices/0x027a/zen30.json
@@ -480,11 +480,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Scene control disabled",
+					"label": "Disable",
 					"value": 0
 				},
 				{
-					"label": "Scene control enabled",
+					"label": "Enable",
 					"value": 1
 				}
 			]

--- a/packages/config/config/devices/0x027a/zen30.json
+++ b/packages/config/config/devices/0x027a/zen30.json
@@ -498,11 +498,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Scene control disabled",
+					"label": "Disable",
 					"value": 0
 				},
 				{
-					"label": "Scene control enabled",
+					"label": "Enable",
 					"value": 1
 				}
 			]

--- a/packages/config/config/devices/0x027a/zen30.json
+++ b/packages/config/config/devices/0x027a/zen30.json
@@ -474,8 +474,7 @@
 		{
 			"#": "28",
 			"$if": "firmwareVersion >= 1.2",
-			"label": "Enable/Disable Scene Control for Dimmer",
-			"description": "Enable or disable scene control functionality for quick double tap triggers on the dimmer.",
+			"label": "Scene Control (Dimmer)",
 			"valueSize": 1,
 			"defaultValue": 1,
 			"allowManualEntry": false,

--- a/packages/config/config/devices/0x027a/zen30.json
+++ b/packages/config/config/devices/0x027a/zen30.json
@@ -473,7 +473,7 @@
 		},
 		{
 			"#": "28",
-			"$if": "firmwareVersion >= 2.1",
+			"$if": "firmwareVersion >= 1.2",
 			"label": "Enable/Disable Scene Control for Dimmer",
 			"description": "Enable or disable scene control functionality for quick double tap triggers on the dimmer.",
 			"valueSize": 1,
@@ -492,7 +492,7 @@
 		},
 		{
 			"#": "29",
-			"$if": "firmwareVersion >= 2.1",
+			"$if": "firmwareVersion >= 1.2",
 			"label": "Enable/Disable Scene Control for Relay",
 			"description": "Enable or disable scene control functionality for quick double tap triggers on the relay button.",
 			"valueSize": 1,


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

Update Zooz ZEN30 parameter options to include paramaters 28, 29, and 30, added in recent firmware updates.

https://www.support.getzooz.com/kb/article/468-zen30-double-switch-advanced-settings/
https://www.support.getzooz.com/kb/article/393-zen30-double-switch-change-log/
