### PR TITLE
feat: add methods for whether firmware update is in progress

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -709,6 +709,14 @@ Restores an NVM backup that was created with `backupNVMRaw`. The optional 2nd ar
 
 > [!WARNING] A failure during this process may brick your controller. Use at your own risk!
 
+### `isAnyFirmwareUpdateInProgress`
+
+```ts
+isAnyFirmwareUpdateInProgress(): boolean;
+```
+
+Returns whether an OTA firmware update is in progress for any node.
+
 ## Controller properties
 
 ### `nodes`
@@ -830,14 +838,6 @@ enum InclusionState {
 	SmartStart,
 }
 ```
-
-### `isAnyFirmwareUpdateInProgress`
-
-```ts
-readonly isAnyFirmwareUpdateInProgress: boolean;
-```
-
-Returns whether a firmware update is in progress for any node.
 
 ## Controller events
 

--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -709,10 +709,10 @@ Restores an NVM backup that was created with `backupNVMRaw`. The optional 2nd ar
 
 > [!WARNING] A failure during this process may brick your controller. Use at your own risk!
 
-### `isAnyFirmwareUpdateInProgress`
+### `isAnyOTAFirmwareUpdateInProgress`
 
 ```ts
-isAnyFirmwareUpdateInProgress(): boolean;
+isAnyOTAFirmwareUpdateInProgress(): boolean;
 ```
 
 Returns whether an OTA firmware update is in progress for any node.

--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -831,6 +831,14 @@ enum InclusionState {
 }
 ```
 
+### `isAnyFirmwareUpdateInProgress`
+
+```ts
+readonly isAnyFirmwareUpdateInProgress: boolean;
+```
+
+Returns whether a firmware update is in progress for any node.
+
 ## Controller events
 
 The `Controller` class inherits from the Node.js [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) and thus also supports its methods like `on`, `removeListener`, etc. The available events are avaiable:

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -877,6 +877,14 @@ keepAwake: boolean;
 In order to save energy, battery powered devices should go back to sleep after they no longer need to communicate with the controller. This library honors this requirement by sending nodes back to sleep as soon as there are no more pending messages.
 When configuring devices or during longer message exchanges, this behavior may be annoying. You can set the `keepAwake` property of a node to `true` to avoid sending the node back to sleep immediately.
 
+### `isFirmwareUpdateInProgress`
+
+```ts
+readonly isFirmwareUpdateInProgress: boolean;
+```
+
+Return whether a firmware update is in progress for this node.
+
 ## ZWaveNode events
 
 The `Node` class inherits from the Node.js [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) and thus also supports its methods like `on`, `removeListener`, etc. The available events are avaiable:

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -527,6 +527,14 @@ The health rating expressed as a number from 0 (not working at all) to 10 (perfe
 
 > [!NOTE] The test results are also printed to the driver logs. If you want to format the results in the same way in your application, you can use the `formatRouteHealthCheckSummary` and/or `formatRouteHealthCheckRound` methods which are exposed from `zwave-js/Utils`.
 
+### `isFirmwareUpdateInProgress`
+
+```ts
+isFirmwareUpdateInProgress(): boolean;
+```
+
+Return whether a firmware update is in progress for this node.
+
 ## ZWaveNode properties
 
 ### `id`
@@ -876,14 +884,6 @@ keepAwake: boolean;
 
 In order to save energy, battery powered devices should go back to sleep after they no longer need to communicate with the controller. This library honors this requirement by sending nodes back to sleep as soon as there are no more pending messages.
 When configuring devices or during longer message exchanges, this behavior may be annoying. You can set the `keepAwake` property of a node to `true` to avoid sending the node back to sleep immediately.
-
-### `isFirmwareUpdateInProgress`
-
-```ts
-readonly isFirmwareUpdateInProgress: boolean;
-```
-
-Return whether a firmware update is in progress for this node.
 
 ## ZWaveNode events
 

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -534,6 +534,13 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 		this.driver.cacheSet(cacheKeys.controller.supportsSoftReset, value);
 	}
 
+	public get isAnyFirmwareUpdateInProgress(): boolean {
+		for (const node of this._nodes.values()) {
+			if (node.isFirmwareUpdateInProgress) return true;
+		}
+		return false;
+	}
+
 	private _nodes: ThrowingMap<number, ZWaveNode>;
 	/** A dictionary of the nodes connected to this controller */
 	public get nodes(): ReadonlyThrowingMap<number, ZWaveNode> {

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -534,13 +534,6 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 		this.driver.cacheSet(cacheKeys.controller.supportsSoftReset, value);
 	}
 
-	public get isAnyFirmwareUpdateInProgress(): boolean {
-		for (const node of this._nodes.values()) {
-			if (node.isFirmwareUpdateInProgress) return true;
-		}
-		return false;
-	}
-
 	private _nodes: ThrowingMap<number, ZWaveNode>;
 	/** A dictionary of the nodes connected to this controller */
 	public get nodes(): ReadonlyThrowingMap<number, ZWaveNode> {
@@ -4958,5 +4951,16 @@ ${associatedNodes.join(", ")}`,
 			new GetBackgroundRSSIRequest(this.driver),
 		);
 		return pick(ret, ["rssiChannel0", "rssiChannel1", "rssiChannel2"]);
+	}
+
+	/**
+	 *
+	 * Returns whether an OTA firmware update is in progress for any node.
+	 */
+	public isOTAFirmwareUpdateInProgress(): boolean {
+		for (const node of this._nodes.values()) {
+			if (node.isFirmwareUpdateInProgress()) return true;
+		}
+		return false;
 	}
 }

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -4957,7 +4957,7 @@ ${associatedNodes.join(", ")}`,
 	 *
 	 * Returns whether an OTA firmware update is in progress for any node.
 	 */
-	public isOTAFirmwareUpdateInProgress(): boolean {
+	public isAnyOTAFirmwareUpdateInProgress(): boolean {
 		for (const node of this._nodes.values()) {
 			if (node.isFirmwareUpdateInProgress()) return true;
 		}

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -795,10 +795,6 @@ export class ZWaveNode
 		}
 	}
 
-	public get isFirmwareUpdateInProgress(): boolean {
-		return this._firmwareUpdateStatus !== undefined;
-	}
-
 	private _valueDB: ValueDB;
 	/**
 	 * Provides access to this node's values
@@ -4332,5 +4328,13 @@ ${formatRouteHealthCheckSummary(this.id, otherNode.id, summary)}`,
 			ret.lwr = newStats;
 			return ret;
 		});
+	}
+
+	/**
+	 *
+	 * Returns whether a firmware update is in progress for this node.
+	 */
+	public isFirmwareUpdateInProgress(): boolean {
+		return this._firmwareUpdateStatus !== undefined;
 	}
 }

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -795,6 +795,10 @@ export class ZWaveNode
 		}
 	}
 
+	public get isFirmwareUpdateInProgress(): boolean {
+		return this._firmwareUpdateStatus != undefined;
+	}
+
 	private _valueDB: ValueDB;
 	/**
 	 * Provides access to this node's values

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -796,7 +796,7 @@ export class ZWaveNode
 	}
 
 	public get isFirmwareUpdateInProgress(): boolean {
-		return this._firmwareUpdateStatus != undefined;
+		return this._firmwareUpdateStatus !== undefined;
 	}
 
 	private _valueDB: ValueDB;


### PR DESCRIPTION
There's no reason why the driver can't return whether a firmware update is in progress. Instead of relying on the application to track it, consider cases like zwavejs2mqtt where there are two applications (z2m and zwave-js-server) that can initiate updates. IMO it needs to be centralized in the driver
