### PR TITLE
fix: query secure endpoint CCs only once, assume all its known CCs are secure when this fails

### DIFF
--- a/packages/cc/src/cc/SecurityCC.ts
+++ b/packages/cc/src/cc/SecurityCC.ts
@@ -298,17 +298,18 @@ export class SecurityCC extends CommandClass {
 		let supportedCCs: CommandClasses[] | undefined;
 		let controlledCCs: CommandClasses[] | undefined;
 
-		// Try up to 3 times. We REALLY don't want a spurious timeout or collision to cause us to discard a known good security class
-		for (let attempts = 1; attempts <= 3; attempts++) {
+		// Try up to 3 times on the root device. We REALLY don't want a spurious timeout or collision to cause us to discard a known good security class
+		const MAX_ATTEMPTS = this.endpointIndex === 0 ? 3 : 1;
+		for (let attempts = 1; attempts <= MAX_ATTEMPTS; attempts++) {
 			const resp = await api.getSupportedCommands();
 			if (resp) {
 				supportedCCs = resp.supportedCCs;
 				controlledCCs = resp.controlledCCs;
 				break;
-			} else if (attempts < 3) {
+			} else if (attempts < MAX_ATTEMPTS) {
 				applHost.controllerLog.logNode(node.id, {
 					endpoint: this.endpointIndex,
-					message: `Querying securely supported commands (S0), attempt ${attempts}/3 failed. Retrying in 500ms...`,
+					message: `Querying securely supported commands (S0), attempt ${attempts}/${MAX_ATTEMPTS} failed. Retrying in 500ms...`,
 					level: "warn",
 				});
 				await wait(500);

--- a/packages/zwave-js/src/lib/test/driver/nodeUpdateBeforeCallback.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeUpdateBeforeCallback.test.ts
@@ -11,7 +11,7 @@ import { integrationTest } from "../integrationTestSuite";
 integrationTest(
 	"Correctly capture node updates that arrive before the SendData callback",
 	{
-		debug: true,
+		// debug: true,
 		provisioningDirectory: path.join(__dirname, "fixtures/base_2_nodes"),
 
 		// nodeCapabilities: {

--- a/packages/zwave-js/src/lib/test/driver/receiveApplicationCommandHandlerBridge.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/receiveApplicationCommandHandlerBridge.test.ts
@@ -105,5 +105,5 @@ describe("regression tests", () => {
 		await expect(getNoncePromise).resolves.toEqual(
 			Buffer.from("3e55e4b714973b9e", "hex"),
 		);
-	}, 5000);
+	}, 30000);
 });

--- a/packages/zwave-js/src/lib/test/driver/s0AndS2Encapsulation.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s0AndS2Encapsulation.test.ts
@@ -29,7 +29,7 @@ import path from "path";
 import { integrationTest } from "../integrationTestSuite";
 
 integrationTest("S0 commands are S0-encapsulated, even when S2 is supported", {
-	debug: true,
+	// debug: true,
 
 	// We need the cache to skip the CC interviews and mark S2 as supported
 	provisioningDirectory: path.join(


### PR DESCRIPTION
fixes: #5013