### PR TITLE
fix: respect `useLocalTime` flag in `TimeParametersCCSet` constructor

### DIFF
--- a/packages/cc/src/cc/TimeParametersCC.ts
+++ b/packages/cc/src/cc/TimeParametersCC.ts
@@ -330,6 +330,7 @@ export class TimeParametersCCSet extends TimeParametersCC {
 			);
 		} else {
 			this.dateAndTime = options.dateAndTime;
+			this.useLocalTime = options.useLocalTime;
 		}
 	}
 


### PR DESCRIPTION
See https://github.com/AlCalzone/ioBroker.zwave2/issues/945