### PR TITLE
fix(config): fix configuration files for Inovelli LZW41 and LZW42

### DIFF
--- a/packages/config/config/devices/0x031e/lzw41.json
+++ b/packages/config/config/devices/0x031e/lzw41.json
@@ -43,11 +43,11 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Nothing",
+					"label": "Disable",
 					"value": 0
 				},
 				{
-					"label": "Switch Multilevel Report",
+					"label": "Multilevel Switch Report",
 					"value": 1
 				}
 			]

--- a/packages/config/config/devices/0x031e/lzw41.json
+++ b/packages/config/config/devices/0x031e/lzw41.json
@@ -24,35 +24,52 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Prior state",
+					"label": "On",
 					"value": 0
 				},
 				{
-					"label": "Force on",
+					"label": "Previous State",
 					"value": 1
-				},
-				{
-					"label": "Force off",
-					"value": 2
 				}
 			]
 		},
 		{
-			"#": "51",
+			"#": "80",
+			"label": "Notifications to Associated Devices",
+			"description": "What notifications should be sent to associated devices when the state of the LED bulb is changed",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Nothing",
+					"value": 0
+				},
+				{
+					"label": "Switch Multilevel Report",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "81",
 			"label": "Color Temperature (Warm White)",
 			"valueSize": 2,
 			"minValue": 2700,
 			"maxValue": 4999,
 			"defaultValue": 2700,
+			"unit": "K",
 			"unsigned": true
 		},
 		{
-			"#": "52",
+			"#": "82",
 			"label": "Color Temperature (Cool White)",
 			"valueSize": 2,
 			"minValue": 5000,
 			"maxValue": 6500,
-			"defaultValue": 5000,
+			"defaultValue": 6500,
+			"unit": "K",
 			"unsigned": true
 		}
 	],

--- a/packages/config/config/devices/0x031e/lzw41.json
+++ b/packages/config/config/devices/0x031e/lzw41.json
@@ -28,7 +28,7 @@
 					"value": 0
 				},
 				{
-					"label": "Previous State",
+					"label": "Previous state",
 					"value": 1
 				}
 			]

--- a/packages/config/config/devices/0x031e/lzw42.json
+++ b/packages/config/config/devices/0x031e/lzw42.json
@@ -36,7 +36,7 @@
 					"value": 0
 				},
 				{
-					"label": "Previous State",
+					"label": "Previous state",
 					"value": 1
 				}
 			]

--- a/packages/config/config/devices/0x031e/lzw42.json
+++ b/packages/config/config/devices/0x031e/lzw42.json
@@ -67,7 +67,7 @@
 	"metadata": {
 		"inclusion": "With the bulb turned off, start the inclusion process on your hub/gateway.  Once the inclusion process has started, turn on the bulb and it will immediately blink twice (2x) indicating it's in inclusion (pairing) mode.  If the bulb was included successfully, it will blink one more (1x) time.  If it was not included successfully, you may have to run an exclusion.  If there's still issues, please ensure your bulb is within range.",
 		"exclusion": "Put your hub in exclusion mode and turn the power to the bulb on.  Your bulb will blink twice (2x) indicating it's in exclusion mode.  When exclusion is successful, it will blink one more time (1x) to confirm.  Your hub should say that the device is excluded.",
-		"reset": "You may power on/off the bulb 6x (between 0.5-2 seconds each time) or useacertifiedcontroller to remove the device from your network to factory default.  Only use this procedure in the event that the network primary controller is missing or otherwise inoperable.  Your bulb will flash twice to confirm factory reset.",
+		"reset": "You may power on/off the bulb 6x (between 0.5-2 seconds each time) or use a certified controller to remove the device from your network to factory default.  Only use this procedure in the event that the network primary controller is missing or otherwise inoperable.  Your bulb will flash twice to confirm factory reset.",
 		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=product_documents/3613/LZW42%20Manual.pdf"
 	}
 }

--- a/packages/config/config/devices/0x031e/lzw42.json
+++ b/packages/config/config/devices/0x031e/lzw42.json
@@ -6,7 +6,8 @@
 	"devices": [
 		{
 			"productType": "0x0005",
-			"productId": "0x0001"
+			"productId": "0x0001",
+			"zwaveAllianceId": 3613
 		}
 	],
 	"firmwareVersion": {
@@ -31,16 +32,12 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Previous state",
+					"label": "On",
 					"value": 0
 				},
 				{
-					"label": "On",
+					"label": "Previous State",
 					"value": 1
-				},
-				{
-					"label": "Off",
-					"value": 2
 				}
 			]
 		},
@@ -66,5 +63,11 @@
 			"unit": "K",
 			"unsigned": true
 		}
-	]
+	],
+	"metadata": {
+		"inclusion": "With the bulb turned off, start the inclusion process on your hub/gateway.  Once the inclusion process has started, turn on the bulb and it will immediately blink twice (2x) indicating it's in inclusion (pairing) mode.  If the bulb was included successfully, it will blink one more (1x) time.  If it was not included successfully, you may have to run an exclusion.  If there's still issues, please ensure your bulb is within range.",
+		"exclusion": "Put your hub in exclusion mode and turn the power to the bulb on.  Your bulb will blink twice (2x) indicating it's in exclusion mode.  When exclusion is successful, it will blink one more time (1x) to confirm.  Your hub should say that the device is excluded.",
+		"reset": "You may power on/off the bulb 6x (between 0.5-2 seconds each time) or useacertifiedcontroller to remove the device from your network to factory default.  Only use this procedure in the event that the network primary controller is missing or otherwise inoperable.  Your bulb will flash twice to confirm factory reset.",
+		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=product_documents/3613/LZW42%20Manual.pdf"
+	}
 }


### PR DESCRIPTION
The Z-Wave Association product database has some bad information for these devices, so this is to update them to match manufacturer documentation.

* https://support.inovelli.com/portal/en/kb/articles/products-leds-cct-a19-lzw41-spec-sheet
* https://support.inovelli.com/portal/en/kb/articles/products-leds-rgbw-a19-lzw42-spec-sheet
* https://community.inovelli.com/t/lzw42-does-not-remember-previous-state-after-power-outage/11028
