### PR TITLE
fix(config): add temp and humidity calibration params to Aeotec aërQ ZWA039

### DIFF
--- a/packages/config/config/devices/0x0371/zwa039.json
+++ b/packages/config/config/devices/0x0371/zwa039.json
@@ -240,13 +240,7 @@
 			"valueSize": 2,
 			"minValue": -200,
 			"maxValue": 200,
-			"defaultValue": 0,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				}
-			]
+			"defaultValue": 0
 		},
 		{
 			"#": "15",
@@ -255,13 +249,7 @@
 			"valueSize": 1,
 			"minValue": -50,
 			"maxValue": 50,
-			"defaultValue": 0,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				}
-			]
+			"defaultValue": 0
 		},
 		{
 			"#": "65[0x01]",

--- a/packages/config/config/devices/0x0371/zwa039.json
+++ b/packages/config/config/devices/0x0371/zwa039.json
@@ -233,6 +233,40 @@
 			"maxValue": 10,
 			"defaultValue": 0
 		},
+    {
+			"#": "14",
+			"label": "Offset value for Temperature",
+			"description": "Can add or minus this setting value to calibrate temperature when checked. Allowable range: -200 to 200.",
+			"unit": "0.1 °(C/F)",
+			"unsigned": false,
+			"valueSize": 2,
+			"minValue": -200,
+			"maxValue": 200,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
+		},
+		{
+			"#": "15",
+			"label": "Offset value for Humidity",
+			"description": "Can add or minus this setting value to calibrate humidity when checked.",
+			"unit": "%",
+			"unsigned": false,
+			"valueSize": 1,
+			"minValue": -50,
+			"maxValue": 50,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
+		},
 		{
 			"#": "65[0x01]",
 			"label": "Sensor Report after Inclusion: Battery",

--- a/packages/config/config/devices/0x0371/zwa039.json
+++ b/packages/config/config/devices/0x0371/zwa039.json
@@ -235,10 +235,8 @@
 		},
 		{
 			"#": "14",
-			"label": "Offset value for Temperature",
-			"description": "Can add or minus this setting value to calibrate temperature when checked. Allowable range: -200 to 200.",
+			"label": "Temperature Calibration",
 			"unit": "0.1 °(C/F)",
-			"unsigned": false,
 			"valueSize": 2,
 			"minValue": -200,
 			"maxValue": 200,
@@ -252,10 +250,8 @@
 		},
 		{
 			"#": "15",
-			"label": "Offset value for Humidity",
-			"description": "Can add or minus this setting value to calibrate humidity when checked.",
+			"label": "Humidity Calibration",
 			"unit": "%",
-			"unsigned": false,
 			"valueSize": 1,
 			"minValue": -50,
 			"maxValue": 50,

--- a/packages/config/config/devices/0x0371/zwa039.json
+++ b/packages/config/config/devices/0x0371/zwa039.json
@@ -233,7 +233,7 @@
 			"maxValue": 10,
 			"defaultValue": 0
 		},
-    {
+		{
 			"#": "14",
 			"label": "Offset value for Temperature",
 			"description": "Can add or minus this setting value to calibrate temperature when checked. Allowable range: -200 to 200.",


### PR DESCRIPTION
This PR adds param 14 and 15 to the Aeotec aerQ Temperature and Humidity sensor.

https://help.aeotec.com/support/solutions/articles/6000227918-a%C3%ABrq-temperature-and-humidity-sensor-user-guide-