### PR TITLE
feat: add `sendAndReceiveData` method to `ManufacturerProprietaryCCAPI`

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/ManufacturerProprietaryCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ManufacturerProprietaryCC.ts
@@ -55,7 +55,7 @@ export class ManufacturerProprietaryCCAPI extends CCAPI {
 	public async sendAndReceiveData(
 		manufacturerId: number,
 		data?: Buffer,
-	) {
+	): Promise<unknown> {
 		const cc = new ManufacturerProprietaryCCWithResponse(this.driver, {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
@@ -66,12 +66,12 @@ export class ManufacturerProprietaryCCAPI extends CCAPI {
 		const response =
 			await this.driver.sendCommand<ManufacturerProprietaryCC>(
 				cc,
-				this.commandOptions
+				this.commandOptions,
 			);
 		if (response) {
 			return {
 				manufacturerId: response.manufacturerId,
-				data: response.payload
+				data: response.payload,
 			};
 		}
 	}
@@ -305,12 +305,15 @@ export class ManufacturerProprietaryCC extends CommandClass {
 function testResponseForManufacturerProprietaryRequest(
 	sent: ManufacturerProprietaryCCWithResponse,
 	received: ManufacturerProprietaryCC,
-) {
+): boolean {
 	// We expect a Manufacturer Proprietary response that has the same manufacturer ID as the request
 	return sent.manufacturerId === received.manufacturerId;
 }
 
-@expectedCCResponse(ManufacturerProprietaryCC, testResponseForManufacturerProprietaryRequest)
+@expectedCCResponse(
+	ManufacturerProprietaryCC,
+	testResponseForManufacturerProprietaryRequest,
+)
 export class ManufacturerProprietaryCCWithResponse extends ManufacturerProprietaryCC {
 	public constructor(
 		driver: Driver,

--- a/packages/zwave-js/src/lib/commandclass/index.ts
+++ b/packages/zwave-js/src/lib/commandclass/index.ts
@@ -229,7 +229,10 @@ export {
 	FibaroVenetianBlindCCReport,
 	FibaroVenetianBlindCCSet,
 } from "./manufacturerProprietary/Fibaro";
-export { ManufacturerProprietaryCC } from "./ManufacturerProprietaryCC";
+export {
+	ManufacturerProprietaryCC,
+	ManufacturerProprietaryCCWithResponse,
+} from "./ManufacturerProprietaryCC";
 export {
 	ManufacturerSpecificCC,
 	ManufacturerSpecificCCDeviceSpecificGet,


### PR DESCRIPTION
Adds an API that can be used to send ManufacturerProprietaryCC messages that expect responses from the device.

fixes: #4341