### PR TITLE
feat: use Supervision for the remaining SET- and REPORT-type commands

### DIFF
--- a/packages/cc/src/cc/AssociationCC.ts
+++ b/packages/cc/src/cc/AssociationCC.ts
@@ -4,6 +4,7 @@ import type {
 	IZWaveNode,
 	Maybe,
 	MessageRecord,
+	SupervisionResult,
 } from "@zwave-js/core/safe";
 import {
 	CommandClasses,
@@ -32,6 +33,7 @@ import {
 	commandClass,
 	expectedCCResponse,
 	implementedVersion,
+	useSupervision,
 } from "../lib/CommandClassDecorators";
 import * as ccUtils from "../lib/utils";
 import { V } from "../lib/Values";
@@ -184,7 +186,7 @@ export class AssociationCCAPI extends PhysicalCCAPI {
 	public async addNodeIds(
 		groupId: number,
 		...nodeIds: number[]
-	): Promise<void> {
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(AssociationCommand, AssociationCommand.Set);
 
 		const cc = new AssociationCCSet(this.applHost, {
@@ -193,7 +195,7 @@ export class AssociationCCAPI extends PhysicalCCAPI {
 			groupId,
 			nodeIds,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
 	/**
@@ -202,7 +204,7 @@ export class AssociationCCAPI extends PhysicalCCAPI {
 	@validateArgs()
 	public async removeNodeIds(
 		options: AssociationCCRemoveOptions,
-	): Promise<void> {
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(
 			AssociationCommand,
 			AssociationCommand.Remove,
@@ -213,7 +215,7 @@ export class AssociationCCAPI extends PhysicalCCAPI {
 			endpoint: this.endpoint.index,
 			...options,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
 	/**
@@ -228,7 +230,7 @@ export class AssociationCCAPI extends PhysicalCCAPI {
 
 		if (this.version >= 2) {
 			// The node supports bulk removal
-			return this.removeNodeIds({ nodeIds, groupId: 0 });
+			await this.removeNodeIds({ nodeIds, groupId: 0 });
 		} else {
 			// We have to remove the node manually from all groups
 			const groupCount =
@@ -440,6 +442,7 @@ interface AssociationCCSetOptions extends CCCommandOptions {
 }
 
 @CCCommand(AssociationCommand.Set)
+@useSupervision()
 export class AssociationCCSet extends AssociationCC {
 	public constructor(
 		host: ZWaveHost,
@@ -500,6 +503,7 @@ interface AssociationCCRemoveOptions {
 }
 
 @CCCommand(AssociationCommand.Remove)
+@useSupervision()
 export class AssociationCCRemove extends AssociationCC {
 	public constructor(
 		host: ZWaveHost,

--- a/packages/cc/src/cc/AssociationCC.ts
+++ b/packages/cc/src/cc/AssociationCC.ts
@@ -222,7 +222,9 @@ export class AssociationCCAPI extends PhysicalCCAPI {
 	 * Removes nodes from all association groups
 	 */
 	@validateArgs()
-	public async removeNodeIdsFromAllGroups(nodeIds: number[]): Promise<void> {
+	public async removeNodeIdsFromAllGroups(
+		nodeIds: number[],
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(
 			AssociationCommand,
 			AssociationCommand.Remove,
@@ -230,7 +232,7 @@ export class AssociationCCAPI extends PhysicalCCAPI {
 
 		if (this.version >= 2) {
 			// The node supports bulk removal
-			await this.removeNodeIds({ nodeIds, groupId: 0 });
+			return this.removeNodeIds({ nodeIds, groupId: 0 });
 		} else {
 			// We have to remove the node manually from all groups
 			const groupCount =
@@ -240,6 +242,7 @@ export class AssociationCCAPI extends PhysicalCCAPI {
 					),
 				) ?? 0;
 			for (let groupId = 1; groupId <= groupCount; groupId++) {
+				// TODO: evaluate intermediate supervision results
 				await this.removeNodeIds({ nodeIds, groupId });
 			}
 		}

--- a/packages/cc/src/cc/ClimateControlScheduleCC.ts
+++ b/packages/cc/src/cc/ClimateControlScheduleCC.ts
@@ -3,6 +3,7 @@ import {
 	enumValuesToMetadataStates,
 	Maybe,
 	MessageOrCCLogEntry,
+	SupervisionResult,
 	validatePayload,
 	ValueMetadata,
 	ZWaveError,
@@ -27,6 +28,7 @@ import {
 	commandClass,
 	expectedCCResponse,
 	implementedVersion,
+	useSupervision,
 } from "../lib/CommandClassDecorators";
 import {
 	decodeSetbackState,
@@ -95,7 +97,7 @@ export class ClimateControlScheduleCCAPI extends CCAPI {
 	public async set(
 		weekday: Weekday,
 		switchPoints: Switchpoint[],
-	): Promise<void> {
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(
 			ClimateControlScheduleCommand,
 			ClimateControlScheduleCommand.Set,
@@ -107,7 +109,7 @@ export class ClimateControlScheduleCCAPI extends CCAPI {
 			weekday,
 			switchPoints,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
 	@validateArgs({ strictEnums: true })
@@ -178,7 +180,7 @@ export class ClimateControlScheduleCCAPI extends CCAPI {
 	public async setOverride(
 		type: ScheduleOverrideType,
 		state: SetbackState,
-	): Promise<void> {
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(
 			ClimateControlScheduleCommand,
 			ClimateControlScheduleCommand.OverrideSet,
@@ -190,7 +192,7 @@ export class ClimateControlScheduleCCAPI extends CCAPI {
 			overrideType: type,
 			overrideState: state,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 }
 
@@ -207,6 +209,7 @@ interface ClimateControlScheduleCCSetOptions extends CCCommandOptions {
 }
 
 @CCCommand(ClimateControlScheduleCommand.Set)
+@useSupervision()
 export class ClimateControlScheduleCCSet extends ClimateControlScheduleCC {
 	public constructor(
 		host: ZWaveHost,
@@ -422,6 +425,7 @@ interface ClimateControlScheduleCCOverrideSetOptions extends CCCommandOptions {
 }
 
 @CCCommand(ClimateControlScheduleCommand.OverrideSet)
+@useSupervision()
 export class ClimateControlScheduleCCOverrideSet extends ClimateControlScheduleCC {
 	public constructor(
 		host: ZWaveHost,

--- a/packages/cc/src/cc/ClockCC.ts
+++ b/packages/cc/src/cc/ClockCC.ts
@@ -1,4 +1,8 @@
-import type { Maybe, MessageOrCCLogEntry } from "@zwave-js/core/safe";
+import type {
+	Maybe,
+	MessageOrCCLogEntry,
+	SupervisionResult,
+} from "@zwave-js/core/safe";
 import {
 	CommandClasses,
 	MessagePriority,
@@ -23,6 +27,7 @@ import {
 	commandClass,
 	expectedCCResponse,
 	implementedVersion,
+	useSupervision,
 } from "../lib/CommandClassDecorators";
 import { ClockCommand, Weekday } from "../lib/_Types";
 
@@ -62,7 +67,7 @@ export class ClockCCAPI extends CCAPI {
 		hour: number,
 		minute: number,
 		weekday?: Weekday,
-	): Promise<void> {
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(ClockCommand, ClockCommand.Set);
 
 		const cc = new ClockCCSet(this.applHost, {
@@ -72,7 +77,7 @@ export class ClockCCAPI extends CCAPI {
 			minute,
 			weekday: weekday ?? Weekday.Unknown,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 }
 
@@ -135,6 +140,7 @@ interface ClockCCSetOptions extends CCCommandOptions {
 }
 
 @CCCommand(ClockCommand.Set)
+@useSupervision()
 export class ClockCCSet extends ClockCC {
 	public constructor(
 		host: ZWaveHost,

--- a/packages/cc/src/cc/ConfigurationCC.ts
+++ b/packages/cc/src/cc/ConfigurationCC.ts
@@ -1760,6 +1760,7 @@ function getResponseForBulkSet(cc: ConfigurationCCBulkSet) {
 
 @CCCommand(ConfigurationCommand.BulkSet)
 @expectedCCResponse(getResponseForBulkSet)
+@useSupervision()
 export class ConfigurationCCBulkSet extends ConfigurationCC {
 	public constructor(
 		host: ZWaveHost,

--- a/packages/cc/src/cc/EntryControlCC.ts
+++ b/packages/cc/src/cc/EntryControlCC.ts
@@ -1,12 +1,12 @@
-import type {
-	Maybe,
-	MessageOrCCLogEntry,
-	MessageRecord,
-} from "@zwave-js/core/safe";
 import {
 	CommandClasses,
+	Maybe,
+	MessageOrCCLogEntry,
 	MessagePriority,
+	MessageRecord,
 	parseBitMask,
+	supervisedCommandSucceeded,
+	SupervisionResult,
 	validatePayload,
 	ValueMetadata,
 	ZWaveError,
@@ -38,6 +38,7 @@ import {
 	commandClass,
 	expectedCCResponse,
 	implementedVersion,
+	useSupervision,
 } from "../lib/CommandClassDecorators";
 import { V } from "../lib/Values";
 import {
@@ -162,11 +163,10 @@ export class EntryControlCCAPI extends CCAPI {
 	}
 
 	@validateArgs()
-	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	public async setConfiguration(
 		keyCacheSize: number,
 		keyCacheTimeout: number,
-	) {
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(
 			EntryControlCommand,
 			EntryControlCommand.ConfigurationGet,
@@ -178,14 +178,7 @@ export class EntryControlCCAPI extends CCAPI {
 			keyCacheSize,
 			keyCacheTimeout,
 		});
-		const response =
-			await this.applHost.sendCommand<EntryControlCCConfigurationReport>(
-				cc,
-				this.commandOptions,
-			);
-		if (response) {
-			return pick(response, ["keyCacheSize", "keyCacheTimeout"]);
-		}
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
 	protected [SET_VALUE]: SetValueImplementation = async (
@@ -215,9 +208,17 @@ export class EntryControlCCAPI extends CCAPI {
 			}
 			keyCacheSize = oldKeyCacheSize;
 		}
-		await this.setConfiguration(keyCacheSize, keyCacheTimeout);
+		const result = await this.setConfiguration(
+			keyCacheSize,
+			keyCacheTimeout,
+		);
 
-		return undefined;
+		// Verify the change after a short delay, unless the command was supervised and successful
+		if (this.isSinglecast() && !supervisedCommandSucceeded(result)) {
+			this.schedulePoll({ property }, value, { transition: "fast" });
+		}
+
+		return result;
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({
@@ -604,7 +605,7 @@ interface EntryControlCCConfigurationSetOptions extends CCCommandOptions {
 }
 
 @CCCommand(EntryControlCommand.ConfigurationSet)
-@expectedCCResponse(EntryControlCCConfigurationReport)
+@useSupervision()
 export class EntryControlCCConfigurationSet extends EntryControlCC {
 	public constructor(
 		host: ZWaveHost,

--- a/packages/cc/src/cc/IndicatorCC.ts
+++ b/packages/cc/src/cc/IndicatorCC.ts
@@ -1,5 +1,9 @@
 import type { ConfigManager } from "@zwave-js/config";
-import type { MessageOrCCLogEntry, MessageRecord } from "@zwave-js/core/safe";
+import type {
+	MessageOrCCLogEntry,
+	MessageRecord,
+	SupervisionResult,
+} from "@zwave-js/core/safe";
 import {
 	CommandClasses,
 	Maybe,
@@ -35,6 +39,7 @@ import {
 	commandClass,
 	expectedCCResponse,
 	implementedVersion,
+	useSupervision,
 } from "../lib/CommandClassDecorators";
 import { V } from "../lib/Values";
 import { IndicatorCommand } from "../lib/_Types";
@@ -179,7 +184,7 @@ export class IndicatorCCAPI extends CCAPI {
 					typeof value,
 				);
 			}
-			await this.set(value);
+			return this.set(value);
 		} else if (
 			typeof property === "number" &&
 			typeof propertyKey === "number"
@@ -201,7 +206,7 @@ export class IndicatorCCAPI extends CCAPI {
 					typeof value,
 				);
 			}
-			await this.set([
+			return this.set([
 				{
 					indicatorId: property,
 					propertyId: propertyKey,
@@ -211,8 +216,6 @@ export class IndicatorCCAPI extends CCAPI {
 		} else {
 			throwUnsupportedProperty(this.ccId, property);
 		}
-
-		return undefined;
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({
@@ -247,7 +250,9 @@ export class IndicatorCCAPI extends CCAPI {
 	}
 
 	@validateArgs()
-	public async set(value: number | IndicatorObject[]): Promise<void> {
+	public async set(
+		value: number | IndicatorObject[],
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(IndicatorCommand, IndicatorCommand.Set);
 
 		const cc = new IndicatorCCSet(this.applHost, {
@@ -255,7 +260,7 @@ export class IndicatorCCAPI extends CCAPI {
 			endpoint: this.endpoint.index,
 			...(typeof value === "number" ? { value } : { values: value }),
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
 	@validateArgs()
@@ -297,14 +302,14 @@ export class IndicatorCCAPI extends CCAPI {
 	/**
 	 * Instructs the node to identify itself. Available starting with V3 of this CC.
 	 */
-	public async identify(): Promise<void> {
+	public async identify(): Promise<SupervisionResult | undefined> {
 		if (this.version <= 3) {
 			throw new ZWaveError(
 				`The identify command is only supported in Version 3 and above`,
 				ZWaveErrorCodes.CC_NotSupported,
 			);
 		}
-		await this.set([
+		return this.set([
 			{
 				indicatorId: 0x50,
 				propertyId: 0x03,
@@ -499,6 +504,7 @@ type IndicatorCCSetOptions =
 	  };
 
 @CCCommand(IndicatorCommand.Set)
+@useSupervision()
 export class IndicatorCCSet extends IndicatorCC {
 	public constructor(
 		host: ZWaveHost,

--- a/packages/cc/src/cc/IrrigationCC.ts
+++ b/packages/cc/src/cc/IrrigationCC.ts
@@ -604,7 +604,7 @@ export class IrrigationCCAPI extends CCAPI {
 	@validateArgs({ strictEnums: true })
 	public async setSystemConfig(
 		config: IrrigationCCSystemConfigSetOptions,
-	): Promise<void> {
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(
 			IrrigationCommand,
 			IrrigationCommand.SystemConfigSet,
@@ -616,7 +616,7 @@ export class IrrigationCCAPI extends CCAPI {
 			...config,
 		});
 
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
 	@validateArgs()
@@ -654,7 +654,7 @@ export class IrrigationCCAPI extends CCAPI {
 	@validateArgs()
 	public async setValveConfig(
 		options: IrrigationCCValveConfigSetOptions,
-	): Promise<void> {
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(
 			IrrigationCommand,
 			IrrigationCommand.ValveConfigSet,
@@ -666,7 +666,7 @@ export class IrrigationCCAPI extends CCAPI {
 			...options,
 		});
 
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
 	@validateArgs()
@@ -731,7 +731,7 @@ export class IrrigationCCAPI extends CCAPI {
 	public async setValveTable(
 		tableId: number,
 		entries: ValveTableEntry[],
-	): Promise<void> {
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(
 			IrrigationCommand,
 			IrrigationCommand.ValveTableSet,
@@ -760,7 +760,7 @@ export class IrrigationCCAPI extends CCAPI {
 			entries,
 		});
 
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
 	@validateArgs()
@@ -859,7 +859,7 @@ export class IrrigationCCAPI extends CCAPI {
 			options[property as keyof IrrigationCCSystemConfigSetOptions] =
 				value as any;
 
-			await this.setSystemConfig(options);
+			return this.setSystemConfig(options);
 		} else if (property === "shutoff") {
 			return this.shutoffSystem(0);
 		} else if (
@@ -895,7 +895,7 @@ export class IrrigationCCAPI extends CCAPI {
 				}
 				(options as any)[propertyKey] = value;
 
-				await this.setValveConfig(options);
+				return this.setValveConfig(options);
 			} else if (propertyKey === "duration") {
 				// The run duration needs to be set separately from triggering the run
 				// So this is okay
@@ -1424,6 +1424,7 @@ export type IrrigationCCSystemConfigSetOptions = {
 };
 
 @CCCommand(IrrigationCommand.SystemConfigSet)
+@useSupervision()
 export class IrrigationCCSystemConfigSet extends IrrigationCC {
 	public constructor(
 		host: ZWaveHost,
@@ -1779,6 +1780,7 @@ export type IrrigationCCValveConfigSetOptions = {
 };
 
 @CCCommand(IrrigationCommand.ValveConfigSet)
+@useSupervision()
 export class IrrigationCCValveConfigSet extends IrrigationCC {
 	public constructor(
 		host: ZWaveHost,
@@ -2094,6 +2096,7 @@ interface IrrigationCCValveTableSetOptions extends CCCommandOptions {
 }
 
 @CCCommand(IrrigationCommand.ValveTableSet)
+@useSupervision()
 export class IrrigationCCValveTableSet extends IrrigationCC {
 	public constructor(
 		host: ZWaveHost,

--- a/packages/cc/src/cc/LanguageCC.ts
+++ b/packages/cc/src/cc/LanguageCC.ts
@@ -2,6 +2,7 @@ import type {
 	Maybe,
 	MessageOrCCLogEntry,
 	MessageRecord,
+	SupervisionResult,
 } from "@zwave-js/core/safe";
 import {
 	CommandClasses,
@@ -29,6 +30,7 @@ import {
 	commandClass,
 	expectedCCResponse,
 	implementedVersion,
+	useSupervision,
 } from "../lib/CommandClassDecorators";
 import { V } from "../lib/Values";
 import { LanguageCommand } from "../lib/_Types";
@@ -79,7 +81,10 @@ export class LanguageCCAPI extends CCAPI {
 	}
 
 	@validateArgs()
-	public async set(language: string, country?: string): Promise<void> {
+	public async set(
+		language: string,
+		country?: string,
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(LanguageCommand, LanguageCommand.Set);
 
 		const cc = new LanguageCCSet(this.applHost, {
@@ -88,7 +93,7 @@ export class LanguageCCAPI extends CCAPI {
 			language,
 			country,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 }
 
@@ -148,6 +153,7 @@ interface LanguageCCSetOptions extends CCCommandOptions {
 }
 
 @CCCommand(LanguageCommand.Set)
+@useSupervision()
 export class LanguageCCSet extends LanguageCC {
 	public constructor(
 		host: ZWaveHost,

--- a/packages/cc/src/cc/MeterCC.ts
+++ b/packages/cc/src/cc/MeterCC.ts
@@ -3,7 +3,11 @@ import {
 	getDefaultMeterScale,
 	MeterScale,
 } from "@zwave-js/config";
-import type { MessageOrCCLogEntry, MessageRecord } from "@zwave-js/core/safe";
+import type {
+	MessageOrCCLogEntry,
+	MessageRecord,
+	SupervisionResult,
+} from "@zwave-js/core/safe";
 import {
 	CommandClasses,
 	getMinIntegerSize,
@@ -47,6 +51,7 @@ import {
 	expectedCCResponse,
 	getCommandClass,
 	implementedVersion,
+	useSupervision,
 } from "../lib/CommandClassDecorators";
 import { V } from "../lib/Values";
 import { MeterCommand, RateType } from "../lib/_Types";
@@ -296,7 +301,9 @@ export class MeterCCAPI extends PhysicalCCAPI {
 	}
 
 	@validateArgs()
-	public async reset(options?: MeterCCResetOptions): Promise<void> {
+	public async reset(
+		options?: MeterCCResetOptions,
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(MeterCommand, MeterCommand.Reset);
 
 		const cc = new MeterCCReset(this.applHost, {
@@ -304,7 +311,7 @@ export class MeterCCAPI extends PhysicalCCAPI {
 			endpoint: this.endpoint.index,
 			...options,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
 	protected [SET_VALUE]: SetValueImplementation = async (
@@ -898,6 +905,7 @@ type MeterCCResetOptions =
 	  };
 
 @CCCommand(MeterCommand.Reset)
+@useSupervision()
 export class MeterCCReset extends MeterCC {
 	public constructor(
 		host: ZWaveHost,

--- a/packages/cc/src/cc/MultiChannelAssociationCC.ts
+++ b/packages/cc/src/cc/MultiChannelAssociationCC.ts
@@ -1,4 +1,8 @@
-import type { IZWaveEndpoint, MessageRecord } from "@zwave-js/core/safe";
+import type {
+	IZWaveEndpoint,
+	MessageRecord,
+	SupervisionResult,
+} from "@zwave-js/core/safe";
 import {
 	CommandClasses,
 	encodeBitMask,
@@ -29,6 +33,7 @@ import {
 	commandClass,
 	expectedCCResponse,
 	implementedVersion,
+	useSupervision,
 } from "../lib/CommandClassDecorators";
 import * as ccUtils from "../lib/utils";
 import { V } from "../lib/Values";
@@ -239,7 +244,7 @@ export class MultiChannelAssociationCCAPI extends PhysicalCCAPI {
 	@validateArgs()
 	public async addDestinations(
 		options: MultiChannelAssociationCCSetOptions,
-	): Promise<void> {
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(
 			MultiChannelAssociationCommand,
 			MultiChannelAssociationCommand.Set,
@@ -250,7 +255,7 @@ export class MultiChannelAssociationCCAPI extends PhysicalCCAPI {
 			endpoint: this.endpoint.index,
 			...options,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
 	/**
@@ -259,7 +264,7 @@ export class MultiChannelAssociationCCAPI extends PhysicalCCAPI {
 	@validateArgs()
 	public async removeDestinations(
 		options: MultiChannelAssociationCCRemoveOptions,
-	): Promise<void> {
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(
 			MultiChannelAssociationCommand,
 			MultiChannelAssociationCommand.Remove,
@@ -286,6 +291,7 @@ export class MultiChannelAssociationCCAPI extends PhysicalCCAPI {
 							!!d.endpoint,
 					),
 				});
+				// TODO: evaluate intermediate supervision results
 				await this.applHost.sendCommand(cc, this.commandOptions);
 			}
 		} else {
@@ -294,7 +300,7 @@ export class MultiChannelAssociationCCAPI extends PhysicalCCAPI {
 				endpoint: this.endpoint.index,
 				...options,
 			});
-			await this.applHost.sendCommand(cc, this.commandOptions);
+			return this.applHost.sendCommand(cc, this.commandOptions);
 		}
 	}
 }
@@ -562,6 +568,7 @@ type MultiChannelAssociationCCSetOptions = {
 );
 
 @CCCommand(MultiChannelAssociationCommand.Set)
+@useSupervision()
 export class MultiChannelAssociationCCSet extends MultiChannelAssociationCC {
 	public constructor(
 		host: ZWaveHost,

--- a/packages/cc/src/cc/MultilevelSensorCC.ts
+++ b/packages/cc/src/cc/MultilevelSensorCC.ts
@@ -2,6 +2,7 @@ import { getDefaultScale, Scale } from "@zwave-js/config";
 import type {
 	MessageOrCCLogEntry,
 	MessageRecord,
+	SupervisionResult,
 	ValueID,
 } from "@zwave-js/core/safe";
 import {
@@ -41,6 +42,7 @@ import {
 	commandClass,
 	expectedCCResponse,
 	implementedVersion,
+	useSupervision,
 } from "../lib/CommandClassDecorators";
 import { V } from "../lib/Values";
 import { MultilevelSensorCommand, MultilevelSensorValue } from "../lib/_Types";
@@ -317,7 +319,7 @@ export class MultilevelSensorCCAPI extends PhysicalCCAPI {
 		sensorType: number,
 		scale: number | Scale,
 		value: number,
-	): Promise<void> {
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(
 			MultilevelSensorCommand,
 			MultilevelSensorCommand.Report,
@@ -330,7 +332,7 @@ export class MultilevelSensorCCAPI extends PhysicalCCAPI {
 			scale,
 			value,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 }
 
@@ -525,6 +527,7 @@ export interface MultilevelSensorCCReportOptions extends CCCommandOptions {
 }
 
 @CCCommand(MultilevelSensorCommand.Report)
+@useSupervision()
 export class MultilevelSensorCCReport extends MultilevelSensorCC {
 	public constructor(
 		host: ZWaveHost,

--- a/packages/cc/src/cc/NodeNamingCC.ts
+++ b/packages/cc/src/cc/NodeNamingCC.ts
@@ -1,6 +1,7 @@
 import {
 	CommandClasses,
 	MessagePriority,
+	SupervisionResult,
 	validatePayload,
 	ValueMetadata,
 	ZWaveError,
@@ -34,6 +35,7 @@ import {
 	commandClass,
 	expectedCCResponse,
 	implementedVersion,
+	useSupervision,
 } from "../lib/CommandClassDecorators";
 import { V } from "../lib/Values";
 import { NodeNamingAndLocationCommand } from "../lib/_Types";
@@ -90,11 +92,9 @@ export class NodeNamingAndLocationCCAPI extends PhysicalCCAPI {
 
 		switch (property) {
 			case "name":
-				await this.setName(value);
-				break;
+				return this.setName(value);
 			case "location":
-				await this.setLocation(value);
-				break;
+				return this.setLocation(value);
 		}
 
 		return undefined;
@@ -132,7 +132,7 @@ export class NodeNamingAndLocationCCAPI extends PhysicalCCAPI {
 	}
 
 	@validateArgs()
-	public async setName(name: string): Promise<void> {
+	public async setName(name: string): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(
 			NodeNamingAndLocationCommand,
 			NodeNamingAndLocationCommand.NameSet,
@@ -143,7 +143,7 @@ export class NodeNamingAndLocationCCAPI extends PhysicalCCAPI {
 			endpoint: this.endpoint.index,
 			name,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
 	public async getLocation(): Promise<string | undefined> {
@@ -165,7 +165,9 @@ export class NodeNamingAndLocationCCAPI extends PhysicalCCAPI {
 	}
 
 	@validateArgs()
-	public async setLocation(location: string): Promise<void> {
+	public async setLocation(
+		location: string,
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(
 			NodeNamingAndLocationCommand,
 			NodeNamingAndLocationCommand.LocationSet,
@@ -176,7 +178,7 @@ export class NodeNamingAndLocationCCAPI extends PhysicalCCAPI {
 			endpoint: this.endpoint.index,
 			location,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 }
 
@@ -248,6 +250,7 @@ interface NodeNamingAndLocationCCNameSetOptions extends CCCommandOptions {
 }
 
 @CCCommand(NodeNamingAndLocationCommand.NameSet)
+@useSupervision()
 export class NodeNamingAndLocationCCNameSet extends NodeNamingAndLocationCC {
 	public constructor(
 		host: ZWaveHost,
@@ -335,6 +338,7 @@ interface NodeNamingAndLocationCCLocationSetOptions extends CCCommandOptions {
 }
 
 @CCCommand(NodeNamingAndLocationCommand.LocationSet)
+@useSupervision()
 export class NodeNamingAndLocationCCLocationSet extends NodeNamingAndLocationCC {
 	public constructor(
 		host: ZWaveHost,

--- a/packages/cc/src/cc/NotificationCC.ts
+++ b/packages/cc/src/cc/NotificationCC.ts
@@ -15,6 +15,7 @@ import {
 	MessagePriority,
 	MessageRecord,
 	parseBitMask,
+	SupervisionResult,
 	validatePayload,
 	ValueMetadata,
 	ValueMetadataNumeric,
@@ -41,6 +42,7 @@ import {
 	commandClass,
 	expectedCCResponse,
 	implementedVersion,
+	useSupervision,
 } from "../lib/CommandClassDecorators";
 import { isNotificationEventPayload } from "../lib/NotificationEventPayload";
 import * as ccUtils from "../lib/utils";
@@ -192,7 +194,7 @@ export class NotificationCCAPI extends PhysicalCCAPI {
 	@validateArgs()
 	public async sendReport(
 		options: NotificationCCReportOptions,
-	): Promise<void> {
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(
 			NotificationCommand,
 			NotificationCommand.Report,
@@ -203,7 +205,7 @@ export class NotificationCCAPI extends PhysicalCCAPI {
 			endpoint: this.endpoint.index,
 			...options,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
 	@validateArgs()
@@ -226,7 +228,7 @@ export class NotificationCCAPI extends PhysicalCCAPI {
 	public async set(
 		notificationType: number,
 		notificationStatus: boolean,
-	): Promise<void> {
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(
 			NotificationCommand,
 			NotificationCommand.Set,
@@ -238,7 +240,7 @@ export class NotificationCCAPI extends PhysicalCCAPI {
 			notificationType,
 			notificationStatus,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -626,6 +628,7 @@ interface NotificationCCSetOptions extends CCCommandOptions {
 }
 
 @CCCommand(NotificationCommand.Set)
+@useSupervision()
 export class NotificationCCSet extends NotificationCC {
 	public constructor(
 		host: ZWaveHost,
@@ -680,6 +683,7 @@ export type NotificationCCReportOptions =
 	  };
 
 @CCCommand(NotificationCommand.Report)
+@useSupervision()
 export class NotificationCCReport extends NotificationCC {
 	public constructor(
 		host: ZWaveHost,

--- a/packages/cc/src/cc/PowerlevelCC.ts
+++ b/packages/cc/src/cc/PowerlevelCC.ts
@@ -4,6 +4,7 @@ import {
 	MessageOrCCLogEntry,
 	MessageRecord,
 	NodeStatus,
+	SupervisionResult,
 	validatePayload,
 	ZWaveError,
 	ZWaveErrorCodes,
@@ -24,6 +25,7 @@ import {
 	commandClass,
 	expectedCCResponse,
 	implementedVersion,
+	useSupervision,
 } from "../lib/CommandClassDecorators";
 import {
 	Powerlevel,
@@ -45,7 +47,7 @@ export class PowerlevelCCAPI extends PhysicalCCAPI {
 		return super.supportsCommand(cmd);
 	}
 
-	public async setNormalPowerlevel(): Promise<void> {
+	public async setNormalPowerlevel(): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(PowerlevelCommand, PowerlevelCommand.Set);
 
 		const cc = new PowerlevelCCSet(this.applHost, {
@@ -53,14 +55,14 @@ export class PowerlevelCCAPI extends PhysicalCCAPI {
 			endpoint: this.endpoint.index,
 			powerlevel: Powerlevel["Normal Power"],
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
 	@validateArgs({ strictEnums: true })
 	public async setCustomPowerlevel(
 		powerlevel: Powerlevel,
 		timeout: number,
-	): Promise<void> {
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(PowerlevelCommand, PowerlevelCommand.Set);
 
 		const cc = new PowerlevelCCSet(this.applHost, {
@@ -69,7 +71,7 @@ export class PowerlevelCCAPI extends PhysicalCCAPI {
 			powerlevel,
 			timeout,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
 	public async getPowerlevel(): Promise<
@@ -95,7 +97,7 @@ export class PowerlevelCCAPI extends PhysicalCCAPI {
 		testNodeId: number,
 		powerlevel: Powerlevel,
 		testFrameCount: number,
-	): Promise<void> {
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(
 			PowerlevelCommand,
 			PowerlevelCommand.TestNodeSet,
@@ -128,7 +130,7 @@ export class PowerlevelCCAPI extends PhysicalCCAPI {
 			powerlevel,
 			testFrameCount,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
 	public async getNodeTestStatus(): Promise<
@@ -181,6 +183,7 @@ type PowerlevelCCSetOptions = CCCommandOptions &
 	);
 
 @CCCommand(PowerlevelCommand.Set)
+@useSupervision()
 export class PowerlevelCCSet extends PowerlevelCC {
 	public constructor(
 		host: ZWaveHost,
@@ -271,6 +274,7 @@ interface PowerlevelCCTestNodeSetOptions extends CCCommandOptions {
 }
 
 @CCCommand(PowerlevelCommand.TestNodeSet)
+@useSupervision()
 export class PowerlevelCCTestNodeSet extends PowerlevelCC {
 	public constructor(
 		host: ZWaveHost,

--- a/packages/cc/src/cc/SceneActivationCC.ts
+++ b/packages/cc/src/cc/SceneActivationCC.ts
@@ -2,6 +2,7 @@ import type {
 	Maybe,
 	MessageOrCCLogEntry,
 	MessageRecord,
+	SupervisionResult,
 } from "@zwave-js/core/safe";
 import {
 	CommandClasses,
@@ -31,6 +32,7 @@ import {
 	ccValues,
 	commandClass,
 	implementedVersion,
+	useSupervision,
 } from "../lib/CommandClassDecorators";
 import { V } from "../lib/Values";
 import { SceneActivationCommand } from "../lib/_Types";
@@ -76,9 +78,7 @@ export class SceneActivationCCAPI extends CCAPI {
 			throwWrongValueType(this.ccId, property, "number", typeof value);
 		}
 		const duration = Duration.from(options?.transitionDuration);
-		await this.set(value, duration);
-
-		return undefined;
+		return this.set(value, duration);
 	};
 
 	/**
@@ -89,7 +89,7 @@ export class SceneActivationCCAPI extends CCAPI {
 	public async set(
 		sceneId: number,
 		dimmingDuration?: Duration | string,
-	): Promise<void> {
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(
 			SceneActivationCommand,
 			SceneActivationCommand.Set,
@@ -101,7 +101,7 @@ export class SceneActivationCCAPI extends CCAPI {
 			sceneId,
 			dimmingDuration,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 }
 
@@ -118,6 +118,7 @@ interface SceneActivationCCSetOptions extends CCCommandOptions {
 }
 
 @CCCommand(SceneActivationCommand.Set)
+@useSupervision()
 export class SceneActivationCCSet extends SceneActivationCC {
 	public constructor(
 		host: ZWaveHost,

--- a/packages/cc/src/cc/SceneActuatorConfigurationCC.ts
+++ b/packages/cc/src/cc/SceneActuatorConfigurationCC.ts
@@ -4,6 +4,7 @@ import {
 	getCCName,
 	Maybe,
 	MessageOrCCLogEntry,
+	SupervisionResult,
 	validatePayload,
 	ValueMetadata,
 	ZWaveError,
@@ -36,6 +37,7 @@ import {
 	commandClass,
 	expectedCCResponse,
 	implementedVersion,
+	useSupervision,
 } from "../lib/CommandClassDecorators";
 import { V } from "../lib/Values";
 import { SceneActuatorConfigurationCommand } from "../lib/_Types";
@@ -118,7 +120,7 @@ export class SceneActuatorConfigurationCCAPI extends CCAPI {
 						propertyKey,
 					).endpoint(this.endpoint.index),
 				);
-			await this.set(propertyKey, dimmingDuration, value);
+			return this.set(propertyKey, dimmingDuration, value);
 		} else if (property === "dimmingDuration") {
 			if (typeof value !== "string" && !(value instanceof Duration)) {
 				throwWrongValueType(
@@ -150,12 +152,10 @@ export class SceneActuatorConfigurationCCAPI extends CCAPI {
 				),
 			);
 
-			await this.set(propertyKey, dimmingDuration, level);
+			return this.set(propertyKey, dimmingDuration, level);
 		} else {
 			throwUnsupportedProperty(this.ccId, property);
 		}
-
-		return undefined;
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({
@@ -186,7 +186,7 @@ export class SceneActuatorConfigurationCCAPI extends CCAPI {
 		sceneId: number,
 		dimmingDuration?: Duration | string,
 		level?: number,
-	): Promise<void> {
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(
 			SceneActuatorConfigurationCommand,
 			SceneActuatorConfigurationCommand.Set,
@@ -204,7 +204,7 @@ export class SceneActuatorConfigurationCCAPI extends CCAPI {
 			level,
 		});
 
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
 	public async getActive(): Promise<
@@ -328,6 +328,7 @@ interface SceneActuatorConfigurationCCSetOptions extends CCCommandOptions {
 }
 
 @CCCommand(SceneActuatorConfigurationCommand.Set)
+@useSupervision()
 export class SceneActuatorConfigurationCCSet extends SceneActuatorConfigurationCC {
 	public constructor(
 		host: ZWaveHost,

--- a/packages/cc/src/cc/ThermostatSetbackCC.ts
+++ b/packages/cc/src/cc/ThermostatSetbackCC.ts
@@ -1,4 +1,8 @@
-import type { Maybe, MessageOrCCLogEntry } from "@zwave-js/core/safe";
+import type {
+	Maybe,
+	MessageOrCCLogEntry,
+	SupervisionResult,
+} from "@zwave-js/core/safe";
 import {
 	CommandClasses,
 	MessagePriority,
@@ -30,6 +34,7 @@ import {
 	commandClass,
 	expectedCCResponse,
 	implementedVersion,
+	useSupervision,
 } from "../lib/CommandClassDecorators";
 import { decodeSetbackState, encodeSetbackState } from "../lib/serializers";
 import { V } from "../lib/Values";
@@ -109,7 +114,7 @@ export class ThermostatSetbackCCAPI extends CCAPI {
 	public async set(
 		setbackType: SetbackType,
 		setbackState: SetbackState,
-	): Promise<void> {
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(
 			ThermostatSetbackCommand,
 			ThermostatSetbackCommand.Get,
@@ -121,7 +126,7 @@ export class ThermostatSetbackCCAPI extends CCAPI {
 			setbackType,
 			setbackState,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 }
 
@@ -183,6 +188,7 @@ interface ThermostatSetbackCCSetOptions extends CCCommandOptions {
 }
 
 @CCCommand(ThermostatSetbackCommand.Set)
+@useSupervision()
 export class ThermostatSetbackCCSet extends ThermostatSetbackCC {
 	public constructor(
 		host: ZWaveHost,

--- a/packages/cc/src/cc/TimeCC.ts
+++ b/packages/cc/src/cc/TimeCC.ts
@@ -6,6 +6,7 @@ import {
 	Maybe,
 	MessageOrCCLogEntry,
 	MessagePriority,
+	SupervisionResult,
 	validatePayload,
 	ZWaveError,
 	ZWaveErrorCodes,
@@ -27,6 +28,7 @@ import {
 	commandClass,
 	expectedCCResponse,
 	implementedVersion,
+	useSupervision,
 } from "../lib/CommandClassDecorators";
 import { encodeTimezone, parseTimezone } from "../lib/serializers";
 import { TimeCommand } from "../lib/_Types";
@@ -73,7 +75,7 @@ export class TimeCCAPI extends CCAPI {
 		hour: number,
 		minute: number,
 		second: number,
-	): Promise<void> {
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(TimeCommand, TimeCommand.TimeReport);
 
 		const cc = new TimeCCTimeReport(this.applHost, {
@@ -83,7 +85,7 @@ export class TimeCCAPI extends CCAPI {
 			minute,
 			second,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -107,7 +109,7 @@ export class TimeCCAPI extends CCAPI {
 		year: number,
 		month: number,
 		day: number,
-	): Promise<void> {
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(TimeCommand, TimeCommand.DateReport);
 
 		const cc = new TimeCCDateReport(this.applHost, {
@@ -117,11 +119,13 @@ export class TimeCCAPI extends CCAPI {
 			month,
 			day,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
 	@validateArgs()
-	public async setTimezone(timezone: DSTInfo): Promise<void> {
+	public async setTimezone(
+		timezone: DSTInfo,
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(TimeCommand, TimeCommand.TimeOffsetSet);
 
 		const cc = new TimeCCTimeOffsetSet(this.applHost, {
@@ -132,7 +136,7 @@ export class TimeCCAPI extends CCAPI {
 			dstStart: timezone.startDate,
 			dstEnd: timezone.endDate,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
 	public async getTimezone(): Promise<DSTInfo | undefined> {
@@ -158,7 +162,9 @@ export class TimeCCAPI extends CCAPI {
 	}
 
 	@validateArgs()
-	public async reportTimezone(timezone: DSTInfo): Promise<void> {
+	public async reportTimezone(
+		timezone: DSTInfo,
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(TimeCommand, TimeCommand.TimeOffsetReport);
 
 		const cc = new TimeCCTimeOffsetReport(this.applHost, {
@@ -169,7 +175,7 @@ export class TimeCCAPI extends CCAPI {
 			dstStart: timezone.startDate,
 			dstEnd: timezone.endDate,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 }
 
@@ -219,6 +225,7 @@ interface TimeCCTimeReportOptions extends CCCommandOptions {
 }
 
 @CCCommand(TimeCommand.TimeReport)
+@useSupervision()
 export class TimeCCTimeReport extends TimeCC {
 	public constructor(
 		host: ZWaveHost,
@@ -278,6 +285,7 @@ interface TimeCCDateReportOptions extends CCCommandOptions {
 }
 
 @CCCommand(TimeCommand.DateReport)
+@useSupervision()
 export class TimeCCDateReport extends TimeCC {
 	public constructor(
 		host: ZWaveHost,
@@ -338,6 +346,7 @@ interface TimeCCTimeOffsetSetOptions extends CCCommandOptions {
 }
 
 @CCCommand(TimeCommand.TimeOffsetSet)
+@useSupervision()
 export class TimeCCTimeOffsetSet extends TimeCC {
 	public constructor(
 		host: ZWaveHost,
@@ -404,6 +413,7 @@ interface TimeCCTimeOffsetReportOptions extends CCCommandOptions {
 }
 
 @CCCommand(TimeCommand.TimeOffsetReport)
+@useSupervision()
 export class TimeCCTimeOffsetReport extends TimeCC {
 	public constructor(
 		host: ZWaveHost,

--- a/packages/cc/src/cc/TimeParametersCC.ts
+++ b/packages/cc/src/cc/TimeParametersCC.ts
@@ -5,6 +5,7 @@ import {
 	Maybe,
 	MessageOrCCLogEntry,
 	MessagePriority,
+	SupervisionResult,
 	validatePayload,
 	ValueMetadata,
 } from "@zwave-js/core";
@@ -33,6 +34,7 @@ import {
 	commandClass,
 	expectedCCResponse,
 	implementedVersion,
+	useSupervision,
 } from "../lib/CommandClassDecorators";
 import { V } from "../lib/Values";
 import { TimeParametersCommand } from "../lib/_Types";
@@ -132,9 +134,7 @@ export class TimeParametersCCAPI extends CCAPI {
 		if (!(value instanceof Date)) {
 			throwWrongValueType(this.ccId, property, "date", typeof value);
 		}
-		await this.set(value);
-
-		return undefined;
+		return this.set(value);
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({
@@ -167,7 +167,9 @@ export class TimeParametersCCAPI extends CCAPI {
 	}
 
 	@validateArgs()
-	public async set(dateAndTime: Date): Promise<void> {
+	public async set(
+		dateAndTime: Date,
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(
 			TimeParametersCommand,
 			TimeParametersCommand.Set,
@@ -187,7 +189,7 @@ export class TimeParametersCCAPI extends CCAPI {
 			dateAndTime,
 			useLocalTime,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 }
 
@@ -295,6 +297,7 @@ interface TimeParametersCCSetOptions extends CCCommandOptions {
 }
 
 @CCCommand(TimeParametersCommand.Set)
+@useSupervision()
 export class TimeParametersCCSet extends TimeParametersCC {
 	public constructor(
 		host: ZWaveHost,

--- a/packages/cc/src/cc/WakeUpCC.ts
+++ b/packages/cc/src/cc/WakeUpCC.ts
@@ -3,6 +3,8 @@ import {
 	Maybe,
 	MessageOrCCLogEntry,
 	MessagePriority,
+	supervisedCommandSucceeded,
+	SupervisionResult,
 	TransmitOptions,
 	validatePayload,
 	ValueMetadata,
@@ -96,14 +98,17 @@ export class WakeUpCCAPI extends CCAPI {
 		if (typeof value !== "number") {
 			throwWrongValueType(this.ccId, property, "number", typeof value);
 		}
-		await this.setInterval(value, this.applHost.ownNodeId ?? 1);
+		const result = await this.setInterval(
+			value,
+			this.applHost.ownNodeId ?? 1,
+		);
 
-		if (this.isSinglecast()) {
-			// Verify the current value after a (short) delay
+		// Verify the change after a short delay, unless the command was supervised and successful
+		if (this.isSinglecast() && !supervisedCommandSucceeded(result)) {
 			this.schedulePoll({ property }, value, { transition: "fast" });
 		}
 
-		return undefined;
+		return result;
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({
@@ -166,7 +171,7 @@ export class WakeUpCCAPI extends CCAPI {
 	public async setInterval(
 		wakeUpInterval: number,
 		controllerNodeId: number,
-	): Promise<void> {
+	): Promise<SupervisionResult | undefined> {
 		this.assertSupportsCommand(WakeUpCommand, WakeUpCommand.IntervalSet);
 
 		const cc = new WakeUpCCIntervalSet(this.applHost, {
@@ -175,7 +180,7 @@ export class WakeUpCCAPI extends CCAPI {
 			wakeUpInterval,
 			controllerNodeId,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
 	public async sendNoMoreInformation(): Promise<void> {


### PR DESCRIPTION
Investigations have shown that S2-encrypted communication only works reliably if we expect some kind of feedback from the node. With this feedback we can correlate Nonce Reports and re-transmit commands that were not understood.

Depending on the verification strategy, this increases or decreases the command count for a communication attempt:
- no verification GET: +/- 0 (if device reports unsolicited) to +1 command (if no unsolicited reports)
- verification GET (now replaced with Supervision): +/- 0 (if device reports unsolicited) to -1 command (if no unsolicited reports)

also fixes: https://github.com/zwave-js/node-zwave-js/issues/3517
