### PR TITLE
feat(config): import Zooz ZEN14 from zwa templated

### DIFF
--- a/packages/config/config/devices/0x027a/zen14.json
+++ b/packages/config/config/devices/0x027a/zen14.json
@@ -69,7 +69,8 @@
 			"#": "4",
 			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Auto Turn-On Timer (Outlet 1)"
-		},		{
+		},
+		{
 			"#": "5",
 			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Auto Turn-On Timer (Outlet 2)"

--- a/packages/config/config/devices/0x027a/zen14.json
+++ b/packages/config/config/devices/0x027a/zen14.json
@@ -57,118 +57,37 @@
 		},
 		{
 			"#": "2",
-			"label": "Auto-off Timer Outlet 1",
-			"description": "Minutes",
-			"valueSize": 4,
-			"unit": "minutes",
-			"minValue": 0,
-			"maxValue": 65535,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "templates/zooz_template.json#auto_off_timer_duration",
+			"label": "Auto Turn-Off Timer Duration (Outlet 1)"
 		},
 		{
 			"#": "3",
-			"label": "Auto-off Timer Outlet 2",
-			"description": "Minutes",
-			"valueSize": 4,
-			"unit": "minutes",
-			"minValue": 0,
-			"maxValue": 65535,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "templates/zooz_template.json#auto_off_timer_duration",
+			"label": "Auto Turn-Off Timer Duration (Outlet 2)"
 		},
 		{
 			"#": "4",
-			"label": "Auto-on Timer Outlet 1",
-			"description": "Minutes",
-			"valueSize": 4,
-			"unit": "minutes",
-			"minValue": 0,
-			"maxValue": 65535,
-			"defaultValue": 0,
-			"unsigned": true
-		},
-		{
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Auto Turn-On Timer (Outlet 1)"
+		},		{
 			"#": "5",
-			"label": "Auto-on Timer Outlet 2",
-			"description": "Minutes",
-			"valueSize": 4,
-			"unit": "minutes",
-			"minValue": 0,
-			"maxValue": 65535,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Auto Turn-On Timer (Outlet 2)"
 		},
 		{
 			"#": "6",
-			"label": "On/Off Status Recovery After Power Failure",
-			"description": "Choose the recovery state for your double outdoor plug if a power outage occurs",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Both outlets on the plug automatically turn off once power is restored (it ignores the status prior to power outage)",
-					"value": 0
-				},
-				{
-					"label": "Both outlets on the plug automatically turn on once power is restored (it ignores the status prior to the power outage)",
-					"value": 1
-				},
-				{
-					"label": "Both outlets on the plug remember and restore the status prior to the power outage",
-					"value": 2
-				}
-			]
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
 		},
+
 		{
 			"#": "7",
-			"label": "Brightness of LED Indicator",
-			"description": "Set the brightness level of the LED indicator",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 2,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "High",
-					"value": 0
-				},
-				{
-					"label": "Medium",
-					"value": 1
-				},
-				{
-					"label": "Low",
-					"value": 2
-				}
-			]
+			"$import": "templates/zooz_template.json#led_indicator_brightness"
 		},
 		{
 			"#": "8",
-			"label": "Z-Wave Button Control",
-			"description": "Choose if you want to use the physical Z-Wave button on the plug to turn the outlets on or off manually or if you want to disable this function. if this parameter is set to 0 (disabled), you will only be able to turn the outlet on or off remotely using your Z-Wave hub",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Manual control disabled",
-					"value": 0
-				},
-				{
-					"label": "Manual control enabled",
-					"value": 1
-				}
-			]
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Manual Control",
+			"defaultValue": 1
 		}
 	],
 	"metadata": {

--- a/packages/config/config/devices/0x027a/zen14.json
+++ b/packages/config/config/devices/0x027a/zen14.json
@@ -77,7 +77,7 @@
 		},
 		{
 			"#": "6",
-			"$import": "~/templates/master_template.json#state_after_power_failure_prev_on_off"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 
 		{


### PR DESCRIPTION
Don't have a ZEN14, but based the two outlets on the ZEN25 which is labeled Left and Right Outlet. Left ZEN14 as Outlet 1 and Outlet 2

