### PR TITLE
feat(config): add Fakro ARF Solar, template Fakro configs

### DIFF
--- a/packages/config/config/devices/0x0085/amz_solar.json
+++ b/packages/config/config/devices/0x0085/amz_solar.json
@@ -72,11 +72,11 @@
 		},
 		{
 			"#": "12",
-			"$import": "~/templates/fakro_template.json#calibration"
+			"$import": "templates/fakro_template.json#calibration"
 		},
 		{
 			"#": "13",
-			"$import": "~/templates/fakro_template.json#shutter_response_to_basic_set_0xff"
+			"$import": "templates/fakro_template.json#shutter_response_to_basic_set_0xff"
 		}
 	]
 }

--- a/packages/config/config/devices/0x0085/amz_solar.json
+++ b/packages/config/config/devices/0x0085/amz_solar.json
@@ -72,19 +72,11 @@
 		},
 		{
 			"#": "12",
-			"label": "Calibration",
-			"valueSize": 1,
-			"minValue": 1,
-			"maxValue": 2,
-			"defaultValue": 1
+			"$import": "~/templates/fakro_template.json#calibration"
 		},
 		{
 			"#": "13",
-			"label": "Positioning",
-			"valueSize": 1,
-			"minValue": 1,
-			"maxValue": 2,
-			"defaultValue": 1
+			"$import": "~/templates/fakro_template.json#shutter_response_to_basic_set_0xff"
 		}
 	]
 }

--- a/packages/config/config/devices/0x0085/arf-solar.json
+++ b/packages/config/config/devices/0x0085/arf-solar.json
@@ -31,15 +31,15 @@
 	"paramInformation": [
 		{
 			"#": "13",
-			"$import": "~/templates/fakro_template.json#shutter_response_to_basic_set_0xff"
+			"$import": "templates/fakro_template.json#shutter_response_to_basic_set_0xff"
 		},
 		{
 			"#": "99",
-			"$import": "~/templates/fakro_template.json#factory_reset"
+			"$import": "templates/fakro_template.json#factory_reset"
 		},
 		{
 			"#": "100",
-			"$import": "~/templates/fakro_template.json#autoexclude"
+			"$import": "templates/fakro_template.json#autoexclude"
 		}
 	]
 }

--- a/packages/config/config/devices/0x0085/arf-solar.json
+++ b/packages/config/config/devices/0x0085/arf-solar.json
@@ -1,0 +1,75 @@
+{
+	"manufacturer": "Fakro",
+	"manufacturerId": "0x0085",
+	"label": "ARF Z-Wave Solar",
+	"description": "Roller Blind",
+	"devices": [
+		{
+			"productType": "0x0004",
+			"productId": "0x0012"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 1,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "Basic Repeat",
+			"maxNodes": 5
+		},
+		"3": {
+			"label": "Multilevel Switch Repeat",
+			"maxNodes": 5
+		}
+	},
+	"paramInformation": [
+		{
+			"#": "13",
+			"$import": "arz_z-wave.json#paramInformation/13"
+		},
+		{
+			"#": "99",
+			"label": "Reset to Factory Defaults",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"unsigned": true,
+			"writeOnly": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Reset to Factory Default",
+					"value": 1
+				},
+				{
+					"label": "Parameters are changed",
+					"value": 2
+				}
+			]
+		},
+		{
+			"#": "100",
+			"label": "Autoexclude",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"unsigned": true,
+			"writeOnly": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Idle",
+					"value": 1
+				},
+				{
+					"label": "Autoexclude",
+					"value": 2
+				}
+			]
+		}
+	]
+}

