### PR TITLE
feat(config): add MP31ZP (rebranded MP21ZP)

### DIFF
--- a/packages/config/config/devices/0x0312/mp21zp_mp31zp.json
+++ b/packages/config/config/devices/0x0312/mp21zp_mp31zp.json
@@ -1,7 +1,7 @@
 {
 	"manufacturer": "Minoston",
 	"manufacturerId": "0x0312",
-	"label": "MP21ZP",
+	"label": "MP21ZP / MP31ZP",
 	"description": "Mini Plug with Power Meter",
 	"devices": [
 		{


### PR DESCRIPTION
Looks like there was either a mixup in the firmware and it is identical to the MP21ZP, or the manual is wrong. Essentially, this device behaves just like the MP21ZP