### PR TITLE
chore: update validateArgs calls to use strictEnums where it makes sense

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/AlarmSensorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/AlarmSensorCC.ts
@@ -117,7 +117,7 @@ export class AlarmSensorCCAPI extends PhysicalCCAPI {
 	 * Retrieves the current value from this sensor
 	 * @param sensorType The (optional) sensor type to retrieve the value for
 	 */
-	@validateArgs()
+	@validateArgs({ strictEnums: true })
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	public async get(sensorType?: AlarmSensorType) {
 		this.assertSupportsCommand(AlarmSensorCommand, AlarmSensorCommand.Get);

--- a/packages/zwave-js/src/lib/commandclass/BarrierOperatorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BarrierOperatorCC.ts
@@ -147,7 +147,7 @@ export class BarrierOperatorCCAPI extends CCAPI {
 		}
 	}
 
-	@validateArgs()
+	@validateArgs({ strictEnums: true })
 	public async set(
 		targetState: BarrierState.Open | BarrierState.Closed,
 	): Promise<void> {
@@ -185,7 +185,7 @@ export class BarrierOperatorCCAPI extends CCAPI {
 		return response?.supportedSubsystemTypes;
 	}
 
-	@validateArgs()
+	@validateArgs({ strictEnums: true })
 	public async getEventSignaling(
 		subsystemType: SubsystemType,
 	): Promise<SubsystemState | undefined> {
@@ -207,7 +207,7 @@ export class BarrierOperatorCCAPI extends CCAPI {
 		return response?.subsystemState;
 	}
 
-	@validateArgs()
+	@validateArgs({ strictEnums: true })
 	public async setEventSignaling(
 		subsystemType: SubsystemType,
 		subsystemState: SubsystemState,

--- a/packages/zwave-js/src/lib/commandclass/BinarySensorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySensorCC.ts
@@ -118,7 +118,7 @@ export class BinarySensorCCAPI extends PhysicalCCAPI {
 	 * Retrieves the current value from this sensor
 	 * @param sensorType The (optional) sensor type to retrieve the value for
 	 */
-	@validateArgs()
+	@validateArgs({ strictEnums: true })
 	public async get(
 		sensorType?: BinarySensorType,
 	): Promise<boolean | undefined> {

--- a/packages/zwave-js/src/lib/commandclass/ClimateControlScheduleCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ClimateControlScheduleCC.ts
@@ -70,7 +70,7 @@ export class ClimateControlScheduleCCAPI extends CCAPI {
 		return super.supportsCommand(cmd);
 	}
 
-	@validateArgs()
+	@validateArgs({ strictEnums: true })
 	public async set(
 		weekday: Weekday,
 		switchPoints: Switchpoint[],
@@ -89,7 +89,7 @@ export class ClimateControlScheduleCCAPI extends CCAPI {
 		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
-	@validateArgs()
+	@validateArgs({ strictEnums: true })
 	public async get(
 		weekday: Weekday,
 	): Promise<readonly Switchpoint[] | undefined> {
@@ -153,7 +153,7 @@ export class ClimateControlScheduleCCAPI extends CCAPI {
 		}
 	}
 
-	@validateArgs()
+	@validateArgs({ strictEnums: true })
 	public async setOverride(
 		type: ScheduleOverrideType,
 		state: SetbackState,

--- a/packages/zwave-js/src/lib/commandclass/ClockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ClockCC.ts
@@ -75,7 +75,7 @@ export class ClockCCAPI extends CCAPI {
 		}
 	}
 
-	@validateArgs()
+	@validateArgs({ strictEnums: true })
 	public async set(
 		hour: number,
 		minute: number,

--- a/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
@@ -206,7 +206,7 @@ export class ColorSwitchCCAPI extends CCAPI {
 		return response?.supportedColorComponents;
 	}
 
-	@validateArgs()
+	@validateArgs({ strictEnums: true })
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	public async get(component: ColorComponent) {
 		this.assertSupportsCommand(ColorSwitchCommand, ColorSwitchCommand.Get);
@@ -328,7 +328,7 @@ export class ColorSwitchCCAPI extends CCAPI {
 		}
 	}
 
-	@validateArgs()
+	@validateArgs({ strictEnums: true })
 	public async startLevelChange(
 		options: ColorSwitchCCStartLevelChangeOptions,
 	): Promise<void> {
@@ -346,7 +346,7 @@ export class ColorSwitchCCAPI extends CCAPI {
 		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
-	@validateArgs()
+	@validateArgs({ strictEnums: true })
 	public async stopLevelChange(
 		colorComponent: ColorComponent,
 	): Promise<void> {

--- a/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
@@ -343,7 +343,7 @@ export class DoorLockCCAPI extends PhysicalCCAPI {
 		}
 	}
 
-	@validateArgs()
+	@validateArgs({ strictEnums: true })
 	public async set(mode: DoorLockMode): Promise<void> {
 		this.assertSupportsCommand(
 			DoorLockCommand,

--- a/packages/zwave-js/src/lib/commandclass/HumidityControlModeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/HumidityControlModeCC.ts
@@ -121,7 +121,7 @@ export class HumidityControlModeCCAPI extends CCAPI {
 		}
 	}
 
-	@validateArgs()
+	@validateArgs({ strictEnums: true })
 	public async set(mode: HumidityControlMode): Promise<void> {
 		this.assertSupportsCommand(
 			HumidityControlModeCommand,

--- a/packages/zwave-js/src/lib/commandclass/IrrigationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/IrrigationCC.ts
@@ -655,7 +655,7 @@ export class IrrigationCCAPI extends CCAPI {
 		}
 	}
 
-	@validateArgs()
+	@validateArgs({ strictEnums: true })
 	public async setSystemConfig(
 		config: IrrigationCCSystemConfigSetOptions,
 	): Promise<void> {

--- a/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
@@ -213,7 +213,7 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 		}
 	};
 
-	@validateArgs({ strictEnums: true })
+	@validateArgs()
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	public async get(setpointType: ThermostatSetpointType) {
 		this.assertSupportsCommand(
@@ -242,7 +242,7 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 			  };
 	}
 
-	@validateArgs({ strictEnums: true })
+	@validateArgs()
 	public async set(
 		setpointType: ThermostatSetpointType,
 		value: number,
@@ -263,7 +263,7 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 		await this.driver.sendCommand(cc, this.commandOptions);
 	}
 
-	@validateArgs({ strictEnums: true })
+	@validateArgs()
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	public async getCapabilities(setpointType: ThermostatSetpointType) {
 		this.assertSupportsCommand(


### PR DESCRIPTION
fixes: #4414