### PR TITLE
feat(config): add Enbrighten 58438 / ZWA3016

### DIFF
--- a/packages/config/config/devices/0x0063/58438_zwa3016.json
+++ b/packages/config/config/devices/0x0063/58438_zwa3016.json
@@ -65,15 +65,15 @@
 		},
 		{
 			"#": "34",
-			"$import": "templates/jasco_template.json#led_light_color"
+			"$import": "templates/jasco_template.json#led_indicator_color"
 		},
 		{
 			"#": "35",
-			"$import": "templates/jasco_template.json#led_light_intensity"
+			"$import": "templates/jasco_template.json#led_indicator_intensity"
 		},
 		{
 			"#": "36",
-			"$import": "templates/jasco_template.json#led_light_intensity",
+			"$import": "templates/jasco_template.json#led_indicator_intensity",
 			"label": "Guidelight Mode Intensity"
 		},
 		{
@@ -82,6 +82,7 @@
 		}
 	],
 	"compat": {
+		// Needed for double-tap support
 		"treatBasicSetAsEvent": true
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x0063/58438_zwa3016.json
+++ b/packages/config/config/devices/0x0063/58438_zwa3016.json
@@ -41,7 +41,7 @@
 		},
 		{
 			"#": "5",
-			"$import": "templates/jasco_template.json#3way_setup"
+			"$import": "templates/jasco_template.json#three_way_setup"
 		},
 		{
 			"#": "16",

--- a/packages/config/config/devices/0x0063/58438_zwa3016.json
+++ b/packages/config/config/devices/0x0063/58438_zwa3016.json
@@ -1,0 +1,92 @@
+{
+	"manufacturer": "GE/Jasco/Enbrighten",
+	"manufacturerId": "0x0063",
+	"label": "58438/ZWA3016",
+	"description": "Enbrighten Z-Wave Plus In-Wall Smart Dimmer, White and Light Almond Paddles, 700S",
+	"devices": [
+		{
+			"productType": "0x4944",
+			"productId": "0x3430",
+			"zwaveAllianceId": 4462
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "Local Load",
+			"maxNodes": 5
+		},
+		"3": {
+			"label": "Double Tap",
+			"maxNodes": 5,
+			"isLifeline": true
+		}
+	},
+	"paramInformation": [
+		{
+			"#": "3",
+			"$import": "~/templates/master_template.json#led_indicator_four_options"
+		},
+		{
+			"#": "4",
+			"$import": "~/templates/master_template.json#orientation"
+		},
+		{
+			"#": "5",
+			"$import": "templates/jasco_template.json#3way_setup"
+		},
+		{
+			"#": "16",
+			"$import": "templates/jasco_template.json#switch_mode"
+		},
+		{
+			"#": "19",
+			"$import": "templates/jasco_template.json#alternate_exclusion"
+		},
+		{
+			"#": "30",
+			"$import": "templates/jasco_template.json#dim_threshold_min"
+		},
+		{
+			"#": "31",
+			"$import": "templates/jasco_template.json#dim_threshold_max"
+		},
+		{
+			"#": "32",
+			"$import": "templates/jasco_template.json#default_brightness_level"
+		},
+		{
+			"#": "34",
+			"$import": "templates/jasco_template.json#led_light_color"
+		},
+		{
+			"#": "35",
+			"$import": "templates/jasco_template.json#led_light_intensity"
+		},
+		{
+			"#": "36",
+			"$import": "templates/jasco_template.json#led_light_intensity",
+			"label": "Guidelight Mode Intensity"
+		},
+		{
+			"#": "84",
+			"$import": "templates/jasco_template.json#factory_default"
+		}
+	],
+	"compat": {
+		"treatBasicSetAsEvent": true
+	},
+	"metadata": {
+		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and release the top or bottom of the smart dimmer (rocker)",
+		"exclusion": "1. Follow the instructions for your Z-Wave certified controller to remove a device from the Z-Wave network.\n2. Once the controller is ready to remove your device, press and release the top or bottom of the smart dimmer (rocker)",
+		"reset": "1. Quickly press ON (top) button three times, then immediately press the OFF (bottom) button three times. The LED will flash ON/OFF five times when completed successfully"
+	}
+}

--- a/packages/config/config/devices/0x0063/58438_zwa3016.json
+++ b/packages/config/config/devices/0x0063/58438_zwa3016.json
@@ -1,8 +1,8 @@
 {
-	"manufacturer": "GE/Jasco/Enbrighten",
+	"manufacturer": "Enbrighten",
 	"manufacturerId": "0x0063",
-	"label": "58438/ZWA3016",
-	"description": "Enbrighten Z-Wave Plus In-Wall Smart Dimmer, White and Light Almond Paddles, 700S",
+	"label": "58438 / ZWA3016",
+	"description": "In-Wall Paddle Dimmer, 700S",
 	"devices": [
 		{
 			"productType": "0x4944",

--- a/packages/config/config/devices/0x0063/templates/jasco_template.json
+++ b/packages/config/config/devices/0x0063/templates/jasco_template.json
@@ -414,7 +414,7 @@
 		]
 	},
 	"led_light_color": {
-		"label": "LED Light Color",
+		"label": "LED Indicator Color",
 		"valueSize": 1,
 		"defaultValue": 5,
 		"unsigned": true,
@@ -455,11 +455,17 @@
 		]
 	},
 	"led_light_intensity": {
-		"label": "LED Light Intensity",
+		"label": "LED Indicator Intensity",
 		"valueSize": 1,
 		"minValue": 0,
 		"maxValue": 7,
 		"defaultValue": 4,
-		"unsigned": true
+		"unsigned": true,
+		"options": [
+			{
+				"label": "Off",
+				"value": 0
+			}
+		]
 	}
 }

