### PR TITLE
feat: remember requested security classes, support inactive provisioning entries

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -169,12 +169,12 @@ Stops the inclusion process for a new node. The returned promise resolves to `tr
 ### `beginExclusion`
 
 ```ts
-async beginExclusion(unprovision?: boolean): Promise<boolean>
+async beginExclusion(unprovision?: boolean | "inactive"): Promise<boolean>
 ```
 
 Starts the exclusion process to remove a node from the network. The returned promise resolves to `true` if starting the exclusion was successful, `false` if it failed or if it was already active.
 
-The optional parameter `unprovision` specifies whether the removed node should be removed from the Smart Start provisioning list as well.
+The optional parameter `unprovision` specifies whether the removed node should be removed from the Smart Start provisioning list as well. A value of `"inactive"` will keep the provisioning entry, but disable it, preventing automatic inclusion of the corresponding nodes.
 
 ### `stopExclusion`
 

--- a/packages/core/src/security/QR.test.ts
+++ b/packages/core/src/security/QR.test.ts
@@ -43,6 +43,10 @@ describe("QR code parsing", () => {
 				SecurityClass.S2_Unauthenticated,
 				SecurityClass.S2_Authenticated,
 			],
+			requestedSecurityClasses: [
+				SecurityClass.S2_Unauthenticated,
+				SecurityClass.S2_Authenticated,
+			],
 			dsk: "51525-35455-41424-34445-31323-33435-21222-32425",
 			applicationVersion: "2.66",
 			genericDeviceClass: 0x11,
@@ -61,6 +65,11 @@ describe("QR code parsing", () => {
 		expect(result).toEqual({
 			version: QRCodeVersion.SmartStart,
 			securityClasses: [
+				SecurityClass.S2_Unauthenticated,
+				SecurityClass.S2_Authenticated,
+				SecurityClass.S2_AccessControl,
+			],
+			requestedSecurityClasses: [
 				SecurityClass.S2_Unauthenticated,
 				SecurityClass.S2_Authenticated,
 				SecurityClass.S2_AccessControl,
@@ -84,6 +93,10 @@ describe("QR code parsing", () => {
 		expect(result).toEqual({
 			version: QRCodeVersion.S2,
 			securityClasses: [
+				SecurityClass.S2_Unauthenticated,
+				SecurityClass.S2_Authenticated,
+			],
+			requestedSecurityClasses: [
 				SecurityClass.S2_Unauthenticated,
 				SecurityClass.S2_Authenticated,
 			],

--- a/packages/core/src/security/QR.ts
+++ b/packages/core/src/security/QR.ts
@@ -88,7 +88,7 @@ export interface ProvisioningInformation_SupportedProtocols {
 export type QRProvisioningInformation = {
 	version: QRCodeVersion;
 	/** The security classes that were **requested** by the device */
-	requestedSecurityClasses: SecurityClass[];
+	readonly requestedSecurityClasses: SecurityClass[];
 	/**
 	 * The security classes that will be **granted** to this device.
 	 * Until this has been changed by a user, this will be identical to {@link requestedSecurityClasses}.

--- a/packages/core/src/security/QR.ts
+++ b/packages/core/src/security/QR.ts
@@ -87,7 +87,9 @@ export interface ProvisioningInformation_SupportedProtocols {
 
 export type QRProvisioningInformation = {
 	version: QRCodeVersion;
-	/** The security classes that were **requested** by the device */
+	/**
+	 * The security classes that were **requested** by the device.
+	 */
 	readonly requestedSecurityClasses: SecurityClass[];
 	/**
 	 * The security classes that will be **granted** to this device.
@@ -250,6 +252,7 @@ export function parseQRCodeString(qr: string): QRProvisioningInformation {
 
 	const ret = {
 		version,
+		// This seems like a duplication, but it's more convenient for applications to not have to copy this field over
 		requestedSecurityClasses,
 		securityClasses: [...requestedSecurityClasses],
 		dsk: dskToString(dsk),

--- a/packages/zwave-js/src/lib/controller/Inclusion.ts
+++ b/packages/zwave-js/src/lib/controller/Inclusion.ts
@@ -154,7 +154,7 @@ export interface PlannedProvisioningEntry {
 	 * The security classes that were **requested** by the device.
 	 * When this is not set, applications should default to {@link securityClasses} instead.
 	 */
-	requestedSecurityClasses?: SecurityClass[];
+	requestedSecurityClasses?: readonly SecurityClass[];
 
 	/**
 	 * Additional properties to be stored in this provisioning entry, e.g. the device ID from a scanned QR code

--- a/packages/zwave-js/src/lib/controller/Inclusion.ts
+++ b/packages/zwave-js/src/lib/controller/Inclusion.ts
@@ -133,10 +133,29 @@ export type ReplaceNodeOptions =
 				| InclusionStrategy.Security_S0;
 	  };
 
+export enum ProvisioningEntryStatus {
+	Active,
+	Inactive,
+}
+
 export interface PlannedProvisioningEntry {
+	/**
+	 * The status of this provisioning entry, which is assumed to be active by default.
+	 * Inactive entries do not get included automatically.
+	 */
+	status?: ProvisioningEntryStatus;
+
 	/** The device specific key (DSK) in the form aaaaa-bbbbb-ccccc-ddddd-eeeee-fffff-11111-22222 */
 	dsk: string;
+
+	/** The security classes that have been **granted** by the user */
 	securityClasses: SecurityClass[];
+	/**
+	 * The security classes that were **requested** by the device.
+	 * When this is not set, applications should default to {@link securityClasses} instead.
+	 */
+	requestedSecurityClasses?: SecurityClass[];
+
 	/**
 	 * Additional properties to be stored in this provisioning entry, e.g. the device ID from a scanned QR code
 	 */

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -99,7 +99,10 @@ import {
 } from "../commandclass/WakeUpCC";
 import { SupervisionStatus } from "../commandclass/_Types";
 import { ZWaveController } from "../controller/Controller";
-import { InclusionState } from "../controller/Inclusion";
+import {
+	InclusionState,
+	ProvisioningEntryStatus,
+} from "../controller/Inclusion";
 import { TransmitOptions, TXReport } from "../controller/_Types";
 import { ControllerLogger } from "../log/Controller";
 import { DriverLogger } from "../log/Driver";
@@ -3166,6 +3169,14 @@ ${handlers.length} left`,
 				if (!provisioningEntry) {
 					this.controllerLog.print(
 						"NWI Home ID not found in provisioning list, ignoring request...",
+					);
+					return;
+				} else if (
+					provisioningEntry.status ===
+					ProvisioningEntryStatus.Inactive
+				) {
+					this.controllerLog.print(
+						"The provisioning entry for this node is inactive, ignoring request...",
 					);
 					return;
 				}


