### PR TITLE
ci(bot): add command to approve PR

### DIFF
--- a/.github/workflows/bot-approve.yml
+++ b/.github/workflows/bot-approve.yml
@@ -1,0 +1,36 @@
+name: 'Z-Wave Bot: Approve PR'
+
+on:
+  issue_comment:
+    types: [created] # edited, deleted
+
+jobs:
+  # #########################################################################
+  # Approves a PR when authorized person comments
+  # @zwave-js-bot approve
+  approve-pr-manually:
+    if: |
+      contains(github.event.issue.html_url, '/pull/') &&
+      contains(github.event.comment.body, '@zwave-js-bot approve') &&
+      github.event.comment.user.login == 'AlCalzone'
+
+    runs-on: [ubuntu-latest]
+    strategy:
+      matrix:
+        node-version: [16.x] # This should be LTS
+
+    steps:
+    - uses: actions/github-script@v6
+      with:
+        github-token: ${{secrets.BOT_TOKEN}}
+        script: |
+          const options = {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          };
+
+          await github.rest.pulls.createReview({
+            ...options,
+            pull_number: context.payload.issue.number,
+            event: "APPROVE"
+          });


### PR DESCRIPTION
This PR adds a new command (for me only) to have Botty approve a PR. This enables auto-merging PRs that are still in the testing pipeline