### PR TITLE
fix: correct nested encapsulation of Supervision CC Reports

### DIFF
--- a/packages/cc/src/cc/SupervisionCC.ts
+++ b/packages/cc/src/cc/SupervisionCC.ts
@@ -88,6 +88,7 @@ export class SupervisionCCAPI extends PhysicalCCAPI {
 			options;
 		const cc = new SupervisionCCReport(this.applHost, {
 			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
 			...cmdOptions,
 		});
 

--- a/packages/cc/src/cc/SupervisionCC.ts
+++ b/packages/cc/src/cc/SupervisionCC.ts
@@ -128,7 +128,8 @@ export class SupervisionCC extends CommandClass {
 	public static requiresEncapsulation(cc: CommandClass): boolean {
 		return (
 			!!(cc.encapsulationFlags & EncapsulationFlags.Supervision) &&
-			!(cc instanceof SupervisionCCGet)
+			!(cc instanceof SupervisionCCGet) &&
+			!(cc instanceof SupervisionCCReport)
 		);
 	}
 

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -2362,7 +2362,11 @@ export class Driver
 								// If it was, we need to notify the sender that we couldn't decode the command
 								const node = this.getNodeUnsafe(msg);
 								if (node) {
-									await node
+									const endpoint =
+										node.getEndpoint(
+											msg.command.endpointIndex,
+										) ?? node;
+									await endpoint
 										.createAPI(
 											CommandClasses.Supervision,
 											false,
@@ -3217,7 +3221,10 @@ ${handlers.length} left`,
 
 						// send back a Supervision Report if the command was received via Supervision Get
 						if (supervisionSessionId !== undefined) {
-							await node
+							const endpoint =
+								node.getEndpoint(msg.command.endpointIndex) ??
+								node;
+							await endpoint
 								.createAPI(CommandClasses.Supervision, false)
 								.sendReport({
 									sessionId: supervisionSessionId,
@@ -3235,10 +3242,12 @@ ${handlers.length} left`,
 				// No one is waiting, dispatch the command to the node itself
 				if (supervisionSessionId !== undefined) {
 					// Wrap the handleCommand in try-catch so we can notify the node that we weren't able to handle the command
+					const endpoint =
+						node.getEndpoint(msg.command.endpointIndex) ?? node;
 					try {
 						await node.handleCommand(msg.command);
 
-						await node
+						await endpoint
 							.createAPI(CommandClasses.Supervision, false)
 							.sendReport({
 								sessionId: supervisionSessionId,
@@ -3249,7 +3258,7 @@ ${handlers.length} left`,
 								encapsulationFlags,
 							});
 					} catch (e) {
-						await node
+						await endpoint
 							.createAPI(CommandClasses.Supervision, false)
 							.sendReport({
 								sessionId: supervisionSessionId,


### PR DESCRIPTION
Reported [here](https://github.com/zwave-js/node-zwave-js/issues/4879?notification_referrer_id=NT_kwDOAQ0vDbM0MTMyMzE5Nzc2OjE3NjQxMjI5#issuecomment-1206733794)