### PR TITLE
fix: remove unused _null methods, improve strict enum checks in auto-generated argument validation

### DIFF
--- a/packages/transformers/src/validateArgs/reason.ts
+++ b/packages/transformers/src/validateArgs/reason.ts
@@ -54,6 +54,11 @@ export interface ExpectedNonPrimitive {
 	type: "non-primitive";
 }
 
+export interface ExpectedEnum {
+	type: "enum";
+	name: string;
+}
+
 export interface MissingObjectProperty {
 	type: "missing-property";
 	property: string;
@@ -127,4 +132,5 @@ export type Reason =
 	| ExpectedStringLiteral
 	| ExpectedNumberLiteral
 	| ExpectedBooleanLiteral
-	| ExpectedTemplateLiteral;
+	| ExpectedTemplateLiteral
+	| ExpectedEnum;

--- a/packages/transformers/src/validateArgs/transform-node.ts
+++ b/packages/transformers/src/validateArgs/transform-node.ts
@@ -218,11 +218,10 @@ function transformDecoratedMethod(
 					// This is a type with an "easy" name we can factor out of the method body
 
 					// Disable strict value checks for numeric enums
-					const isNumericEnum =
-						!!(type.flags & ts.TypeFlags.EnumLiteral) &&
-						type.isUnion() &&
-						type.types.every((t) => t.isNumberLiteral());
-					if (isNumericEnum && !options?.strictEnums) {
+					if (
+						VisitorUtils.isNumericEnum(type) &&
+						!options?.strictEnums
+					) {
 						// Fake the number type
 						type = { flags: ts.TypeFlags.Number } as ts.Type;
 						publicTypeName = param.type.getText();

--- a/packages/transformers/src/validateArgs/visitor-utils.ts
+++ b/packages/transformers/src/validateArgs/visitor-utils.ts
@@ -594,16 +594,18 @@ export function createDisjunctionFunction(
 	functionName: string,
 	visitorContext: VisitorContext,
 ): ts.FunctionDeclaration {
-	if (functionNames.length === 2) {
-		const nullTypeCheckFunction = getNullFunction(visitorContext);
-		const nullIndex = functionNames.indexOf(nullTypeCheckFunction);
-		if (nullIndex > -1) {
-			return createNullableTypeCheck(
-				functionNames[1 - nullIndex],
-				functionName,
-			);
-		}
-	}
+	// Not sure why this was here. It created spurious uncalled _null methods
+	//
+	// if (functionNames.length === 2) {
+	// 	const nullTypeCheckFunction = getNullFunction(visitorContext);
+	// 	const nullIndex = functionNames.indexOf(nullTypeCheckFunction);
+	// 	if (nullIndex > -1) {
+	// 		return createNullableTypeCheck(
+	// 			functionNames[1 - nullIndex],
+	// 			functionName,
+	// 		);
+	// 	}
+	// }
 
 	const conditionsIdentifier = ts.createIdentifier("conditions");
 	const conditionIdentifier = ts.createIdentifier("condition");
@@ -694,46 +696,46 @@ export function createDisjunctionFunction(
 	);
 }
 
-function createNullableTypeCheck(
-	typeCheckFunction: string,
-	functionName: string,
-) {
-	return ts.createFunctionDeclaration(
-		undefined,
-		undefined,
-		undefined,
-		functionName,
-		undefined,
-		[
-			ts.createParameter(
-				undefined,
-				undefined,
-				undefined,
-				objectIdentifier,
-				undefined,
-				undefined,
-				undefined,
-			),
-		],
-		undefined,
-		ts.createBlock(
-			[
-				ts.createIf(
-					ts.createStrictEquality(objectIdentifier, ts.createNull()),
-					ts.createReturn(ts.createNull()),
-					ts.createReturn(
-						ts.createCall(
-							ts.createIdentifier(typeCheckFunction),
-							undefined,
-							[objectIdentifier],
-						),
-					),
-				),
-			],
-			true,
-		),
-	);
-}
+// function createNullableTypeCheck(
+// 	typeCheckFunction: string,
+// 	functionName: string,
+// ) {
+// 	return ts.createFunctionDeclaration(
+// 		undefined,
+// 		undefined,
+// 		undefined,
+// 		functionName,
+// 		undefined,
+// 		[
+// 			ts.createParameter(
+// 				undefined,
+// 				undefined,
+// 				undefined,
+// 				objectIdentifier,
+// 				undefined,
+// 				undefined,
+// 				undefined,
+// 			),
+// 		],
+// 		undefined,
+// 		ts.createBlock(
+// 			[
+// 				ts.createIf(
+// 					ts.createStrictEquality(objectIdentifier, ts.createNull()),
+// 					ts.createReturn(ts.createNull()),
+// 					ts.createReturn(
+// 						ts.createCall(
+// 							ts.createIdentifier(typeCheckFunction),
+// 							undefined,
+// 							[objectIdentifier],
+// 						),
+// 					),
+// 				),
+// 			],
+// 			true,
+// 		),
+// 	);
+// }
 
 export function createStrictNullCheckStatement(
 	identifier: ts.Identifier,

--- a/packages/transformers/src/validateArgs/visitor-utils.ts
+++ b/packages/transformers/src/validateArgs/visitor-utils.ts
@@ -94,6 +94,16 @@ export function checkIsIgnoredIntrinsic(type: ts.ObjectType): boolean {
 	);
 }
 
+export function isNumericEnum(
+	type: ts.Type,
+): type is ts.UnionType & { types: ts.NumberLiteralType[] } {
+	return (
+		!!(type.flags & ts.TypeFlags.EnumLiteral) &&
+		type.isUnion() &&
+		type.types.every((t) => t.isNumberLiteral())
+	);
+}
+
 export function setFunctionIfNotExists(
 	name: string,
 	visitorContext: VisitorContext,
@@ -1003,6 +1013,10 @@ function createErrorMessage(reason: Reason): ts.Expression {
 		case "class":
 			return createAssertionString(
 				`expected instance of class '${reason.name}'`,
+			);
+		case "enum":
+			return createAssertionString(
+				`expected value from enum '${reason.name}'`,
 			);
 		case "function":
 			return createAssertionString("expected a function");

--- a/packages/transformers/test/fixtures/testOptionalArgument.ts
+++ b/packages/transformers/test/fixtures/testOptionalArgument.ts
@@ -1,0 +1,41 @@
+import { validateArgs } from "@zwave-js/transformers";
+import assert from "assert";
+
+interface Foo {
+	p1: number;
+	p2?: string | number;
+}
+
+class Test {
+	@validateArgs()
+	foo(arg1?: Foo | string): void {
+		arg1;
+		return void 0;
+	}
+
+	@validateArgs()
+	bar(arg1?: number | null): void {
+		arg1;
+		return void 0;
+	}
+}
+
+const test = new Test();
+// These should not throw
+test.foo({ p1: 1 });
+test.foo(undefined);
+test.bar(1);
+test.bar(undefined);
+test.bar(null);
+
+// These should throw
+assert.throws(
+	// @ts-expect-error
+	() => test.foo({ p2: "a string" }),
+	/arg1 has the wrong type/,
+);
+assert.throws(
+	// @ts-expect-error
+	() => test.foo(null),
+	/arg1 has the wrong type/,
+);


### PR DESCRIPTION
Fixes the first two items of #4414

Strict enums are now checked like `!([1,2,3].includes(foo))` instead of having a separate typeguard for each enum value.