### PR TITLE
fix(config): correct LED Indicator (param 3) for GE 14287 / ZW4002

### DIFF
--- a/packages/config/config/devices/0x0063/14287_zw4002.json
+++ b/packages/config/config/devices/0x0063/14287_zw4002.json
@@ -34,7 +34,7 @@
 		{
 			"$if": "firmwareVersion >= 5.24",
 			"#": "3",
-			"$import": "~/templates/master_template.json#led_indicator_three_options"
+			"$import": "~/templates/master_template.json#led_indicator_three_options_inverted"
 		},
 		{
 			"#": "4",


### PR DESCRIPTION
Personally own this device and after updating the firmware to 5.24 I tested new parameter #3 that defines LED Indicator behavior as originally configured and found it needed to be inverted.  The non-inverted settings are opposite reality.
Performed troubleshooting steps and found no solution.

Captured debug logs (attached Node 042) to confirm the parameter value was being written and confirmed as expected.  With TRUTH:  Parameter 3 value = 1 ; the indicator light is On when the Load is Off.

Device 14287 / ZW4002
[zwave_js_Node_42_parm_update.log](https://github.com/zwave-js/node-zwave-js/files/9539509/zwave_js_Node_42_parm_update.log)

This is my first commit and PR - constructive comments always welcome.  A wise man seeks correction.