### PR TITLE
feat: add labels to Multilevel Switch/Entry Control notifications

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -1105,7 +1105,7 @@ interface ZWaveNotificationCallbackArgs_MultilevelSwitchCC {
 		| MultilevelSwitchCommand.StartLevelChange
 		| MultilevelSwitchCommand.StopLevelChange;
 	/** The label for the event type */
-	eventTypeLabel: "Start level change" | "Stop level change";
+	eventTypeLabel: string;
 	/** The direction of the level change */
 	direction?: string;
 }

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -1073,8 +1073,10 @@ where the argument object has the type
 ```ts
 interface ZWaveNotificationCallbackArgs_EntryControlCC {
 	eventType: EntryControlEventTypes;
+	/** A human-readable label for the event type */
 	eventTypeLabel: string;
 	dataType: EntryControlDataTypes;
+	/** A human-readable label for the data type */
 	dataTypeLabel: string;
 	eventData?: Buffer | string;
 }
@@ -1104,7 +1106,7 @@ interface ZWaveNotificationCallbackArgs_MultilevelSwitchCC {
 	eventType:
 		| MultilevelSwitchCommand.StartLevelChange
 		| MultilevelSwitchCommand.StopLevelChange;
-	/** The label for the event type */
+	/** A human-readable label for the event type */
 	eventTypeLabel: string;
 	/** The direction of the level change */
 	direction?: string;

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -1073,7 +1073,9 @@ where the argument object has the type
 ```ts
 interface ZWaveNotificationCallbackArgs_EntryControlCC {
 	eventType: EntryControlEventTypes;
+	eventTypeLabel: string;
 	dataType: EntryControlDataTypes;
+	dataTypeLabel: string;
 	eventData?: Buffer | string;
 }
 ```
@@ -1102,6 +1104,8 @@ interface ZWaveNotificationCallbackArgs_MultilevelSwitchCC {
 	eventType:
 		| MultilevelSwitchCommand.StartLevelChange
 		| MultilevelSwitchCommand.StopLevelChange;
+	/** The label for the event type */
+	eventTypeLabel: "Start level change" | "Stop level change";
 	/** The direction of the level change */
 	direction?: string;
 }

--- a/packages/zwave-js/src/lib/commandclass/EntryControlCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/EntryControlCC.ts
@@ -14,7 +14,7 @@ import {
 } from "@zwave-js/core";
 import type { ZWaveHost } from "@zwave-js/host";
 import { MessagePriority } from "@zwave-js/serial";
-import { buffer2hex, pick } from "@zwave-js/shared";
+import { buffer2hex, getEnumMemberName, pick } from "@zwave-js/shared";
 import { validateArgs } from "@zwave-js/transformers";
 import type { Driver } from "../driver/Driver";
 import {
@@ -377,6 +377,14 @@ export class EntryControlCCNotification extends EntryControlCC {
 	public readonly dataType: EntryControlDataTypes;
 	public readonly eventType: EntryControlEventTypes;
 	public readonly eventData?: Buffer | string;
+
+	public get eventTypeLabel(): string {
+		return getEnumMemberName(EntryControlEventTypes, this.eventType);
+	}
+
+	public get dataTypeLabel(): string {
+		return getEnumMemberName(EntryControlDataTypes, this.dataType);
+	}
 
 	public toLogEntry(): MessageOrCCLogEntry {
 		const message: MessageRecord = {

--- a/packages/zwave-js/src/lib/commandclass/EntryControlCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/EntryControlCC.ts
@@ -14,7 +14,7 @@ import {
 } from "@zwave-js/core";
 import type { ZWaveHost } from "@zwave-js/host";
 import { MessagePriority } from "@zwave-js/serial";
-import { buffer2hex, getEnumMemberName, pick } from "@zwave-js/shared";
+import { buffer2hex, pick } from "@zwave-js/shared";
 import { validateArgs } from "@zwave-js/transformers";
 import type { Driver } from "../driver/Driver";
 import {
@@ -377,14 +377,6 @@ export class EntryControlCCNotification extends EntryControlCC {
 	public readonly dataType: EntryControlDataTypes;
 	public readonly eventType: EntryControlEventTypes;
 	public readonly eventData?: Buffer | string;
-
-	public get eventTypeLabel(): string {
-		return getEnumMemberName(EntryControlEventTypes, this.eventType);
-	}
-
-	public get dataTypeLabel(): string {
-		return getEnumMemberName(EntryControlDataTypes, this.dataType);
-	}
 
 	public toLogEntry(): MessageOrCCLogEntry {
 		const message: MessageRecord = {

--- a/packages/zwave-js/src/lib/commandclass/_Types.ts
+++ b/packages/zwave-js/src/lib/commandclass/_Types.ts
@@ -677,7 +677,9 @@ export enum EntryControlDataTypes {
 /** @publicAPI */
 export interface ZWaveNotificationCallbackArgs_EntryControlCC {
 	eventType: EntryControlEventTypes;
+	eventTypeLabel: string;
 	dataType: EntryControlDataTypes;
+	dataTypeLabel: string;
 	eventData?: Buffer | string;
 }
 
@@ -1071,6 +1073,8 @@ export interface ZWaveNotificationCallbackArgs_MultilevelSwitchCC {
 	eventType:
 		| MultilevelSwitchCommand.StartLevelChange
 		| MultilevelSwitchCommand.StopLevelChange;
+	/** The label for the event type */
+	eventTypeLabel: "Start level change" | "Stop level change";
 	/** The direction of the level change */
 	direction?: string;
 }

--- a/packages/zwave-js/src/lib/commandclass/_Types.ts
+++ b/packages/zwave-js/src/lib/commandclass/_Types.ts
@@ -1074,7 +1074,7 @@ export interface ZWaveNotificationCallbackArgs_MultilevelSwitchCC {
 		| MultilevelSwitchCommand.StartLevelChange
 		| MultilevelSwitchCommand.StopLevelChange;
 	/** The label for the event type */
-	eventTypeLabel: "Start level change" | "Stop level change";
+	eventTypeLabel: string;
 	/** The direction of the level change */
 	direction?: string;
 }

--- a/packages/zwave-js/src/lib/commandclass/_Types.ts
+++ b/packages/zwave-js/src/lib/commandclass/_Types.ts
@@ -549,6 +549,38 @@ export enum EntryControlEventTypes {
 	Cancel = 0x19,
 }
 
+export const entryControlEventTypeLabels: Record<
+	EntryControlEventTypes,
+	string
+> = {
+	[EntryControlEventTypes.Caching]: "Caching",
+	[EntryControlEventTypes.CachedKeys]: "Cached keys",
+	[EntryControlEventTypes.Enter]: "Enter",
+	[EntryControlEventTypes.DisarmAll]: "Disarm all",
+	[EntryControlEventTypes.ArmAll]: "Arm all",
+	[EntryControlEventTypes.ArmAway]: "Away",
+	[EntryControlEventTypes.ArmHome]: "Home",
+	[EntryControlEventTypes.ExitDelay]: "Arm delay",
+	[EntryControlEventTypes.Arm1]: "Arm zone 1",
+	[EntryControlEventTypes.Arm2]: "Arm zone 2",
+	[EntryControlEventTypes.Arm3]: "Arm zone 3",
+	[EntryControlEventTypes.Arm4]: "Arm zone 4",
+	[EntryControlEventTypes.Arm5]: "Arm zone 5",
+	[EntryControlEventTypes.Arm6]: "Arm zone 6",
+	[EntryControlEventTypes.Rfid]: "RFID",
+	[EntryControlEventTypes.Bell]: "Bell",
+	[EntryControlEventTypes.Fire]: "Fire",
+	[EntryControlEventTypes.Police]: "Police",
+	[EntryControlEventTypes.AlertPanic]: "Panic alert",
+	[EntryControlEventTypes.AlertMedical]: "Medical alert",
+	[EntryControlEventTypes.GateOpen]: "Open gate",
+	[EntryControlEventTypes.GateClose]: "Close gate",
+	[EntryControlEventTypes.Lock]: "Lock",
+	[EntryControlEventTypes.Unlock]: "Unlock",
+	[EntryControlEventTypes.Test]: "Test",
+	[EntryControlEventTypes.Cancel]: "Cancel",
+};
+
 export enum DoorLockLoggingCommand {
 	RecordsSupportedGet = 0x01,
 	RecordsSupportedReport = 0x02,
@@ -677,8 +709,10 @@ export enum EntryControlDataTypes {
 /** @publicAPI */
 export interface ZWaveNotificationCallbackArgs_EntryControlCC {
 	eventType: EntryControlEventTypes;
+	/** A human-readable label for the event type */
 	eventTypeLabel: string;
 	dataType: EntryControlDataTypes;
+	/** A human-readable label for the data type */
 	dataTypeLabel: string;
 	eventData?: Buffer | string;
 }
@@ -1073,7 +1107,7 @@ export interface ZWaveNotificationCallbackArgs_MultilevelSwitchCC {
 	eventType:
 		| MultilevelSwitchCommand.StartLevelChange
 		| MultilevelSwitchCommand.StopLevelChange;
-	/** The label for the event type */
+	/** A human-readable label for the event type */
 	eventTypeLabel: string;
 	/** The direction of the level change */
 	direction?: string;

--- a/packages/zwave-js/src/lib/node/Node.test.ts
+++ b/packages/zwave-js/src/lib/node/Node.test.ts
@@ -1733,7 +1733,7 @@ describe("lib/node/Node", () => {
 				dataType: EntryControlDataTypes.ASCII,
 				dataTypeLabel: "ASCII",
 				eventType: EntryControlEventTypes.DisarmAll,
-				eventTypeLabel: "DisarmAll",
+				eventTypeLabel: "Disarm all",
 				eventData: "1234",
 			});
 

--- a/packages/zwave-js/src/lib/node/Node.test.ts
+++ b/packages/zwave-js/src/lib/node/Node.test.ts
@@ -1731,7 +1731,9 @@ describe("lib/node/Node", () => {
 			expect(call[1]).toBe(CommandClasses["Entry Control"]);
 			expect(call[2]).toEqual({
 				dataType: EntryControlDataTypes.ASCII,
+				dataTypeLabel: "ASCII",
 				eventType: EntryControlEventTypes.DisarmAll,
+				eventTypeLabel: "DisarmAll",
 				eventData: "1234",
 			});
 

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -2818,6 +2818,7 @@ protocol version:      ${this.protocolVersion}`;
 				CommandClasses["Multilevel Switch"],
 				{
 					eventType: MultilevelSwitchCommand.StartLevelChange,
+					eventTypeLabel: "Start level change",
 					direction: command.direction,
 				},
 			);
