### PR TITLE
fix: cancel verification poll only when expected value is received

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/API.ts
+++ b/packages/zwave-js/src/lib/commandclass/API.ts
@@ -137,6 +137,7 @@ export class CCAPI {
 	 */
 	protected schedulePoll(
 		property: ValueIDProperties,
+		expectedValue: unknown,
 		{ duration, transition = "slow" }: SchedulePollOptions = {},
 	): boolean {
 		// Figure out the delay. If a non-zero duration was given or this is a "fast" transition,
@@ -158,7 +159,7 @@ export class CCAPI {
 					endpoint: this.endpoint.index,
 					...property,
 				},
-				timeoutMs,
+				{ timeoutMs, expectedValue },
 			);
 		} else if (this.isMulticast()) {
 			// Only poll supporting nodes in multicast
@@ -176,7 +177,7 @@ export class CCAPI {
 						endpoint: this.endpoint.index,
 						...property,
 					},
-					timeoutMs,
+					{ timeoutMs, expectedValue },
 				);
 			}
 			return ret;

--- a/packages/zwave-js/src/lib/commandclass/BarrierOperatorCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BarrierOperatorCC.ts
@@ -220,7 +220,7 @@ export class BarrierOperatorCCAPI extends CCAPI {
 
 			// Verify the change after a delay
 			if (this.isSinglecast()) {
-				this.schedulePoll({ property });
+				this.schedulePoll({ property }, targetValue);
 			}
 		} else if (property === "signalingState") {
 			if (propertyKey == undefined) {

--- a/packages/zwave-js/src/lib/commandclass/BasicCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BasicCC.ts
@@ -105,7 +105,7 @@ export class BasicCCAPI extends CCAPI {
 			// and verify the current value after a delay. We query currentValue instead of targetValue to make sure
 			// that unsolicited updates cancel the scheduled poll
 			if (property === "targetValue") property = "currentValue";
-			this.schedulePoll({ property });
+			this.schedulePoll({ property }, value);
 		} else if (this.isMulticast()) {
 			// Only update currentValue for valid target values
 			if (
@@ -133,7 +133,7 @@ export class BasicCCAPI extends CCAPI {
 
 				// We query currentValue instead of targetValue to make sure that unsolicited updates cancel the scheduled poll
 				if (property === "targetValue") property = "currentValue";
-				this.schedulePoll({ property });
+				this.schedulePoll({ property }, undefined);
 			}
 		}
 	};

--- a/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
@@ -136,14 +136,11 @@ export class BinarySwitchCCAPI extends CCAPI {
 			// Verify the current value after a delay
 			// We query currentValue instead of targetValue to make sure that unsolicited updates cancel the scheduled poll
 			if (property === "targetValue") property = "currentValue";
-			this.schedulePoll(
-				{ property },
-				{
-					duration,
-					// on/off "transitions" are usually fast
-					transition: "fast",
-				},
-			);
+			this.schedulePoll({ property }, value, {
+				duration,
+				// on/off "transitions" are usually fast
+				transition: "fast",
+			});
 		} else if (this.isMulticast()) {
 			if (!this.driver.options.disableOptimisticValueUpdate) {
 				// Figure out which nodes were affected by this command

--- a/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
@@ -351,10 +351,10 @@ export class ColorSwitchCCAPI extends CCAPI {
 
 				if (this.isSinglecast()) {
 					// Verify the current value after a (short) delay
-					this.schedulePoll(
-						{ property, propertyKey },
-						{ duration, transition: "fast" },
-					);
+					this.schedulePoll({ property, propertyKey }, value, {
+						duration,
+						transition: "fast",
+					});
 				}
 			} else {
 				// Set the compound color object

--- a/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
@@ -398,6 +398,7 @@ export class ConfigurationCCAPI extends CCAPI {
 			// Verify the current value after a delay
 			(this as ConfigurationCCAPI).schedulePoll(
 				{ property, propertyKey },
+				targetValue,
 				// Configuration changes are instant
 				{ transition: "fast" },
 			);

--- a/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts
@@ -180,7 +180,7 @@ export class DoorLockCCAPI extends PhysicalCCAPI {
 			await this.set(value);
 
 			// Verify the current value after a delay
-			this.schedulePoll({ property });
+			this.schedulePoll({ property }, value);
 		} else if (
 			typeof property === "string" &&
 			configurationSetParameters.includes(property as any)

--- a/packages/zwave-js/src/lib/commandclass/HumidityControlModeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/HumidityControlModeCC.ts
@@ -70,7 +70,7 @@ export class HumidityControlModeCCAPI extends CCAPI {
 		await this.set(value);
 
 		if (this.isSinglecast()) {
-			this.schedulePoll({ property });
+			this.schedulePoll({ property }, value);
 		}
 	};
 

--- a/packages/zwave-js/src/lib/commandclass/HumidityControlSetpointCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/HumidityControlSetpointCC.ts
@@ -128,7 +128,7 @@ export class HumidityControlSetpointCCAPI extends CCAPI {
 
 		if (this.isSinglecast()) {
 			// Verify the current value after a delay
-			this.schedulePoll({ property, propertyKey });
+			this.schedulePoll({ property, propertyKey }, value);
 		}
 	};
 

--- a/packages/zwave-js/src/lib/commandclass/LockCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/LockCC.ts
@@ -95,7 +95,7 @@ export class LockCCAPI extends PhysicalCCAPI {
 		await this.set(value);
 
 		// Verify the current value after a delay
-		this.schedulePoll({ property });
+		this.schedulePoll({ property }, value);
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({

--- a/packages/zwave-js/src/lib/commandclass/ManufacturerProprietaryCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ManufacturerProprietaryCC.ts
@@ -126,7 +126,7 @@ export class ManufacturerProprietaryCCAPI extends CCAPI {
 		}
 
 		// Verify the current value after a delay
-		this.schedulePoll({ property, propertyKey });
+		this.schedulePoll({ property, propertyKey }, value);
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -326,7 +326,11 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 						if (property === "targetValue")
 							property = "currentValue";
 
-						this.schedulePoll({ property }, { duration });
+						this.schedulePoll(
+							{ property },
+							value === 255 ? undefined : value,
+							{ duration },
+						);
 					}
 				} else if (this.isMulticast()) {
 					// Only update currentValue for valid target values
@@ -356,7 +360,9 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 						// We query currentValue instead of targetValue to make sure that unsolicited updates cancel the scheduled poll
 						if (property === "targetValue")
 							property = "currentValue";
-						this.schedulePoll({ property }, { duration });
+						this.schedulePoll({ property }, undefined, {
+							duration,
+						});
 					}
 				}
 			}

--- a/packages/zwave-js/src/lib/commandclass/SoundSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SoundSwitchCC.ts
@@ -259,7 +259,7 @@ export class SoundSwitchCCAPI extends CCAPI {
 			}
 			if (this.isSinglecast()) {
 				// Verify the current value after a (short) delay
-				this.schedulePoll({ property }, { transition: "fast" });
+				this.schedulePoll({ property }, value, { transition: "fast" });
 			}
 		} else {
 			throwUnsupportedProperty(this.ccId, property);

--- a/packages/zwave-js/src/lib/commandclass/ThermostatFanModeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatFanModeCC.ts
@@ -116,7 +116,7 @@ export class ThermostatFanModeCCAPI extends CCAPI {
 			// Verify the current value after a delay
 			// TODO: Ideally this would be a short delay, but some thermostats like Remotec ZXT-600
 			// aren't able to handle the GET this quickly.
-			this.schedulePoll({ property });
+			this.schedulePoll({ property }, value);
 		}
 	};
 

--- a/packages/zwave-js/src/lib/commandclass/ThermostatModeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatModeCC.ts
@@ -86,7 +86,7 @@ export class ThermostatModeCCAPI extends CCAPI {
 			// Verify the current value after a delay
 			// TODO: Ideally this would be a short delay, but some thermostats like Remotec ZXT-600
 			// aren't able to handle the GET this quickly.
-			this.schedulePoll({ property });
+			this.schedulePoll({ property }, value);
 		}
 	};
 

--- a/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
@@ -140,7 +140,7 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 			// Verify the current value after a delay
 			// TODO: Ideally this would be a short delay, but some thermostats like Remotec ZXT-600
 			// aren't able to handle the GET this quickly.
-			this.schedulePoll({ property, propertyKey });
+			this.schedulePoll({ property, propertyKey }, value);
 		}
 	};
 

--- a/packages/zwave-js/src/lib/commandclass/UserCodeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/UserCodeCC.ts
@@ -400,7 +400,9 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 		}
 
 		// Verify the current value after a (short) delay
-		this.schedulePoll({ property, propertyKey }, { transition: "fast" });
+		this.schedulePoll({ property, propertyKey }, value, {
+			transition: "fast",
+		});
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({

--- a/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
@@ -86,7 +86,7 @@ export class WakeUpCCAPI extends CCAPI {
 
 		if (this.isSinglecast()) {
 			// Verify the current value after a (short) delay
-			this.schedulePoll({ property }, { transition: "fast" });
+			this.schedulePoll({ property }, value, { transition: "fast" });
 		}
 	};
 

--- a/packages/zwave-js/src/lib/driver/Driver.test.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.test.ts
@@ -796,7 +796,7 @@ describe("lib/driver/Driver => ", () => {
 				commandClass: CommandClasses.Basic,
 				property: "currentValue",
 			};
-			node2.schedulePoll(valueId, 1000);
+			node2.schedulePoll(valueId, { timeoutMs: 1000 });
 			expect(driver["hasPendingMessages"](node2)).toBeTrue();
 			node2.cancelScheduledPoll(valueId);
 			expect(driver["hasPendingMessages"](node2)).toBeFalse();


### PR DESCRIPTION
With this PR, we no longer blindly cancel value verification polls when an unsolicited report is received. Instead, for each scheduled poll, an expected value can/will be saved and value updates only cancel the poll when the value was changed to this expected value (assuming one is set).

fixes: #3523
fixes: #4453
