### PR TITLE
fix(config): param 9 for STEINEL devices, rework to templates

### DIFF
--- a/packages/config/config/devices/0x0271/is140-2.json
+++ b/packages/config/config/devices/0x0271/is140-2.json
@@ -20,159 +20,59 @@
 	"paramInformation": [
 		{
 			"#": "1",
-			"label": "Time",
-			"description": "Duration of light after motion detection",
-			"unit": "s",
-			"valueSize": 2,
-			"minValue": 5,
-			"maxValue": 900,
-			"defaultValue": 180
+			"$import": "templates/steinel_template.json#motion_light_duration"
 		},
 		{
 			"#": "2",
-			"label": "Light",
-			"description": "Light threshold",
-			"unit": "lx",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 2000,
-			"defaultValue": 2000
+			"$import": "templates/steinel_template.json#light_threshold"
 		},
 		{
 			"#": "5",
-			"label": "Sensitivity",
-			"description": "Motion Radar Sensitivity",
-			"unit": "Percent",
-			"valueSize": 1,
-			"minValue": 2,
-			"maxValue": 100,
-			"defaultValue": 100
+			"$import": "templates/steinel_template.json#motion_sensor_sensitivity"
 		},
 		{
 			"#": "8",
-			"label": "Global_Light",
-			"description": "External ambient light value",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1
+			"$import": "templates/steinel_template.json#external_light_sensor"
 		},
 		{
 			"#": "9[0x01]",
-			"label": "External Control",
-			"description": "Lamp is controlled via Z-Wave and internal sensors are not used.",
-			"valueSize": 1,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
+			"$import": "templates/steinel_template.json#lamp_external_control"
 		},
 		{
 			"#": "9[0x02]",
-			"label": "Gateway Check",
-			"description": "",
-			"valueSize": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
+			"$import": "templates/steinel_template.json#lamp_gateway_check"
 		},
 		{
 			"#": "9[0x04]",
-			"label": "Permanently On",
-			"description": "",
-			"valueSize": 1,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
+			"$import": "templates/steinel_template.json#lamp_permanently_on"
 		},
 		{
 			"#": "10",
-			"label": "(OFF_BEHAVIOUR)",
-			"description": "Off behaviour (timeout)",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 10
+			"$import": "templates/steinel_template.json#off_command_duration"
 		},
 		{
 			"#": "11",
-			"label": "ON_BEHAVIOUR",
-			"description": "On behaviour (timeout)",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 255
+			"$import": "templates/steinel_template.json#on_command_duration"
 		},
 		{
 			"#": "12",
-			"label": "ON_TIME_OVER",
-			"description": "On behaviour time over (timeout)",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 204
+			"$import": "templates/steinel_template.json#motion_wait_limit"
 		},
 		{
 			"#": "13",
-			"label": "ON_OFF_ BEHAVIOUR",
-			"description": "Sequence On-Off behaviour (timeout)",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 204
+			"$import": "templates/steinel_template.json#on_off_sequence_off_duration"
 		},
 		{
 			"#": "14",
-			"label": "OFF_ON_ BEHAVIOUR",
-			"description": "Sequence Off-On behaviour (timeout)",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 204
+			"$import": "templates/steinel_template.json#off_on_sequence_on_duration"
 		},
 		{
 			"#": "15",
-			"label": "SEQUENCE_ TIME",
-			"description": "Sequence timing",
-			"valueSize": 1,
-			"minValue": 10,
-			"maxValue": 50,
-			"defaultValue": 10
+			"$import": "templates/steinel_template.json#sequence_timing"
 		},
 		{
 			"#": "16",
-			"label": "MOTION_ DISABLE",
-			"description": "Motion Off behaviour (timeout)",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 0
+			"$import": "templates/steinel_template.json#command_motion_disable_timeout"
 		}
 	]
 }

--- a/packages/config/config/devices/0x0271/is140-2.json
+++ b/packages/config/config/devices/0x0271/is140-2.json
@@ -35,16 +35,8 @@
 			"$import": "templates/steinel_template.json#external_light_sensor"
 		},
 		{
-			"#": "9[0x01]",
-			"$import": "templates/steinel_template.json#lamp_external_control"
-		},
-		{
-			"#": "9[0x02]",
-			"$import": "templates/steinel_template.json#lamp_gateway_check"
-		},
-		{
-			"#": "9[0x04]",
-			"$import": "templates/steinel_template.json#lamp_permanently_on"
+			"#": "9[0x07]",
+			"$import": "templates/steinel_template.json#light_behavior"
 		},
 		{
 			"#": "10",

--- a/packages/config/config/devices/0x0271/is140-2.json
+++ b/packages/config/config/devices/0x0271/is140-2.json
@@ -173,6 +173,6 @@
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 0
-		}	
+		}
 	]
 }

--- a/packages/config/config/devices/0x0271/is140-2.json
+++ b/packages/config/config/devices/0x0271/is140-2.json
@@ -60,7 +60,7 @@
 		{
 			"#": "9[0x01]",
 			"label": "External Control",
-			"description": "When enabled, the lamp is controlled externally via Z-Wave and internal sensors are not used.",
+			"description": "Lamp is controlled via Z-Wave and internal sensors are not used.",
 			"valueSize": 1,
 			"defaultValue": 0,
 			"allowManualEntry": false,
@@ -78,7 +78,7 @@
 		{
 			"#": "9[0x02]",
 			"label": "Gateway Check",
-			"description": "External Control disabled: Lamp signalizes failure to reach the gateway. External Control enabled: Lamp falls back to normal mode after gateway could not be reached repeatedly.",
+			"description": "",
 			"valueSize": 1,
 			"defaultValue": 1,
 			"allowManualEntry": false,
@@ -96,7 +96,7 @@
 		{
 			"#": "9[0x04]",
 			"label": "Permanently On",
-			"description": "When enabled, overrides the External Control and Gateway Check parameters",
+			"description": "",
 			"valueSize": 1,
 			"defaultValue": 0,
 			"allowManualEntry": false,

--- a/packages/config/config/devices/0x0271/is140-2.json
+++ b/packages/config/config/devices/0x0271/is140-2.json
@@ -58,6 +58,60 @@
 			"defaultValue": 1
 		},
 		{
+			"#": "9[0x01]",
+			"label": "External Control",
+			"description": "When enabled, the lamp is controlled externally via Z-Wave and internal sensors are not used.",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "9[0x02]",
+			"label": "Gateway Check",
+			"description": "External Control disabled: Lamp signalizes failure to reach the gateway. External Control enabled: Lamp falls back to normal mode after gateway could not be reached repeatedly.",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "9[0x04]",
+			"label": "Permanently On",
+			"description": "When enabled, overrides the External Control and Gateway Check parameters",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		{
 			"#": "10",
 			"label": "(OFF_BEHAVIOUR)",
 			"description": "Off behaviour (timeout)",
@@ -119,60 +173,6 @@
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 0
-		},
-		{
-			"#": "9[0x01]",
-			"label": "Bit 0: Slave Mode",
-			"description": "0=Disable, 1=Enable",
-			"valueSize": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
-		},
-		{
-			"#": "9[0x02]",
-			"label": "Bit 1: Central Unit checking",
-			"description": "0=Disable, 1=Enable",
-			"valueSize": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
-		},
-		{
-			"#": "9[0x04]",
-			"label": "Bit 2: Stupid Mode",
-			"description": "0=Disable, 1=Enable",
-			"valueSize": 1,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
-		}
+		}	
 	]
 }