--- a/packages/config/config/devices/0x0063/templates/jasco_template.json
+++ b/packages/config/config/devices/0x0063/templates/jasco_template.json
@@ -396,9 +396,8 @@
 			}
 		]
 	},
-	"3way_setup": {
+	"three_way_setup": {
 		"label": "3-Way Setup",
-		"description": "Set the 3-way switch configuration as add-on or standard.",
 		"valueSize": 1,
 		"defaultValue": 0,
 		"unsigned": true,

--- a/packages/config/config/devices/0x0063/templates/jasco_template.json
+++ b/packages/config/config/devices/0x0063/templates/jasco_template.json
@@ -395,5 +395,72 @@
 				"value": 2
 			}
 		]
+	},
+	"3way_setup": {
+		"label": "3-Way Setup",
+		"description": "Set the 3-way switch configuration as add-on or standard.",
+		"valueSize": 1,
+		"defaultValue": 0,
+		"unsigned": true,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Add-on",
+				"value": 0
+			},
+			{
+				"label": "Standard",
+				"value": 1
+			}
+		]
+	},
+	"led_light_color": {
+		"label": "LED Light Color",
+		"valueSize": 1,
+		"defaultValue": 5,
+		"unsigned": true,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Red",
+				"value": 1
+			},
+			{
+				"label": "Orange",
+				"value": 2
+			},
+			{
+				"label": "Yellow",
+				"value": 3
+			},
+			{
+				"label": "Green",
+				"value": 4
+			},
+			{
+				"label": "Blue",
+				"value": 5
+			},
+			{
+				"label": "Pink",
+				"value": 6
+			},
+			{
+				"label": "Purple",
+				"value": 7
+			},
+			{
+				"label": "White",
+				"value": 8
+			}
+		]
+	},
+	"led_light_intensity": {
+		"label": "LED Light Intensity",
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 7,
+		"defaultValue": 4,
+		"unsigned": true
 	}
 }

--- a/packages/config/config/devices/0x0063/templates/jasco_template.json
+++ b/packages/config/config/devices/0x0063/templates/jasco_template.json
@@ -413,7 +413,7 @@
 			}
 		]
 	},
-	"led_light_color": {
+	"led_indicator_color": {
 		"label": "LED Indicator Color",
 		"valueSize": 1,
 		"defaultValue": 5,
@@ -454,7 +454,7 @@
 			}
 		]
 	},
-	"led_light_intensity": {
+	"led_indicator_intensity": {
 		"label": "LED Indicator Intensity",
 		"valueSize": 1,
 		"minValue": 0,


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

Add Enbrighten 58438 / ZWA3016 device config file