--- a/packages/config/config/devices/0x0085/arf-solar.json
+++ b/packages/config/config/devices/0x0085/arf-solar.json
@@ -31,45 +31,15 @@
 	"paramInformation": [
 		{
 			"#": "13",
-			"$import": "arz_z-wave.json#paramInformation/13"
+			"$import": "~/templates/fakro_template.json#shutter_response_to_basic_set_0xff"
 		},
 		{
 			"#": "99",
-			"label": "Reset to Factory Defaults",
-			"valueSize": 1,
-			"defaultValue": 1,
-			"unsigned": true,
-			"writeOnly": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Reset to Factory Default",
-					"value": 1
-				},
-				{
-					"label": "Parameters are changed",
-					"value": 2
-				}
-			]
+			"$import": "~/templates/fakro_template.json#factory_reset"
 		},
 		{
 			"#": "100",
-			"label": "Autoexclude",
-			"valueSize": 1,
-			"defaultValue": 1,
-			"unsigned": true,
-			"writeOnly": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Idle",
-					"value": 1
-				},
-				{
-					"label": "Autoexclude",
-					"value": 2
-				}
-			]
+			"$import": "~/templates/fakro_template.json#autoexclude"
 		}
 	]
 }

--- a/packages/config/config/devices/0x0085/arz_z-wave.json
+++ b/packages/config/config/devices/0x0085/arz_z-wave.json
@@ -38,38 +38,11 @@
 	"paramInformation": [
 		{
 			"#": "12",
-			"label": "Calibration",
-			"description": "To calibrate, first select Discalibrated, then Calibrated",
-			"valueSize": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Calibrated",
-					"value": 1
-				},
-				{
-					"label": "Discalibrated",
-					"value": 2
-				}
-			]
+			"$import": "~/templates/fakro_template.json#calibration"
 		},
 		{
 			"#": "13",
-			"label": "Response to Basic Set (0xff)",
-			"valueSize": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Fully open",
-					"value": 1
-				},
-				{
-					"label": "Previous position",
-					"value": 2
-				}
-			]
+			"$import": "~/templates/fakro_template.json#shutter_response_to_basic_set_0xff"
 		}
 	],
 	"metadata": {

--- a/packages/config/config/devices/0x0085/arz_z-wave.json
+++ b/packages/config/config/devices/0x0085/arz_z-wave.json
@@ -38,11 +38,11 @@
 	"paramInformation": [
 		{
 			"#": "12",
-			"$import": "~/templates/fakro_template.json#calibration"
+			"$import": "templates/fakro_template.json#calibration"
 		},
 		{
 			"#": "13",
-			"$import": "~/templates/fakro_template.json#shutter_response_to_basic_set_0xff"
+			"$import": "templates/fakro_template.json#shutter_response_to_basic_set_0xff"
 		}
 	],
 	"metadata": {

--- a/packages/config/config/devices/0x0085/arz_z-wave_solar.json
+++ b/packages/config/config/devices/0x0085/arz_z-wave_solar.json
@@ -32,15 +32,15 @@
 	"paramInformation": [
 		{
 			"#": "13",
-			"$import": "~/templates/fakro_template.json#shutter_response_to_basic_set_0xff"
+			"$import": "templates/fakro_template.json#shutter_response_to_basic_set_0xff"
 		},
 		{
 			"#": "99",
-			"$import": "~/templates/fakro_template.json#factory_reset"
+			"$import": "templates/fakro_template.json#factory_reset"
 		},
 		{
 			"#": "100",
-			"$import": "~/templates/fakro_template.json#autoexclude"
+			"$import": "templates/fakro_template.json#autoexclude"
 		}
 	]
 }

--- a/packages/config/config/devices/0x0085/arz_z-wave_solar.json
+++ b/packages/config/config/devices/0x0085/arz_z-wave_solar.json
@@ -32,45 +32,15 @@
 	"paramInformation": [
 		{
 			"#": "13",
-			"$import": "arz_z-wave.json#paramInformation/13"
+			"$import": "~/templates/fakro_template.json#shutter_response_to_basic_set_0xff"
 		},
 		{
 			"#": "99",
-			"label": "Reset to Factory Defaults",
-			"valueSize": 1,
-			"defaultValue": 1,
-			"unsigned": true,
-			"writeOnly": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Reset to Factory Default",
-					"value": 1
-				},
-				{
-					"label": "Parameters are changed",
-					"value": 2
-				}
-			]
+			"$import": "~/templates/fakro_template.json#factory_reset"
 		},
 		{
 			"#": "100",
-			"label": "Autoexclude",
-			"valueSize": 1,
-			"defaultValue": 1,
-			"unsigned": true,
-			"writeOnly": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Idle",
-					"value": 1
-				},
-				{
-					"label": "Autoexclude",
-					"value": 2
-				}
-			]
+			"$import": "~/templates/fakro_template.json#autoexclude"
 		}
 	]
 }