@@ -2831,7 +2832,10 @@ protocol version:      ${this.protocolVersion}`;
 				"notification",
 				this,
 				CommandClasses["Multilevel Switch"],
-				{ eventType: MultilevelSwitchCommand.StopLevelChange },
+				{
+					eventType: MultilevelSwitchCommand.StopLevelChange,
+					eventTypeLabel: "Stop level change",
+				},
 			);
 		}
 	}
@@ -3666,7 +3670,13 @@ protocol version:      ${this.protocolVersion}`;
 			"notification",
 			this,
 			CommandClasses["Entry Control"],
-			pick(command, ["eventType", "dataType", "eventData"]),
+			pick(command, [
+				"eventType",
+				"eventTypeLabel",
+				"dataType",
+				"dataTypeLabel",
+				"eventData",
+			]),
 		);
 	}
 

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -2818,7 +2818,10 @@ protocol version:      ${this.protocolVersion}`;
 				CommandClasses["Multilevel Switch"],
 				{
 					eventType: MultilevelSwitchCommand.StartLevelChange,
-					eventTypeLabel: "Start level change",
+					eventTypeLabel: getEnumMemberName(
+						MultilevelSwitchCommand,
+						MultilevelSwitchCommand.StartLevelChange,
+					),
 					direction: command.direction,
 				},
 			);
@@ -2834,7 +2837,10 @@ protocol version:      ${this.protocolVersion}`;
 				CommandClasses["Multilevel Switch"],
 				{
 					eventType: MultilevelSwitchCommand.StopLevelChange,
-					eventTypeLabel: "Stop level change",
+					eventTypeLabel: getEnumMemberName(
+						MultilevelSwitchCommand,
+						MultilevelSwitchCommand.StopLevelChange,
+					),
 				},
 			);
 		}

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -145,6 +145,8 @@ import {
 import {
 	CentralSceneKeys,
 	DoorLockMode,
+	EntryControlDataTypes,
+	entryControlEventTypeLabels,
 	FirmwareUpdateCapabilities,
 	FirmwareUpdateRequestStatus,
 	FirmwareUpdateStatus,
@@ -2818,10 +2820,7 @@ protocol version:      ${this.protocolVersion}`;
 				CommandClasses["Multilevel Switch"],
 				{
 					eventType: MultilevelSwitchCommand.StartLevelChange,
-					eventTypeLabel: getEnumMemberName(
-						MultilevelSwitchCommand,
-						MultilevelSwitchCommand.StartLevelChange,
-					),
+					eventTypeLabel: "Start level change",
 					direction: command.direction,
 				},
 			);
@@ -2837,10 +2836,7 @@ protocol version:      ${this.protocolVersion}`;
 				CommandClasses["Multilevel Switch"],
 				{
 					eventType: MultilevelSwitchCommand.StopLevelChange,
-					eventTypeLabel: getEnumMemberName(
-						MultilevelSwitchCommand,
-						MultilevelSwitchCommand.StopLevelChange,
-					),
+					eventTypeLabel: "Stop level change",
 				},
 			);
 		}
@@ -3672,18 +3668,14 @@ protocol version:      ${this.protocolVersion}`;
 		}
 
 		// Notify listeners
-		this.emit(
-			"notification",
-			this,
-			CommandClasses["Entry Control"],
-			pick(command, [
-				"eventType",
-				"eventTypeLabel",
-				"dataType",
-				"dataTypeLabel",
-				"eventData",
-			]),
-		);
+		this.emit("notification", this, CommandClasses["Entry Control"], {
+			...pick(command, ["eventType", "dataType", "eventData"]),
+			eventTypeLabel: entryControlEventTypeLabels[command.eventType],
+			dataTypeLabel: getEnumMemberName(
+				EntryControlDataTypes,
+				command.dataType,
+			),
+		});
 	}
 
 	private handlePowerlevelTestNodeReport(


### PR DESCRIPTION
We get friendly labels on the Notification CC notifications but not for these other two CCs. These labels help downstream systems understand what to present to the user.

~~Question: will `pick` work with getter functions?~~ 🎉 it does