### PR TITLE
feat: allow duration strings in all CC APIs, make duration values r/o

### DIFF
--- a/docs/api/CCs/SceneActuatorConfiguration.md
+++ b/docs/api/CCs/SceneActuatorConfiguration.md
@@ -9,7 +9,7 @@
 ```ts
 async set(
 	sceneId: number,
-	dimmingDuration?: Duration,
+	dimmingDuration?: Duration | string,
 	level?: number,
 ): Promise<void>;
 ```

--- a/docs/api/CCs/SceneControllerConfiguration.md
+++ b/docs/api/CCs/SceneControllerConfiguration.md
@@ -16,7 +16,7 @@ async disable(groupId: number): Promise<void>;
 async set(
 	groupId: number,
 	sceneId: number,
-	dimmingDuration?: Duration,
+	dimmingDuration?: Duration | string,
 ): Promise<void>;
 ```
 

--- a/packages/core/src/values/Primitive.ts
+++ b/packages/core/src/values/Primitive.ts
@@ -30,7 +30,7 @@ export function parseBoolean(val: number): boolean | undefined {
 	return val === 0 ? false : val === 0xff ? true : undefined;
 }
 
-/** Parses a single-byte number from 0 to 100, which might also be "unknown" */
+/** Parses a single-byte number from 0 to 99, which might also be "unknown" */
 export function parseMaybeNumber(
 	val: number,
 	preserveUnknown: boolean = true,
@@ -42,7 +42,7 @@ export function parseMaybeNumber(
 		: parseNumber(val);
 }
 
-/** Parses a single-byte number from 0 to 100 */
+/** Parses a single-byte number from 0 to 99 */
 export function parseNumber(val: number): number | undefined {
 	return val <= 99 ? val : val === 0xff ? 99 : undefined;
 }

--- a/packages/zwave-js/src/lib/commandclass/BasicCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BasicCC.ts
@@ -353,7 +353,7 @@ export class BasicCCReport extends BasicCC {
 	@ccValue({ minVersion: 2 })
 	@ccValueMetadata({
 		...ValueMetadata.ReadOnlyDuration,
-		label: "Remaining duration until target value",
+		label: "Remaining duration",
 	})
 	public readonly duration: Duration | undefined;
 

--- a/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
@@ -103,7 +103,7 @@ export class BinarySwitchCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 			targetValue,
-			duration: Duration.from(duration),
+			duration,
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
 	}
@@ -245,7 +245,7 @@ remaining duration: ${resp.duration?.toString() ?? "undefined"}`;
 
 interface BinarySwitchCCSetOptions extends CCCommandOptions {
 	targetValue: boolean;
-	duration?: Duration;
+	duration?: Duration | string;
 }
 
 @CCCommand(BinarySwitchCommand.Set)
@@ -262,7 +262,7 @@ export class BinarySwitchCCSet extends BinarySwitchCC {
 			);
 		} else {
 			this.targetValue = options.targetValue;
-			this.duration = options.duration;
+			this.duration = Duration.from(options.duration);
 		}
 	}
 
@@ -335,8 +335,8 @@ export class BinarySwitchCCReport extends BinarySwitchCC {
 	private _duration: Duration | undefined;
 	@ccValue({ minVersion: 2 })
 	@ccValueMetadata({
-		...ValueMetadata.Duration,
-		label: "Transition duration",
+		...ValueMetadata.ReadOnlyDuration,
+		label: "Remaining duration",
 	})
 	public get duration(): Duration | undefined {
 		return this._duration;

--- a/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
@@ -535,6 +535,7 @@ export class ColorSwitchCC extends CommandClass {
 				minLength: 6,
 				maxLength: 7, // to allow #rrggbb
 				label: `RGB Color`,
+				valueChangeOptions: ["transitionDuration"],
 			});
 		}
 

--- a/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
@@ -716,7 +716,7 @@ export class ColorSwitchCCReport extends ColorSwitchCC {
 
 	@ccValue()
 	@ccValueMetadata({
-		...ValueMetadata.Duration,
+		...ValueMetadata.ReadOnlyDuration,
 		label: "Remaining duration",
 	})
 	public readonly duration: Duration | undefined;
@@ -805,7 +805,7 @@ export class ColorSwitchCCGet extends ColorSwitchCC {
 }
 
 export type ColorSwitchCCSetOptions = (ColorTable | { hexColor: string }) & {
-	duration?: Duration;
+	duration?: Duration | string;
 };
 
 @CCCommand(ColorSwitchCommand.Set)
@@ -841,7 +841,7 @@ export class ColorSwitchCCSet extends ColorSwitchCC {
 			} else {
 				this.colorTable = pick(options, colorTableKeys as any[]);
 			}
-			this.duration = options.duration;
+			this.duration = Duration.from(options.duration);
 		}
 	}
 
