### PR TITLE
fix(config): skip querying config param name and info for TH6320ZW

### DIFF
--- a/packages/config/config/devices/0x0039/th6320zw.json
+++ b/packages/config/config/devices/0x0039/th6320zw.json
@@ -182,5 +182,9 @@
 			"#": "42",
 			"$import": "templates/honeywell_template.json#temperature_offset"
 		}
-	]
+	],
+	"compat": {
+		"skipConfigurationNameQuery": true,
+		"skipConfigurationInfoQuery": true
+	}
 }

--- a/packages/config/config/devices/0x0039/th6320zw.json
+++ b/packages/config/config/devices/0x0039/th6320zw.json
@@ -184,6 +184,7 @@
 		}
 	],
 	"compat": {
+		// The device responds in a weird way to these requests which causes S2 collisions
 		"skipConfigurationNameQuery": true,
 		"skipConfigurationInfoQuery": true
 	}


### PR DESCRIPTION
Ref: https://github.com/zwave-js/node-red-contrib-zwave-js/discussions/230#discussioncomment-3195496