### PR TITLE
fix(config): add parameter 17 to Zooz ZEN76, FW 10.0+

### DIFF
--- a/packages/config/config/devices/0x027a/zen76.json
+++ b/packages/config/config/devices/0x027a/zen76.json
@@ -93,7 +93,27 @@
 		{
 			"#": "16",
 			"$import": "templates/zooz_template.json#association_reports"
-		}
+		},
+		{
+			"#": "17",
+			"$if": "firmwareVersion >= 10.0",
+			"label": "Enable/Disable Programming on the Paddles",
+			"description": "Enable or disable programming functionality on the switch paddles. If this setting is disabled, then inclusion, exclusion, smart bulb mode no longer work when switch paddles are activated (factory reset and scene control will still work) - that means you can now use triple-tap triggers on the switch for scenes and remote control of other devices.",
+			"defaultValue": 0,
+			"valueSize": 1,
+			"unsigned": true,
+			"allowManualEntry": false,			
+			"options": [
+				{
+					"label": "Programming Enabled",
+					"value": 0
+				},
+				{
+					"label": "Programming Disabled",
+					"value": 1
+				}
+			]			
+		}		
 	],
 	"compat": {
 		// The device sends Configuration CC info reports in 4-byte chunks, causing each query to block the network for roughly 1.5 seconds.

--- a/packages/config/config/devices/0x027a/zen76.json
+++ b/packages/config/config/devices/0x027a/zen76.json
@@ -102,7 +102,7 @@
 			"defaultValue": 0,
 			"valueSize": 1,
 			"unsigned": true,
-			"allowManualEntry": false,			
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Programming Enabled",
@@ -112,8 +112,8 @@
 					"label": "Programming Disabled",
 					"value": 1
 				}
-			]			
-		}		
+			]
+		}
 	],
 	"compat": {
 		// The device sends Configuration CC info reports in 4-byte chunks, causing each query to block the network for roughly 1.5 seconds.

--- a/packages/config/config/devices/0x027a/zen76.json
+++ b/packages/config/config/devices/0x027a/zen76.json
@@ -97,22 +97,7 @@
 		{
 			"#": "17",
 			"$if": "firmwareVersion >= 10.0",
-			"label": "Enable/Disable Programming on the Paddles",
-			"description": "Enable or disable programming functionality on the switch paddles. If this setting is disabled, then inclusion, exclusion, smart bulb mode no longer work when switch paddles are activated (factory reset and scene control will still work) - that means you can now use triple-tap triggers on the switch for scenes and remote control of other devices.",
-			"defaultValue": 0,
-			"valueSize": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Programming Enabled",
-					"value": 0
-				},
-				{
-					"label": "Programming Disabled",
-					"value": 1
-				}
-			]
+			"$import": "templates/zooz_template.json#local_programming"
 		}
 	],
 	"compat": {


### PR DESCRIPTION
Reference: https://www.support.getzooz.com/kb/article/549-zen76-s2-on-off-switch-700-advanced-settings/

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

Update Zen76 config for parameter 17
