### PR TITLE
fix: update zen72.json with more parameters

### DIFF
--- a/packages/config/config/devices/0x027a/zen72.json
+++ b/packages/config/config/devices/0x027a/zen72.json
@@ -60,7 +60,19 @@
 		},
 		{
 			"#": "9",
-			"$import": "templates/zooz_template.json#dimmer_ramp_rate"
+			"$import": "templates/zooz_template.json#dimmer_on_ramp_rate"
+		},
+		{
+			"#": "27",
+			"$import": "templates/zooz_template.json#dimmer_off_ramp_rate"
+		},
+		{
+			"#": "28",
+			"$import": "templates/zooz_template.json#zwave_on_dimmer_ramp_rate"
+		},
+		{
+			"#": "29",
+			"$import": "templates/zooz_template.json#zwave_off_dimmer_ramp_rate"
 		},
 		{
 			"#": "10",


### PR DESCRIPTION
Correct Parameter 9 for the ZEN72 and add 27, 29, and 29 parameters Parameter 30 was not added despite being part of 
https://www.support.getzooz.com/kb/article/538-zen72-dimmer-switch-700-advanced-settings/

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

This should expand the device config for the Zooz ZEN72 based on the ZEN72 Dimmer Switch 700 Advanced Settings described in https://www.support.getzooz.com/kb/article/538-zen72-dimmer-switch-700-advanced-settings/

I did not add Parameter 30 "Remote Z-Wave Dimming Duration (Multilevel Commands For Group 3 And 4)" as I didn't find existing template references for that feature.