### PR TITLE
feat: align GetSerialApiInitData with new Host API specs, read chip info

### DIFF
--- a/packages/core/src/capabilities/NodeInfo.ts
+++ b/packages/core/src/capabilities/NodeInfo.ts
@@ -146,7 +146,9 @@ export type DataRate = 9600 | 40000 | 100000;
 
 export enum NodeType {
 	Controller,
+	/** @deprecated Use `NodeType["End Node"]` instead */
 	"Routing End Node",
+	"End Node" = 1,
 }
 
 export interface NodeProtocolInfo {
@@ -220,7 +222,7 @@ export function parseNodeProtocolInfo(
 	let nodeType: NodeType;
 	switch (capability & 0b1010) {
 		case 0b1000:
-			nodeType = NodeType["Routing End Node"];
+			nodeType = NodeType["End Node"];
 			break;
 		case 0b0010:
 		default:
@@ -262,7 +264,7 @@ export function encodeNodeProtocolInfo(info: NodeProtocolInfo): Buffer {
 
 	if (info.supportsBeaming) ret[1] |= 0b0001_0000;
 	if (info.supportsSecurity) ret[1] |= 0b1;
-	if (info.nodeType === NodeType["Routing End Node"]) ret[1] |= 0b1000;
+	if (info.nodeType === NodeType["End Node"]) ret[1] |= 0b1000;
 	else ret[1] |= 0b0010; // Controller
 
 	if (info.hasSpecificDeviceClass) ret[1] |= 0b100;

--- a/packages/nvmedit/src/convert.ts
+++ b/packages/nvmedit/src/convert.ts
@@ -178,7 +178,7 @@ function createEmptyPhysicalNode(): NVMJSONNodeWithInfo {
 		supportedDataRates: [],
 		protocolVersion: 0,
 		optionalFunctionality: false,
-		nodeType: NodeType["Routing End Node"],
+		nodeType: NodeType["End Node"],
 		supportsSecurity: false,
 		supportsBeaming: false,
 		genericDeviceClass: 0,

--- a/packages/zwave-js/src/Controller.ts
+++ b/packages/zwave-js/src/Controller.ts
@@ -18,4 +18,7 @@ export {
 	ControllerSelfLogContext,
 	ControllerValueLogContext,
 } from "./lib/log/Controller";
-export type { ZWaveLibraryTypes } from "./lib/serialapi/_Types";
+export type {
+	ZWaveApiVersion,
+	ZWaveLibraryTypes,
+} from "./lib/serialapi/_Types";

--- a/packages/zwave-js/src/lib/controller/ZWaveChipTypes.ts
+++ b/packages/zwave-js/src/lib/controller/ZWaveChipTypes.ts
@@ -1,0 +1,25 @@
+const chipTypes = Object.freeze({
+	[0x0102]: "ZW0102",
+	[0x0201]: "ZW0201",
+	[0x0301]: "ZW0301",
+	[0x0401]: "ZM0401 / ZM4102 / SD3402",
+	[0x0500]: "ZW050x",
+	[0x0700]: "EFR32ZG14",
+});
+
+export interface UnknownZWaveChipType {
+	type: number;
+	version: number;
+}
+
+export function getZWaveChipType(
+	type: number,
+	version: number,
+): string | UnknownZWaveChipType {
+	return (
+		(chipTypes as any)[(type << 8) | version] ?? {
+			type,
+			version,
+		}
+	);
+}

--- a/packages/zwave-js/src/lib/controller/ZWaveChipTypes.ts
+++ b/packages/zwave-js/src/lib/controller/ZWaveChipTypes.ts
@@ -4,7 +4,7 @@ const chipTypes = Object.freeze({
 	[0x0301]: "ZW0301",
 	[0x0401]: "ZM0401 / ZM4102 / SD3402",
 	[0x0500]: "ZW050x",
-	[0x0700]: "EFR32ZG14",
+	[0x0700]: "EFR32ZG14 / ZGM130S",
 });
 
 export interface UnknownZWaveChipType {

--- a/packages/zwave-js/src/lib/serialapi/_Types.ts
+++ b/packages/zwave-js/src/lib/serialapi/_Types.ts
@@ -17,3 +17,8 @@ export enum NodeIDType {
 	Short = 0x01,
 	Long = 0x02,
 }
+
+export interface ZWaveApiVersion {
+	kind: "official" | "legacy";
+	version: number;
+}


### PR DESCRIPTION
The new Host API specs have a slightly different response format for the `GetSerialApiInitData` command response, where two bits are sneakily flipped in meaning. With this PR, we now also read additional info from that response and expose it, like chip type and Serial API version.

We also take this opportunity and clean up some controller properties which didn't convey the correct meaning before. All old properties still exist but are now deprecated and pending removal in v10.

fixes: #4529