### PR TITLE
fix(config): add missing fingerprints to Fibargroup fgwp102 and fgdw002

### DIFF
--- a/packages/config/config/devices/0x010f/fgdw002.json
+++ b/packages/config/config/devices/0x010f/fgdw002.json
@@ -18,6 +18,10 @@
 		},
 		{
 			"productType": "0x0702",
+			"productId": "0x4000"
+		},
+		{
+			"productType": "0x0702",
 			"productId": "0x7000"
 		}
 	],

--- a/packages/config/config/devices/0x010f/fgwp102.json
+++ b/packages/config/config/devices/0x010f/fgwp102.json
@@ -14,6 +14,10 @@
 		},
 		{
 			"productType": "0x0602",
+			"productId": "0x4001"
+		},
+		{
+			"productType": "0x0602",
 			"productId": "0x4003"
 		}
 	],


### PR DESCRIPTION
Added missing 0x4001 product ID to fgwp102.json.