### PR TITLE
fix: randomize Supervision session ID on startup

### DIFF
--- a/packages/shared/api.md
+++ b/packages/shared/api.md
@@ -58,10 +58,11 @@ export function cpp2js(str: string): string;
 export function createThrowingMap<K, V>(throwKeyNotFound?: (key: K) => never): ThrowingMap<K, V>;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (ae-missing-release-tag) "createWrappingCounter" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-export function createWrappingCounter(maxValue: number): () => number;
+export function createWrappingCounter(maxValue: number, randomSeed?: boolean): () => number;
 
 // Warning: (ae-missing-release-tag) "DeepPartial" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/packages/shared/src/wrappingCounter.ts
+++ b/packages/shared/src/wrappingCounter.ts
@@ -1,8 +1,12 @@
 /**
  * Creates a counter that starts at 1 and wraps after surpassing `maxValue`.
  * @param maxValue The maximum value that the counter can reach. Must a number where all bits are set to 1.
+ * @param randomSeed Whether the initial value should be randomized. Default: `false`.
  */
-export function createWrappingCounter(maxValue: number): () => number {
+export function createWrappingCounter(
+	maxValue: number,
+	randomSeed: boolean = false,
+): () => number {
 	const ret = (() => {
 		ret.value = (ret.value + 1) & maxValue;
 		if (ret.value === 0) ret.value = 1;
@@ -14,6 +18,6 @@ export function createWrappingCounter(maxValue: number): () => number {
 		// no longer need this
 		value: number;
 	};
-	ret.value = 0;
+	ret.value = randomSeed ? Math.round(Math.random() * maxValue) : 0;
 	return ret;
 }

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -3575,6 +3575,7 @@ ${handlers.length} left`,
 	 */
 	public readonly getNextSupervisionSessionId = createWrappingCounter(
 		MAX_SUPERVISION_SESSION_ID,
+		true,
 	);
 
 	private encapsulateCommands(msg: Message & ICommandClassContainer): void {


### PR DESCRIPTION
Otherwise a driver restart may result in devices ignoring the request