### PR TITLE
feat: pass user agent to firmware update service

### DIFF
--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -78,14 +78,6 @@ disableStatistics(): void
 
 Disable sending usage statistics.
 
-### `statisticsEnabled`
-
-```ts
-statisticsEnabled(): boolean
-```
-
-Returns whether reporting usage statistics is currently enabled.
-
 ### `getSupportedCCVersionForEndpoint`
 
 ```ts
@@ -275,6 +267,14 @@ getLogConfig(): LogConfig
 
 Returns the current logging configuration.
 
+### `updateUserAgent`
+
+```ts
+updateUserAgent(components: Record<string, string | null | undefined>): void
+```
+
+Adds or updates individual components (name => version) of the user agent. By setting a version to `null` or `undefined`, the component will be removed from the user agent.
+
 ### `setPreferredScales`
 
 ```ts
@@ -298,6 +298,7 @@ Updates a subset of the driver options without having to restart the driver. The
 -   `logConfig`
 -   `preferences`
 -   `preserveUnknownValues`
+-   `userAgent` (behaves like `updateUserAgent`)
 
 ### `checkForConfigUpdates`
 
@@ -361,6 +362,22 @@ readonly allNodesReady: boolean
 ```
 
 Returns `true` after the `"all nodes ready"` event has been emitted. This is useful for client-server setups where listeners might not be set up while the driver is initializing.
+
+### `statisticsEnabled`
+
+```ts
+readonly statisticsEnabled: boolean
+```
+
+Returns whether reporting usage statistics is currently enabled.
+
+### `userAgent`
+
+```ts
+readonly userAgent: string
+```
+
+Returns the user agent string used for service requests.
 
 ## Driver events
 
@@ -796,6 +813,12 @@ interface ZWaveOptions extends ZWaveHostOptions {
 		/** API key for the Z-Wave JS Firmware Update Service (https://github.com/zwave-js/firmware-updates/) */
 		firmwareUpdateService?: string;
 	};
+
+	/**
+	 * An object with application/module/component names and their versions.
+	 * This will be used to build a user-agent string for requests to Z-Wave JS webservices.
+	 */
+	userAgent?: Record<string, string>;
 }
 ````
 

--- a/package.json
+++ b/package.json
@@ -130,7 +130,8 @@
     "nvmedit": "yarn ts packages/nvmedit/src/cli.ts",
     "ls-changed": "yarn changed list --exclude \"@zwave-js/repo\" --git-range=$(git describe --abbrev=0) --json | cut -d'\"' -f4",
     "for-changed": "yarn changed foreach --exclude \"@zwave-js/repo\" --git-range=$(git describe --abbrev=0)",
-    "codefind": "yarn ts packages/maintenance/src/codefind.ts"
+    "codefind": "yarn ts packages/maintenance/src/codefind.ts",
+    "accept-api": "yarn clean && yarn build && yarn extract-api --local"
   },
   "readme": "README.md",
   "config": {

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -245,6 +245,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> implements Z
     destroy(): Promise<void>;
     disableStatistics(): void;
     enableErrorReporting(): void;
+    // Warning: (ae-forgotten-export) The symbol "AppInfo" needs to be exported by the entry point index.d.ts
     enableStatistics(appInfo: Pick<AppInfo, "applicationName" | "applicationVersion">): void;
     static enumerateSerialPorts(): Promise<string[]>;
     getLogConfig(): LogConfig;
@@ -289,10 +290,6 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> implements Z
     setPreferredScales(scales: ZWaveOptions["preferences"]["scales"]): void;
     softReset(): Promise<void>;
     start(): Promise<void>;
-    // Warning: (ae-forgotten-export) The symbol "AppInfo" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    get statisticsAppInfo(): Pick<AppInfo, "applicationName" | "applicationVersion"> | undefined;
     get statisticsEnabled(): boolean;
     // (undocumented)
     tryGetEndpoint(cc: CommandClass): Endpoint | undefined;
@@ -304,6 +301,9 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> implements Z
     unwrapCommands(msg: Message & ICommandClassContainer): void;
     updateLogConfig(config: DeepPartial<LogConfig>): void;
     updateOptions(options: DeepPartial<EditableZWaveOptions>): void;
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    updateUserAgent(components: Record<string, string | null | undefined>): void;
+    get userAgent(): string;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     waitForCommand<T extends ICommandClass>(predicate: (cc: ICommandClass) => boolean, timeout: number): Promise<T>;
@@ -328,7 +328,9 @@ export { DurationUnit }
 // Warning: (ae-missing-release-tag) "EditableZWaveOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export type EditableZWaveOptions = Pick<ZWaveOptions, "disableOptimisticValueUpdate" | "emitValueUpdateAfterSetValue" | "inclusionUserCallbacks" | "interview" | "logConfig" | "preferences" | "preserveUnknownValues">;
+export type EditableZWaveOptions = Pick<ZWaveOptions, "disableOptimisticValueUpdate" | "emitValueUpdateAfterSetValue" | "inclusionUserCallbacks" | "interview" | "logConfig" | "preferences" | "preserveUnknownValues"> & {
+    userAgent?: Record<string, string | null | undefined>;
+};
 
 // Warning: (ae-missing-release-tag) "Endpoint" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -1435,6 +1437,7 @@ export interface ZWaveOptions extends ZWaveHostOptions {
         nonce: number;
         serialAPIStarted: number;
     };
+    userAgent?: Record<string, string>;
 }
 
 

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -245,7 +245,6 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> implements Z
     destroy(): Promise<void>;
     disableStatistics(): void;
     enableErrorReporting(): void;
-    // Warning: (ae-forgotten-export) The symbol "AppInfo" needs to be exported by the entry point index.d.ts
     enableStatistics(appInfo: Pick<AppInfo, "applicationName" | "applicationVersion">): void;
     static enumerateSerialPorts(): Promise<string[]>;
     getLogConfig(): LogConfig;
@@ -290,6 +289,10 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> implements Z
     setPreferredScales(scales: ZWaveOptions["preferences"]["scales"]): void;
     softReset(): Promise<void>;
     start(): Promise<void>;
+    // Warning: (ae-forgotten-export) The symbol "AppInfo" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    get statisticsAppInfo(): Pick<AppInfo, "applicationName" | "applicationVersion"> | undefined;
     get statisticsEnabled(): boolean;
     // (undocumented)
     tryGetEndpoint(cc: CommandClass): Endpoint | undefined;

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -71,7 +71,7 @@ import { isObject } from "alcalzone-shared/typeguards";
 import crypto from "crypto";
 import semver from "semver";
 import util from "util";
-import type { Driver } from "../driver/Driver";
+import { Driver, libVersion } from "../driver/Driver";
 import { cacheKeys, cacheKeyUtils } from "../driver/NetworkCache";
 import type { StatisticsEventCallbacks } from "../driver/Statistics";
 import { DeviceClass } from "../node/DeviceClass";
@@ -4539,6 +4539,11 @@ ${associatedNodes.join(", ")}`,
 		}
 		const firmwareVersion = versionResponse.firmwareVersions[0];
 
