### PR TITLE
refactor: move S2 inclusion user callbacks into `ZWaveOptions`

### DIFF
--- a/docs/api/CCs/Supervision.md
+++ b/docs/api/CCs/Supervision.md
@@ -4,20 +4,12 @@
 
 ## Supervision CC methods
 
-### `sendEncapsulated`
-
-```ts
-async sendEncapsulated(
-	encapsulated: CommandClass,
-	// If possible, keep us updated about the progress
-	requestStatusUpdates: boolean = true,
-): Promise<void>;
-```
-
 ### `sendReport`
 
 ```ts
 async sendReport(
-	options: SupervisionCCReportOptions & { secure?: boolean },
+	options: SupervisionCCReportOptions & {
+		encapsulationFlags?: EncapsulationFlags;
+	},
 ): Promise<void>;
 ```

--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -57,7 +57,6 @@ Depending on the chosen inclusion strategy, the options object requires addition
 type InclusionOptions =
 	| {
 			strategy: InclusionStrategy.Default;
-			userCallbacks: InclusionUserCallbacks;
 			/**
 			 * Force secure communication (S0) even when S2 is not supported and S0 is supported but not necessary.
 			 * This is not recommended due to the overhead caused by S0.
@@ -66,11 +65,12 @@ type InclusionOptions =
 	  }
 	| {
 			strategy: InclusionStrategy.Security_S2;
-			userCallbacks: InclusionUserCallbacks;
-	  }
-	| {
-			strategy: InclusionStrategy.Security_S2;
-			provisioning: PlannedProvisioningEntry;
+			/**
+			 * The optional provisioning entry for the device to be included.
+			 * If not given, the inclusion user callbacks of the driver options
+			 * will be used.
+			 */
+			provisioning?: PlannedProvisioningEntry;
 	  }
 	| {
 			strategy:
@@ -79,7 +79,7 @@ type InclusionOptions =
 	  };
 ```
 
-For inclusion with _Security S2_, this includes callbacks into the application which are defined as follows:
+For inclusion with _Security S2_, callbacks into the application must be defined as part of the [driver options](#ZWaveOptions) (`inclusionUserCallbacks`). They are defined as follows:
 
 <!-- #import InclusionUserCallbacks from "zwave-js" -->
 
@@ -143,6 +143,8 @@ enum SecurityClass {
 	S0_Legacy = 7,
 }
 ```
+
+> [!NOTE] These callbacks will also be called when inclusion is initiated by an inclusion controller. As such, the corresponding UI must not be linked to an application-initiated inclusion.
 
 Alternatively, the node can be pre-provisioned by providing the full DSK and the granted security classes instead of the user callbacks:
 