--- a/packages/config/config/devices/0x0085/templates/fakro_template.json
+++ b/packages/config/config/devices/0x0085/templates/fakro_template.json
@@ -1,0 +1,72 @@
+{
+	"shutter_response_to_basic_set_0xff": {
+		"label": "Response to Basic Set (0xff)",
+		"valueSize": 1,
+		"defaultValue": 1,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Fully open",
+				"value": 1
+			},
+			{
+				"label": "Previous position",
+				"value": 2
+			}
+		]
+	},
+	"factory_reset": {
+		"label": "Reset Parameters to Factory Defaults",
+		"description": "If the value changes to 2 after resetting the parameters, some non-default parameters were reset to their respective default values.",
+		"valueSize": 1,
+		"defaultValue": 1,
+		"unsigned": true,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Reset all parameters",
+				"value": 1
+			},
+			{
+				"label": "Some parameters were reset",
+				"value": 2
+			}
+		]
+	},
+	"autoexclude": {
+		"label": "Autoexclude",
+		"description": "Can be used to exclude the device in hard-to-reach locations.",
+		"valueSize": 1,
+		"defaultValue": 1,
+		"unsigned": true,
+		"writeOnly": true,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Idle",
+				"value": 1
+			},
+			{
+				"label": "Autoexclude",
+				"value": 2
+			}
+		]
+	},
+	"calibration": {
+		"label": "Calibration",
+		"description": "To calibrate, first select Discalibrated, then Calibrated",
+		"valueSize": 1,
+		"defaultValue": 1,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Calibrated",
+				"value": 1
+			},
+			{
+				"label": "Discalibrated",
+				"value": 2
+			}
+		]
+	}
+}

--- a/packages/config/config/devices/0x0085/vmz_solar_z-wave_plus.json
+++ b/packages/config/config/devices/0x0085/vmz_solar_z-wave_plus.json
@@ -102,7 +102,7 @@
 		},
 		{
 			"#": "13",
-			"$import": "~/templates/fakro_template.json#shutter_response_to_basic_set_0xff"
+			"$import": "templates/fakro_template.json#shutter_response_to_basic_set_0xff"
 		},
 		{
 			"#": "17",
@@ -164,11 +164,11 @@
 		},
 		{
 			"#": "99",
-			"$import": "~/templates/fakro_template.json#factory_reset"
+			"$import": "templates/fakro_template.json#factory_reset"
 		},
 		{
 			"#": "100",
-			"$import": "~/templates/fakro_template.json#autoexclude"
+			"$import": "templates/fakro_template.json#autoexclude"
 		}
 	]
 }

