### PR TITLE
fix(config): Correct Jasco 55256 configuration

### DIFF
--- a/packages/config/config/devices/0x0063/55256_zw1002.json
+++ b/packages/config/config/devices/0x0063/55256_zw1002.json
@@ -41,11 +41,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "LED ON when load is Off",
+					"label": "LED On when load is On",
 					"value": 0
 				},
 				{
-					"label": "LED On when light is turned On",
+					"label": "LED On when load is Off",
 					"value": 1
 				},
 				{

--- a/packages/config/config/devices/0x0063/55256_zw1002.json
+++ b/packages/config/config/devices/0x0063/55256_zw1002.json
@@ -36,7 +36,7 @@
 			"label": "LED Light",
 			"description": "LED status when device on or off.",
 			"valueSize": 1,
-			"defaultValue": 1,
+			"defaultValue": 0,
 			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
@@ -51,6 +51,10 @@
 				{
 					"label": "LED always Off",
 					"value": 2
+				},
+				{
+					"label": "LED always On",
+					"value": 3
 				}
 			]
 		}


### PR DESCRIPTION
The settings defined for the Jasco 55256 do not match the actual behavior of the switch.  The options as originally defined match an older version of the manual that is not correct. 

I've updated these options to reflect the actual behavior of the physical device. 

- The PDF manual from z-wavealliance.org has the incorrect settings:  https://products.z-wavealliance.org/ProductManual/File?folder=&filename=product_documents/3892/55256_QSG_v1[1].pdf 

- The updated manual from Jasco reflects the correct behavior: https://byjasco.com/mwdownloads/download/link/id/2572

The edit date on the two sets of instructions are separated by 4 days, I guess they figured out their error? 