### PR TITLE
ci: use upstream turborepo cache action again

### DIFF
--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -23,7 +23,7 @@ runs:
       run: yarn install --immutable
 
     - name: TurboRepo local server
-      uses: felixmosh/turborepo-gh-artifacts@v1.1
+      uses: felixmosh/turborepo-gh-artifacts@v1.1.0
       with:
         repo-token: ${{ inputs.githubToken }}
         server-token: foo

--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -23,7 +23,7 @@ runs:
       run: yarn install --immutable
 
     - name: TurboRepo local server
-      uses: AlCalzone/turborepo-gh-artifacts@zwavejs-stable
+      uses: felixmosh/turborepo-gh-artifacts@v1.1
       with:
         repo-token: ${{ inputs.githubToken }}
         server-token: foo


### PR DESCRIPTION
All required PRs have landed, so we can switch back again.