### PR TITLE
fix(config): add Load Power parameter to Heltun HE-TPS01

### DIFF
--- a/packages/config/config/devices/0x0344/he-tps01.json
+++ b/packages/config/config/devices/0x0344/he-tps01.json
@@ -51,7 +51,7 @@
 		{
 			"#": "12",
 			"$import": "templates/heltun_template.json#relay_load_power",
-			"label": "Relay Load Power in watt"
+			"label": "Relay 1: Load Power"
 		},
 		{
 			"#": "17",

--- a/packages/config/config/devices/0x0344/he-tps01.json
+++ b/packages/config/config/devices/0x0344/he-tps01.json
@@ -50,7 +50,7 @@
 		},
 		{
 			"#": "12",
-			"$import": "templates/heltun_template.json#relay_load_power_in_watt",
+			"$import": "templates/heltun_template.json#relay_load_power",
 			"label": "Relay Load Power in watt"
 		},
 		{

--- a/packages/config/config/devices/0x0344/he-tps01.json
+++ b/packages/config/config/devices/0x0344/he-tps01.json
@@ -49,6 +49,11 @@
 			"label": "Relay 1: Output Mode"
 		},
 		{
+			"#": "12",
+			"$import": "templates/heltun_template.json#relay_load_power_in_watt",
+			"label": "Relay Load Power in watt"
+		},
+		{
 			"#": "17",
 			"$import": "templates/heltun_template.json#temp_sensor_calibration",
 			"label": "Air Temperature Calibration"


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

Simple PR to add power consumption on heltun HE-TPS01.
There are probably other parameters missing, but that will be for another day 😄 
The full doc is available here: https://drive.google.com/file/d/1jNJK13OCMVjrlQWunG04pwIp9D60Yk0B/view
