### PR TITLE
feat(driver): support updating some options on the fly

### DIFF
--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -283,6 +283,22 @@ setPreferredScales(scales: ZWaveOptions["preferences"]["scales"]): void
 
 Configures a new set of preferred sensor scales without having to restart the driver. The `scales` argument has the same type as `preferences.scales` in [`ZWaveOptions`](#ZWaveOptions).
 
+### `updateOptions`
+
+```ts
+updateOptions(options: DeepPartial<EditableZWaveOptions>): void
+```
+
+Updates a subset of the driver options without having to restart the driver. The following properties from [`ZWaveOptions`](#ZWaveOptions) are supported:
+
+-   `disableOptimisticValueUpdate`
+-   `emitValueUpdateAfterSetValue`
+-   `inclusionUserCallbacks`
+-   `interview`
+-   `logConfig`
+-   `preferences`
+-   `preserveUnknownValues`
+
 ### `checkForConfigUpdates`
 
 ```ts

--- a/packages/shared/api.md
+++ b/packages/shared/api.md
@@ -145,7 +145,7 @@ export function keysOf<T>(obj: T): (keyof T)[];
 // Warning: (ae-missing-release-tag) "mergeDeep" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-export function mergeDeep(target: Record<string, any> | undefined, source: Record<string, any>): Record<string, any>;
+export function mergeDeep(target: Record<string, any> | undefined, source: Record<string, any>, overwrite?: boolean): Record<string, any>;
 
 // Warning: (ae-missing-release-tag) "MethodsNamesOf" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/packages/shared/src/utils.test.ts
+++ b/packages/shared/src/utils.test.ts
@@ -2,6 +2,7 @@ import {
 	cloneDeep,
 	discreteBinarySearch,
 	discreteLinearSearch,
+	mergeDeep,
 	throttle,
 } from "./utils";
 
@@ -294,5 +295,32 @@ describe("cloneDeep()", () => {
 		expect(target).toEqual(source);
 		expect(target).not.toBe(source);
 		expect(target.a).not.toBe(source.a);
+	});
+});
+
+describe("mergeDeep()", () => {
+	it("can delete keys when undefined is passed", () => {
+		const target = { a: 1, b: 2, c: 3 };
+		const result = mergeDeep(target, { a: undefined });
+		expect(result).toEqual({ b: 2, c: 3 });
+	});
+
+	it("sanity check with overwrite: true", () => {
+		const target = { a: 1, b: { c: 3, d: 4 }, e: [5, 6, 7] };
+		const source = { b: { c: undefined }, e: "foo" };
+		const result = mergeDeep(target, source, true);
+		expect(result).toEqual({ a: 1, b: { d: 4 }, e: "foo" });
+	});
+
+	it("sanity check with overwrite: false", () => {
+		const target = { a: 1, b: { c: 3, d: 4 }, e: [5, 6, 7] };
+		const source = { b: { c: undefined }, e: "foo", f: "bar" };
+		const result = mergeDeep(target, source, false);
+		expect(result).toEqual({
+			a: 1,
+			b: { c: 3, d: 4 },
+			e: [5, 6, 7],
+			f: "bar",
+		});
 	});
 });

--- a/packages/shared/src/utils.test.ts
+++ b/packages/shared/src/utils.test.ts
@@ -301,7 +301,7 @@ describe("cloneDeep()", () => {
 describe("mergeDeep()", () => {
 	it("can delete keys when undefined is passed", () => {
 		const target = { a: 1, b: 2, c: 3 };
-		const result = mergeDeep(target, { a: undefined });
+		const result = mergeDeep(target, { a: undefined }, true);
 		expect(result).toEqual({ b: 2, c: 3 });
 	});
 

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -105,19 +105,23 @@ export function throttle<T extends any[]>(
 export function mergeDeep(
 	target: Record<string, any> | undefined,
 	source: Record<string, any>,
+	overwrite?: boolean,
 ): Record<string, any> {
 	target = target || {};
 	for (const [key, value] of Object.entries(source)) {
-		if (!(key in target)) {
-			target[key] = value;
-		} else {
-			if (typeof value === "object") {
+		if (key in target) {
+			if (value === undefined) {
+				// Explicitly delete keys that were set to `undefined`, but only if overwriting is enabled
+				if (overwrite) delete target[key];
+			} else if (typeof value === "object") {
 				// merge objects
-				target[key] = mergeDeep(target[key], value);
-			} else if (typeof target[key] === "undefined") {
-				// don't override single keys
+				target[key] = mergeDeep(target[key], value, overwrite);
+			} else if (overwrite || typeof target[key] === "undefined") {
+				// Only overwrite existing primitives if the overwrite flag is set
 				target[key] = value;
 			}
+		} else if (value !== undefined) {
+			target[key] = value;
 		}
 	}
 	return target;

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -299,6 +299,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> implements Z
     // (undocumented)
     unwrapCommands(msg: Message & ICommandClassContainer): void;
     updateLogConfig(config: DeepPartial<LogConfig>): void;
+    updateOptions(options: DeepPartial<EditableZWaveOptions>): void;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     waitForCommand<T extends ICommandClass>(predicate: (cc: ICommandClass) => boolean, timeout: number): Promise<T>;
@@ -319,6 +320,11 @@ export interface DriverLogContext extends LogContext<"driver"> {
 export { Duration }
 
 export { DurationUnit }
+
+// Warning: (ae-missing-release-tag) "EditableZWaveOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type EditableZWaveOptions = Pick<ZWaveOptions, "disableOptimisticValueUpdate" | "emitValueUpdateAfterSetValue" | "inclusionUserCallbacks" | "interview" | "logConfig" | "preferences" | "preserveUnknownValues">;
 
 // Warning: (ae-missing-release-tag) "Endpoint" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/packages/zwave-js/src/Driver.ts
+++ b/packages/zwave-js/src/Driver.ts
@@ -8,5 +8,8 @@ export type {
 	ResponseRole,
 } from "@zwave-js/serial";
 export { Driver, libName, libVersion } from "./lib/driver/Driver";
-export type { ZWaveOptions } from "./lib/driver/ZWaveOptions";
+export type {
+	EditableZWaveOptions,
+	ZWaveOptions,
+} from "./lib/driver/ZWaveOptions";
 export { DriverLogContext } from "./lib/log/Driver";

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -231,3 +231,14 @@ export interface ZWaveOptions extends ZWaveHostOptions {
 		loadConfiguration?: boolean;
 	};
 }
+
+export type EditableZWaveOptions = Pick<
+	ZWaveOptions,
+	| "disableOptimisticValueUpdate"
+	| "emitValueUpdateAfterSetValue"
+	| "inclusionUserCallbacks"
+	| "interview"
+	| "logConfig"
+	| "preferences"
+	| "preserveUnknownValues"
+>;


### PR DESCRIPTION
This PR adds support for updating the following driver options on the fly without having to restart the driver throug a new `updateOptions` method:

-   `disableOptimisticValueUpdate`
-   `emitValueUpdateAfterSetValue`
-   `inclusionUserCallbacks`
-   `interview`
-   `logConfig`
-   `preferences`
-   `preserveUnknownValues`