### PR TITLE
feat: delay initial interview of newly added nodes, notify about found nodes earlier

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -858,6 +858,14 @@ A node could not be included into or excluded from the network for some reason.
 
 The process to include or exclude a node was stopped successfully. Note that these events are also emitted after a node was included or excluded.
 
+### `"node found"`
+
+A node has successfully been registered with the controller
+
+```ts
+(node: ZWaveNode) => void
+```
+
 ### `"node added"`
 
 A node has successfully been added to the network

--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -860,7 +860,9 @@ The process to include or exclude a node was stopped successfully. Note that the
 
 ### `"node found"`
 
-A node has successfully been registered with the controller
+A node has successfully been added to the network.
+
+> [!NOTE] At this point, the initial setup and the node interview is still pending, so the node is **not yet operational**.
 
 ```ts
 (node: ZWaveNode) => void
@@ -868,7 +870,7 @@ A node has successfully been registered with the controller
 
 ### `"node added"`
 
-A node has successfully been added to the network
+A node has successfully been added to the network and the initial setup was completed. After this event is emitted, a node is operational but **not yet ready to be used** until after the node interview.
 
 ```ts
 (node: ZWaveNode, result: InclusionResult) => void

--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -35,10 +35,12 @@ The following table gives you an overview of what happens during the startup pro
 ### `interviewNode`
 
 ```ts
-interviewNode(node: ZWaveNode): <Promise>void
+interviewNode(node: ZWaveNode): Promise<void>
 ```
 
-Starts or resumes the interview of a Z-Wave node only when the initial interview was bypassed.
+Starts or resumes the interview of a Z-Wave node.
+
+> [!WARNING] This is only allowed when the initial interview was bypassed using the `interview.disableOnNodeAdded` option. Otherwise, this method will throw an error.
 
 > [!NOTE] It is advised to NOT await this method as it can take a very long time (minutes to hours)!
 

--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -32,6 +32,16 @@ The following table gives you an overview of what happens during the startup pro
 |  4   | -                                                                       | `"all nodes ready"` event is emitted for the driver when all nodes can be used                                                                                                |
 |  5   | -                                                                       | `"interview completed"` event is emitted for every node when its interview is completed for the first time. This only gets emitted once, unless the node gets re-interviewed. |
 
+### `interviewNode`
+
+```ts
+interviewNode(node: ZWaveNode): <Promise>void
+```
+
+Starts or resumes the interview of a Z-Wave node only when the initial interview was bypassed.
+
+> [!NOTE] It is advised to NOT await this method as it can take a very long time (minutes to hours)!
+
 ### `enableErrorReporting`
 
 ```ts
@@ -656,6 +666,13 @@ interface ZWaveOptions {
 		 * Note that enabling this can cause a lot of traffic during the interview.
 		 */
 		queryAllUserCodes?: boolean;
+
+		/**
+		 * Whether a node should be interviewed after successful inclusion
+		 * Note: When enabled, the interview must be triggered manually using
+		 *		 `driver.interviewNode(nodeid)`
+		 */
+		disableOnNodeAdded?: boolean;
 	};
 
 	storage: {

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -271,6 +271,7 @@ interface ControllerEventCallbacks
 	"exclusion started": () => void;
 	"inclusion stopped": () => void;
 	"exclusion stopped": () => void;
+	"node found": (node: ZWaveNode) => void;
 	"node added": (node: ZWaveNode, result: InclusionResult) => void;
 	"node removed": (node: ZWaveNode, replaced: boolean) => void;
 	"heal network progress": (
@@ -2431,6 +2432,9 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 
 				// Inclusion is now completed, bootstrap the node
 				const newNode = this._nodePendingInclusion;
+
+				this.emit("node found", newNode);
+
 				const supportedCommandClasses = [
 					...newNode.implementedCommandClasses.entries(),
 				]
@@ -2612,6 +2616,8 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 					);
 					this._nodePendingReplace = undefined;
 					this._nodes.set(newNode.id, newNode);
+
+					this.emit("node found", newNode);
 
 					// We're communicating with the device, so assume it is alive
 					// If it is actually a sleeping device, it will be marked as such later

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1300,16 +1300,17 @@ export class Driver
 	}
 
 	/**
-	 * Starts or resumes the interview of a Z-Wave node only when the initial
-	 * interview was bypassed.
+	 * Starts or resumes the interview of a Z-Wave node.
 	 *
-	 * It is advised to NOT await this method as it can take a very long 
-	 * time (minutes to hours)!
+	 * **NOTE:** This is only allowed when the initial interview was bypassed using the
+	 * `interview.disableOnNodeAdded` option. Otherwise, this method will throw an error.
+	 *
+	 * **NOTE:** It is advised to NOT await this method as it can take a very long time (minutes to hours)!
 	 */
 	public async interviewNode(node: ZWaveNode): Promise<void> {
 		if (!this.options.interview?.disableOnNodeAdded) {
 			throw new ZWaveError(
-				`Interview is blocked, use ZWaveNode.refreshInfo`,
+				`Calling Driver.interviewNode is not allowed because automatic node interviews are enabled. Use ZWaveNode.refreshInfo() to re-interview a node.`,
 				ZWaveErrorCodes.Driver_FeatureDisabled,
 			);
 		}

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -78,9 +78,13 @@ export interface ZWaveOptions {
 		queryAllUserCodes?: boolean;
 
 		/**
-		 * Whether a node should be interviewed after successful inclusion
-		 * Note: When enabled, the interview must be triggered manually using
-		 *		 `driver.interviewNode(node: ZWaveNode)`
+		 * Disable the automatic node interview after successful inclusion.
+		 * Note: When this is `true`, the interview must be started manually using
+		 * ```ts
+		 * driver.interviewNode(node: ZWaveNode)
+		 * ```
+		 *
+		 * Default: `false` (automatic interviews enabled)
 		 */
 		disableOnNodeAdded?: boolean;
 	};

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -76,6 +76,13 @@ export interface ZWaveOptions {
 		 * Note that enabling this can cause a lot of traffic during the interview.
 		 */
 		queryAllUserCodes?: boolean;
+
+		/**
+		 * Whether a node should be interviewed after successful inclusion
+		 * Note: When enabled, the interview must be triggered manually using
+		 *		 `driver.interviewNode(node: ZWaveNode)`
+		 */
+		disableOnNodeAdded?: boolean;
 	};
 
 	storage: {

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1256,7 +1256,7 @@ export class ZWaveNode
 
 		// Don't keep the node awake after the interview
 		this.keepAwake = false;
-		void this.driver.interviewNode(this);
+		void this.driver.interviewNodeInternal(this);
 	}
 
 	/**


### PR DESCRIPTION
This feature adds:

- early notification of node prior to bootstrapping
- disabling the post bootstrapping interview
- allowing the user to interview nodes at will

This is generally useful in commercial installs where many devices are being
paired quickly. Many interviews being processed in a short period of
time tends to slow the inclusion process and in turn reduces install
productivity.

fixes #4631
closes: #4685

**This PR is basically #4685, but with a few nits changed**.
I couldn't push to the other branch so here it goes.