### PR TITLE
fix: check that the argument of `provisionSmartStartNode` is valid

### DIFF
--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -248,6 +248,7 @@ import {
 	ReplaceNodeOptions,
 	SmartStartProvisioningEntry,
 } from "./Inclusion";
+import { assertProvisioningEntry } from "./utils";
 import { protocolVersionToSDKVersion } from "./ZWaveSDKVersions";
 import type { HealNodeStatus, RSSI, SDKVersion } from "./_Types";
 
@@ -562,6 +563,9 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 	public provisionSmartStartNode(entry: PlannedProvisioningEntry): void {
 		// Make sure the controller supports SmartStart
 		this.assertFeature(ZWaveFeature.SmartStart);
+
+		// And that the entry contains valid data
+		assertProvisioningEntry(entry);
 
 		const provisioningList = [...this.provisioningList];
 

--- a/packages/zwave-js/src/lib/controller/Inclusion.ts
+++ b/packages/zwave-js/src/lib/controller/Inclusion.ts
@@ -1,4 +1,4 @@
-import type { SecurityClass } from "@zwave-js/core";
+import type { SecurityClass } from "@zwave-js/core/safe";
 
 /** Additional information about the outcome of a node inclusion */
 export interface InclusionResult {

--- a/packages/zwave-js/src/lib/controller/utils.test.ts
+++ b/packages/zwave-js/src/lib/controller/utils.test.ts
@@ -1,0 +1,117 @@
+import { assertZWaveError, SecurityClass } from "@zwave-js/core";
+import { ProvisioningEntryStatus } from "./Inclusion";
+import { assertProvisioningEntry } from "./utils";
+
+// A valid DSK
+const dsk = "11111-22222-12345-54321-99999-00001-11111-22222";
+const status = ProvisioningEntryStatus.Inactive;
+const securityClasses = [
+	SecurityClass.S2_AccessControl,
+	SecurityClass.S2_Unauthenticated,
+];
+
+describe("controller/utils", () => {
+	describe("assertProvisioningEntry", () => {
+		it("should throw if the argument is not an object", () => {
+			assertZWaveError(() => assertProvisioningEntry(undefined), {
+				messageMatches: "not an object",
+			});
+
+			assertZWaveError(() => assertProvisioningEntry(1), {
+				messageMatches: "not an object",
+			});
+		});
+
+		it("should throw if the argument does not have a valid dsk", () => {
+			assertZWaveError(() => assertProvisioningEntry({}), {
+				messageMatches: "dsk must be a string",
+			});
+			assertZWaveError(() => assertProvisioningEntry({ dsk: 1 }), {
+				messageMatches: "dsk must be a string",
+			});
+			assertZWaveError(() => assertProvisioningEntry({ dsk: "abc" }), {
+				messageMatches: "dsk does not have the correct format",
+			});
+		});
+
+		it("should throw if the status is invalid", () => {
+			assertZWaveError(
+				() =>
+					assertProvisioningEntry({
+						dsk,
+						status: -1,
+					}),
+				{ messageMatches: "not a ProvisioningEntryStatus" },
+			);
+			assertZWaveError(
+				() =>
+					assertProvisioningEntry({
+						dsk,
+						status: true,
+					}),
+				{ messageMatches: "not a ProvisioningEntryStatus" },
+			);
+		});
+
+		it("should throw if the securityClasses are invalid", () => {
+			assertZWaveError(
+				() =>
+					assertProvisioningEntry({
+						dsk,
+						status,
+						securityClasses: 1,
+					}),
+				{ messageMatches: "securityClasses must be an array" },
+			);
+			assertZWaveError(
+				() =>
+					assertProvisioningEntry({
+						dsk,
+						status,
+						securityClasses: [1, "1"],
+					}),
+				{ messageMatches: "securityClasses contains invalid entries" },
+			);
+		});
+
+		it("should throw if the requestedSecurityClasses are invalid", () => {
+			assertZWaveError(
+				() =>
+					assertProvisioningEntry({
+						dsk,
+						status,
+						securityClasses,
+						requestedSecurityClasses: 1,
+					}),
+				{ messageMatches: "requestedSecurityClasses must be an array" },
+			);
+			assertZWaveError(
+				() =>
+					assertProvisioningEntry({
+						dsk,
+						status,
+						securityClasses,
+						requestedSecurityClasses: [1, "1"],
+					}),
+				{
+					messageMatches:
+						"requestedSecurityClasses contains invalid entries",
+				},
+			);
+		});
+
+		it("happy path", () => {
+			assertProvisioningEntry({
+				dsk,
+				securityClasses: [SecurityClass.S0_Legacy],
+			});
+
+			assertProvisioningEntry({
+				dsk,
+				securityClasses: [SecurityClass.S0_Legacy],
+				status: ProvisioningEntryStatus.Active,
+				requestedSecurityClasses: [SecurityClass.S0_Legacy],
+			});
+		});
+	});
+});

--- a/packages/zwave-js/src/lib/controller/utils.ts
+++ b/packages/zwave-js/src/lib/controller/utils.ts
@@ -1,0 +1,51 @@
+import {
+	SecurityClass,
+	ZWaveError,
+	ZWaveErrorCodes,
+} from "@zwave-js/core/safe";
+import { isArray, isObject } from "alcalzone-shared/typeguards";
+import { PlannedProvisioningEntry, ProvisioningEntryStatus } from "./Inclusion";
+
+export function assertProvisioningEntry(
+	arg: any,
+): asserts arg is PlannedProvisioningEntry {
+	const fail = (why: string) => {
+		throw new ZWaveError(
+			`Invalid provisioning entry: ${why}`,
+			ZWaveErrorCodes.Argument_Invalid,
+		);
+	};
+
+	if (!isObject(arg)) throw fail("not an object");
+	if (typeof arg.dsk !== "string") throw fail("dsk must be a string");
+	if (
+		arg.status != undefined &&
+		(typeof arg.status !== "number" ||
+			!(arg.status in ProvisioningEntryStatus))
+	) {
+		throw fail("status is not a ProvisioningEntryStatus");
+	}
+	if (!isArray(arg.securityClasses)) {
+		throw fail("securityClasses must be an array");
+	} else if (
+		!arg.securityClasses.every(
+			(sc: any) => typeof sc === "number" && sc in SecurityClass,
+		)
+	) {
+		throw fail("securityClasses contains invalid entries");
+	}
+
+	if (arg.requestedSecurityClasses != undefined) {
+		if (!isArray(arg.requestedSecurityClasses)) {
+			throw fail("requestedSecurityClasses must be an array");
+		} else if (
+			!arg.requestedSecurityClasses.every(
+				(sc: any) => typeof sc === "number" && sc in SecurityClass,
+			)
+		) {
+			{
+				throw fail("requestedSecurityClasses contains invalid entries");
+			}
+		}
+	}
+}

--- a/packages/zwave-js/src/lib/controller/utils.ts
+++ b/packages/zwave-js/src/lib/controller/utils.ts
@@ -1,4 +1,5 @@
 import {
+	isValidDSK,
 	SecurityClass,
 	ZWaveError,
 	ZWaveErrorCodes,
@@ -17,7 +18,11 @@ export function assertProvisioningEntry(
 	};
 
 	if (!isObject(arg)) throw fail("not an object");
+
 	if (typeof arg.dsk !== "string") throw fail("dsk must be a string");
+	else if (!isValidDSK(arg.dsk))
+		throw fail("dsk does not have the correct format");
+
 	if (
 		arg.status != undefined &&
 		(typeof arg.status !== "number" ||
@@ -25,6 +30,7 @@ export function assertProvisioningEntry(
 	) {
 		throw fail("status is not a ProvisioningEntryStatus");
 	}
+
 	if (!isArray(arg.securityClasses)) {
 		throw fail("securityClasses must be an array");
 	} else if (


### PR DESCRIPTION
fixes: #4579