--- a/packages/config/config/devices/0x0271/l_810_led_ihf.json
+++ b/packages/config/config/devices/0x0271/l_810_led_ihf.json
@@ -78,13 +78,58 @@
 			"defaultValue": 1
 		},
 		{
-			"#": "9",
-			"label": "Slave_Mode",
-			"description": "Disable local control",
+			"#": "9[0x01]",
+			"label": "External Control",
+			"description": "When enabled, the lamp is controlled externally via Z-Wave and internal sensors are not used.",
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 4,
-			"defaultValue": 2
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "9[0x02]",
+			"label": "Gateway Check",
+			"description": "External Control disabled: Lamp signalizes failure to reach the gateway. External Control enabled: Lamp falls back to normal mode after gateway could not be reached repeatedly.",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "9[0x04]",
+			"label": "Permanently On",
+			"description": "When enabled, overrides the External Control and Gateway Check parameters",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
 		},
 		{
 			"#": "10",

--- a/packages/config/config/devices/0x0271/l_810_led_ihf.json
+++ b/packages/config/config/devices/0x0271/l_810_led_ihf.json
@@ -43,16 +43,8 @@
 			"$import": "templates/steinel_template.json#external_light_sensor"
 		},
 		{
-			"#": "9[0x01]",
-			"$import": "templates/steinel_template.json#lamp_external_control"
-		},
-		{
-			"#": "9[0x02]",
-			"$import": "templates/steinel_template.json#lamp_gateway_check"
-		},
-		{
-			"#": "9[0x04]",
-			"$import": "templates/steinel_template.json#lamp_permanently_on"
+			"#": "9[0x07]",
+			"$import": "templates/steinel_template.json#light_behavior"
 		},
 		{
 			"#": "10",

--- a/packages/config/config/devices/0x0271/l_810_led_ihf.json
+++ b/packages/config/config/devices/0x0271/l_810_led_ihf.json
@@ -80,7 +80,7 @@
 		{
 			"#": "9[0x01]",
 			"label": "External Control",
-			"description": "When enabled, the lamp is controlled externally via Z-Wave and internal sensors are not used.",
+			"description": "Lamp is controlled via Z-Wave and internal sensors are not used.",
 			"valueSize": 1,
 			"defaultValue": 0,
 			"allowManualEntry": false,
@@ -98,7 +98,7 @@
 		{
 			"#": "9[0x02]",
 			"label": "Gateway Check",
-			"description": "External Control disabled: Lamp signalizes failure to reach the gateway. External Control enabled: Lamp falls back to normal mode after gateway could not be reached repeatedly.",
+			"description": "",
 			"valueSize": 1,
 			"defaultValue": 1,
 			"allowManualEntry": false,
@@ -116,7 +116,7 @@
 		{
 			"#": "9[0x04]",
 			"label": "Permanently On",
-			"description": "When enabled, overrides the External Control and Gateway Check parameters",
+			"description": "",
 			"valueSize": 1,
 			"defaultValue": 0,
 			"allowManualEntry": false,

--- a/packages/config/config/devices/0x0271/l_810_led_ihf.json
+++ b/packages/config/config/devices/0x0271/l_810_led_ihf.json
@@ -16,182 +16,71 @@
 	"paramInformation": [
 		{
 			"#": "1",
-			"label": "Time",
-			"description": "Duration of light after motion detection.",
-			"valueSize": 2,
-			"minValue": 5,
-			"maxValue": 900,
-			"defaultValue": 180
+			"$import": "templates/steinel_template.json#motion_light_duration"
 		},
 		{
 			"#": "2",
-			"label": "Light",
-			"description": "Light threshold [lx]",
-			"valueSize": 2,
-			"minValue": 2,
-			"maxValue": 2000,
-			"defaultValue": 2000
+			"$import": "templates/steinel_template.json#light_threshold"
 		},
 		{
 			"#": "3",
-			"label": "Dim",
-			"description": "Night dim mode and time [min]: (only for SLAMP with DIM ability)",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 60,
-			"defaultValue": 0
+			"$import": "templates/steinel_template.json#night_dim_mode"
 		},
 		{
 			"#": "4",
-			"label": "Range",
-			"description": "Motion Radar Range [cm]: (only for iHF sensor)",
-			"valueSize": 2,
-			"minValue": 100,
-			"maxValue": 500,
-			"defaultValue": 500
+			"$import": "templates/steinel_template.json#motion_sensor_range"
 		},
 		{
 			"#": "5",
-			"label": "Sensity",
-			"description": "Motion Radar Sensitivity [%]: (SLAMP+SPIR)",
-			"valueSize": 1,
-			"minValue": 2,
-			"maxValue": 100,
-			"defaultValue": 100
+			"$import": "templates/steinel_template.json#motion_sensor_sensitivity"
 		},
 		{
 			"#": "6",
-			"label": "Brighntes Meas Interval",
-			"description": "Brightness measuring interval [min]: (only SLAMP)",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 120,
-			"defaultValue": 0
+			"$import": "templates/steinel_template.json#brightness_measuring_interval"
 		},
 		{
 			"#": "8",
-			"label": "Global_Light",
-			"description": "Use external Ambient Light value",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1
+			"$import": "templates/steinel_template.json#external_light_sensor"
 		},
 		{
 			"#": "9[0x01]",
-			"label": "External Control",
-			"description": "Lamp is controlled via Z-Wave and internal sensors are not used.",
-			"valueSize": 1,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
+			"$import": "templates/steinel_template.json#lamp_external_control"
 		},
 		{
 			"#": "9[0x02]",
-			"label": "Gateway Check",
-			"description": "",
-			"valueSize": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
+			"$import": "templates/steinel_template.json#lamp_gateway_check"
 		},
 		{
 			"#": "9[0x04]",
-			"label": "Permanently On",
-			"description": "",
-			"valueSize": 1,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
+			"$import": "templates/steinel_template.json#lamp_permanently_on"
 		},
 		{
 			"#": "10",
-			"label": "Off_Behaviour",
-			"description": "Off behaviour (timeout)",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 10
+			"$import": "templates/steinel_template.json#off_command_duration"
 		},
 		{
 			"#": "11",
-			"label": "On_Behaviour",
-			"description": "On behaviour (timeout)",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 255
+			"$import": "templates/steinel_template.json#on_command_duration"
 		},
 		{
 			"#": "12",
-			"label": "On_Time_Over",
-			"description": "On behaviour time over (timeout)",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 204
+			"$import": "templates/steinel_template.json#motion_wait_limit"
 		},
 		{
 			"#": "13",
-			"label": "On_Off_Behaviour",
-			"description": "Sequence On-Off behaviour (timeout)",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 204
+			"$import": "templates/steinel_template.json#on_off_sequence_off_duration"
 		},
 		{
 			"#": "14",
-			"label": "Off_On_Behaviour",
-			"description": "Sequence Off-On behaviour (timeout)",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 204
+			"$import": "templates/steinel_template.json#off_on_sequence_on_duration"
 		},
 		{
 			"#": "15",
-			"label": "Sequence_Time",
-			"valueSize": 1,
-			"minValue": 10,
-			"maxValue": 50,
-			"defaultValue": 10
+			"$import": "templates/steinel_template.json#sequence_timing"
 		},
 		{
 			"#": "16",
-			"label": "Motion_Disable",
-			"description": "Motion Off behaviour (timeout)",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 209
+			"$import": "templates/steinel_template.json#command_motion_disable_timeout"
 		}
 	]
 }

--- a/packages/config/config/devices/0x0271/motionswitch_led.json
+++ b/packages/config/config/devices/0x0271/motionswitch_led.json
@@ -77,7 +77,7 @@
 		{
 			"#": "9[0x01]",
 			"label": "Gateway Check",
-			"description": "Lamp signalizes failure to reach the gateway.",
+			"description": "",
 			"valueSize": 1,
 			"defaultValue": 1,
 			"allowManualEntry": false,
@@ -95,7 +95,7 @@
 		{
 			"#": "9[0x02]",
 			"label": "Permanently On",
-			"description": "When enabled, overrides the Gateway Check parameter",
+			"description": "",
 			"valueSize": 1,
 			"defaultValue": 0,
 			"allowManualEntry": false,

--- a/packages/config/config/devices/0x0271/motionswitch_led.json
+++ b/packages/config/config/devices/0x0271/motionswitch_led.json
@@ -35,16 +35,8 @@
 			"$import": "templates/steinel_template.json#external_light_sensor"
 		},
 		{
-			"#": "9[0x01]",
-			"$import": "templates/steinel_template.json#lamp_external_control"
-		},
-		{
-			"#": "9[0x02]",
-			"$import": "templates/steinel_template.json#lamp_gateway_check"
-		},
-		{
-			"#": "9[0x04]",
-			"$import": "templates/steinel_template.json#lamp_permanently_on"
+			"#": "9[0x07]",
+			"$import": "templates/steinel_template.json#light_behavior"
 		},
 		{
 			"#": "10",

--- a/packages/config/config/devices/0x0271/motionswitch_led.json
+++ b/packages/config/config/devices/0x0271/motionswitch_led.json
@@ -16,186 +16,150 @@
 	"paramInformation": [
 		{
 			"#": "1",
-			"label": "TIME",
-			"description": "Duration of light after motion detection [s]",
-			"unit": "s",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 900,
-			"defaultValue": 180,
-			"options": [
-				{
-					"label": "Duration of light after motion detection [s]",
-					"value": 0
-				}
-			]
+			"$import": "templates/steinel_template.json#motion_light_duration"
 		},
 		{
 			"#": "2",
-			"label": "LIGHT",
-			"description": "Light threshold [lx]",
-			"unit": "lx",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 2000,
-			"defaultValue": 2000,
-			"options": [
-				{
-					"label": "Light threshold [lx]",
-					"value": 0
-				}
-			]
+			"$import": "templates/steinel_template.json#light_threshold"
 		},
 		{
 			"#": "5",
-			"label": "SENSITIVITY",
-			"description": "Motion Radar Sensitivity [%]",
-			"unit": "%",
-			"valueSize": 1,
-			"minValue": 2,
-			"maxValue": 100,
-			"defaultValue": 100
+			"$import": "templates/steinel_template.json#motion_sensor_sensitivity"
 		},
 		{
 			"#": "6",
-			"label": "Brightness measuring interval",
-			"unit": "minutes",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 120,
-			"defaultValue": 0
+			"$import": "templates/steinel_template.json#brightness_measuring_interval"
 		},
 		{
 			"#": "8",
-			"label": "GLOBAL_LIGHT",
-			"description": "Use external Ambient Light Value",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1
+			"$import": "templates/steinel_template.json#external_light_sensor"
 		},
 		{
 			"#": "9[0x01]",
-			"label": "Gateway Check",
-			"description": "",
-			"valueSize": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
+			"$import": "templates/steinel_template.json#lamp_external_control"
 		},
 		{
 			"#": "9[0x02]",
-			"label": "Permanently On",
-			"description": "",
+			"$import": "templates/steinel_template.json#lamp_gateway_check"
+		},
+		{
+			"#": "9[0x04]",
+			"$import": "templates/steinel_template.json#lamp_permanently_on"
+		},
+		{
+			"#": "10",
+			"$import": "templates/steinel_template.json#off_command_duration"
+		},
+		{
+			"#": "11",
+			"$import": "templates/steinel_template.json#on_command_duration"
+		},
+		{
+			"#": "12",
+			"$import": "templates/steinel_template.json#motion_wait_limit"
+		},
+		{
+			"#": "13",
+			"$import": "templates/steinel_template.json#on_off_sequence_off_duration"
+		},
+		{
+			"#": "14",
+			"$import": "templates/steinel_template.json#off_on_sequence_on_duration"
+		},
+		{
+			"#": "15",
+			"$import": "templates/steinel_template.json#sequence_timing"
+		},
+		{
+			"#": "16",
+			"$import": "templates/steinel_template.json#command_motion_disable_timeout"
+		},
+		{
+			"#": "17[0x01]",
+			"label": "Button: Long Press",
 			"valueSize": 1,
 			"defaultValue": 0,
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Disable",
+					"label": "Lower brightness",
 					"value": 0
 				},
 				{
-					"label": "Enable",
+					"label": "Increase brightness",
 					"value": 1
 				}
 			]
 		},
 		{
-			"#": "10",
-			"label": "OFF_BEHAVIOUR",
-			"description": "Off behaviour ( timeout )",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 209,
-			"defaultValue": 10
-		},
-		{
-			"#": "11",
-			"label": "ON_BEHAVIOUR",
-			"description": "On behaviour ( timeout )",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 255
-		},
-		{
-			"#": "12",
-			"label": "ON_TIME_OVER",
-			"description": "On behaviour time over ( timeout )",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 209,
-			"defaultValue": 204
-		},
-		{
-			"#": "13",
-			"label": "ON_OFF_BEHAVIOUR",
-			"description": "Sequence On-Off behaviour ( timeout )",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 209,
-			"defaultValue": 204
-		},
-		{
-			"#": "14",
-			"label": "OFF_ON_BEHAVIOUR",
-			"description": "Sequence Off-On behaviour ( timeout )",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 209,
-			"defaultValue": 204
-		},
-		{
-			"#": "15",
-			"label": "SEQUENCE_TIME",
-			"description": "Sequence Off-On behaviour ( timeout )",
-			"unit": "100 ms",
+			"#": "17[0x02]",
+			"label": "Button: Short Press",
 			"valueSize": 1,
-			"minValue": 10,
-			"maxValue": 50,
-			"defaultValue": 10
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Toggle",
+					"value": 0
+				},
+				{
+					"label": "Control scene (parameter 18)",
+					"value": 1
+				}
+			]
 		},
 		{
-			"#": "16",
-			"label": "MOTION_DISABLE",
-			"description": "Motion Off behaviour ( timeout )",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 209,
-			"defaultValue": 0
-		},
-		{
-			"#": "17",
-			"label": "BUTTON_BEHAVIOUR",
-			"description": "Toggle button behaviour",
+			"#": "17[0x04]",
+			"label": "Button: Override Sensors (Standalone Mode)",
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 31,
-			"defaultValue": 8
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "According to parameter 19 (legacy behavior)",
+					"value": 0
+				},
+				{
+					"label": "According to parameters 10-14",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "17[0x08]",
+			"label": "Button: Override Sensors (Network Mode)",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "According to parameter 19 (legacy behavior)",
+					"value": 0
+				},
+				{
+					"label": "According to parameters 10-14",
+					"value": 1
+				}
+			]
 		},
 		{
 			"#": "18",
-			"label": "BUTTON_SCENES",
-			"description": "Toggle button Scene 1-4",
+			"label": "Button: Scene Number",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 127,
-			"defaultValue": 1
+			"defaultValue": 1,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
 		},
 		{
 			"#": "19",
-			"label": "LEGACY_INACTIVITY_TIME )",
-			"description": "Toggle button inactivity time in \"legacy\" mode ( timeout )",
+			"label": "Sensor Override Duration (Legacy Behavior)",
+			"description": "After motion ends, wait for the specified duration, then return to normal operation: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
 			"valueSize": 2,
 			"minValue": 1,
 			"maxValue": 209,

--- a/packages/config/config/devices/0x0271/motionswitch_led.json
+++ b/packages/config/config/devices/0x0271/motionswitch_led.json
@@ -75,13 +75,40 @@
 			"defaultValue": 1
 		},
 		{
-			"#": "9",
-			"label": "SLAVE_MODE",
-			"description": "Disable local control",
+			"#": "9[0x01]",
+			"label": "Gateway Check",
+			"description": "Lamp signalizes failure to reach the gateway.",
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 4,
-			"defaultValue": 2
+			"defaultValue": 1,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "9[0x02]",
+			"label": "Permanently On",
+			"description": "When enabled, overrides the Gateway Check parameter",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
 		},
 		{
 			"#": "10",

--- a/packages/config/config/devices/0x0271/motionswitch_led.json
+++ b/packages/config/config/devices/0x0271/motionswitch_led.json
@@ -76,6 +76,24 @@
 		},
 		{
 			"#": "9[0x01]",
+			"label": "External Control",
+			"description": "Lamp is controlled via Z-Wave and internal sensors are not used.",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "9[0x02]",
 			"label": "Gateway Check",
 			"description": "",
 			"valueSize": 1,
@@ -93,7 +111,7 @@
 			]
 		},
 		{
-			"#": "9[0x02]",
+			"#": "9[0x04]",
 			"label": "Permanently On",
 			"description": "",
 			"valueSize": 1,

--- a/packages/config/config/devices/0x0271/rs_led_d2_z-wave.json
+++ b/packages/config/config/devices/0x0271/rs_led_d2_z-wave.json
@@ -71,13 +71,58 @@
 			"defaultValue": 1
 		},
 		{
-			"#": "9",
-			"label": "Disable local control",
-			"description": "SLAVE_MODE",
+			"#": "9[0x01]",
+			"label": "External Control",
+			"description": "When enabled, the lamp is controlled externally via Z-Wave and internal sensors are not used.",
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 4,
-			"defaultValue": 2
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "9[0x02]",
+			"label": "Gateway Check",
+			"description": "External Control disabled: Lamp signalizes failure to reach the gateway. External Control enabled: Lamp falls back to normal mode after gateway could not be reached repeatedly.",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "9[0x04]",
+			"label": "Permanently On",
+			"description": "When enabled, overrides the External Control and Gateway Check parameters",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "Enable",
+					"value": 1
+				}
+			]
 		},
 		{
 			"#": "10",

--- a/packages/config/config/devices/0x0271/rs_led_d2_z-wave.json
+++ b/packages/config/config/devices/0x0271/rs_led_d2_z-wave.json
@@ -16,182 +16,67 @@
 	"paramInformation": [
 		{
 			"#": "1",
-			"label": "Time [s]",
-			"description": "Duration of light after motion detection.",
-			"unit": "seconds",
-			"valueSize": 2,
-			"minValue": 5,
-			"maxValue": 900,
-			"defaultValue": 180
+			"$import": "templates/steinel_template.json#motion_light_duration"
 		},
 		{
 			"#": "2",
-			"label": "Light threshold [lx]",
-			"description": "LIGHT",
-			"valueSize": 2,
-			"minValue": 2,
-			"maxValue": 2000,
-			"defaultValue": 2000
+			"$import": "templates/steinel_template.json#light_threshold"
 		},
 		{
 			"#": "4",
-			"label": "Motion Radar Range [cm]",
-			"description": "RANGE",
-			"unit": "cm",
-			"valueSize": 2,
-			"minValue": 100,
-			"maxValue": 500,
-			"defaultValue": 500
+			"$import": "templates/steinel_template.json#motion_sensor_range"
 		},
 		{
 			"#": "5",
-			"label": "Motion Radar Sensitivity [%]",
-			"description": "SENSITIVITY",
-			"valueSize": 1,
-			"minValue": 2,
-			"maxValue": 100,
-			"defaultValue": 100
+			"$import": "templates/steinel_template.json#motion_sensor_sensitivity"
 		},
 		{
 			"#": "6",
-			"label": "Brightness measuring interval [min]",
-			"description": "(only SLAMP)",
-			"valueSize": 1,
-			"minValue": 5,
-			"maxValue": 120,
-			"defaultValue": 0
+			"$import": "templates/steinel_template.json#brightness_measuring_interval"
 		},
 		{
 			"#": "8",
-			"label": "Use external Ambient Light value",
-			"description": "GLOBAL_LIGHT",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1
+			"$import": "templates/steinel_template.json#external_light_sensor"
 		},
 		{
 			"#": "9[0x01]",
-			"label": "External Control",
-			"description": "Lamp is controlled via Z-Wave and internal sensors are not used.",
-			"valueSize": 1,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
+			"$import": "templates/steinel_template.json#lamp_external_control"
 		},
 		{
 			"#": "9[0x02]",
-			"label": "Gateway Check",
-			"description": "",
-			"valueSize": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
+			"$import": "templates/steinel_template.json#lamp_gateway_check"
 		},
 		{
 			"#": "9[0x04]",
-			"label": "Permanently On",
-			"description": "",
-			"valueSize": 1,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
+			"$import": "templates/steinel_template.json#lamp_permanently_on"
 		},
 		{
 			"#": "10",
-			"label": "Off behaviour (timeout)",
-			"description": "OFF_BEHAVIOUR",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 10,
-			"options": [
-				{
-					"label": "Lamp/relay is switched off for TIME (cfg 1)",
-					"value": 255
-				}
-			]
+			"$import": "templates/steinel_template.json#off_command_duration"
 		},
 		{
 			"#": "11",
-			"label": "On behaviour (timeout)",
-			"description": "ON_BEHAVIOUR",
-			"valueSize": 2,
-			"minValue": 2,
-			"maxValue": 209,
-			"defaultValue": 255
+			"$import": "templates/steinel_template.json#on_command_duration"
 		},
 		{
 			"#": "12",
-			"label": "On behaviour time over (timeout)",
-			"description": "ON_TIME_OVER",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 209,
-			"defaultValue": 204
+			"$import": "templates/steinel_template.json#motion_wait_limit"
 		},
 		{
 			"#": "13",
-			"label": "Sequence On-Off behaviour (timeout)",
-			"description": "ON_OFF_ BEHAVIOUR",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 209,
-			"defaultValue": 204
+			"$import": "templates/steinel_template.json#on_off_sequence_off_duration"
 		},
 		{
 			"#": "14",
-			"label": "Sequence Off-On behaviour (timeout)",
-			"description": "OFF_ON_ BEHAVIOUR",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 209,
-			"defaultValue": 204
+			"$import": "templates/steinel_template.json#off_on_sequence_on_duration"
 		},
 		{
 			"#": "15",
-			"label": "Sequence timing",
-			"description": "SEQUENCE_TIME",
-			"valueSize": 1,
-			"minValue": 10,
-			"maxValue": 50,
-			"defaultValue": 10
+			"$import": "templates/steinel_template.json#sequence_timing"
 		},
 		{
 			"#": "16",
-			"label": "Motion Off behaviour (timeout)",
-			"description": "MOTION_ DISABLE",
-			"valueSize": 2,
-			"minValue": 2,
-			"maxValue": 209,
-			"defaultValue": 0
+			"$import": "templates/steinel_template.json#command_motion_disable_timeout"
 		}
 	]
 }

