### PR TITLE
feat(config): add alarm mappings to ZSMOKE

### DIFF
--- a/packages/config/config/devices/0x0138/zsmoke.json
+++ b/packages/config/config/devices/0x0138/zsmoke.json
@@ -41,5 +41,59 @@
 				}
 			]
 		}
-	]
+	],
+	"compat": {
+		"alarmMapping": [
+			{
+				"from": {
+					"alarmType": 1,
+					"alarmLevel": 255
+				},
+				"to": {
+					"notificationType": 1,
+					"notificationEvent": 2
+				}
+			},
+			{
+				"from": {
+					"alarmType": 1,
+					"alarmLevel": 0
+				},
+				"to": {
+					"notificationType": 1,
+					"notificationEvent": 0
+				}
+			},
+			{
+				"from": {
+					"alarmType": 12,
+					"alarmLevel": 255
+				},
+				"to": {
+					"notificationType": 1,
+					"notificationEvent": 3
+				}
+			},
+			{
+				"from": {
+					"alarmType": 12,
+					"alarmLevel": 0
+				},
+				"to": {
+					"notificationType": 1,
+					"notificationEvent": 0
+				}
+			},
+			{
+				"from": {
+					"alarmType": 13,
+					"alarmLevel": 255
+				},
+				"to": {
+					"notificationType": 1,
+					"notificationEvent": 0
+				}
+			}
+		]
+	}
 }


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

Copy the non-CO related alarm mappings from ZCOMBO to ZSMOKE. These mappings have been tested and confirmed on a ZSMOKE device.