@@ -902,7 +902,7 @@ type ColorSwitchCCStartLevelChangeOptions = {
 	  }
 ) & {
 		// Version >= 3:
-		duration?: Duration;
+		duration?: Duration | string;
 	};
 
 @CCCommand(ColorSwitchCommand.StartLevelChange)
@@ -921,7 +921,7 @@ export class ColorSwitchCCStartLevelChange extends ColorSwitchCC {
 				ZWaveErrorCodes.Deserialization_NotImplemented,
 			);
 		} else {
-			this.duration = options.duration;
+			this.duration = Duration.from(options.duration);
 			this.ignoreStartLevel = options.ignoreStartLevel;
 			this.startLevel = options.startLevel ?? 0;
 			this.direction = options.direction;

--- a/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
@@ -734,7 +734,7 @@ export class DoorLockCCOperationReport extends DoorLockCC {
 
 	@ccValue({ minVersion: 3 })
 	@ccValueMetadata({
-		...ValueMetadata.ReadOnly,
+		...ValueMetadata.ReadOnlyDuration,
 		label: "Remaining duration until target lock mode",
 	})
 	public readonly duration?: Duration;

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -140,7 +140,7 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 			targetValue,
-			duration: Duration.from(duration),
+			duration,
 		});
 
 		// Multilevel Switch commands may take some time to be executed.
@@ -554,7 +554,7 @@ export class MultilevelSwitchCC extends CommandClass {
 interface MultilevelSwitchCCSetOptions extends CCCommandOptions {
 	targetValue: number;
 	// Version >= 2:
-	duration?: Duration;
+	duration?: Duration | string;
 }
 
 @CCCommand(MultilevelSwitchCommand.Set)
@@ -575,7 +575,7 @@ export class MultilevelSwitchCCSet extends MultilevelSwitchCC {
 			}
 		} else {
 			this.targetValue = options.targetValue;
-			this.duration = options.duration;
+			this.duration = Duration.from(options.duration);
 		}
 	}
 
@@ -635,8 +635,8 @@ export class MultilevelSwitchCCReport extends MultilevelSwitchCC {
 
 	@ccValue()
 	@ccValueMetadata({
-		...ValueMetadata.Duration,
-		label: "Transition duration",
+		...ValueMetadata.ReadOnlyDuration,
+		label: "Remaining duration",
 	})
 	public readonly duration: Duration | undefined;
 
@@ -679,7 +679,7 @@ type MultilevelSwitchCCStartLevelChangeOptions = {
 	  }
 ) & {
 		// Version >= 2:
-		duration?: Duration;
+		duration?: Duration | string;
 	};
 
 @CCCommand(MultilevelSwitchCommand.StartLevelChange)
@@ -703,7 +703,7 @@ export class MultilevelSwitchCCStartLevelChange extends MultilevelSwitchCC {
 			this.startLevel = startLevel;
 			this.direction = direction ? "down" : "up";
 		} else {
-			this.duration = options.duration;
+			this.duration = Duration.from(options.duration);
 			this.ignoreStartLevel = options.ignoreStartLevel;
 			this.startLevel = options.startLevel ?? 0;
 			this.direction = options.direction;

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -538,6 +538,7 @@ export class MultilevelSwitchCC extends CommandClass {
 			this.getValueDB().setMetadata(upValueId, {
 				...ValueMetadata.Boolean,
 				label: `Perform a level change (${up})`,
+				valueChangeOptions: ["transitionDuration"],
 				ccSpecific: { switchType },
 			});
 		}
@@ -545,6 +546,7 @@ export class MultilevelSwitchCC extends CommandClass {
 			this.getValueDB().setMetadata(downValueId, {
 				...ValueMetadata.Boolean,
 				label: `Perform a level change (${down})`,
+				valueChangeOptions: ["transitionDuration"],
 				ccSpecific: { switchType },
 			});
 		}

--- a/packages/zwave-js/src/lib/commandclass/SceneActivationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneActivationCC.ts
@@ -91,7 +91,7 @@ export class SceneActivationCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 			sceneId,
-			dimmingDuration: Duration.from(dimmingDuration),
+			dimmingDuration,
 		});
 		await this.driver.sendCommand(cc, this.commandOptions);
 	}
