### PR TITLE
Proof of concept: let device config files override the interview for specific CCs

### DIFF
--- a/packages/config/config/devices/0x0005/pe653.json
+++ b/packages/config/config/devices/0x0005/pe653.json
@@ -55,5 +55,63 @@
 			"maxValue": 7,
 			"defaultValue": 0
 		}
+	],
+	"endpoints": {
+		"0": {
+			"associations": {
+				"1": {
+					"label": "Lifeline",
+					"maxNodes": 5,
+					"isLifeline": true
+				}
+			}
+		}
+	},
+	"compat": [
+		{
+			// Fixes #4588: Firmware v3.4 has numerous bugs related to multi-endpoint support.
+			// Firmware v3.3 and v3.1 do not appear to have the same issues.
+			"$if": "firmwareVersion === 3.4",
+			"commandClasses": {
+				// Force use of MultiChannelCC v1.
+				"add": {
+					"0x60": {
+						"isSupported": true,
+						"version": 1
+					}
+				},
+				// The firmware handles requests on some endpoints incorrectly, often reporting garbage
+				// that confuses discovery or inhibits operation. Remove all of these broken CCs.
+				"remove": {
+					// BasicCC: All endpoints control the state of Switch 1 so only keep the root endpoint
+					// to reduce clutter and to handle received BASIC_SET events.
+					"0x20": {
+						"endpoints": [1, 2, 3, 4, 5]
+					},
+					// ManufacturerSpecificCC: Endpoint 1 erroneously reports an incorrect manufacturer
+					// and product ID, unlike on the root endpoint.
+					"0x72": {
+						"endpoints": [1]
+					},
+					// ClockCC: Endpoint 1 erroneously reports a time with an invalid minute field,
+					// unlike on the root endpoint.
+					"0x81": {
+						"endpoints": [1]
+					},
+					// AssociationCC: Endpoint 1 erroneously reports that it supports 133 associated nodes
+					// but association commands don't work at all, unlike on the root endpoint.
+					"0x85": {
+						"endpoints": [1]
+					},
+					// VersionCC: Endpoint 1 reports an unknown version, unlike on the root endpoint.
+					"0x86": {
+						"endpoints": [1]
+					}
+				}
+			},
+			// The device sometimes sends BASIC_SET to the lifeline association when the state of Switch 1
+			// changes but the value is always 0 so treat it as an event.
+			"treatBasicSetAsEvent": true
+		}
 	]
 }

--- a/packages/config/config/devices/0x0005/pe653.json
+++ b/packages/config/config/devices/0x0005/pe653.json
@@ -80,6 +80,30 @@
 						"version": 1
 					}
 				},
+				// The firmware reports an thermostat setpoint type bitmap with an off-by-one error.
+				// It also reports a scale of 1 in ThermostatSetpointReport but rejects
+				// ThermostatSetpointSet requests with any scale other than 0 instead of 1 as would
+				// be expected according to the spec.
+				"interview": {
+					"0x43": {
+						"values": [
+							{
+								"property": "supportedSetpointTypes",
+								"value": [1, 7]
+							},
+							{
+								"property": "setpointScale",
+								"propertyKey": 1,
+								"value": 0
+							},
+							{
+								"property": "setpointScale",
+								"propertyKey": 7,
+								"value": 0
+							}
+						]
+					}
+				},
 				// The firmware handles requests on some endpoints incorrectly, often reporting garbage
 				// that confuses discovery or inhibits operation. Remove all of these broken CCs.
 				"remove": {
@@ -87,6 +111,10 @@
 					// to reduce clutter and to handle received BASIC_SET events.
 					"0x20": {
 						"endpoints": [1, 2, 3, 4, 5]
+					},
+					// ThermostatSetpointCC: Endpoint 1 is a duplicate of the root.
+					"0x43": {
+						"endpoints": [1]
 					},
 					// ManufacturerSpecificCC: Endpoint 1 erroneously reports an incorrect manufacturer
 					// and product ID, unlike on the root endpoint.

--- a/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
@@ -664,7 +664,9 @@ export class ThermostatSetpointCCReport extends ThermostatSetpointCC {
 			this.endpointIndex,
 			this._type,
 		);
-		valueDB.setValue(scaleValueId, this._scale.key);
+		if (!valueDB.hasValue(scaleValueId)) {
+			valueDB.setValue(scaleValueId, this._scale.key);
+		}
 		return true;
 	}
 


### PR DESCRIPTION
This is a proof of concept of a general purpose mechanism to allow device config files to work around invalid information supplied by devices.  It introduces a new config flag "commandClasses.interview" that when present causes the node to skip the interview for a given CC and endpoint and to store the supplied values into the valueDB.

This set of patches includes a configuration file that has a rather absurd number of bugs including off-by-one errors in the thermostat setpoint bitmap and some quirks with the setpoint scale.  These changes completely resolve #4588.

Let me know what you think!

fixes: https://github.com/zwave-js/node-zwave-js/issues/1625