### PR TITLE
feat: update the controller NIF before hard resetting

### DIFF
--- a/packages/core/src/capabilities/CommandClasses.ts
+++ b/packages/core/src/capabilities/CommandClasses.ts
@@ -254,6 +254,47 @@ export const applicationCCs: readonly CommandClasses[] = [
 ];
 
 /**
+ * Defines which CCs are considered Encapsulation CCs
+ */
+export const encapsulationCCs: readonly CommandClasses[] = [
+	CommandClasses["CRC-16 Encapsulation"],
+	CommandClasses["Multi Channel"],
+	CommandClasses["Multi Command"],
+	CommandClasses.Security,
+	CommandClasses["Security 2"],
+	CommandClasses["Transport Service"],
+];
+
+/**
+ * Defines which CCs are considered Management CCs
+ */
+export const managementCCs: readonly CommandClasses[] = [
+	CommandClasses["Application Capability"],
+	CommandClasses["Application Status"],
+	CommandClasses.Association,
+	CommandClasses["Association Command Configuration"],
+	CommandClasses["Association Group Information"],
+	// Battery is in the Management CC specs, but we consider it a Sensor CC
+	CommandClasses["Device Reset Locally"],
+	CommandClasses["Firmware Update Meta Data"],
+	CommandClasses["Grouping Name"],
+	CommandClasses.Hail,
+	CommandClasses.Indicator,
+	CommandClasses["IP Association"],
+	CommandClasses["Manufacturer Specific"],
+	CommandClasses["Multi Channel Association"],
+	CommandClasses["Node Naming and Location"],
+	CommandClasses["Remote Association Activation"],
+	CommandClasses["Remote Association Configuration"],
+	CommandClasses.Time,
+	CommandClasses["Time Parameters"],
+	CommandClasses.Version,
+	CommandClasses["Wake Up"],
+	CommandClasses["Z/IP Naming and Location"],
+	CommandClasses["Z-Wave Plus Info"],
+];
+
+/**
  * An array of all defined CCs that are not application CCs
  */
 export const nonApplicationCCs: readonly CommandClasses[] = Object.freeze(

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -1,5 +1,6 @@
 import {
 	actuatorCCs,
+	allCCs,
 	authHomeIdFromDSK,
 	CommandClasses,
 	computePRK,
@@ -7,6 +8,7 @@ import {
 	deriveTempKeys,
 	dskFromString,
 	dskToString,
+	encapsulationCCs,
 	encodeX25519KeyDERSPKI,
 	indexDBsByNode,
 	isRecoverableZWaveError,
@@ -19,6 +21,7 @@ import {
 	SecurityClass,
 	securityClassIsS2,
 	securityClassOrder,
+	sensorCCs,
 	ValueDB,
 	ZWaveError,
 	ZWaveErrorCodes,
@@ -55,6 +58,7 @@ import {
 } from "../commandclass";
 import type { AssociationCC } from "../commandclass/AssociationCC";
 import type { AssociationGroupInfoCC } from "../commandclass/AssociationGroupInfoCC";
+import { getImplementedVersion } from "../commandclass/CommandClass";
 import {
 	getManufacturerIdValueId,
 	getManufacturerIdValueMetadata,
@@ -134,6 +138,7 @@ import {
 	SerialAPISetup_SetTXStatusReportRequest,
 	SerialAPISetup_SetTXStatusReportResponse,
 } from "../serialapi/capability/SerialAPISetupMessages";
+import { SetApplicationNodeInformationRequest } from "../serialapi/capability/SetApplicationNodeInformationRequest";
 import {
 	GetControllerIdRequest,
 	GetControllerIdResponse,
@@ -1028,55 +1033,6 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 			);
 		}
 
-		// TODO: Tell the Z-Wave stick what kind of application this is
-		//   The Z-Wave Application Layer MUST use the \ref ApplicationNodeInformation
-		//   function to generate the Node Information frame and to save information about
-		//   node capabilities. All Z Wave application related fields of the Node Information
-		//   structure MUST be initialized by this function.
-
-		// Afterwards, a hard reset is required, so we need to move this into another method
-		// if (
-		// 	this.isFunctionSupported(
-		// 		FunctionType.FUNC_ID_SERIAL_API_APPL_NODE_INFORMATION,
-		// 	)
-		// ) {
-		// 	this.driver.controllerLog.print(`sending application info...`);
-
-		// 	// TODO: Generate this list dynamically
-		// 	// A list of all CCs the controller will respond to
-		// 	const supportedCCs = [CommandClasses.Time];
-		// 	// Turn the CCs into buffers and concat them
-		// 	const supportedCCBuffer = Buffer.concat(
-		// 		supportedCCs.map(cc =>
-		// 			cc >= 0xf1
-		// 				? // extended CC
-		// 				  Buffer.from([cc >>> 8, cc & 0xff])
-		// 				: // normal CC
-		// 				  Buffer.from([cc]),
-		// 		),
-		// 	);
-
-		// 	const appInfoMsg = new Message(this.driver, {
-		// 		type: MessageType.Request,
-		// 		functionType:
-		// 			FunctionType.FUNC_ID_SERIAL_API_APPL_NODE_INFORMATION,
-		// 		payload: Buffer.concat([
-		// 			Buffer.from([
-		// 				0x01, // APPLICATION_NODEINFO_LISTENING
-		// 				GenericDeviceClasses["Static Controller"],
-		// 				0x01, // specific static PC controller
-		// 				supportedCCBuffer.length, // length of supported CC list
-		// 			]),
-		// 			// List of supported CCs
-		// 			supportedCCBuffer,
-		// 		]),
-		// 	});
-		// 	await this.driver.sendMessage(appInfoMsg, {
-		// 		priority: MessagePriority.Controller,
-		// 		supportCheck: false,
-		// 	});
-		// }
-
 		this.driver.controllerLog.print("Interview completed");
 	}
 
@@ -1086,6 +1042,82 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 			this.driver.valueDB!,
 			this.driver.metadataDB!,
 			ownKeys,
+		);
+	}
+
+	/**
+	 * Sets the NIF of the controller to the Gateway device type and to include the CCs supported by Z-Wave JS.
+	 * Warning: This only works when followed up by a hard-reset, so don't call this directly
+	 * @internal
+	 */
+	public async setControllerNIF(): Promise<void> {
+		const deviceClass = new DeviceClass(
+			this.driver.configManager,
+			0x02, // Static Controller
+			0x02, // Static Controller
+			0x07, // Gateway
+		);
+
+		const implementedCCs = allCCs.filter(
+			(cc) => getImplementedVersion(cc) > 0,
+		);
+
+		// Encapsulation CCs are always supported
+		const implementedEncapsulationCCs = encapsulationCCs.filter((cc) =>
+			implementedCCs.includes(cc),
+		);
+
+		const implementedActuatorCCs = actuatorCCs.filter((cc) =>
+			implementedCCs.includes(cc),
+		);
+		const implementedSensorCCs = sensorCCs.filter((cc) =>
+			implementedCCs.includes(cc),
+		);
+
+		const supportedCCs = [
+			// Z-Wave Plus Info must be listed first
+			CommandClasses["Z-Wave Plus Info"],
+			// TODO: Z-Wave Plus v2 Device Type Specification
+			// Gateway device type MUST **support** Inclusion Controller and Time CC
+			...implementedEncapsulationCCs,
+		];
+
+		const controlledCCs = [
+			// Non-actuator CCs that MUST be supported by the gateway DT:
+			CommandClasses.Association,
+			CommandClasses["Association Group Information"],
+			CommandClasses.Basic,
+			CommandClasses["Central Scene"],
+			CommandClasses["CRC-16 Encapsulation"],
+			CommandClasses["Firmware Update Meta Data"],
+			CommandClasses.Indicator,
+			CommandClasses.Meter,
+			CommandClasses["Multi Channel"],
+			CommandClasses["Multi Channel Association"],
+			CommandClasses["Multilevel Sensor"],
+			CommandClasses.Notification,
+			CommandClasses.Security,
+			CommandClasses["Security 2"],
+			CommandClasses.Version,
+			CommandClasses["Wake Up"],
+		];
+		// Add implemented actuator and sensor CCs to fill up the space. These might get cut off
+		controlledCCs.push(
+			...[...implementedActuatorCCs, ...implementedSensorCCs].filter(
+				(cc) => !controlledCCs.includes(cc),
+			),
+		);
+
+		// TODO: Consider if the CCs should follow a certain order
+
+		this.driver.controllerLog.print("Updating the controller NIF...");
+		await this.driver.sendMessage(
+			new SetApplicationNodeInformationRequest(this.driver, {
+				isListening: true,
+				deviceClass,
+				supportedCCs,
+				controlledCCs,
+			}),
 		);
 	}
 

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -2054,7 +2054,9 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> {
 	 */
 	public async hardReset(): Promise<void> {
 		this.ensureReady(true);
-		// Calling ensureReady with true ensures that _controller is defined
+
+		// Update the controller NIF prior to hard resetting
+		await this._controller!.setControllerNIF();
 		await this._controller!.hardReset();
 
 		// Clean up

--- a/packages/zwave-js/src/lib/message/Constants.ts
+++ b/packages/zwave-js/src/lib/message/Constants.ts
@@ -45,8 +45,7 @@ export enum MessageType {
  */
 export enum FunctionType {
 	GetSerialApiInitData = 0x02,
-
-	FUNC_ID_SERIAL_API_APPL_NODE_INFORMATION = 0x03,
+	SetApplicationNodeInformation = 0x03, // Set up the controller NIF prior to starting or joining a Z-Wave network
 
 	ApplicationCommand = 0x04, // A message from another node
 

--- a/packages/zwave-js/src/lib/serialapi/capability/HardResetRequest.ts
+++ b/packages/zwave-js/src/lib/serialapi/capability/HardResetRequest.ts
@@ -1,20 +1,63 @@
+import type { MessageOrCCLogEntry } from "@zwave-js/core";
+import type { Driver } from "../../driver/Driver";
 import {
 	FunctionType,
 	MessagePriority,
 	MessageType,
 } from "../../message/Constants";
-import { Message, messageTypes, priority } from "../../message/Message";
+import {
+	expectedCallback,
+	gotDeserializationOptions,
+	Message,
+	MessageDeserializationOptions,
+	MessageOptions,
+	messageTypes,
+	priority,
+} from "../../message/Message";
 
 @messageTypes(MessageType.Request, FunctionType.HardReset)
-// This will be responded to with a HardResetRequest
 @priority(MessagePriority.Controller)
-export class HardResetRequest extends Message {
-	// the response "request" contains one payload byte
-	// it was 0xc1 in our case (0b1100_0001), but we don't know what it means
-	// ^-- TODO: Is that the callbackId?
+export class HardResetRequestBase extends Message {
+	public constructor(driver: Driver, options?: MessageOptions) {
+		if (
+			gotDeserializationOptions(options) &&
+			(new.target as any) !== HardResetCallback
+		) {
+			return new HardResetCallback(driver, options);
+		}
+		super(driver, options);
+	}
+}
 
+@expectedCallback(FunctionType.HardReset)
+export class HardResetRequest extends HardResetRequestBase {
 	public serialize(): Buffer {
 		this.payload = Buffer.from([this.callbackId]);
 		return super.serialize();
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: {
+				"callback id": this.callbackId,
+			},
+		};
+	}
+}
+
+export class HardResetCallback extends HardResetRequestBase {
+	public constructor(driver: Driver, options: MessageDeserializationOptions) {
+		super(driver, options);
+		this.callbackId = this.payload[0];
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: {
+				"callback id": this.callbackId,
+			},
+		};
 	}
 }

--- a/packages/zwave-js/src/lib/serialapi/capability/SetApplicationNodeInformationRequest.ts
+++ b/packages/zwave-js/src/lib/serialapi/capability/SetApplicationNodeInformationRequest.ts
@@ -1,0 +1,77 @@
+import { CommandClasses, getCCName, MessageOrCCLogEntry } from "@zwave-js/core";
+import type { Driver } from "../../driver/Driver";
+import {
+	FunctionType,
+	MessagePriority,
+	MessageType,
+} from "../../message/Constants";
+import {
+	Message,
+	MessageBaseOptions,
+	messageTypes,
+	priority,
+} from "../../message/Message";
+import type { DeviceClass } from "../../node/DeviceClass";
+
+export interface SetApplicationNodeInformationRequestOptions
+	extends MessageBaseOptions {
+	isListening: boolean;
+	deviceClass: DeviceClass;
+	supportedCCs: CommandClasses[];
+	controlledCCs: CommandClasses[];
+}
+
+@messageTypes(MessageType.Request, FunctionType.SetApplicationNodeInformation)
+@priority(MessagePriority.Controller)
+export class SetApplicationNodeInformationRequest extends Message {
+	public constructor(
+		driver: Driver,
+		options: SetApplicationNodeInformationRequestOptions,
+	) {
+		super(driver, options);
+		this.isListening = options.isListening;
+		this.deviceClass = options.deviceClass;
+		this.supportedCCs = options.supportedCCs;
+		this.controlledCCs = options.controlledCCs;
+	}
+
+	public isListening: boolean;
+	public deviceClass: DeviceClass;
+	public supportedCCs: CommandClasses[];
+	public controlledCCs: CommandClasses[];
+
+	public serialize(): Buffer {
+		const ccList = [
+			...this.supportedCCs,
+			CommandClasses["Support/Control Mark"],
+			...this.controlledCCs,
+		];
+		const ccListLength = Math.min(ccList.length, 35);
+		this.payload = Buffer.from([
+			this.isListening ? 0x01 : 0, // APPLICATION_NODEINFO_LISTENING
+			this.deviceClass.generic.key,
+			this.deviceClass.specific.key,
+			ccListLength,
+			...ccList.slice(0, ccListLength),
+		]);
+
+		return super.serialize();
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: {
+				"is listening": this.isListening,
+				"generic device class": this.deviceClass.generic.label,
+				"specific device class": this.deviceClass.specific.label,
+				"supported CCs": this.supportedCCs
+					.map((cc) => `\n· ${getCCName(cc)}`)
+					.join(""),
+				"controlled CCs": this.controlledCCs
+					.map((cc) => `\n· ${getCCName(cc)}`)
+					.join(""),
+			},
+		};
+	}
+}


### PR DESCRIPTION
With this PR, we now set the controller NIF to the correct Z-Wave+ v2 device type (Gateway) and the CCs implemented by Z-Wave JS when hard-resetting the controller. 

fixes: [#4600](https://github.com/zwave-js/node-zwave-js/issues/4600)
fixes: https://github.com/zwave-js/node-zwave-js/issues/4601