### PR TITLE
fix(config): add Motion Sensor Timeout param to Ring Keypad v2, FW 1.18+

### DIFF
--- a/packages/config/config/devices/0x0346/keypad_v2.json
+++ b/packages/config/config/devices/0x0346/keypad_v2.json
@@ -300,7 +300,6 @@
 			"#": "26",
 			"$if": "firmwareVersion >= 1.18",
 			"label": "Motion Sensor Timeout",
-			"description": "How long after motion stops should the keypad wait before sending a no-motion report",
 			"unit": "seconds",
 			"valueSize": 1,
 			"defaultValue": 3,

--- a/packages/config/config/devices/0x0346/keypad_v2.json
+++ b/packages/config/config/devices/0x0346/keypad_v2.json
@@ -295,6 +295,18 @@
 					"value": 1
 				}
 			]
+		},
+		{
+			"#": "26",
+			"$if": "firmwareVersion >= 1.18",
+			"label": "Motion Sensor Timeout",
+			"description": "How long after motion stops should the keypad wait before sending a no-motion report",
+			"unit": "seconds",
+			"valueSize": 1,
+			"defaultValue": 3,
+			"unsigned": true,
+			"minvalue": 0,
+			"maxvalue": 60
 		}
 	],
 	"compat": {

--- a/packages/config/config/devices/0x0346/keypad_v2.json
+++ b/packages/config/config/devices/0x0346/keypad_v2.json
@@ -305,8 +305,8 @@
 			"valueSize": 1,
 			"defaultValue": 3,
 			"unsigned": true,
-			"minvalue": 0,
-			"maxvalue": 60
+			"minValue": 0,
+			"maxValue": 60
 		}
 	],
 	"compat": {


### PR DESCRIPTION
The documentation for this device only covers the original release version, however a later firmware version (v 1.18) exposes the motion sensor built into the keypad as a Z-wave motion sensor.  Experimentation shows that the timeout of the motion sensor is configurable config parameter 26.

This PR adds that configuration parameter for appropriate firmware versions.

See https://community.home-assistant.io/t/using-the-ring-alarm-keypad-with-home-assistant/343367/56?u=imsorrybutwho
