### PR TITLE
fix(config): change param 3 label to Enable/Disable Auto Off for ZEN-21

### DIFF
--- a/packages/config/config/devices/0x027a/zen21.json
+++ b/packages/config/config/devices/0x027a/zen21.json
@@ -86,17 +86,17 @@
 		},
 		{
 			"#": "3",
-			"label": "Enable/Disable LED Indicator",
+			"label": "Enable/Disable Auto Off",
 			"valueSize": 1,
 			"defaultValue": 0,
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Enable",
+					"label": "Disable",
 					"value": 0
 				},
 				{
-					"label": "Disable",
+					"label": "Enable",
 					"value": 1
 				}
 			]


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

After checking the manual for the ZEN21 I found that parameter 3 was incorrectly labeled along with the primary and secondary options being flipped.  I changed the file to what it should be and included the manual for review so these changes can be committed to the master copy.
[zooz-zwave-plus-on-off-switch-zen21-ver4.0-manual.pdf](https://github.com/zwave-js/node-zwave-js/files/8721714/zooz-zwave-plus-on-off-switch-zen21-ver4.0-manual.pdf)