--- a/packages/config/config/devices/0x0271/rs_led_d2_z-wave.json
+++ b/packages/config/config/devices/0x0271/rs_led_d2_z-wave.json
@@ -73,7 +73,7 @@
 		{
 			"#": "9[0x01]",
 			"label": "External Control",
-			"description": "When enabled, the lamp is controlled externally via Z-Wave and internal sensors are not used.",
+			"description": "Lamp is controlled via Z-Wave and internal sensors are not used.",
 			"valueSize": 1,
 			"defaultValue": 0,
 			"allowManualEntry": false,
@@ -91,7 +91,7 @@
 		{
 			"#": "9[0x02]",
 			"label": "Gateway Check",
-			"description": "External Control disabled: Lamp signalizes failure to reach the gateway. External Control enabled: Lamp falls back to normal mode after gateway could not be reached repeatedly.",
+			"description": "",
 			"valueSize": 1,
 			"defaultValue": 1,
 			"allowManualEntry": false,
@@ -109,7 +109,7 @@
 		{
 			"#": "9[0x04]",
 			"label": "Permanently On",
-			"description": "When enabled, overrides the External Control and Gateway Check parameters",
+			"description": "",
 			"valueSize": 1,
 			"defaultValue": 0,
 			"allowManualEntry": false,

--- a/packages/config/config/devices/0x0271/rs_led_d2_z-wave.json
+++ b/packages/config/config/devices/0x0271/rs_led_d2_z-wave.json
@@ -39,16 +39,8 @@
 			"$import": "templates/steinel_template.json#external_light_sensor"
 		},
 		{
-			"#": "9[0x01]",
-			"$import": "templates/steinel_template.json#lamp_external_control"
-		},
-		{
-			"#": "9[0x02]",
-			"$import": "templates/steinel_template.json#lamp_gateway_check"
-		},
-		{
-			"#": "9[0x04]",
-			"$import": "templates/steinel_template.json#lamp_permanently_on"
+			"#": "9[0x07]",
+			"$import": "templates/steinel_template.json#light_behavior"
 		},
 		{
 			"#": "10",

--- a/packages/config/config/devices/0x0271/templates/steinel_template.json
+++ b/packages/config/config/devices/0x0271/templates/steinel_template.json
@@ -85,21 +85,38 @@
 		"description": "Measurements from associated Z-Wave light sensors are preferred if not older than 30 minutes.",
 		"defaultValue": 1
 	},
-	"lamp_external_control": {
-		"$import": "~/templates/master_template.json#base_enable_disable",
-		"label": "Lamp: External Control",
-		"description": "Lamp is controlled via Z-Wave and internal sensors are not used."
+	"light_behavior": {
+		// Meant to be used with the bitmask 0x07
+		"label": "Light Behavior",
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 4,
+		"defaultValue": 2,
+		"unsigned": true,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Normal mode",
+				"value": 0
+			},
+			{
+				"label": "External control",
+				"value": 1
+			},
+			{
+				"label": "Normal mode + gateway check",
+				"value": 2
+			},
+			{
+				"label": "External control + gateway check",
+				"value": 3
+			},
+			{
+				"label": "Permanently on",
+				"value": 4
+			}
+		]
 	},
-	"lamp_gateway_check": {
-		"$import": "~/templates/master_template.json#base_enable_disable",
-		"label": "Lamp: Gateway Check",
-		"defaultValue": 1
-	},
-	"lamp_permanently_on": {
-		"$import": "~/templates/master_template.json#base_enable_disable",
-		"label": "Lamp: Permanently On"
-	},
-
 	"off_command_duration": {
 		"label": "Z-Wave Off Command: Turn Off Duration",
 		"description": "On motion detection, light turns off for the configured duration: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",

--- a/packages/config/config/devices/0x0271/templates/steinel_template.json
+++ b/packages/config/config/devices/0x0271/templates/steinel_template.json
@@ -1,0 +1,220 @@
+{
+	"motion_light_duration": {
+		"label": "Light Duration After Motion",
+		"valueSize": 2,
+		"unit": "seconds",
+		"minValue": 5,
+		"maxValue": 900,
+		"defaultValue": 180
+	},
+	"light_threshold": {
+		"label": "Light Threshold",
+		"description": "Allowable range: 0, 2-2000. Moving the potentiometer overwrites the current setting.",
+		"valueSize": 2,
+		"unit": "lux",
+		"minValue": 0,
+		"maxValue": 2000,
+		"defaultValue": 2000,
+		"options": [
+			{
+				"label": "Execute learn sequence",
+				"value": 0
+			},
+			{
+				"label": "Disable threshold (always night)",
+				"value": 2000
+			}
+		]
+	},
+	"night_dim_mode": {
+		"label": "Night Dim Mode Duration",
+		"description": "Allowable range: 0-60, 255. External control overrides this setting.",
+		"valueSize": 1,
+		"unit": "minutes",
+		"minValue": 0,
+		"maxValue": 255,
+		"defaultValue": 0,
+		"unsigned": true,
+		"options": [
+			{
+				"label": "Disable, light off completely",
+				"value": 0
+			},
+			{
+				"label": "Whole night",
+				"value": 255
+			}
+		]
+	},
+	"motion_sensor_range": {
+		"label": "Motion Sensor Range",
+		"description": "Moving the potentiometer overwrites the current setting.",
+		"unit": "cm",
+		"valueSize": 2,
+		"minValue": 100,
+		"maxValue": 500,
+		"defaultValue": 500
+	},
+	"motion_sensor_sensitivity": {
+		"label": "Motion Sensor Sensitivity",
+		"description": "Moving the potentiometer overwrites the current setting.",
+		"valueSize": 1,
+		"unit": "%",
+		"minValue": 2,
+		"maxValue": 100,
+		"defaultValue": 100
+	},
+	"brightness_measuring_interval": {
+		"label": "Brightness Measuring Interval",
+		"description": "Lamp switches off briefly and measures the ambient light. Allowable range: 5-120.",
+		"valueSize": 1,
+		"unit": "minutes",
+		"minValue": 0,
+		"maxValue": 120,
+		"defaultValue": 0,
+		"options": [
+			{
+				"label": "Disable",
+				"value": 0
+			}
+		]
+	},
+	"external_light_sensor": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "External Ambient Light Sensor",
+		"description": "Measurements from associated Z-Wave light sensors are preferred if not older than 30 minutes.",
+		"defaultValue": 1
+	},
+	"lamp_external_control": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Lamp: External Control",
+		"description": "Lamp is controlled via Z-Wave and internal sensors are not used."
+	},
+	"lamp_gateway_check": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Lamp: Gateway Check",
+		"defaultValue": 1
+	},
+	"lamp_permanently_on": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Lamp: Permanently On"
+	},
+
+	"off_command_duration": {
+		"label": "Z-Wave Off Command: Turn Off Duration",
+		"description": "On motion detection, light turns off for the configured duration: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
+		"valueSize": 2,
+		"minValue": 0,
+		"maxValue": 255,
+		"defaultValue": 10,
+		"options": [
+			{
+				"label": "Turn off immediately, until motion detected",
+				"value": 0
+			},
+			{
+				"label": "Turn off immediately for duration of param 1 (Light Duration After Motion) or until motion detected",
+				"value": 255
+			}
+		]
+	},
+	"on_command_duration": {
+		"label": "Z-Wave On Command: Turn On Duration",
+		"description": "Light turns on for the configured duration, then waits for motion to return to normal operation: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
+		"valueSize": 2,
+		"minValue": 0,
+		"maxValue": 255,
+		"defaultValue": 255,
+		"options": [
+			{
+				"label": "Turn on, wait for motion immediately",
+				"value": 0
+			},
+			{
+				"label": "Turn on immediately for duration of param 1 (Light Duration After Motion) or until motion detected",
+				"value": 255
+			}
+		]
+	},
+	"motion_wait_limit": {
+		"label": "Z-Wave On / Off-On: Motion Wait Time Limit",
+		"description": "How long to wait for motion after the configured duration before returning to normal operation to prevent staying on forever: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
+		"valueSize": 2,
+		"minValue": 0,
+		"maxValue": 255,
+		"defaultValue": 204,
+		"options": [
+			{
+				"label": "Do not wait for motion",
+				"value": 0
+			},
+			{
+				"label": "Wait for motion indefinitely",
+				"value": 255
+			}
+		]
+	},
+	"on_off_sequence_off_duration": {
+		"label": "Z-Wave On-Off Sequence: Turn Off Duration",
+		"description": "On motion detection, light turns off for the configured duration: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
+		"valueSize": 2,
+		"minValue": 0,
+		"maxValue": 255,
+		"defaultValue": 204,
+		"options": [
+			{
+				"label": "Immediately, until motion detected",
+				"value": 0
+			},
+			{
+				"label": "Ignore sequence, treat like off command",
+				"value": 255
+			}
+		]
+	},
+	"off_on_sequence_on_duration": {
+		"label": "Z-Wave Off-On Sequence: Turn On Duration",
+		"description": "Light turns on for the configured duration, then waits for motion to return to normal operation: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
+		"valueSize": 2,
+		"minValue": 0,
+		"maxValue": 255,
+		"defaultValue": 204,
+		"options": [
+			{
+				"label": "Turn on, wait for motion immediately",
+				"value": 0
+			},
+			{
+				"label": "Ignore sequence, treat like on command",
+				"value": 255
+			}
+		]
+	},
+	"sequence_timing": {
+		"label": "Sequence Timing",
+		"description": "Maximum delay between on-off or off-on commands to treat as a sequence",
+		"valueSize": 1,
+		"unit": "0.1 s",
+		"minValue": 10,
+		"maxValue": 50,
+		"defaultValue": 10
+	},
+	"command_motion_disable_timeout": {
+		"label": "Motion Sensor Disable Timeout",
+		"description": "How long to disable internal motion sensor after Basic Set command to motion endpoint: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
+		"valueSize": 2,
+		"minValue": 0,
+		"maxValue": 255,
+		"defaultValue": 0,
+		"options": [
+			{
+				"label": "Ignore command, sensor permanently enabled",
+				"value": 0
+			},
+			{
+				"label": "Ignore command, sensor permanently disabled",
+				"value": 255
+			}
+		]
+	}
+}

