### PR TITLE
fix(config): correct Zooz ZAC36 param numbers for Auto Test Mode

### DIFF
--- a/packages/config/config/devices/0x027a/zac36.json
+++ b/packages/config/config/devices/0x027a/zac36.json
@@ -465,7 +465,7 @@
 			]
 		},
 		{
-			"#": "61",
+			"#": "97",
 			"label": "Auto Test Mode",
 			"description": "Causes the valve to periodically make a 1/8 turn to ensure it is operational",
 			"valueSize": 1,
@@ -488,7 +488,7 @@
 			]
 		},
 		{
-			"#": "62",
+			"#": "98",
 			"label": "Auto Test Mode: Frequency",
 			"valueSize": 1,
 			"unit": "days",


### PR DESCRIPTION
There was an error in the documentation created by ZooZ for the ZAC36 Valve Actuator. They had provided the "Auto Test Mode" and "Auto Test Mode: Frequency" configuration param numbers in hexadecimal instead of base-10. While troubleshooting these parameters with their support team, I pointed it out to them and they have [since updated their documentation](https://www.support.getzooz.com/kb/article/733-zac36-valve-actuator-advanced-settings/). We should update the config file to match.

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->