### PR TITLE
fix(config): add param 6 to HomeSeer HS-WS200+, FW 5.12+

### DIFF
--- a/packages/config/config/devices/0x000c/hs-ws200.json
+++ b/packages/config/config/devices/0x000c/hs-ws200.json
@@ -24,6 +24,11 @@
 			"$import": "~/templates/master_template.json#orientation"
 		},
 		{
+			"#": "6",
+			"$if": "firmwareVersion >= 5.12",
+			"$import": "templates/homeseer_template.json#scene_control"
+		},
+		{
 			"#": "13",
 			"$import": "templates/homeseer_template.json#status_mode"
 		},


### PR DESCRIPTION
Add missing parameter 6 for the HomeSeer HS-WS200+  Fixes #4717