### PR TITLE
fix(cc): parse `supportedOperationTypes` bitmask of `User Code CC` correctly

### DIFF
--- a/packages/cc/src/cc/DoorLockCC.ts
+++ b/packages/cc/src/cc/DoorLockCC.ts
@@ -1144,6 +1144,8 @@ export class DoorLockCCCapabilitiesReport extends DoorLockCC {
 		validatePayload(this.payload.length >= offset + bitMaskLength + 1);
 		this.supportedOperationTypes = parseBitMask(
 			this.payload.slice(offset, offset + bitMaskLength),
+			// bit 0 is reserved, bitmask starts at 1
+			0,
 		);
 		offset += bitMaskLength;
 

--- a/packages/zwave-js/src/lib/test/cc/DoorLockCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/DoorLockCC.test.ts
@@ -356,7 +356,7 @@ describe("lib/commandclass/DoorLockCC => ", () => {
 			Buffer.from([
 				DoorLockCommand.CapabilitiesReport, // CC Command
 				1, // bit mask length
-				0b11, // operation types
+				0b110, // operation types
 				3, // list length
 				DoorLockMode.Unsecured,
 				DoorLockMode.InsideUnsecured,


### PR DESCRIPTION
fixes: #4844