### PR TITLE
fix: export missing controller-related types/enums from safe entrypoint

### DIFF
--- a/packages/zwave-js/src/Controller_safe.ts
+++ b/packages/zwave-js/src/Controller_safe.ts
@@ -1,6 +1,4 @@
 export { ProtocolDataRate, RFRegion } from "@zwave-js/core/safe";
-export { ZWaveController } from "./lib/controller/Controller";
-export type { ControllerEvents } from "./lib/controller/Controller";
 export type { ControllerStatistics } from "./lib/controller/ControllerStatistics";
 export { ZWaveFeature } from "./lib/controller/Features";
 export * from "./lib/controller/Inclusion";
@@ -12,10 +10,4 @@ export {
 	SDKVersion,
 	TXReport,
 } from "./lib/controller/_Types";
-export {
-	ControllerLogContext,
-	ControllerNodeLogContext,
-	ControllerSelfLogContext,
-	ControllerValueLogContext,
-} from "./lib/log/Controller";
 export type { ZWaveLibraryTypes } from "./lib/serialapi/_Types";

--- a/packages/zwave-js/src/index_safe.ts
+++ b/packages/zwave-js/src/index_safe.ts
@@ -1,7 +1,7 @@
 /* @noExternalImports */
 
 export * from "./CommandClass_safe";
-// export * from "./Controller";
+export * from "./Controller_safe";
 // export * from "./Driver";
 export * from "./Error";
 export * from "./Node_safe";

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -249,12 +249,7 @@ import {
 	SmartStartProvisioningEntry,
 } from "./Inclusion";
 import { protocolVersionToSDKVersion } from "./ZWaveSDKVersions";
-import type { RSSI } from "./_Types";
-
-export type HealNodeStatus = "pending" | "done" | "failed" | "skipped";
-export type SDKVersion =
-	| `${number}.${number}`
-	| `${number}.${number}.${number}`;
+import type { HealNodeStatus, RSSI, SDKVersion } from "./_Types";
 
 export type ThrowingMap<K, V> = Map<K, V> & { getOrThrow(key: K): V };
 export type ReadonlyThrowingMap<K, V> = ReadonlyMap<K, V> & {

--- a/packages/zwave-js/src/lib/controller/Features.ts
+++ b/packages/zwave-js/src/lib/controller/Features.ts
@@ -1,4 +1,4 @@
-import type { SDKVersion } from "./Controller";
+import type { SDKVersion } from "./_Types";
 
 /** A named list of Z-Wave features */
 export enum ZWaveFeature {

--- a/packages/zwave-js/src/lib/controller/_Types.ts
+++ b/packages/zwave-js/src/lib/controller/_Types.ts
@@ -90,3 +90,8 @@ export interface TXReport {
 	/** Noise floor measured by the destination during the ACK transmission */
 	destinationAckMeasuredNoiseFloor?: RSSI;
 }
+
+export type HealNodeStatus = "pending" | "done" | "failed" | "skipped";
+export type SDKVersion =
+	| `${number}.${number}`
+	| `${number}.${number}.${number}`;


### PR DESCRIPTION
cc @robertsLando 