### PR TITLE
fix: add ZWavePlusRoleType.NetworkAwareSlave

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/_Types.ts
+++ b/packages/zwave-js/src/lib/commandclass/_Types.ts
@@ -1554,6 +1554,7 @@ export enum ZWavePlusRoleType {
 	AlwaysOnSlave = 0x05,
 	SleepingReportingSlave = 0x06,
 	SleepingListeningSlave = 0x07,
+	NetworkAwareSlave = 0x08,
 }
 
 /** @publicAPI */


### PR DESCRIPTION
Minor fix to add a missing ZWavePlusRoleType.

From `Z-Wave Plus v2 Specifications\Z-Wave Plus Role Type Specification.pdf`:

![image](https://user-images.githubusercontent.com/6445614/174535287-d4113685-62eb-4de1-8a0d-91d133684ae9.png)
