### PR TITLE
fix: missing/incorrect dependencies

### DIFF
--- a/packages/cc/package.json
+++ b/packages/cc/package.json
@@ -63,6 +63,7 @@
     "@zwave-js/serial": "workspace:*",
     "@zwave-js/shared": "workspace:*",
     "alcalzone-shared": "^4.0.1",
+    "ansi-colors": "^4.1.3",
     "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {

--- a/packages/serial/package.json
+++ b/packages/serial/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "@sentry/node": "^7.8.1",
+    "@serialport/stream": "^10.3.0",
     "@zwave-js/core": "workspace:*",
     "@zwave-js/host": "workspace:*",
     "@zwave-js/shared": "workspace:*",
@@ -65,7 +66,6 @@
     "@microsoft/api-extractor": "*",
     "@serialport/binding-mock": "^10.2.2",
     "@serialport/bindings-interface": "*",
-    "@serialport/stream": "*",
     "@types/jest": "^27.5.2",
     "@types/node": "^14.18.23",
     "@zwave-js/testing": "workspace:*",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -40,14 +40,14 @@
     "@zwave-js/core": "workspace:*",
     "@zwave-js/host": "workspace:*",
     "@zwave-js/serial": "workspace:*",
-    "@zwave-js/shared": "workspace:*"
+    "@zwave-js/shared": "workspace:*",
+    "ansi-colors": "^4.1.3"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "*",
     "@types/jest": "^27.5.2",
     "@types/node": "^14.18.23",
     "@types/triple-beam": "^1.3.2",
-    "ansi-colors": "^4.1.3",
     "esbuild": "0.14.51",
     "esbuild-register": "^3.3.3",
     "jest-extended": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3495,7 +3495,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@serialport/stream@npm:*, @serialport/stream@npm:10.3.0":
+"@serialport/stream@npm:10.3.0, @serialport/stream@npm:^10.3.0":
   version: 10.3.0
   resolution: "@serialport/stream@npm:10.3.0"
   dependencies:
@@ -4050,6 +4050,7 @@ __metadata:
     "@zwave-js/testing": "workspace:*"
     "@zwave-js/transformers": "workspace:*"
     alcalzone-shared: ^4.0.1
+    ansi-colors: ^4.1.3
     fs-extra: ^10.1.0
     jest-extended: ^2.0.0
     reflect-metadata: ^0.1.13
@@ -4266,7 +4267,7 @@ __metadata:
     "@sentry/node": ^7.8.1
     "@serialport/binding-mock": ^10.2.2
     "@serialport/bindings-interface": "*"
-    "@serialport/stream": "*"
+    "@serialport/stream": ^10.3.0
     "@types/jest": ^27.5.2
     "@types/node": ^14.18.23
     "@zwave-js/core": "workspace:*"


### PR DESCRIPTION
Without this, the wrong versions can be loaded on systems with other packages using older versions of these dependencies.