### PR TITLE
fix: soft-reset controller after NVM backup, preventing strange controller behavior

### DIFF
--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -4611,6 +4611,9 @@ ${associatedNodes.join(", ")}`,
 		try {
 			if (this.sdkVersionGte("7.0")) {
 				ret = await this.backupNVMRaw700(onProgress);
+				// All 7.xx versions so far seem to have a bug where the NVM is not properly closed after reading
+				// resulting in extremely strange controller behavior after a backup. To work around this, restart the stick if possible
+				await this.driver.trySoftReset();
 			} else {
 				ret = await this.backupNVMRaw500(onProgress);
 			}

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1943,7 +1943,7 @@ export class Driver
 	 * Soft-resets the controller if the feature is enabled
 	 */
 	public async trySoftReset(): Promise<void> {
-		if (this.options.enableSoftReset) {
+		if (this.options.enableSoftReset && this.maySoftReset()) {
 			await this.softReset();
 		} else {
 			const message = `The soft reset feature is not enabled, skipping API call.`;


### PR DESCRIPTION
This is a workaround for a bug in the 700 series firmware, where even after closing the NVM, the controller seemingly reads garbage, cannot write to the NVM, and sends garbage in most situations. This yields to strange behavior when including/excluding nodes.