### PR TITLE
fix: emit value event after successful supervised `setValue`

### DIFF
--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -857,7 +857,10 @@ export class ZWaveNode
 				this._valueDB.setValue(
 					valueId,
 					value,
-					!!this.driver.options.emitValueUpdateAfterSetValue
+					// We need to emit an event if applications opted in, or if this was a supervised call
+					// because in this case there won't be a verification query which would result in an update
+					!!result ||
+						!!this.driver.options.emitValueUpdateAfterSetValue
 						? { source: "driver" }
 						: { noEvent: true },
 				);

--- a/packages/zwave-js/src/lib/test/driver/setValueSuccessfulSupervisionNoGet.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/setValueSuccessfulSupervisionNoGet.test.ts
@@ -57,6 +57,10 @@ integrationTest(
 			mockNode.defineBehavior(respondToSupervisionGet);
 		},
 		testBody: async (driver, node, mockController, mockNode) => {
+			const onValueChange = jest.fn();
+			node.on("value added", onValueChange);
+			node.on("value updated", onValueChange);
+
 			await node.setValue(BinarySwitchCCValues.targetValue.id, true);
 
 			await wait(500);
@@ -86,6 +90,22 @@ integrationTest(
 				BinarySwitchCCValues.currentValue.id,
 			);
 			expect(currentValue).toBeTrue();
+
+			// And make sure the value event handlers are called
+			expect(onValueChange).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.objectContaining({
+					property: "currentValue",
+					newValue: true,
+				}),
+			);
+			expect(onValueChange).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.objectContaining({
+					property: "targetValue",
+					newValue: true,
+				}),
+			);
 		},
 	},
 );


### PR DESCRIPTION
reported in https://github.com/zwave-js/node-red-contrib-zwave-js/discussions/249#discussioncomment-3360152