--- a/packages/config/config/devices/0x0271/xled_home_2.json
+++ b/packages/config/config/devices/0x0271/xled_home_2.json
@@ -35,16 +35,8 @@
 			"$import": "templates/steinel_template.json#external_light_sensor"
 		},
 		{
-			"#": "9[0x01]",
-			"$import": "templates/steinel_template.json#lamp_external_control"
-		},
-		{
-			"#": "9[0x02]",
-			"$import": "templates/steinel_template.json#lamp_gateway_check"
-		},
-		{
-			"#": "9[0x04]",
-			"$import": "templates/steinel_template.json#lamp_permanently_on"
+			"#": "9[0x07]",
+			"$import": "templates/steinel_template.json#light_behavior"
 		},
 		{
 			"#": "10",

--- a/packages/config/config/devices/0x0271/xled_home_2.json
+++ b/packages/config/config/devices/0x0271/xled_home_2.json
@@ -16,250 +16,63 @@
 	"paramInformation": [
 		{
 			"#": "1",
-			"label": "Light Duration After Motion",
-			"valueSize": 2,
-			"unit": "seconds",
-			"minValue": 5,
-			"maxValue": 900,
-			"defaultValue": 180
+			"$import": "templates/steinel_template.json#motion_light_duration"
 		},
 		{
 			"#": "2",
-			"label": "Light Threshold",
-			"description": "Allowable Range: 2-2000. Moving the potentiometer overwrites the current setting.",
-			"valueSize": 2,
-			"unit": "lux",
-			"minValue": 0,
-			"maxValue": 2000,
-			"defaultValue": 2000,
-			"options": [
-				{
-					"label": "Execute learn sequence",
-					"value": 0
-				}
-			]
+			"$import": "templates/steinel_template.json#light_threshold"
 		},
 		{
 			"#": "5",
-			"label": "Motion Sensor Sensitivity",
-			"description": "Moving the potentiometer overwrites the current setting.",
-			"valueSize": 1,
-			"unit": "%",
-			"minValue": 2,
-			"maxValue": 100,
-			"defaultValue": 100
+			"$import": "templates/steinel_template.json#motion_sensor_sensitivity"
 		},
 		{
 			"#": "6",
-			"label": "Brightness Measuring Interval",
-			"description": "Lamp switches off shortly and measures the ambient light.",
-			"valueSize": 1,
-			"unit": "minutes",
-			"minValue": 0,
-			"maxValue": 120,
-			"defaultValue": 0,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				}
-			]
+			"$import": "templates/steinel_template.json#brightness_measuring_interval"
 		},
 		{
 			"#": "8",
-			"label": "External Ambient Light Sensor",
-			"description": "Measurements from associated Z-Wave light sensors are preferred if not older than 30 minutes.",
-			"valueSize": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
+			"$import": "templates/steinel_template.json#external_light_sensor"
 		},
 		{
 			"#": "9[0x01]",
-			"label": "External Control",
-			"description": "Lamp is controlled via Z-Wave and internal sensors are not used.",
-			"valueSize": 1,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
+			"$import": "templates/steinel_template.json#lamp_external_control"
 		},
 		{
 			"#": "9[0x02]",
-			"label": "Gateway Check",
-			"description": "",
-			"valueSize": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
+			"$import": "templates/steinel_template.json#lamp_gateway_check"
 		},
 		{
 			"#": "9[0x04]",
-			"label": "Permanently On",
-			"description": "",
-			"valueSize": 1,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable",
-					"value": 1
-				}
-			]
+			"$import": "templates/steinel_template.json#lamp_permanently_on"
 		},
 		{
 			"#": "10",
-			"label": "Z-Wave Off Command: Turn Off Duration",
-			"description": "On motion detection, light turns off for the configured duration: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 10,
-			"options": [
-				{
-					"label": "Turn off immediately, until motion detected",
-					"value": 0
-				},
-				{
-					"label": "Turn off immediately for duration of param 1 (Light Duration After Motion) or until motion detected",
-					"value": 255
-				}
-			]
+			"$import": "templates/steinel_template.json#off_command_duration"
 		},
 		{
 			"#": "11",
-			"label": "Z-Wave On Command: Turn On Duration",
-			"description": "Light turns on for the configured duration, then waits for motion to return to normal operation: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 255,
-			"options": [
-				{
-					"label": "Turn on, wait for motion immediately",
-					"value": 0
-				},
-				{
-					"label": "Turn on immediately for duration of param 1 (Light Duration After Motion) or until motion detected",
-					"value": 255
-				}
-			]
+			"$import": "templates/steinel_template.json#on_command_duration"
 		},
 		{
 			"#": "12",
-			"label": "Z-Wave On / Off-On: Motion Wait Time Limit",
-			"description": "How long to wait for motion after the configured duration before returning to normal operation to prevent staying on forever: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 204,
-			"options": [
-				{
-					"label": "Do not wait for motion",
-					"value": 0
-				},
-				{
-					"label": "Wait for motion indefinitely",
-					"value": 255
-				}
-			]
+			"$import": "templates/steinel_template.json#motion_wait_limit"
 		},
 		{
 			"#": "13",
-			"label": "Z-Wave On-Off Sequence: Turn Off Duration",
-			"description": "On motion detection, light turns off for the configured duration: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 204,
-			"options": [
-				{
-					"label": "Immediately, until motion detected",
-					"value": 0
-				},
-				{
-					"label": "Ignore sequence, treat like off command",
-					"value": 255
-				}
-			]
+			"$import": "templates/steinel_template.json#on_off_sequence_off_duration"
 		},
 		{
 			"#": "14",
-			"label": "Z-Wave Off-On Sequence: Turn On Duration",
-			"description": "Light turns on for the configured duration, then waits for motion to return to normal operation: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 204,
-			"options": [
-				{
-					"label": "Turn on, wait for motion immediately",
-					"value": 0
-				},
-				{
-					"label": "Ignore sequence, treat like on command",
-					"value": 255
-				}
-			]
+			"$import": "templates/steinel_template.json#off_on_sequence_on_duration"
 		},
 		{
 			"#": "15",
-			"label": "Sequence Timing",
-			"description": "Maximum delay between on-off or off-on commands to treat as a sequence",
-			"valueSize": 1,
-			"unit": "0.1 s",
-			"minValue": 10,
-			"maxValue": 50,
-			"defaultValue": 10
+			"$import": "templates/steinel_template.json#sequence_timing"
 		},
 		{
 			"#": "16",
-			"label": "Motion Sensor Disable Timeout",
-			"description": "How long to disable internal motion sensor after Basic Set command to motion endpoint: 1...100 = seconds, 101...200 = minutes (minus 100), 201...209 = hours (minus 200)",
-			"valueSize": 2,
-			"minValue": 0,
-			"maxValue": 255,
-			"defaultValue": 0,
-			"options": [
-				{
-					"label": "Ignore command, sensor permanently enabled",
-					"value": 0
-				},
-				{
-					"label": "Ignore command, sensor permanently disabled",
-					"value": 255
-				}
-			]
+			"$import": "templates/steinel_template.json#command_motion_disable_timeout"
 		}
 	]
 }

