### PR TITLE
fix(config): simplify base_options templates

### DIFF
--- a/packages/config/config/devices/0x0086/dsb28.json
+++ b/packages/config/config/devices/0x0086/dsb28.json
@@ -34,7 +34,7 @@
 	"paramInformation": [
 		{
 			"#": "2",
-			"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+			"$import": "~/templates/master_template.json#base_options_nounit",
 			"label": "Energy Detection Mode",
 			"options": [
 				{

--- a/packages/config/config/devices/0x0086/dsc14.json
+++ b/packages/config/config/devices/0x0086/dsc14.json
@@ -60,7 +60,7 @@
 		},
 		{
 			"#": "8",
-			"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+			"$import": "~/templates/master_template.json#base_options_nounit",
 			"label": "Count of External Buttons/Switches",
 			"options": [
 				{

--- a/packages/config/config/devices/0x0086/templates/aeotec_template.json
+++ b/packages/config/config/devices/0x0086/templates/aeotec_template.json
@@ -351,7 +351,7 @@
 		]
 	},
 	"celsius_fahrenheit_0": {
-		"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+		"$import": "~/templates/master_template.json#base_options_nounit",
 		"label": "Temperature Unit",
 		"valueSize": 4,
 		"options": [
@@ -699,7 +699,7 @@
 		]
 	},
 	"invert_state_report": {
-		"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+		"$import": "~/templates/master_template.json#base_options_nounit",
 		"label": "Invert Binary Report Value",
 		"options": [
 			{
@@ -713,7 +713,7 @@
 		]
 	},
 	"invert_basic_set": {
-		"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+		"$import": "~/templates/master_template.json#base_options_nounit",
 		"label": "Invert Basic Set on Open/Close Event",
 		"options": [
 			{
@@ -808,7 +808,7 @@
 		"unsigned": true
 	},
 	"report_power_voltage": {
-		"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+		"$import": "~/templates/master_template.json#base_options_nounit",
 		"label": "Multilevel Sensor Report Content",
 		"options": [
 			{
@@ -1520,7 +1520,7 @@
 		]
 	},
 	"sensor_operation_mode": {
-		"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+		"$import": "~/templates/master_template.json#base_options_nounit",
 		"label": "Sensor Operation Mode",
 		"options": [
 			{
@@ -1654,7 +1654,7 @@
 		"defaultValue": 1
 	},
 	"external_switch_two": {
-		"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+		"$import": "~/templates/master_template.json#base_options_nounit",
 		"label": "External Switch Type",
 		"options": [
 			{
@@ -1783,7 +1783,7 @@
 		]
 	},
 	"switch_mode_state_s1": {
-		"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+		"$import": "~/templates/master_template.json#base_options_nounit",
 		"label": "Switch Mode (S1): State Sync",
 		"allowManualEntry": false,
 		"options": [
@@ -1798,7 +1798,7 @@
 		]
 	},
 	"switch_mode_state_s2": {
-		"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+		"$import": "~/templates/master_template.json#base_options_nounit",
 		"label": "Switch Mode (S2): State Sync",
 		"allowManualEntry": false,
 		"options": [
@@ -2151,7 +2151,7 @@
 		]
 	},
 	"dimming_principle": {
-		"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+		"$import": "~/templates/master_template.json#base_options_nounit",
 		"label": "Dimming Principle",
 		"defaultValue": 1,
 		"options": [
@@ -3069,7 +3069,7 @@
 		]
 	},
 	"wallmote_command_type": {
-		"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+		"$import": "~/templates/master_template.json#base_options_nounit",
 		"label": "Command Type to Send Association Groups",
 		"options": [
 			{
@@ -3114,7 +3114,7 @@
 		"defaultValue": 1
 	},
 	"wave_option": {
-		"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+		"$import": "~/templates/master_template.json#base_options_nounit",
 		"label": "Wave Option",
 		"valueSize": 4,
 		"defaultValue": 1,
@@ -3289,7 +3289,7 @@
 		"label": "WallSwipe Sensitivity"
 	},
 	"wallswipe_status": {
-		"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+		"$import": "~/templates/master_template.json#base_options_nounit",
 		"label": "WallSwipe Status",
 		"options": [
 			{

--- a/packages/config/config/devices/0x0086/zw056.json
+++ b/packages/config/config/devices/0x0086/zw056.json
@@ -117,7 +117,7 @@
 		},
 		{
 			"#": "10",
-			"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+			"$import": "~/templates/master_template.json#base_options_nounit",
 			"label": "Define The Function of Button- and Button+",
 			"options": [
 				{
@@ -132,7 +132,7 @@
 		},
 		{
 			"#": "11",
-			"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+			"$import": "~/templates/master_template.json#base_options_nounit",
 			"label": "Short/Long Press Function of Button- And Button+",
 			"options": [
 				{

--- a/packages/config/config/devices/0x0086/zw062.json
+++ b/packages/config/config/devices/0x0086/zw062.json
@@ -49,7 +49,7 @@
 		},
 		{
 			"#": "34",
-			"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+			"$import": "~/templates/master_template.json#base_options_nounit",
 			"label": "Sensor Calibration",
 			"description": "To calibrate, close door fully. Initiate calibration. Open door fully, then close door fully.",
 			"options": [
@@ -261,7 +261,7 @@
 		},
 		{
 			"#": "47",
-			"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+			"$import": "~/templates/master_template.json#base_options_nounit",
 			"label": "Short/Long Press Function of Button- And Button+",
 			"options": [
 				{

--- a/packages/config/config/devices/0x0086/zw121.json
+++ b/packages/config/config/devices/0x0086/zw121.json
@@ -77,7 +77,7 @@
 		},
 		{
 			"#": "35",
-			"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+			"$import": "~/templates/master_template.json#base_options_nounit",
 			"label": "Cold/Warm White Display Mode",
 			"defaultValue": 1,
 			"options": [

--- a/packages/config/config/devices/0x0086/zw122.json
+++ b/packages/config/config/devices/0x0086/zw122.json
@@ -255,7 +255,7 @@
 		},
 		{
 			"#": "94",
-			"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+			"$import": "~/templates/master_template.json#base_options_nounit",
 			"label": "Battery Source to Report",
 			"options": [
 				{

--- a/packages/config/config/devices/0x019b/z-dim2.json
+++ b/packages/config/config/devices/0x019b/z-dim2.json
@@ -154,7 +154,7 @@
 		{
 			"#": "6",
 			"label": "Rotary Wheel Press Functionality",
-			"$import": "~/templates/master_template.json#base_0-2_options_nounit",
+			"$import": "~/templates/master_template.json#base_options_nounit",
 			"unsigned": true,
 			"options": [
 				{
@@ -174,7 +174,7 @@
 		{
 			"#": "7",
 			"label": "External Switch Functionality",
-			"$import": "~/templates/master_template.json#base_0-2_options_nounit",
+			"$import": "~/templates/master_template.json#base_options_nounit",
 			"unsigned": true,
 			"options": [
 				{
@@ -204,7 +204,7 @@
 		{
 			"#": "9",
 			"label": "Dimmer Curve",
-			"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+			"$import": "~/templates/master_template.json#base_options_nounit",
 			"unsigned": true,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0371/zw175.json
+++ b/packages/config/config/devices/0x0371/zw175.json
@@ -34,7 +34,7 @@
 		},
 		{
 			"#": "9[0x01]",
-			"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+			"$import": "~/templates/master_template.json#base_options_nounit",
 			"label": "Alarm Trigger State",
 			"valueSize": 2,
 			"options": [

--- a/packages/config/config/devices/0x0371/zwa012.json
+++ b/packages/config/config/devices/0x0371/zwa012.json
@@ -92,7 +92,7 @@
 		},
 		{
 			"#": "3",
-			"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+			"$import": "~/templates/master_template.json#base_options_nounit",
 			"label": "State when magnet is close to sensor",
 			"options": [
 				{
@@ -168,7 +168,7 @@
 		},
 		{
 			"#": "16",
-			"$import": "~/templates/master_template.json#base_0-1_options_nounit",
+			"$import": "~/templates/master_template.json#base_options_nounit",
 			"label": "Tilt sensor polarity when sensor is vertical",
 			"options": [
 				{

--- a/packages/config/config/devices/templates/master_template.json
+++ b/packages/config/config/devices/templates/master_template.json
@@ -63,18 +63,11 @@
 			}
 		]
 	},
-	"base_0-1_options_nounit": {
-		// This template is meant to be used for parameters that have predefined options
+	"base_options_nounit": {
+		// This template is meant to be used for all parameters that
+		// allow selection of predefined options without manual entry
 		"valueSize": 1,
-		"minValue": 0,
-		"maxValue": 1,
-		"defaultValue": 0,
-		"allowManualEntry": false
-	},
-	"base_0-2_options_nounit": {
-		"valueSize": 1,
-		"minValue": 0,
-		"maxValue": 2,
+		// min/max value are inferred from the defined options
 		"defaultValue": 0,
 		"allowManualEntry": false
 	},


### PR DESCRIPTION
Since min and max are inferred from the given options when `allowManualEntry` is `false`, it no longer makes sense to define them in the template - and especially have another set for different ranges. This change should simplify things a bit.