### PR TITLE
refactor: move Supervision Session ID onto `ZWaveHost` interface

### DIFF
--- a/packages/cc/src/cc/SupervisionCC.ts
+++ b/packages/cc/src/cc/SupervisionCC.ts
@@ -54,15 +54,6 @@ export const SupervisionCCValues = Object.freeze({
 // @noSetValueAPI - This CC has no values to set
 // @noInterview - This CC is only used for encapsulation
 
-let sessionId = 0;
-/** Returns the next session ID to be used for supervision */
-export function getNextSessionId(): number {
-	// TODO: Check if this needs to be on the applHost for Security 2
-	sessionId = (sessionId + 1) & 0b111111;
-	if (sessionId === 0) sessionId++;
-	return sessionId;
-}
-
 // @noValidateArgs - Encapsulation CCs are used internally and too frequently that we
 // want to pay the cost of validating each call
 @API(CommandClasses.Supervision)
@@ -372,7 +363,7 @@ export class SupervisionCCGet extends SupervisionCC {
 				origin: options.origin,
 			});
 		} else {
-			this.sessionId = getNextSessionId();
+			this.sessionId = host.getNextSupervisionSessionId();
 			this.requestStatusUpdates = options.requestStatusUpdates;
 			this.encapsulated = options.encapsulated;
 			options.encapsulated.encapsulatingCC = this as any;

--- a/packages/core/api.md
+++ b/packages/core/api.md
@@ -1318,6 +1318,11 @@ export const MAX_NODES = 232;
 // @public
 export const MAX_REPEATERS = 4;
 
+// Warning: (ae-missing-release-tag) "MAX_SUPERVISION_SESSION_ID" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const MAX_SUPERVISION_SESSION_ID = 63;
+
 // Warning: (ae-forgotten-export) The symbol "BrandedUnknown" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "Maybe" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/packages/core/src/consts/index.ts
+++ b/packages/core/src/consts/index.ts
@@ -19,3 +19,5 @@ export const MAX_REPEATERS = 4;
 export { InterviewStage } from "./InterviewStage";
 export { NodeStatus } from "./NodeStatus";
 export * from "./Transmission";
+
+export const MAX_SUPERVISION_SESSION_ID = 0b111111;

--- a/packages/host/api.md
+++ b/packages/host/api.md
@@ -11,7 +11,7 @@ import type { ConfigManager } from '@zwave-js/config';
 import type { ControllerLogger } from '@zwave-js/core';
 import type { DeviceConfig } from '@zwave-js/config';
 import type { ICommandClass } from '@zwave-js/core';
-import type { IZWaveNode } from '@zwave-js/core';
+import { IZWaveNode } from '@zwave-js/core';
 import type { Maybe } from '@zwave-js/core';
 import type { Overwrite } from 'alcalzone-shared/types';
 import type { ReadonlyThrowingMap } from '@zwave-js/shared';
@@ -102,6 +102,7 @@ export interface ZWaveHost {
     // (undocumented)
     getHighestSecurityClass(nodeId: number): SecurityClass | undefined;
     getNextCallbackId(): number;
+    getNextSupervisionSessionId(): number;
     getSafeCCVersionForNode(cc: CommandClasses, nodeId: number, endpointIndex?: number): number;
     // (undocumented)
     hasSecurityClass(nodeId: number, securityClass: SecurityClass): Maybe<boolean>;

--- a/packages/host/src/ZWaveHost.ts
+++ b/packages/host/src/ZWaveHost.ts
@@ -67,6 +67,11 @@ export interface ZWaveHost {
 	 */
 	getNextCallbackId(): number;
 
+	/**
+	 * Returns the next session ID for supervised communication
+	 */
+	getNextSupervisionSessionId(): number;
+
 	getDeviceConfig?: (nodeId: number) => DeviceConfig | undefined;
 }
 

--- a/packages/host/src/mocks.ts
+++ b/packages/host/src/mocks.ts
@@ -1,8 +1,17 @@
 /* eslint-disable @typescript-eslint/require-await */
 import { ConfigManager } from "@zwave-js/config";
-import type { IZWaveNode } from "@zwave-js/core";
-import { ValueDB, ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
-import { createThrowingMap, type ThrowingMap } from "@zwave-js/shared";
+import {
+	IZWaveNode,
+	MAX_SUPERVISION_SESSION_ID,
+	ValueDB,
+	ZWaveError,
+	ZWaveErrorCodes,
+} from "@zwave-js/core";
+import {
+	createThrowingMap,
+	createWrappingCounter,
+	type ThrowingMap,
+} from "@zwave-js/shared";
 import type { Overwrite } from "alcalzone-shared/types";
 import type { ZWaveApplicationHost, ZWaveHost } from "./ZWaveHost";
 
@@ -21,13 +30,6 @@ export type TestingHost = Overwrite<
 export function createTestingHost(
 	options: Partial<CreateTestingHostOptions> = {},
 ): TestingHost {
-	let callbackId = 0xff;
-	const getNextCallbackId = () => {
-		callbackId = (callbackId + 1) & 0xff;
-		if (callbackId < 1) callbackId = 1;
-		return callbackId;
-	};
-
 	const valuesStorage = new Map();
 	const metadataStorage = new Map();
 	const valueDBCache = new Map<number, ValueDB>();
@@ -66,7 +68,10 @@ export function createTestingHost(
 			);
 		}),
 		getSafeCCVersionForNode: options.getSafeCCVersionForNode ?? (() => 100),
-		getNextCallbackId,
+		getNextCallbackId: createWrappingCounter(0xff),
+		getNextSupervisionSessionId: createWrappingCounter(
+			MAX_SUPERVISION_SESSION_ID,
+		),
 		getValueDB: (nodeId) => {
 			if (!valueDBCache.has(nodeId)) {
 				valueDBCache.set(

--- a/packages/shared/api.md
+++ b/packages/shared/api.md
@@ -57,6 +57,12 @@ export function cpp2js(str: string): string;
 // @public
 export function createThrowingMap<K, V>(throwKeyNotFound?: (key: K) => never): ThrowingMap<K, V>;
 
+// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// Warning: (ae-missing-release-tag) "createWrappingCounter" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function createWrappingCounter(maxValue: number): () => number;
+
 // Warning: (ae-missing-release-tag) "DeepPartial" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,3 +10,4 @@ export * from "./ThrowingMap";
 export * from "./TimedExpectation";
 export * from "./types";
 export * from "./utils";
+export * from "./wrappingCounter";

--- a/packages/shared/src/index_safe.ts
+++ b/packages/shared/src/index_safe.ts
@@ -9,3 +9,4 @@ export * from "./ThrowingMap";
 export * from "./TimedExpectation";
 export * from "./types";
 export * from "./utils";
+export * from "./wrappingCounter";

--- a/packages/shared/src/wrappingCounter.test.ts
+++ b/packages/shared/src/wrappingCounter.test.ts
@@ -1,0 +1,25 @@
+import { createWrappingCounter } from "./wrappingCounter";
+
+describe("wrappingCounter", () => {
+	it("should return 1 first", () => {
+		const c1 = createWrappingCounter(1);
+		const c2 = createWrappingCounter(0b1111);
+		expect(c1()).toBe(1);
+		expect(c2()).toBe(1);
+	});
+
+	it("should wrap back to 1 after surpassing the max value", () => {
+		// Useless counter, but it's a good test to make sure that the wrapping works
+		const c1 = createWrappingCounter(1);
+		expect(c1()).toBe(1);
+		expect(c1()).toBe(1);
+		expect(c1()).toBe(1);
+		expect(c1()).toBe(1);
+
+		const c2 = createWrappingCounter(0b11);
+		expect(c2()).toBe(1);
+		expect(c2()).toBe(2);
+		expect(c2()).toBe(3);
+		expect(c2()).toBe(1);
+	});
+});

--- a/packages/shared/src/wrappingCounter.ts
+++ b/packages/shared/src/wrappingCounter.ts
@@ -3,10 +3,17 @@
  * @param maxValue The maximum value that the counter can reach. Must a number where all bits are set to 1.
  */
 export function createWrappingCounter(maxValue: number): () => number {
-	let value = 0;
-	return () => {
-		value = (value + 1) & maxValue;
-		if (value === 0) value = 1;
-		return value;
+	const ret = (() => {
+		ret.value = (ret.value + 1) & maxValue;
+		if (ret.value === 0) ret.value = 1;
+		return ret.value;
+	}) as {
+		(): number;
+		// Little hack for testing purposes.
+		// TODO: Remove when packages/zwave-js/src/lib/test/driver/nodeAsleepBlockNonceReport.test.ts and packages/zwave-js/src/lib/test/driver/nodeAsleepMessageOrder.test.ts
+		// no longer need this
+		value: number;
 	};
+	ret.value = 0;
+	return ret;
 }

--- a/packages/shared/src/wrappingCounter.ts
+++ b/packages/shared/src/wrappingCounter.ts
@@ -1,0 +1,12 @@
+/**
+ * Creates a counter that starts at 1 and wraps after surpassing `maxValue`.
+ * @param maxValue The maximum value that the counter can reach. Must a number where all bits are set to 1.
+ */
+export function createWrappingCounter(maxValue: number): () => number {
+	let value = 0;
+	return () => {
+		value = (value + 1) & maxValue;
+		if (value === 0) value = 1;
+		return value;
+	};
+}

--- a/packages/testing/api.md
+++ b/packages/testing/api.md
@@ -10,7 +10,7 @@
 import { CommandClasses } from '@zwave-js/core';
 import { CommandClassInfo } from '@zwave-js/core';
 import { FunctionType } from '@zwave-js/serial/safe';
-import type { ICommandClass } from '@zwave-js/core';
+import { ICommandClass } from '@zwave-js/core';
 import { Message } from '@zwave-js/serial';
 import type { MockPortBinding } from '@zwave-js/serial/mock';
 import { NodeProtocolInfoAndDeviceClass } from '@zwave-js/core';

--- a/packages/testing/src/MockController.ts
+++ b/packages/testing/src/MockController.ts
@@ -1,4 +1,4 @@
-import type { ICommandClass } from "@zwave-js/core";
+import { ICommandClass, MAX_SUPERVISION_SESSION_ID } from "@zwave-js/core";
 import type { ZWaveHost } from "@zwave-js/host";
 import {
 	Message,
@@ -7,7 +7,7 @@ import {
 	SerialAPIParser,
 } from "@zwave-js/serial";
 import type { MockPortBinding } from "@zwave-js/serial/mock";
-import { TimedExpectation } from "@zwave-js/shared/safe";
+import { createWrappingCounter, TimedExpectation } from "@zwave-js/shared/safe";
 import {
 	getDefaultMockControllerCapabilities,
 	MockControllerCapabilities,
@@ -52,9 +52,11 @@ export class MockController {
 			securityManager2: undefined,
 			// nodes: this.nodes as any,
 			getNextCallbackId: () => 1,
+			getNextSupervisionSessionId: createWrappingCounter(
+				MAX_SUPERVISION_SESSION_ID,
+			),
 			getSafeCCVersionForNode: () => 100,
 			isCCSecure: () => false,
-
 			// TODO: We don't care about security classes yet
 			getHighestSecurityClass: () => undefined,
 			hasSecurityClass: () => false,

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -247,7 +247,8 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> implements Z
     enableStatistics(appInfo: Pick<AppInfo, "applicationName" | "applicationVersion">): void;
     static enumerateSerialPorts(): Promise<string[]>;
     getLogConfig(): LogConfig;
-    getNextCallbackId(): number;
+    readonly getNextCallbackId: () => number;
+    readonly getNextSupervisionSessionId: () => number;
     // (undocumented)
     getNodeUnsafe(msg: Message): ZWaveNode | undefined;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/packages/zwave-js/src/lib/driver/Driver.integration.test.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.integration.test.ts
@@ -86,7 +86,7 @@ describe("lib/driver/Driver", () => {
 			driver.removeAllListeners();
 		});
 
-		it("the automatically created callback ID should be incremented and wrap from 0xff back to 10", () => {
+		it("the automatically created callback ID should be incremented and wrap from 0xff back to 1", () => {
 			let lastCallbackId: number | undefined;
 			for (let i = 0; i <= 300; i++) {
 				if (i === 300) {

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -47,6 +47,7 @@ import {
 	ICommandClass,
 	isZWaveError,
 	LogConfig,
+	MAX_SUPERVISION_SESSION_ID,
 	Maybe,
 	MessagePriority,
 	nwiHomeIdFromDSK,
@@ -92,6 +93,7 @@ import {
 	ZWaveSocket,
 } from "@zwave-js/serial";
 import {
+	createWrappingCounter,
 	DeepPartial,
 	getErrorMessage,
 	isDocker,
@@ -3406,16 +3408,19 @@ ${handlers.length} left`,
 		}
 	}
 
-	private lastCallbackId = 0xff;
 	/**
 	 * Returns the next callback ID. Callback IDs are used to correlate requests
 	 * to the controller/nodes with its response
 	 */
-	public getNextCallbackId(): number {
-		this.lastCallbackId = (this.lastCallbackId + 1) & 0xff;
-		if (this.lastCallbackId < 1) this.lastCallbackId = 1;
-		return this.lastCallbackId;
-	}
+	public readonly getNextCallbackId = createWrappingCounter(0xff);
+
+	/**
+	 * Returns the next callback ID. Callback IDs are used to correlate requests
+	 * to the controller/nodes with its response
+	 */
+	public readonly getNextSupervisionSessionId = createWrappingCounter(
+		MAX_SUPERVISION_SESSION_ID,
+	);
 
 	private encapsulateCommands(msg: Message & ICommandClassContainer): void {
 		// The encapsulation order (from outside to inside) is as follows:

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepBlockNonceReport.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepBlockNonceReport.test.ts
@@ -53,7 +53,8 @@ describe("regression tests", () => {
 		for (const node of driver.controller.nodes.values()) {
 			driver["addNodeEventHandlers"](node);
 		}
-		driver["lastCallbackId"] = 2;
+		// TODO: remove hack in packages/shared/src/wrappingCounter.ts when reworking this test to the new testing setup
+		(driver.getNextCallbackId as any).value = 2;
 
 		node44["isListening"] = false;
 		node44["isFrequentListening"] = false;

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepMessageOrder.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepMessageOrder.test.ts
@@ -55,7 +55,8 @@ describe("regression tests", () => {
 		node10.markAsAwake();
 		expect(node10.status).toBe(NodeStatus.Awake);
 
-		driver["lastCallbackId"] = 2;
+		// TODO: remove hack in packages/shared/src/wrappingCounter.ts when reworking this test to the new testing setup
+		(driver.getNextCallbackId as any).value = 2;
 		const ACK = Buffer.from([MessageHeaders.ACK]);
 
 		const pingPromise10 = node10.ping();


### PR DESCRIPTION
Otherwise we end up with coupled session IDs in testing