--- a/packages/config/config/devices/0x0271/xled_home_2.json
+++ b/packages/config/config/devices/0x0271/xled_home_2.json
@@ -106,7 +106,7 @@
 			"label": "Gateway Check",
 			"description": "External Control disabled: Lamp signalizes failure to reach the gateway. External Control enabled: Lamp falls back to normal mode after gateway could not be reached repeatedly.",
 			"valueSize": 1,
-			"defaultValue": 0,
+			"defaultValue": 1,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0271/xled_home_2.json
+++ b/packages/config/config/devices/0x0271/xled_home_2.json
@@ -86,7 +86,7 @@
 		{
 			"#": "9[0x01]",
 			"label": "External Control",
-			"description": "When enabled, the lamp is controlled externally via Z-Wave and internal sensors are not used.",
+			"description": "Lamp is controlled via Z-Wave and internal sensors are not used.",
 			"valueSize": 1,
 			"defaultValue": 0,
 			"allowManualEntry": false,
@@ -104,7 +104,7 @@
 		{
 			"#": "9[0x02]",
 			"label": "Gateway Check",
-			"description": "External Control disabled: Lamp signalizes failure to reach the gateway. External Control enabled: Lamp falls back to normal mode after gateway could not be reached repeatedly.",
+			"description": "",
 			"valueSize": 1,
 			"defaultValue": 1,
 			"allowManualEntry": false,
@@ -122,7 +122,7 @@
 		{
 			"#": "9[0x04]",
 			"label": "Permanently On",
-			"description": "When enabled, overrides the External Control and Gateway Check parameters",
+			"description": "",
 			"valueSize": 1,
 			"defaultValue": 0,
 			"allowManualEntry": false,


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

PR description here
fix(config): param 9 for STEINEL devices