### PR TITLE
fix: negative globs aren't supported by turborepo yet

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -60,7 +60,7 @@
     "lint:zwave": "yarn ts maintenance/lintConfigFiles.ts",
     "ts": "node -r esbuild-register",
     "lint:ts": "eslint --ext .ts --rule \"prettier/prettier: off\" \"src/**/*.ts\"",
-    "lint:prettier": "prettier -c \"src/**/*.ts\" -c \"config/**/*.json\"",
+    "lint:prettier": "prettier -c \"src/**/*.ts\" \"config/**/*.json\"",
     "lint:ts:fix": "yarn run lint:ts --fix",
     "lint:prettier:fix": "yarn run lint:prettier -w"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -21,7 +21,9 @@
 		"lint": {
 			"dependsOn": [],
 			"inputs": [
-				"!(build)/**/*.{ts,json}"
+				// https://github.com/vercel/turborepo/issues/1407
+				":!:build/",
+				"**/*.{ts,json}"
 				// The style based linting tasks depend on the corresponding configuration in the repo root
 			],
 			"outputs": []
@@ -30,7 +32,9 @@
 		"lint:ts": {
 			"dependsOn": [],
 			"inputs": [
-				"!(build)/**/*.{ts,json}"
+				// https://github.com/vercel/turborepo/issues/1407
+				":!:build/",
+				"**/*.{ts,json}"
 				// The style based linting tasks depend on the corresponding configuration in the repo root
 			],
 			"outputs": []
@@ -42,7 +46,9 @@
 		"lint:prettier": {
 			"dependsOn": [],
 			"inputs": [
-				"!(build)/**/*.{ts,json}"
+				// https://github.com/vercel/turborepo/issues/1407
+				":!:build/",
+				"**/*.{ts,json}"
 				// The style based linting tasks depend on the corresponding configuration in the repo root
 			],
 			"outputs": []


### PR DESCRIPTION
except through git pathspec syntax