--- a/packages/config/config/devices/0x0085/vmz_solar_z-wave_plus.json
+++ b/packages/config/config/devices/0x0085/vmz_solar_z-wave_plus.json
@@ -102,20 +102,7 @@
 		},
 		{
 			"#": "13",
-			"label": "Restore last position",
-			"valueSize": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "go down",
-					"value": 1
-				},
-				{
-					"label": "restore last position",
-					"value": 2
-				}
-			]
+			"$import": "~/templates/fakro_template.json#shutter_response_to_basic_set_0xff"
 		},
 		{
 			"#": "17",
@@ -177,37 +164,11 @@
 		},
 		{
 			"#": "99",
-			"label": "Restore default config values",
-			"valueSize": 1,
-			"defaultValue": 2,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "restore default config values",
-					"value": 1
-				},
-				{
-					"label": "user values",
-					"value": 2
-				}
-			]
+			"$import": "~/templates/fakro_template.json#factory_reset"
 		},
 		{
 			"#": "100",
-			"label": "Autoexclude",
-			"valueSize": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "off",
-					"value": 1
-				},
-				{
-					"label": "on",
-					"value": 2
-				}
-			]
+			"$import": "~/templates/fakro_template.json#autoexclude"
 		}
 	]
 }

--- a/packages/config/config/devices/0x0085/zws12.json
+++ b/packages/config/config/devices/0x0085/zws12.json
@@ -52,39 +52,11 @@
 		},
 		{
 			"#": "12",
-			"label": "Calibrate",
-			"description": "This parameter on/off callibration function",
-			"valueSize": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Calibrated",
-					"value": 1
-				},
-				{
-					"label": "Discalibrated",
-					"value": 2
-				}
-			]
+			"$import": "~/templates/fakro_template.json#calibration"
 		},
 		{
 			"#": "13",
-			"label": "Last saved position",
-			"description": "Set servomotor in previous position",
-			"valueSize": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "FF go to Max",
-					"value": 1
-				},
-				{
-					"label": "FF go to previous position",
-					"value": 2
-				}
-			]
+			"$import": "~/templates/fakro_template.json#shutter_response_to_basic_set_0xff"
 		},
 		{
 			"#": "15",

--- a/packages/config/config/devices/0x0085/zws12.json
+++ b/packages/config/config/devices/0x0085/zws12.json
@@ -52,11 +52,11 @@
 		},
 		{
 			"#": "12",
-			"$import": "~/templates/fakro_template.json#calibration"
+			"$import": "templates/fakro_template.json#calibration"
 		},
 		{
 			"#": "13",
-			"$import": "~/templates/fakro_template.json#shutter_response_to_basic_set_0xff"
+			"$import": "templates/fakro_template.json#shutter_response_to_basic_set_0xff"
 		},
 		{
 			"#": "15",

--- a/packages/config/config/devices/0x0085/zws12n.json
+++ b/packages/config/config/devices/0x0085/zws12n.json
@@ -36,21 +36,11 @@
 		},
 		{
 			"#": "12",
-			"label": "Callibrate",
-			"description": "This parameter on/off callibration function",
-			"valueSize": 1,
-			"minValue": 1,
-			"maxValue": 2,
-			"defaultValue": 1
+			"$import": "~/templates/fakro_template.json#calibration"
 		},
 		{
 			"#": "13",
-			"label": "Last saved position",
-			"description": "Set servomotor in previous position",
-			"valueSize": 1,
-			"minValue": 1,
-			"maxValue": 2,
-			"defaultValue": 1
+			"$import": "~/templates/fakro_template.json#shutter_response_to_basic_set_0xff"
 		},
 		{
 			"#": "15",

--- a/packages/config/config/devices/0x0085/zws12n.json
+++ b/packages/config/config/devices/0x0085/zws12n.json
@@ -36,11 +36,11 @@
 		},
 		{
 			"#": "12",
-			"$import": "~/templates/fakro_template.json#calibration"
+			"$import": "templates/fakro_template.json#calibration"
 		},
 		{
 			"#": "13",
-			"$import": "~/templates/fakro_template.json#shutter_response_to_basic_set_0xff"
+			"$import": "templates/fakro_template.json#shutter_response_to_basic_set_0xff"
 		},
 		{
 			"#": "15",


### PR DESCRIPTION
Add configuration for Fakro ARF Solar roller blind.   Based on configuration for ARZ Z-Wave Solar, as they share the same configuration parameters when looking at the respective manuals. 

Fixes #4644 