### PR TITLE
feat(config): add wakeup instruction to Zooz ZEN34

### DIFF
--- a/packages/config/config/devices/0x027a/zen34.json
+++ b/packages/config/config/devices/0x027a/zen34.json
@@ -171,6 +171,7 @@
 	"metadata": {
 		"inclusion": "Put your Z-Wave hub into inclusion mode and click the upper paddle 6 times quickly. The LED indicator\nwill blink blue during the process and light up green once added successfully. It will light up red if failed",
 		"exclusion": "1. Bring the Remote Switch within direct range of your Z-Wave gateway (hub).\n2. Put the Z-Wave hub into exclusion mode (not sure how to do that? ask@getzooz.com).\n3. Click the lower paddle 6 times very quickly\n4. Your hub will confirm exclusion and the device will disappear from your controller's device list",
+		"wakeup": "1. Bring the Remote Switch within direct range of your Z-Wave gateway (hub).\n2. Click the upper paddle 7 times very quickly\n3. Your device's indicator light will remain on to indicate that the device is awake.",
 		"reset": "When your network’s primary controller is missing or otherwise inoperable, you may need to reset the device\nto factory settings manually. In order to complete the process, make sure the device is powered, then tap-tap-\ntap’and’hold the upper paddle. The LED indicator will blink red 5 times to indicate successful reset",
 		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=product_documents/4114/zooz-700-series-remote-switch-zen34-manual-online.pdf"
 	}


### PR DESCRIPTION
- Add wakeup instruction to Zooz zen34 remote switch

I had to go look this up on the web, maybe it will help someone else.
(I LOVE that my other devices have inclusion/exclusion instructions in the "wiki")