### PR TITLE
refactor: move `Driver.interviewNode` method to the `ZWaveNode` class 

### DIFF
--- a/docs/getting-started/migrating-to-v10.md
+++ b/docs/getting-started/migrating-to-v10.md
@@ -128,6 +128,11 @@ public static getNotificationMode(
 If you're constructing `SendData[Bridge][Multicast]Request`s manually, the `maxSendAttempts` property now needs to be set if more than 1 attempts are desired.
 The driver does this automatically when using the `sendCommand` method, so most use cases should not be affected.
 
+## Moved the `Driver.interviewNode` method to the `ZWaveNode` class
+
+The method `interviewNode(node: ZWaveNode)` which is meant to kick off a deferred initial interview for a node was moved to the `ZWaveNode` class.
+The new signature is now `node.interview()`.
+
 ## Removed the `"zwave-js/CommandClass"` sub-package export
 
 The CC implementations have been moved to their own package, `@zwave-js/cc`. Simply replace the imports with the new package name.

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1280,25 +1280,6 @@ export class Driver
 		}
 	}
 
-	/**
-	 * Starts or resumes the interview of a Z-Wave node.
-	 *
-	 * **NOTE:** This is only allowed when the initial interview was bypassed using the
-	 * `interview.disableOnNodeAdded` option. Otherwise, this method will throw an error.
-	 *
-	 * **NOTE:** It is advised to NOT await this method as it can take a very long time (minutes to hours)!
-	 */
-	public async interviewNode(node: ZWaveNode): Promise<void> {
-		if (!this.options.interview?.disableOnNodeAdded) {
-			throw new ZWaveError(
-				`Calling Driver.interviewNode is not allowed because automatic node interviews are enabled. Use ZWaveNode.refreshInfo() to re-interview a node.`,
-				ZWaveErrorCodes.Driver_FeatureDisabled,
-			);
-		}
-
-		return this.interviewNodeInternal(node);
-	}
-
 	private retryNodeInterviewTimeouts = new Map<number, NodeJS.Timeout>();
 	/**
 	 * @internal
@@ -1332,7 +1313,7 @@ export class Driver
 		const maxInterviewAttempts = this.options.attempts.nodeInterview;
 
 		try {
-			if (!(await node.interview())) {
+			if (!(await node.interviewInternal())) {
 				// Find out if we may retry the interview
 				if (node.status === NodeStatus.Dead) {
 					this.controllerLog.logNode(

--- a/packages/zwave-js/src/lib/node/Node.test.ts
+++ b/packages/zwave-js/src/lib/node/Node.test.ts
@@ -642,7 +642,7 @@ describe("lib/node/Node", () => {
 
 			it("should execute all the interview methods", async () => {
 				node.interviewStage = InterviewStage.None;
-				await node.interview();
+				await node.interviewInternal();
 				for (const method of Object.keys(originalMethods)) {
 					expect((node as any)[method]).toBeCalled();
 				}
@@ -650,7 +650,7 @@ describe("lib/node/Node", () => {
 
 			it("should not execute any interview method if the interview is completed", async () => {
 				node.interviewStage = InterviewStage.Complete;
-				await node.interview();
+				await node.interviewInternal();
 				for (const method of Object.keys(originalMethods)) {
 					expect((node as any)[method]).not.toBeCalled();
 				}
@@ -658,7 +658,7 @@ describe("lib/node/Node", () => {
 
 			it("should skip all methods that belong to an earlier stage", async () => {
 				node.interviewStage = InterviewStage.NodeInfo;
-				await node.interview();
+				await node.interviewInternal();
 
 				const expectCalled = [
 					"interviewCCs",


### PR DESCRIPTION
The method was added on the driver class in 9.4.0 because it exposed a driver method that was originally internal. However it makes more sense to have this method directly on the node instance, so it is now moved there and renamed to `interview()`.