### PR TITLE
fix(config): apply compat flag to GreenWave PowerNode 5

### DIFF
--- a/packages/config/config/devices/0x0099/gwpn5.json
+++ b/packages/config/config/devices/0x0099/gwpn5.json
@@ -146,5 +146,9 @@
 				}
 			]
 		}
-	]
+	],
+	"compat": {
+		// This device incorrectly uses the destination endpoint to indicate which endpoint sent the command
+		"treatDestinationEndpointAsSource": true
+	}
 }


### PR DESCRIPTION
The issue on https://github.com/zwave-js/node-zwave-js/issues/2792 for PowerNode 6 also applies for PowerNode 5. I have confirmed that this patch works for my device and now the power consumption values are reported into the correct endpoints.

As such it would be great if the same patch that has already been applied to PowerNode 6 on https://github.com/zwave-js/node-zwave-js/pull/2885/commits/a5ee6316373dcd019a54d7562e422ec0f769df24 could be applied to PowerNode 5 as well.

Thank you!
