### PR TITLE
docs: correct `json2nvm` documentation to use `--protocolVersion` flag

### DIFF
--- a/packages/nvmedit/README.md
+++ b/packages/nvmedit/README.md
@@ -46,7 +46,7 @@ The `.bin` file must either contain a 700-series NVM (SDK version 7.x) or a 500-
 ## Convert JSON NVM file to binary
 
 ```
-npx @zwave-js/nvmedit json2nvm --in /path/to/nvm.json --out /path/to/nvm.bin --version <ver.si.on>
+npx @zwave-js/nvmedit json2nvm --in /path/to/nvm.json --out /path/to/nvm.bin --protocolVersion <ver.si.on>
 ```
 
 `<ver.si.on>` determines the output format of the NVM file and must be replaced with the target SDK version which must match your stick's firmware version


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

The json2nvm example command in the [readme](https://github.com/Tirenoth/node-zwave-js/blob/nvmeditDocumentationFix/packages/nvmedit/README.md) specifies using the "--version" flag, which only prints version information. The correct flag, according to the json2nvm help text, is "--protocolVersion"