+		let userAgent = `node-zwave-js v${libVersion}`;
+		if (this.driver.statisticsEnabled && this.driver.statisticsAppInfo) {
+			userAgent += ` (${this.driver.statisticsAppInfo.applicationName} ${this.driver.statisticsAppInfo.applicationVersion})`;
+		}
+
 		// Now invoke the service
 		try {
 			return await getAvailableFirmwareUpdates(
@@ -4548,6 +4553,7 @@ ${associatedNodes.join(", ")}`,
 				firmwareVersion,
 				options?.apiKey ??
 					this.driver.options.apiKeys?.firmwareUpdateService,
+				userAgent,
 			);
 		} catch (e: any) {
 			let message = `Cannot check for firmware updates for node ${nodeId}: `;

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -71,7 +71,7 @@ import { isObject } from "alcalzone-shared/typeguards";
 import crypto from "crypto";
 import semver from "semver";
 import util from "util";
-import { Driver, libVersion } from "../driver/Driver";
+import type { Driver } from "../driver/Driver";
 import { cacheKeys, cacheKeyUtils } from "../driver/NetworkCache";
 import type { StatisticsEventCallbacks } from "../driver/Statistics";
 import { DeviceClass } from "../node/DeviceClass";
@@ -4539,21 +4539,21 @@ ${associatedNodes.join(", ")}`,
 		}
 		const firmwareVersion = versionResponse.firmwareVersions[0];
 
-		let userAgent = `node-zwave-js v${libVersion}`;
-		if (this.driver.statisticsEnabled && this.driver.statisticsAppInfo) {
-			userAgent += ` (${this.driver.statisticsAppInfo.applicationName} ${this.driver.statisticsAppInfo.applicationVersion})`;
-		}
-
 		// Now invoke the service
 		try {
 			return await getAvailableFirmwareUpdates(
-				manufacturerId,
-				productType,
-				productId,
-				firmwareVersion,
-				options?.apiKey ??
-					this.driver.options.apiKeys?.firmwareUpdateService,
-				userAgent,
+				{
+					manufacturerId,
+					productType,
+					productId,
+					firmwareVersion,
+				},
+				{
+					userAgent: this.driver.userAgent,
+					apiKey:
+						options?.apiKey ??
+						this.driver.options.apiKeys?.firmwareUpdateService,
+				},
 			);
 		} catch (e: any) {
 			let message = `Cannot check for firmware updates for node ${nodeId}: `;

--- a/packages/zwave-js/src/lib/controller/FirmwareUpdateService.ts
+++ b/packages/zwave-js/src/lib/controller/FirmwareUpdateService.ts
@@ -1,4 +1,4 @@
-import got, { OptionsOfTextResponseBody } from "@esm2cjs/got";
+import got, { Headers, OptionsOfTextResponseBody } from "@esm2cjs/got";
 import PQueue from "@esm2cjs/p-queue";
 import {
 	extractFirmware,
@@ -124,7 +124,9 @@ export function getAvailableFirmwareUpdates(
 	productId: number,
 	firmwareVersion: string,
 	apiKey?: string,
+	userAgent?: string,
 ): Promise<FirmwareUpdateInfo[]> {
+	const headers: Headers = {};
 	const config: OptionsOfTextResponseBody = {
 		method: "POST",
 		url: `${serviceURL}/api/v1/updates`,
@@ -139,11 +141,13 @@ export function getAvailableFirmwareUpdates(
 		// cacheOptions: {
 		// 	shared: false,
 		// },
+		headers,
 	};
 	if (apiKey) {
-		config.headers = {
-			"X-API-Key": apiKey,
-		};
+		headers["X-API-Key"] = apiKey;
+	}
+	if (userAgent) {
+		headers["User-Agent"] = userAgent;
 	}
 
 	return requestQueue.add(() => cachedGot(config));

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1646,9 +1646,14 @@ export class Driver
 		return this._statisticsEnabled;
 	}
 
-	private statisticsAppInfo:
+	private _statisticsAppInfo:
 		| Pick<AppInfo, "applicationName" | "applicationVersion">
 		| undefined;
+	public get statisticsAppInfo():
+		| Pick<AppInfo, "applicationName" | "applicationVersion">
+		| undefined {
+		return this._statisticsAppInfo;
+	}
 
 	/**
 	 * Enable sending usage statistics. Although this does not include any sensitive information, we expect that you
@@ -1658,7 +1663,6 @@ export class Driver
 		appInfo: Pick<AppInfo, "applicationName" | "applicationVersion">,
 	): void {
 		if (this._statisticsEnabled) return;
-		this._statisticsEnabled = true;
 
 		if (
 			!isObject(appInfo) ||
@@ -1681,7 +1685,8 @@ export class Driver
 			);
 		}
 
-		this.statisticsAppInfo = appInfo;
+		this._statisticsEnabled = true;
+		this._statisticsAppInfo = appInfo;
 
 		// If we're already ready, send statistics
 		if (this._nodesReadyEventEmitted) {
@@ -1696,7 +1701,7 @@ export class Driver
 	 */
 	public disableStatistics(): void {
 		this._statisticsEnabled = false;
-		this.statisticsAppInfo = undefined;
+		this._statisticsAppInfo = undefined;
 		if (this.statisticsTimeout) {
 			clearTimeout(this.statisticsTimeout);
 			this.statisticsTimeout = undefined;
@@ -1717,7 +1722,7 @@ export class Driver
 	private statisticsTimeout: NodeJS.Timeout | undefined;
 	private async compileAndSendStatistics(): Promise<void> {
 		// Don't send anything if statistics are not enabled
-		if (!this.statisticsEnabled || !this.statisticsAppInfo) return;
+		if (!this.statisticsEnabled || !this._statisticsAppInfo) return;
 
 		if (this.statisticsTimeout) {
 			clearTimeout(this.statisticsTimeout);
@@ -1728,7 +1733,7 @@ export class Driver
 		try {
 			const statistics = await compileStatistics(this, {
 				driverVersion: libVersion,
-				...this.statisticsAppInfo,
+				...this._statisticsAppInfo,
 				nodeVersion: process.versions.node,
 				os: process.platform,
 				arch: process.arch,

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1655,6 +1655,15 @@ export class Driver
 		return this._statisticsAppInfo;
 	}
 
+	/** Returns the user agent used for service requests */
+	public get userAgent(): string {
+		let ret = `node-zwave-js/${libVersion}`;
+		if (this.statisticsEnabled && this.statisticsAppInfo) {
+			ret += ` ${this.statisticsAppInfo.applicationName}/${this.statisticsAppInfo.applicationVersion}`;
+		}
+		return ret;
+	}
+
 	/**
 	 * Enable sending usage statistics. Although this does not include any sensitive information, we expect that you
 	 * inform your users before enabling statistics.

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -206,6 +206,12 @@ export interface ZWaveOptions extends ZWaveHostOptions {
 		firmwareUpdateService?: string;
 	};
 
+	/**
+	 * An object with application/module/component names and their versions.
+	 * This will be used to build a user-agent string for requests to Z-Wave JS webservices.
+	 */
+	userAgent?: Record<string, string>;
+
 	/** @internal Used for testing internally */
 	testingHooks?: {
 		serialPortBinding?: typeof SerialPort;
@@ -241,4 +247,6 @@ export type EditableZWaveOptions = Pick<
 	| "logConfig"
 	| "preferences"
 	| "preserveUnknownValues"
->;
+> & {
+	userAgent?: Record<string, string | null | undefined>;
+};


### PR DESCRIPTION
With this PR, we pass a user agent containing the driver version to the firmware update service.

For this reason, a few new options to configure the user-agent are added:
1. An optional driver option `userAgent`. This will become mandatory in future releases.
2. The method `updateUserAgent`.

Both accept a `Record<string, string>` where the key is the application/component/module name and the value is the version. In `updateUserAgent` the version can be explicitly set to `null/undefined` to remove a component.

If no user agent is configured, but the application has enabled statistics, the application name and version will be taken from there.

fixes: #5002 
/cc @balloob 