### PR TITLE
feat(config): add wake time and dimming duration params to Zooz ZEN34

### DIFF
--- a/packages/config/config/devices/0x027a/zen34.json
+++ b/packages/config/config/devices/0x027a/zen34.json
@@ -132,6 +132,32 @@
 					"value": 6
 				}
 			]
+		},		
+		{
+			"#": "4",
+			"label": "30 second Wake-up time",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Short wake-up time (default)",
+					"value": 0
+				},
+				{
+					"label": "30-second wake-up time",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "5",
+			"label": "Dimming Duration (seconds)"
+			"valueSize": 2,
+			"minValue": 1,
+			"maxValue": 99,
+			"defaultValue": 5,
+			"allowManualEntry": true
 		}
 	],
 	"metadata": {

--- a/packages/config/config/devices/0x027a/zen34.json
+++ b/packages/config/config/devices/0x027a/zen34.json
@@ -157,7 +157,6 @@
 			"minValue": 1,
 			"maxValue": 99,
 			"defaultValue": 5,
-			"allowManualEntry": true
 		}
 	],
 	"metadata": {

--- a/packages/config/config/devices/0x027a/zen34.json
+++ b/packages/config/config/devices/0x027a/zen34.json
@@ -152,7 +152,7 @@
 		},
 		{
 			"#": "5",
-			"label": "Dimming Duration - seconds"
+			"label": "Dimming Duration - seconds",
 			"valueSize": 2,
 			"minValue": 1,
 			"maxValue": 99,

--- a/packages/config/config/devices/0x027a/zen34.json
+++ b/packages/config/config/devices/0x027a/zen34.json
@@ -135,7 +135,7 @@
 		},
 		{
 			"#": "4",
-			"$if": "firmwareVersion >= 1.3",
+			"$if": "firmwareVersion >= 1.30",
 			"label": "Manual Wake-Up Duration",
 			"description": "A longer duration makes it easier to change multiple parameters at once",
 			"valueSize": 1,
@@ -154,7 +154,7 @@
 		},
 		{
 			"#": "5",
-			"$if": "firmwareVersion >= 1.4",
+			"$if": "firmwareVersion >= 1.40",
 			"label": "Dimmer Control Group: Dimming Duration",
 			"unit": "seconds",
 			"valueSize": 2,

--- a/packages/config/config/devices/0x027a/zen34.json
+++ b/packages/config/config/devices/0x027a/zen34.json
@@ -141,7 +141,7 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Short wake-up time - default",
+					"label": "Short wake-up time",
 					"value": 0
 				},
 				{

--- a/packages/config/config/devices/0x027a/zen34.json
+++ b/packages/config/config/devices/0x027a/zen34.json
@@ -132,7 +132,7 @@
 					"value": 6
 				}
 			]
-		},		
+		},
 		{
 			"#": "4",
 			"label": "30 second Wake-up time",

--- a/packages/config/config/devices/0x027a/zen34.json
+++ b/packages/config/config/devices/0x027a/zen34.json
@@ -141,7 +141,7 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Short wake-up time (default)",
+					"label": "Short wake-up time - default",
 					"value": 0
 				},
 				{
@@ -152,7 +152,7 @@
 		},
 		{
 			"#": "5",
-			"label": "Dimming Duration (seconds)"
+			"label": "Dimming Duration - seconds"
 			"valueSize": 2,
 			"minValue": 1,
 			"maxValue": 99,

--- a/packages/config/config/devices/0x027a/zen34.json
+++ b/packages/config/config/devices/0x027a/zen34.json
@@ -135,7 +135,7 @@
 		},
 		{
 			"#": "4",
-			"label": "30 second Wake-up time",
+			"label": "30 second wake-up time",
 			"valueSize": 1,
 			"defaultValue": 0,
 			"allowManualEntry": false,
@@ -152,7 +152,8 @@
 		},
 		{
 			"#": "5",
-			"label": "Dimming Duration - seconds",
+			"label": "Dimming duration",
+			"unit": "seconds",
 			"valueSize": 2,
 			"minValue": 1,
 			"maxValue": 99,

--- a/packages/config/config/devices/0x027a/zen34.json
+++ b/packages/config/config/devices/0x027a/zen34.json
@@ -135,24 +135,27 @@
 		},
 		{
 			"#": "4",
-			"label": "30 second wake-up time",
+			"$if": "firmwareVersion >= 1.3",
+			"label": "Manual Wake-Up Duration",
+			"description": "A longer duration makes it easier to change multiple parameters at once",
 			"valueSize": 1,
 			"defaultValue": 0,
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Short wake-up time",
+					"label": "Short",
 					"value": 0
 				},
 				{
-					"label": "30-second wake-up time",
+					"label": "30 seconds",
 					"value": 1
 				}
 			]
 		},
 		{
 			"#": "5",
-			"label": "Dimming duration",
+			"$if": "firmwareVersion >= 1.4",
+			"label": "Dimmer Control Group: Dimming Duration",
 			"unit": "seconds",
 			"valueSize": 2,
 			"minValue": 1,

--- a/packages/config/config/devices/0x027a/zen34.json
+++ b/packages/config/config/devices/0x027a/zen34.json
@@ -156,7 +156,7 @@
 			"valueSize": 2,
 			"minValue": 1,
 			"maxValue": 99,
-			"defaultValue": 5,
+			"defaultValue": 5
 		}
 	],
 	"metadata": {


### PR DESCRIPTION
https://www.support.getzooz.com/kb/article/996-zen34-remote-switch-advanced-settings/

Wake-up time
Parameter 4: Choose how long the ZEN34 will stay awake for when manually woken up (with 7 tap up on paddle).
Values: 0 – short wake-up until it receives the wake up no more command from the hub (default); 1 – longer 30-second wake-up time (to make it easier to change multiple parameters at a time).
Size: 1 byte dec

Remote Z-Wave Dimming Duration (Multilevel Commands For Group 3)
Parameter 5: Set the time it takes to get from 0% to 100% brightness on dimmers and smart bulbs directly associated with your Remote Switch in Group 3 when pressing and holding the paddles (physical dimming) on your Remote Switch. The number entered as value corresponds to the number of seconds.

Values: 1 – 99 (seconds). Default: 5.

Size: 1 byte dec