### PR TITLE
feat(config): add fingerprint for Radio Thermostat CT30

### DIFF
--- a/packages/config/config/devices/0x0098/ct30.json
+++ b/packages/config/config/devices/0x0098/ct30.json
@@ -40,6 +40,10 @@
 		{
 			"productType": "0x3200",
 			"productId": "0x015e"
+		},
+		{
+			"productType": "0x1e12",
+			"productId": "0x0163"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
defines an additional product ID for Radio Thermostat ct30