### PR TITLE
fix: attempt endpoint communication with S0, even if S0 is not listed in the endpoint capabilities

### DIFF
--- a/packages/cc/src/cc/SecurityCC.ts
+++ b/packages/cc/src/cc/SecurityCC.ts
@@ -22,6 +22,7 @@ import {
 } from "@zwave-js/core";
 import type { ZWaveApplicationHost, ZWaveHost } from "@zwave-js/host/safe";
 import { buffer2hex, num2hex, pick } from "@zwave-js/shared/safe";
+import { wait } from "alcalzone-shared/async";
 import { randomBytes } from "crypto";
 import { CCAPI, PhysicalCCAPI } from "../lib/API";
 import {
@@ -294,13 +295,31 @@ export class SecurityCC extends CommandClass {
 			direction: "outbound",
 		});
 
-		const resp = await api.getSupportedCommands();
-		if (!resp) {
+		let supportedCCs: CommandClasses[] | undefined;
+		let controlledCCs: CommandClasses[] | undefined;
+
+		// Try up to 3 times. We REALLY don't want a spurious timeout or collision to cause us to discard a known good security class
+		for (let attempts = 1; attempts <= 3; attempts++) {
+			const resp = await api.getSupportedCommands();
+			if (resp) {
+				supportedCCs = resp.supportedCCs;
+				controlledCCs = resp.controlledCCs;
+				break;
+			} else if (attempts < 3) {
+				applHost.controllerLog.logNode(node.id, {
+					endpoint: this.endpointIndex,
+					message: `Querying securely supported commands (S0), attempt ${attempts}/3 failed. Retrying in 500ms...`,
+					level: "warn",
+				});
+				await wait(500);
+			}
+		}
+
+		if (!supportedCCs || !controlledCCs) {
 			if (node.hasSecurityClass(SecurityClass.S0_Legacy) === true) {
 				applHost.controllerLog.logNode(node.id, {
 					endpoint: this.endpointIndex,
-					message:
-						"Querying securely supported commands (S0) timed out",
+					message: "Querying securely supported commands (S0) failed",
 					level: "warn",
 				});
 				// TODO: Abort interview?
@@ -320,11 +339,11 @@ export class SecurityCC extends CommandClass {
 			"received secure commands (S0)",
 			"supported CCs:",
 		];
-		for (const cc of resp.supportedCCs) {
+		for (const cc of supportedCCs) {
 			logLines.push(`· ${getCCName(cc)}`);
 		}
 		logLines.push("controlled CCs:");
-		for (const cc of resp.controlledCCs) {
+		for (const cc of controlledCCs) {
 			logLines.push(`· ${getCCName(cc)}`);
 		}
 		applHost.controllerLog.logNode(node.id, {
@@ -333,17 +352,11 @@ export class SecurityCC extends CommandClass {
 		});
 
 		// Remember which commands are supported securely
-		for (const cc of resp.supportedCCs) {
-			endpoint.addCC(cc, {
-				isSupported: true,
-				secure: true,
-			});
+		for (const cc of supportedCCs) {
+			endpoint.addCC(cc, { isSupported: true, secure: true });
 		}
-		for (const cc of resp.controlledCCs) {
-			endpoint.addCC(cc, {
-				isControlled: true,
-				secure: true,
-			});
+		for (const cc of controlledCCs) {
+			endpoint.addCC(cc, { isControlled: true, secure: true });
 		}
 
 		// We know for sure that the node is included securely

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -2063,9 +2063,8 @@ protocol version:      ${this.protocolVersion}`;
 							message: `Endpoint ${endpoint.index} is actually not using S0`,
 							level: "silly",
 						});
-						endpoint.addCC(CommandClasses["Z-Wave Plus Info"], {
-							secure: false,
-						});
+						// Mark the CC as not secure again
+						endpoint.addCC(ccId, { secure: false });
 					}
 				}
 			}


### PR DESCRIPTION
Something in v10 changed so the endpoint security capabilities are now correctly considered when communication with endpoints. However this broke some legacy multichannel devices which do not list S0 in the endpoint capabilities and which do not respond to the secure CC query.

We now test whether an endpoint responds to secure queries and mark all endpoints CCs as secure if it does.

fixes: #4977 