### PR TITLE
fix: ensure value ID is valid and normalized before passing through

### DIFF
--- a/packages/core/src/values/ValueDB.ts
+++ b/packages/core/src/values/ValueDB.ts
@@ -75,13 +75,13 @@ export function normalizeValueID(valueID: ValueID): ValueID {
 	assertValueID(valueID);
 	const { commandClass, endpoint, property, propertyKey } = valueID;
 
-	const jsonKey: ValueID = {
+	const normalized: ValueID = {
 		commandClass,
 		endpoint: endpoint ?? 0,
 		property,
 	};
-	if (propertyKey != undefined) jsonKey.propertyKey = propertyKey;
-	return jsonKey;
+	if (propertyKey != undefined) normalized.propertyKey = propertyKey;
+	return normalized;
 }
 
 export function valueIdToString(valueID: ValueID): string {

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -885,6 +885,9 @@ export class ZWaveNode
 		value: unknown,
 		options?: SetValueAPIOptions,
 	): Promise<boolean> {
+		// Ensure we're dealing with a valid value ID, with no extra properties
+		valueId = normalizeValueID(valueId);
+
 		// Try to retrieve the corresponding CC API
 		const loglevel = this.driver.getLogConfig().level;
 
@@ -1025,6 +1028,9 @@ export class ZWaveNode
 		valueId: ValueID,
 		sendCommandOptions: SendCommandOptions = {},
 	): Promise<T | undefined> {
+		// Ensure we're dealing with a valid value ID, with no extra properties
+		valueId = normalizeValueID(valueId);
+
 		// Try to retrieve the corresponding CC API
 		const endpointInstance = this.getEndpoint(valueId.endpoint || 0);
 		if (!endpointInstance) {

--- a/packages/zwave-js/src/lib/node/VirtualNode.ts
+++ b/packages/zwave-js/src/lib/node/VirtualNode.ts
@@ -3,6 +3,7 @@ import {
 	actuatorCCs,
 	isZWaveError,
 	IVirtualNode,
+	normalizeValueID,
 	TranslatedValueID,
 	ValueID,
 	valueIdToString,
@@ -51,6 +52,9 @@ export class VirtualNode extends VirtualEndpoint implements IVirtualNode {
 		value: unknown,
 		options?: SetValueAPIOptions,
 	): Promise<boolean> {
+		// Ensure we're dealing with a valid value ID, with no extra properties
+		valueId = normalizeValueID(valueId);
+
 		// Try to retrieve the corresponding CC API
 		try {
 			// Access the CC API by name


### PR DESCRIPTION
fixes: #5021

Most of the value DB already made sure of this, except for value IDs that get passed through in events. By validating and normalizing value IDs in `setValue` and `pollValue`, value IDs passed back to applications are guaranteed to be normalized.