### PR TITLE
fix(config): parameter 6 for the Leviton ZW4SF is led_timeout, not locator_led

### DIFF
--- a/packages/config/config/devices/0x001d/zw4sf.json
+++ b/packages/config/config/devices/0x001d/zw4sf.json
@@ -30,7 +30,7 @@
 		},
 		{
 			"#": "6",
-			"$import": "templates/config_template.json#locator_led"
+			"$import": "templates/config_template.json#led_timeout"
 		},
 		{
 			"#": "7",


### PR DESCRIPTION
Parameter 6 for the Leviton ZW4SF is led_timeout, not locator_led
See: https://products.z-wavealliance.org/products/3832/configs
