### PR TITLE
feat(config): add undocumented param to Eaton RF9501 & RF9540, add RaZberry 7 Pro

### DIFF
--- a/packages/config/config/devices/0x001a/rf9501.json
+++ b/packages/config/config/devices/0x001a/rf9501.json
@@ -106,8 +106,8 @@
 		},
 		{
 			"#": "10",
-			"label": "Notify Accessory",
-			"description": "Ensures that changes to the master node automatically notify accessory switches",
+			"label": "Forward Z-Wave Commands",
+			"description": "Keep associated accessory switches in sync",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
@@ -116,11 +116,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "DISABLE",
+					"label": "Disable",
 					"value": 0
 				},
 				{
-					"label": "ENABLE",
+					"label": "Enable",
 					"value": 1
 				}
 			]

--- a/packages/config/config/devices/0x001a/rf9501.json
+++ b/packages/config/config/devices/0x001a/rf9501.json
@@ -103,6 +103,29 @@
 					"value": 2
 				}
 			]
+		},
+		{
+			"#": "10",
+			"label": "Notify Accessory",
+			"description": "Ensures that changes to the master node automatically notify accessory switches",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [{
+					"label": "DISABLE",
+					"value": 0
+				},
+				{
+					"label": "ENABLE",
+					"value": 1
+				}
+			]
 		}
-	]
+	],
+	"compat": {
+		"enableBasicSetMapping": true
+	}
 }

--- a/packages/config/config/devices/0x001a/rf9501.json
+++ b/packages/config/config/devices/0x001a/rf9501.json
@@ -114,7 +114,8 @@
 			"defaultValue": 0,
 			"unsigned": true,
 			"allowManualEntry": false,
-			"options": [{
+			"options": [
+				{
 					"label": "DISABLE",
 					"value": 0
 				},

--- a/packages/config/config/devices/0x001a/rf9540-n_0.0_1.1.json
+++ b/packages/config/config/devices/0x001a/rf9540-n_0.0_1.1.json
@@ -150,6 +150,26 @@
 			]
 		},
 		{
+			"#": "10",
+			"label": "Notify Accessory",
+			"description": "Ensures that changes to the master node automatically notify accessory switches",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [{
+					"label": "DISABLE",
+					"value": 0
+				},
+				{
+					"label": "ENABLE",
+					"value": 1
+				}
+			]
+		},				
+		{
 			"#": "11",
 			"label": "Minimum Dimmer Level",
 			"description": "The minimum dim level the switch will allow",
@@ -167,5 +187,8 @@
 			"maxValue": 99,
 			"defaultValue": 99
 		}
-	]
+	],
+	"compat": {
+		"enableBasicSetMapping": true
+	}
 }

--- a/packages/config/config/devices/0x001a/rf9540-n_0.0_1.1.json
+++ b/packages/config/config/devices/0x001a/rf9540-n_0.0_1.1.json
@@ -151,8 +151,8 @@
 		},
 		{
 			"#": "10",
-			"label": "Notify Accessory",
-			"description": "Ensures that changes to the master node automatically notify accessory switches",
+			"label": "Forward Z-Wave Commands",
+			"description": "Keep associated accessory switches in sync",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
@@ -161,11 +161,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "DISABLE",
+					"label": "Disable",
 					"value": 0
 				},
 				{
-					"label": "ENABLE",
+					"label": "Enable",
 					"value": 1
 				}
 			]

--- a/packages/config/config/devices/0x001a/rf9540-n_0.0_1.1.json
+++ b/packages/config/config/devices/0x001a/rf9540-n_0.0_1.1.json
@@ -159,7 +159,8 @@
 			"defaultValue": 0,
 			"unsigned": true,
 			"allowManualEntry": false,
-			"options": [{
+			"options": [
+				{
 					"label": "DISABLE",
 					"value": 0
 				},
@@ -168,7 +169,7 @@
 					"value": 1
 				}
 			]
-		},				
+		},
 		{
 			"#": "11",
 			"label": "Minimum Dimmer Level",

--- a/packages/config/config/devices/0x001a/rf9540-n_1.2.json
+++ b/packages/config/config/devices/0x001a/rf9540-n_1.2.json
@@ -155,7 +155,8 @@
 			"defaultValue": 0,
 			"unsigned": true,
 			"allowManualEntry": false,
-			"options": [{
+			"options": [
+				{
 					"label": "DISABLE",
 					"value": 0
 				},
@@ -164,7 +165,7 @@
 					"value": 1
 				}
 			]
-		},		
+		},
 		{
 			"#": "11",
 			"label": "Minimum Dimmer Level",

--- a/packages/config/config/devices/0x001a/rf9540-n_1.2.json
+++ b/packages/config/config/devices/0x001a/rf9540-n_1.2.json
@@ -146,6 +146,26 @@
 			]
 		},
 		{
+			"#": "10",
+			"label": "Notify Accessory",
+			"description": "Ensures that changes to the master node automatically notify accessory switches",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [{
+					"label": "DISABLE",
+					"value": 0
+				},
+				{
+					"label": "ENABLE",
+					"value": 1
+				}
+			]
+		},		
+		{
 			"#": "11",
 			"label": "Minimum Dimmer Level",
 			"description": "The minimum dim level the switch will allow",

--- a/packages/config/config/devices/0x001a/rf9540-n_1.2.json
+++ b/packages/config/config/devices/0x001a/rf9540-n_1.2.json
@@ -147,8 +147,8 @@
 		},
 		{
 			"#": "10",
-			"label": "Notify Accessory",
-			"description": "Ensures that changes to the master node automatically notify accessory switches",
+			"label": "Forward Z-Wave Commands",
+			"description": "Keep associated accessory switches in sync",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
@@ -157,11 +157,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "DISABLE",
+					"label": "Disable",
 					"value": 0
 				},
 				{
-					"label": "ENABLE",
+					"label": "Enable",
 					"value": 1
 				}
 			]

--- a/packages/config/config/devices/0x0147/zme_razberry7_pro.json
+++ b/packages/config/config/devices/0x0147/zme_razberry7_pro.json
@@ -1,8 +1,8 @@
 {
 	"manufacturer": "Z-Wave.me",
 	"manufacturerId": "0x0147",
-	"label": "Razberry7 PRO",
-	"description": "Raspbery PI Z-Wave Controller",
+	"label": "RaZberry 7 Pro",
+	"description": "Z-Wave Shield for Raspberry Pi",
 	"devices": [
 		{
 			"productType": "0x0401",

--- a/packages/config/config/devices/0x0147/zme_razberry7_pro.json
+++ b/packages/config/config/devices/0x0147/zme_razberry7_pro.json
@@ -1,0 +1,20 @@
+{
+	"manufacturer": "Z-Wave.me",
+	"manufacturerId": "0x0147",
+	"label": "Razberry7 PRO",
+	"description": "Raspbery PI Z-Wave Controller",
+	"devices": [
+		{
+			"productType": "0x0401",
+			"productId": "0x0101"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"metadata": {
+		"reset": "Z-Wave Serial API SetDefault command is used to reset the RaZberry7 Pro board to factory default settings.",
+		"manual": "https://rus.z-wave.me/drive/?file=24e4716409e82d0e27379e3e5208c8667b99"
+	}
+}


### PR DESCRIPTION
Adding additional param for Eaton rf9501 and rf9540
- Accessory Notify is an undocumented param and is used to update associated device on/off lights when triggered remotely through a z-wave controller

Added z-wave.me razberry 7 pro device file
- Only had basic information for the US version and z-wave alliance page has not been updated with detailed information