### PR TITLE
fix: use highest CC version implemented by the driver when node's CC version is unknown

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1970,7 +1970,7 @@ export class Driver
 
 	/**
 	 * Retrieves the maximum version of a command class that can be used to communicate with a node.
-	 * Returns 1 if the node claims that it does not support a CC.
+	 * Returns the highest implemented version if the node's CC version is unknown.
 	 * Throws if the CC is not implemented in this library yet.
 	 *
 	 * @param cc The command class whose version should be retrieved
@@ -1988,8 +1988,14 @@ export class Driver
 			endpointIndex,
 		);
 		if (supportedVersion === 0) {
-			// For unsupported CCs use version 1, no matter what
-			return 1;
+			// Unknown, use the highest implemented version
+			const implementedVersion = getImplementedVersion(cc);
+			if (
+				implementedVersion !== 0 &&
+				implementedVersion !== Number.POSITIVE_INFINITY
+			) {
+				return implementedVersion;
+			}
 		} else {
 			// For supported versions find the maximum version supported by both the
 			// node and this library
@@ -2000,11 +2006,11 @@ export class Driver
 			) {
 				return Math.min(supportedVersion, implementedVersion);
 			}
-			throw new ZWaveError(
-				"Cannot retrieve the version of a CC that is not implemented",
-				ZWaveErrorCodes.CC_NotSupported,
-			);
 		}
+		throw new ZWaveError(
+			"Cannot retrieve the version of a CC that is not implemented",
+			ZWaveErrorCodes.CC_NotSupported,
+		);
 	}
 
 	/**

--- a/packages/zwave-js/src/lib/test/driver/fixtures/multiChannelUnknownVersions/7e570001.jsonl
+++ b/packages/zwave-js/src/lib/test/driver/fixtures/multiChannelUnknownVersions/7e570001.jsonl
@@ -1,0 +1,22 @@
+{"k":"cacheFormat","v":1}
+{"k":"node.1.isListening","v":true}
+{"k":"node.1.isFrequentListening","v":false}
+{"k":"node.1.isRouting","v":true}
+{"k":"node.1.supportedDataRates","v":[40000,9600,100000]}
+{"k":"node.1.protocolVersion","v":3}
+{"k":"node.1.nodeType","v":"Controller"}
+{"k":"node.1.supportsSecurity","v":false}
+{"k":"node.1.supportsBeaming","v":true}
+{"k":"node.1.deviceClass","v":{"basic":2,"generic":2,"specific":7}}
+{"k":"node.1.endpoint.0.commandClass.0x72","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x86","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x20","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x60","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.interviewStage","v":"Complete"}
+{"k":"node.2.hasSUCReturnRoute","v":true}
+
+// Define some base functionality for node 2 so we can skip the interview of these CCs
+{"k":"node.2.endpoint.0.commandClass.0x60","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.2.endpoint.0.commandClass.0x25","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.2.endpoint.1.commandClass.0x25","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.2.endpoint.2.commandClass.0x25","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}

--- a/packages/zwave-js/src/lib/test/driver/fixtures/multiChannelUnknownVersions/7e570001.values.jsonl
+++ b/packages/zwave-js/src/lib/test/driver/fixtures/multiChannelUnknownVersions/7e570001.values.jsonl
@@ -1,0 +1,5 @@
+{"k":"{\"nodeId\":2,\"commandClass\":96,\"endpoint\":0,\"property\":\"interviewComplete\"}","v":true}
+{"k":"{\"nodeId\":2,\"commandClass\":96,\"endpoint\":0,\"property\":\"endpointIndizes\"}","v":[1,2]}
+{"k":"{\"nodeId\":2,\"commandClass\":37,\"endpoint\":1,\"property\":\"interviewComplete\"}","v":true}
+{"k":"{\"nodeId\":2,\"commandClass\":37,\"endpoint\":2,\"property\":\"interviewComplete\"}","v":true}
+{"k":"{\"nodeId\":2,\"commandClass\":37,\"endpoint\":0,\"property\":\"interviewComplete\"}","v":true}

--- a/packages/zwave-js/src/lib/test/driver/multiChannelUnknownVersions.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/multiChannelUnknownVersions.test.ts
@@ -1,0 +1,32 @@
+import {
+	BinarySwitchCCSet,
+	MultiChannelCCCommandEncapsulation,
+} from "@zwave-js/cc";
+import { MockZWaveFrameType } from "@zwave-js/testing";
+import path from "path";
+import { integrationTest } from "../integrationTestSuite";
+
+integrationTest(
+	"When CC versions are unknown, commands are sent using the highest implemented CC version",
+	{
+		// debug: true,
+		provisioningDirectory: path.join(
+			__dirname,
+			"fixtures/multiChannelUnknownVersions",
+		),
+
+		testBody: async (driver, node, mockController, mockNode) => {
+			await node
+				.getEndpoint(1)!
+				.commandClasses["Binary Switch"].set(true);
+
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request &&
+					frame.payload instanceof
+						MultiChannelCCCommandEncapsulation &&
+					frame.payload.encapsulated instanceof BinarySwitchCCSet,
+			);
+		},
+	},
+);


### PR DESCRIPTION
not sure why this ever worked, but this should help with https://github.com/home-assistant/core/issues/77466