### PR TITLE
feat: add values to Basic and Multilevel Switch CC to restore prev. lvl

### DIFF
--- a/packages/cc/src/cc/BasicCC.ts
+++ b/packages/cc/src/cc/BasicCC.ts
@@ -57,6 +57,12 @@ export const BasicCCValues = Object.freeze({
 			label: "Remaining duration" as const,
 			minVersion: 2,
 		}),
+
+		...V.staticProperty("restorePrevious", {
+			...ValueMetadata.WriteOnlyBoolean,
+			label: "Restore previous value" as const,
+		}),
+
 		// TODO: This should really not be a static CC value, but depend on compat flags:
 		...V.staticPropertyWithName(
 			"compatEvent",
@@ -91,6 +97,12 @@ export class BasicCCAPI extends CCAPI {
 		{ property },
 		value,
 	): Promise<void> => {
+		// Enable restoring the previous non-zero value
+		if (property === "restorePrevious") {
+			property = "targetValue";
+			value = 255;
+		}
+
 		if (property !== "targetValue") {
 			throwUnsupportedProperty(this.ccId, property);
 		}

--- a/packages/cc/src/cc/MultilevelSwitchCC.ts
+++ b/packages/cc/src/cc/MultilevelSwitchCC.ts
@@ -79,6 +79,11 @@ export const MultilevelSwitchCCValues = Object.freeze({
 			label: "Remaining duration",
 		} as const),
 
+		...V.staticProperty("restorePrevious", {
+			...ValueMetadata.WriteOnlyBoolean,
+			label: "Restore previous value" as const,
+		}),
+
 		...V.staticPropertyWithName(
 			"compatEvent",
 			"event",
@@ -126,7 +131,7 @@ export const MultilevelSwitchCCValues = Object.freeze({
 				);
 				const [, up] = switchTypeToActions(switchTypeName);
 				return {
-					...ValueMetadata.Boolean,
+					...ValueMetadata.WriteOnlyBoolean,
 					label: `Perform a level change (${up})`,
 					valueChangeOptions: ["transitionDuration"],
 					ccSpecific: { switchType },
@@ -156,7 +161,7 @@ export const MultilevelSwitchCCValues = Object.freeze({
 				);
 				const [down] = switchTypeToActions(switchTypeName);
 				return {
-					...ValueMetadata.Boolean,
+					...ValueMetadata.WriteOnlyBoolean,
 					label: `Perform a level change (${down})`,
 					valueChangeOptions: ["transitionDuration"],
 					ccSpecific: { switchType },
@@ -372,6 +377,12 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 		value,
 		options,
 	): Promise<void> => {
+		// Enable restoring the previous non-zero value
+		if (property === "restorePrevious") {
+			property = "targetValue";
+			value = 255;
+		}
+
 		if (property === "targetValue") {
 			if (typeof value !== "number") {
 				throwWrongValueType(


### PR DESCRIPTION
This PR adds a new writeonly value to both Basic and Multilevel Switch CCs, which sends a `255` when written, restoring the previous non-zero level. 

fixes: #532