### PR DESCRIPTION
This PR adds two additional (optional) fields to the `PlannedProvisioningEntry` (and by extension `IncludedProvisioningEntry`) interfaces.

The `status` field can assume the following values:
```ts
enum ProvisioningEntryStatus {
	Active,
	Inactive,
}
```
where an absent status will be assumed to be `Active` for backwards compatibility.
This can be used to disable provisioning entries. Inactive entries will be kept, but won't cause an inclusion when the corresponding node announces itself.
An entry can be set to inactive manually, or automatically during exclusion using the new possible value for the `unprovision` argument of `beginExclusion`:
```ts
await driver.controller.beginExclusion("inactive");
// this will exclude a node and set the corresponding provisioning entry to inactive afterwards
```
fixes: https://github.com/zwave-js/node-zwave-js/issues/3682

---

The optional `requestedSecurityClasses` (readonly) field keeps track of the security classes that have been requested by the device via QR code. This can be used in the provisioning entry editor to disable the checkboxes for security classes that haven't been requested, in order to avoid confusion caused by granting non-requested classes.

This is also added to the `QRProvisioningInformation` interface, so applications which copy the properties rather than pass a `QRProvisioningInformation` as a `PlannedProvisioningEntry` should take care of this new property.

fixes: https://github.com/zwave-js/node-zwave-js/issues/4250