### PR TITLE
fix: ensure `CCAPI` instance uses the same version as the CC instance

### DIFF
--- a/packages/cc/src/lib/API.ts
+++ b/packages/cc/src/lib/API.ts
@@ -21,7 +21,11 @@ import {
 import type { ZWaveApplicationHost } from "@zwave-js/host";
 import { getEnumMemberName, num2hex, OnlyMethods } from "@zwave-js/shared";
 import { isArray } from "alcalzone-shared/typeguards";
-import { getAPI, getCommandClass } from "./CommandClassDecorators";
+import {
+	getAPI,
+	getCommandClass,
+	getImplementedVersion,
+} from "./CommandClassDecorators";
 
 export type ValueIDProperties = Pick<ValueID, "property" | "propertyKey">;
 
@@ -261,7 +265,15 @@ export class CCAPI {
 	 * Retrieves the version of the given CommandClass this endpoint implements
 	 */
 	public get version(): number {
-		return this.endpoint.getCCVersion(this.ccId);
+		if (this.isSinglecast() && this.endpoint.nodeId !== NODE_ID_BROADCAST) {
+			return this.applHost.getSafeCCVersionForNode(
+				this.ccId,
+				this.endpoint.nodeId,
+				this.endpoint.index,
+			);
+		} else {
+			return getImplementedVersion(this.ccId);
+		}
 	}
 
 	/** Determines if this simplified API instance may be used. */


### PR DESCRIPTION
In v10 we assumed that we can use the highest implemented version of a CC when sending and the version couldn't be queried, so the `interview` methods would call most API versions. However the API implementations would then throw because they'd still assume they could only use version 1.