--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -703,6 +703,12 @@ interface ZWaveOptions extends ZWaveHostOptions {
 	};
 
 	/**
+	 * Defines the callbacks that are necessary to trigger user interaction during S2 inclusion.
+	 * If not given, nodes won't be included using S2, unless matching provisioning entries exists.
+	 */
+	inclusionUserCallbacks?: InclusionUserCallbacks;
+
+	/**
 	 * Some Command Classes support reporting that a value is unknown.
 	 * When this flag is `false`, unknown values are exposed as `undefined`.
 	 * When it is `true`, unknown values are exposed as the literal string "unknown" (even if the value is normally numeric).

--- a/docs/getting-started/migrating-to-v10.md
+++ b/docs/getting-started/migrating-to-v10.md
@@ -218,3 +218,9 @@ interface FoundNode {
 	controlledCCs?: CommandClasses[];
 }
 ```
+
+## Moved user callbacks for S2 inclusion into the driver options
+
+In order to support inclusion controllers (which is required for certification), the inclusion user callbacks had to be decoupled from application-initiated inclusion, since inclusion controllers will tell Z-Wave JS when to bootstrap S2 capable nodes.
+
+Instead of passing them via the `userCallbacks` property of the `InclusionOptions`, they are now passed directly to the driver via the `inclusionUserCallbacks` property of the `ZWaveOptions`.

--- a/packages/zwave-js/src/lib/controller/Inclusion.ts
+++ b/packages/zwave-js/src/lib/controller/Inclusion.ts
@@ -93,7 +93,6 @@ export interface InclusionUserCallbacks {
 export type InclusionOptions =
 	| {
 			strategy: InclusionStrategy.Default;
-			userCallbacks: InclusionUserCallbacks;
 			/**
 			 * Force secure communication (S0) even when S2 is not supported and S0 is supported but not necessary.
 			 * This is not recommended due to the overhead caused by S0.
@@ -102,11 +101,12 @@ export type InclusionOptions =
 	  }
 	| {
 			strategy: InclusionStrategy.Security_S2;
-			userCallbacks: InclusionUserCallbacks;
-	  }
-	| {
-			strategy: InclusionStrategy.Security_S2;
-			provisioning: PlannedProvisioningEntry;
+			/**
+			 * The optional provisioning entry for the device to be included.
+			 * If not given, the inclusion user callbacks of the driver options
+			 * will be used.
+			 */
+			provisioning?: PlannedProvisioningEntry;
 	  }
 	| {
 			strategy:
@@ -138,11 +138,7 @@ export type ReplaceNodeOptions =
 	// Therefore we need the user to specify how the node should be included
 	| {
 			strategy: InclusionStrategy.Security_S2;
-			userCallbacks: InclusionUserCallbacks;
-	  }
-	| {
-			strategy: InclusionStrategy.Security_S2;
-			provisioning: PlannedProvisioningEntry;
+			provisioning?: PlannedProvisioningEntry;
 	  }
 	| {
 			strategy:

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -329,6 +329,26 @@ function checkOptions(options: ZWaveOptions): void {
 			ZWaveErrorCodes.Driver_InvalidOptions,
 		);
 	}
+
+	if (options.inclusionUserCallbacks) {
+		if (!isObject(options.inclusionUserCallbacks)) {
+			throw new ZWaveError(
+				`The inclusionUserCallbacks must be an object!`,
+				ZWaveErrorCodes.Driver_InvalidOptions,
+			);
+		} else if (
+			typeof options.inclusionUserCallbacks.grantSecurityClasses !==
+				"function" ||
+			typeof options.inclusionUserCallbacks.validateDSKAndEnterPIN !==
+				"function" ||
+			typeof options.inclusionUserCallbacks.abort !== "function"
+		) {
+			throw new ZWaveError(
+				`The inclusionUserCallbacks must contain the following functions: grantSecurityClasses, validateDSKAndEnterPIN, abort!`,
+				ZWaveErrorCodes.Driver_InvalidOptions,
+			);
+		}
+	}
 }
 
 /**

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -2,6 +2,7 @@ import type { LogConfig } from "@zwave-js/core";
 import type { FileSystem, ZWaveHostOptions } from "@zwave-js/host";
 import type { ZWaveSerialPortBase } from "@zwave-js/serial";
 import type { SerialPort } from "serialport";
+import type { InclusionUserCallbacks } from "../controller/Inclusion";
 
 export interface ZWaveOptions extends ZWaveHostOptions {
 	/** Specify timeouts in milliseconds */
@@ -125,6 +126,12 @@ export interface ZWaveOptions extends ZWaveHostOptions {
 		S2_AccessControl?: Buffer;
 		S0_Legacy?: Buffer;
 	};
+
+	/**
+	 * Defines the callbacks that are necessary to trigger user interaction during S2 inclusion.
+	 * If not given, nodes won't be included using S2, unless matching provisioning entries exists.
+	 */
+	inclusionUserCallbacks?: InclusionUserCallbacks;
 
 	/**
 	 * Some Command Classes support reporting that a value is unknown.


### PR DESCRIPTION
This PR moves the S2 inclusion user callbacks out of the `InclusionOptions` interface and into `ZWaveOptions`. This is required to support inclusion controllers which tell Z-Wave JS when to bootstrap a node.

for https://github.com/zwave-js/node-zwave-js/issues/4852, required by https://github.com/zwave-js/node-zwave-js/pull/4851