### PR TITLE
fix(config): Add new parameters to configuration for the ZEN32 scene controller.

### DIFF
--- a/packages/config/config/devices/0x027a/zen32.json
+++ b/packages/config/config/devices/0x027a/zen32.json
@@ -519,6 +519,46 @@
 					"value": 1
 				}
 			]
+		},
+		{
+			"#": "22",
+			"$if": "firmwareVersion >= 10.0",
+			"label": "Enable / disable programming on the relay button",
+			"description": "Enable or disable programming functionality on the relay button. If this setting is disabled, then inclusion, exclusion, manual LED indicator change mode no longer work when the relay button is activated (factory reset and scene control will still work) - that means you can now use triple-tap triggers on the relay button for scenes and remote control of other devices.",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Programming Enabled",
+					"value": 0
+				},
+				{
+					"label": "Programming Disabled",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "23",
+			"$if": "firmwareVersion >= 10.20",
+			"label": "Enable / disable LED indicator for settings",
+			"description": " Choose if you want the LED indicators to flash whenever a parameter (setting) is adjusted on the device to confirm the change. Disable this feature if you're using the LED indicators in automations.",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 0
+				}
+			]
 		}
 	],
 	"compat": {


### PR DESCRIPTION
This PR is to update the device configuration file for the Zooz ZEN32 Scene Controller.   Configuration parameters 22 and 23 were made available in firmware versions 10.10 and 10.20 respectively.    

Documentation of the parameters is provided by Zooz at https://thesmartesthouse.happyfox.com/kb/article/608-zen32-scene-controller-advanced-settings/ 

I've added these 2 parameters to the existing configuration, providing the values and descriptions as defined by the manufacturer.  I've also added the appropriate firmware version checks.  

