### PR TITLE
fix(log): use predictable filename for log rotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,5 @@ packages/*/cache
 .test-payloads
 
 test/.*-audit.json
+test/*_logrotate.json
 test/zwavejs_*.log

--- a/packages/core/src/log/shared.ts
+++ b/packages/core/src/log/shared.ts
@@ -216,6 +216,9 @@ export class ZWaveLogContainer extends winston.Container {
 	private createFileTransport(): DailyRotateFile {
 		const ret = new DailyRotateFile({
 			filename: this.logConfig.filename,
+			auditFile: `${this.logConfig.filename
+				.replace("_%DATE%", "_logrotate")
+				.replace(/\.log$/, "")}.json`,
 			datePattern: "YYYY-MM-DD",
 			createSymlink: true,
 			symlinkName: path


### PR DESCRIPTION
This should prevent collisions with other applications and make it easier to understand what this file is.