### PR TITLE
fix(controller): check if node can sleep in `getAvailableFirmwareUpdates` before waiting for wake up

### DIFF
--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -4990,12 +4990,12 @@ ${associatedNodes.join(", ")}`,
 	): Promise<FirmwareUpdateInfo[]> {
 		const node = this.nodes.getOrThrow(nodeId);
 
-		// Ensure the node is awake if it supports sleep
-		if (node.canSleep || node.supportsCC(CommandClasses["Wake Up"])) {
+		// Ensure the node is awake if it can sleep
+		if (node.canSleep) {
 			const didNodeWakeup = await Promise.race([
-				wait(60000, true).then(() => false as const),
-				node.waitForWakeup().then(() => true as const),
-			]);
+				wait(60000, true).then(() => false),
+				node.waitForWakeup().then(() => true),
+			]).catch(() => false);
 
 			if (!didNodeWakeup) {
 				throw new ZWaveError(

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -4990,16 +4990,19 @@ ${associatedNodes.join(", ")}`,
 	): Promise<FirmwareUpdateInfo[]> {
 		const node = this.nodes.getOrThrow(nodeId);
 
-		const didNodeWakeup = await Promise.race([
-			wait(60000, true).then(() => false as const),
-			node.waitForWakeup().then(() => true as const),
-		]);
+		// Ensure the node is awake if it supports sleep
+		if (node.canSleep || node.supportsCC(CommandClasses["Wake Up"])) {
+			const didNodeWakeup = await Promise.race([
+				wait(60000, true).then(() => false as const),
+				node.waitForWakeup().then(() => true as const),
+			]);
 
-		if (!didNodeWakeup) {
-			throw new ZWaveError(
-				`Cannot check for firmware updates for node ${nodeId}: The node did not wake up within 1 minute!`,
-				ZWaveErrorCodes.FWUpdateService_MissingInformation,
-			);
+			if (!didNodeWakeup) {
+				throw new ZWaveError(
+					`Cannot check for firmware updates for node ${nodeId}: The node did not wake up within 1 minute!`,
+					ZWaveErrorCodes.FWUpdateService_MissingInformation,
+				);
+			}
 		}
 
 		// Do not rely on stale information, query everything fresh from the node


### PR DESCRIPTION
Fixes https://github.com/zwave-js/node-zwave-js/issues/4799
Ensure the node can sleep, before enforcing a check on its state
