### PR TITLE
feat: remember premature node updates until Serial API command has completed

### DIFF
--- a/packages/serial/api.md
+++ b/packages/serial/api.md
@@ -427,6 +427,7 @@ export class Message {
     needsCallbackId(): boolean;
     // (undocumented)
     payload: Buffer;
+    prematureNodeUpdate: Message | undefined;
     get rtt(): number | undefined;
     serialize(): Buffer;
     toJSON(): JSONObject;

--- a/packages/serial/src/message/Message.ts
+++ b/packages/serial/src/message/Message.ts
@@ -361,6 +361,9 @@ export class Message {
 		return false;
 	}
 
+	/** Gets set by the driver to remember an expected node update for this message that arrived before the Serial API command has finished. */
+	public prematureNodeUpdate: Message | undefined;
+
 	/** Finds the ID of the target or source node in a message, if it contains that information */
 	public getNodeId(): number | undefined {
 		if (isNodeQuery(this)) return this.nodeId;

--- a/packages/zwave-js/src/lib/driver/MessageGenerators.ts
+++ b/packages/zwave-js/src/lib/driver/MessageGenerators.ts
@@ -72,6 +72,9 @@ export const simpleMessageGenerator: MessageGeneratorImplementation =
 		// Pass this message to the send thread and wait for it to be sent
 		let result: Message;
 		let commandTimeMs: number;
+		// At this point we can't have received a premature update
+		msg.prematureNodeUpdate = undefined;
+
 		try {
 			// The yield can throw and must be handled here
 			result = yield msg;
@@ -98,6 +101,9 @@ export const simpleMessageGenerator: MessageGeneratorImplementation =
 
 		// If the sent message expects an update from the node, wait for it
 		if (msg.expectsNodeUpdate()) {
+			// We might have received the update prematurely. In that case, return it.
+			if (msg.prematureNodeUpdate) return msg.prematureNodeUpdate;
+
 			// CommandTime is measured by the application
 			// ReportTime timeout SHOULD be set to CommandTime + 1 second.
 			const timeout =

--- a/packages/zwave-js/src/lib/test/driver/fixtures/base_2_nodes/7e570001.jsonl
+++ b/packages/zwave-js/src/lib/test/driver/fixtures/base_2_nodes/7e570001.jsonl
@@ -1,0 +1,16 @@
+{"k":"cacheFormat","v":1}
+{"k":"node.1.isListening","v":true}
+{"k":"node.1.isFrequentListening","v":false}
+{"k":"node.1.isRouting","v":true}
+{"k":"node.1.supportedDataRates","v":[40000,9600,100000]}
+{"k":"node.1.protocolVersion","v":3}
+{"k":"node.1.nodeType","v":"Controller"}
+{"k":"node.1.supportsSecurity","v":false}
+{"k":"node.1.supportsBeaming","v":true}
+{"k":"node.1.deviceClass","v":{"basic":2,"generic":2,"specific":7}}
+{"k":"node.1.endpoint.0.commandClass.0x72","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x86","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x20","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x60","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.interviewStage","v":"Complete"}
+{"k":"node.2.hasSUCReturnRoute","v":true}

--- a/packages/zwave-js/src/lib/test/driver/nodeUpdateBeforeCallback.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeUpdateBeforeCallback.test.ts
@@ -1,0 +1,61 @@
+import { BasicCCGet, BasicCCReport } from "@zwave-js/cc";
+import {
+	createMockZWaveRequestFrame,
+	MockNodeBehavior,
+	MockZWaveFrameType,
+} from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import path from "path";
+import { integrationTest } from "../integrationTestSuite";
+
+integrationTest(
+	"Correctly capture node updates that arrive before the SendData callback",
+	{
+		debug: true,
+		provisioningDirectory: path.join(__dirname, "fixtures/base_2_nodes"),
+
+		// nodeCapabilities: {
+		// 	commandClasses: [
+		// 		{
+		// 			ccId: CommandClasses["Z-Wave Plus Info"],
+		// 			isSupported: true,
+		// 			version: 2,
+		// 		},
+		// 	],
+		// },
+
+		testBody: async (driver, node, _mockController, mockNode) => {
+			// Make the node respond first before ACKing the command
+			mockNode.autoAckControllerFrames = false;
+
+			const respondToBasicGetWithDelayedAck: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof BasicCCGet
+					) {
+						const cc = new BasicCCReport(controller.host, {
+							nodeId: self.id,
+							currentValue: 55,
+						});
+						await self.sendToController(
+							createMockZWaveRequestFrame(cc, {
+								ackRequested: false,
+							}),
+						);
+
+						await wait(100);
+
+						await self.ackControllerRequestFrame(frame);
+						return true;
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(respondToBasicGetWithDelayedAck);
+
+			const result = await node.commandClasses.Basic.get();
+			expect(result?.currentValue).toBe(55);
+		},
+	},
+);


### PR DESCRIPTION
We have long had issues with the situation where a node's response to a GET-type CC is received and handled before the ACK/callback of the outgoing SendData command. Prior to this PR we would fail to match the response to the request and as a result treat it like a timeout. Now we detect these premature updates and remember them on the correct message until that is ready to be resolved.

fixes: https://github.com/zwave-js/node-zwave-js/issues/3964