@@ -105,7 +105,7 @@ export class SceneActivationCC extends CommandClass {
 
 interface SceneActivationCCSetOptions extends CCCommandOptions {
 	sceneId: number;
-	dimmingDuration?: Duration;
+	dimmingDuration?: Duration | string;
 }
 
 @CCCommand(SceneActivationCommand.Set)
@@ -126,7 +126,7 @@ export class SceneActivationCCSet extends SceneActivationCC {
 			this.persistValues();
 		} else {
 			this.sceneId = options.sceneId;
-			this.dimmingDuration = options.dimmingDuration;
+			this.dimmingDuration = Duration.from(options.dimmingDuration);
 		}
 	}
 
@@ -141,7 +141,7 @@ export class SceneActivationCCSet extends SceneActivationCC {
 
 	@ccValue()
 	@ccValueMetadata({
-		...ValueMetadata.Any,
+		...ValueMetadata.Duration,
 		label: "Dimming duration",
 	})
 	public dimmingDuration: Duration | undefined;

--- a/packages/zwave-js/src/lib/commandclass/SceneActuatorConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneActuatorConfigurationCC.ts
@@ -225,7 +225,7 @@ export class SceneActuatorConfigurationCCAPI extends CCAPI {
 	@validateArgs()
 	public async set(
 		sceneId: number,
-		dimmingDuration?: Duration,
+		dimmingDuration?: Duration | string,
 		level?: number,
 	): Promise<void> {
 		this.assertSupportsCommand(
@@ -240,7 +240,8 @@ export class SceneActuatorConfigurationCCAPI extends CCAPI {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
 			sceneId,
-			dimmingDuration: dimmingDuration ?? new Duration(0, "seconds"),
+			dimmingDuration:
+				Duration.from(dimmingDuration) ?? new Duration(0, "seconds"),
 			level,
 		});
 

--- a/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SceneControllerConfigurationCC.ts
@@ -252,7 +252,7 @@ export class SceneControllerConfigurationCCAPI extends CCAPI {
 	public async set(
 		groupId: number,
 		sceneId: number,
-		dimmingDuration?: Duration,
+		dimmingDuration?: Duration | string,
 	): Promise<void> {
 		this.assertSupportsCommand(
 			SceneControllerConfigurationCommand,
@@ -446,7 +446,7 @@ dimming duration: ${group.dimmingDuration.toString()}`;
 interface SceneControllerConfigurationCCSetOptions extends CCCommandOptions {
 	groupId: number;
 	sceneId: number;
-	dimmingDuration?: Duration;
+	dimmingDuration?: Duration | string;
 }
 
 @CCCommand(SceneControllerConfigurationCommand.Set)
@@ -470,7 +470,8 @@ export class SceneControllerConfigurationCCSet extends SceneControllerConfigurat
 			this.sceneId = options.sceneId;
 			// if dimmingDuration was missing, use default duration.
 			this.dimmingDuration =
-				options.dimmingDuration ?? new Duration(0, "default");
+				Duration.from(options.dimmingDuration) ??
+				new Duration(0, "default");
 
 			// The client SHOULD NOT specify group 1 (the life-line group).
 			// We don't block it here, because the specs don't forbid it,
@@ -485,9 +486,7 @@ export class SceneControllerConfigurationCCSet extends SceneControllerConfigurat
 	}
 
 	public groupId: number;
-
 	public sceneId: number;
-
 	public dimmingDuration: Duration;
 
 	public serialize(): Buffer {


### PR DESCRIPTION
With this PR, all CC APIs that accept a `Duration` instance now also accept duration strings. Those are converted to durations automatically. CC values indicating the remaining duration until a target value/state are now consistently readonly and marked as durations. In addition, all CC values that respect the `transitionDuration` `setValue` option are now marked as such.

fixes: https://github.com/zwave-js/node-zwave-js/issues/4136
fixes: https://github.com/zwave-js/node-zwave-js/issues/4460