### PR TITLE
fix: make Meter CC reset options parameter optional

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/MeterCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MeterCC.ts
@@ -278,7 +278,7 @@ export class MeterCCAPI extends PhysicalCCAPI {
 	}
 
 	@validateArgs()
-	public async reset(options: MeterCCResetOptions): Promise<void> {
+	public async reset(options?: MeterCCResetOptions): Promise<void> {
 		this.assertSupportsCommand(MeterCommand, MeterCommand.Reset);
 
 		const cc = new MeterCCReset(this.driver, {


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

Fixes https://github.com/zwave-js/node-zwave-js/issues/4623
