### PR TITLE
fix(config): no strict validation for Vivint Keypad

### DIFF
--- a/packages/config/config/devices/0x0156/m_n_kp01.json
+++ b/packages/config/config/devices/0x0156/m_n_kp01.json
@@ -100,6 +100,7 @@
 		}
 	],
 	"compat": {
+		// The device does not pad ASCII data to fill 16-byte blocks
 		"disableStrictEntryControlDataValidation": true
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x0156/m_n_kp01.json
+++ b/packages/config/config/devices/0x0156/m_n_kp01.json
@@ -99,6 +99,9 @@
 			"unsigned": true
 		}
 	],
+	"compat": {
+		"disableStrictEntryControlDataValidation": true
+	},
 	"metadata": {
 		"inclusion": "Use this standard method for adding Z-Wave devices at the panel or hub. Use the \"PAIR/RESET\" button next to the battery tray. Follow the onscreen prompts to add the keypad.",
 		"exclusion": "Removing Keypad from System\nTo remove the device, place the panel Use this standard method for excluding Z-Wave devices at the panel or hub. Use the \"PAIR/RESET\" button next to the battery tray. Follow the onscreen prompts to add the keypad",


### PR DESCRIPTION
Like other keypads, the Vivint Keypad doesn't strictly conform when it sends ASCII characters via the EntryControl CC.

Before these changes, my log showed:
```
23:13:07.246 SERIAL « 0x011d0004000a179f037b00c29e71f4473c7553d5397a26c14e04af379753ff (31 bytes)
23:13:07.248 SERIAL » [ACK] (0x06)
23:13:07.250 DRIVER « [Node 010] [REQ] [ApplicationCommand]
└─[Security2CCMessageEncapsulation]
│ sequence number: 123
└─[SupervisionCCGet]
│ session id: 17
│ request updates: false
└─[EntryControlCCNotification] [INVALID]
```

And after these changes, I was able to successfully see the buffered ASCII characters published via ZWavejs2Mqtt and the log now shows this:
```
21:07:39.327 SERIAL « 0x011d0004000a179f03ac00668dc6e808f21c6f7a9e3a97936e13202b0fcbef (31 bytes)
21:07:39.329 SERIAL » [ACK] (0x06)
21:07:39.331 DRIVER « [Node 010] [REQ] [ApplicationCommand]
└─[Security2CCMessageEncapsulation]
│ sequence number: 172
└─[SupervisionCCGet]
│ session id: 1
│ request updates: false
└─[EntryControlCCNotification]
sequence number: 252
data type: 2
event type: 1
event data: 5
2022-07-13 21:07:39.336 INFO ZWAVE: Node 10 CC Entry Control { eventType: 1, dataType: 2, eventData: '5' }
```