### PR TITLE
feat: cache firmware update capabilities during the interview

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -222,6 +222,18 @@ getFirmwareUpdateCapabilities(): Promise<FirmwareUpdateCapabilities>
 
 Retrieves the firmware update capabilities of a node to decide which options (e.g. firmware targets) to offer a user prior to the update.
 
+> [!NOTE] This variant communicates with the node to retrieve fresh information.
+
+### `getFirmwareUpdateCapabilitiesCached`
+
+```ts
+getFirmwareUpdateCapabilitiesCached(): FirmwareUpdateCapabilities
+```
+
+Retrieves the firmware update capabilities of a node to decide which options (e.g. firmware targets) to offer a user prior to the update.
+
+> [!NOTE] This method uses cached information from the most recent interview.
+
 <!-- #import FirmwareUpdateCapabilities from "zwave-js" -->
 
 ```ts


### PR DESCRIPTION
This PR adds the method `getFirmwareUpdateCapabilitiesCached` to the `ZWaveNode` class to retrieve the update capabilities which were cached during the most recent interview. Since this information wasn't cached prior to this PR, the method will return `{ firmwareUpgradable: false }` until a node gets interviewed again after the update.

Also, the already-existing method `getFirmwareUpdateCapabilities` which communicates with a node to retrieve the capabilities no longer throws when a node doesn't support Firmware Update CC.

fixes: #4775