### PR TITLE
chore: upgrade monopack dep to be able to pass the `--absolute` flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@actions/exec": "^1.1.1",
     "@actions/github": "^5.0.3",
     "@alcalzone/jsonl-db": "^2.5.3",
-    "@alcalzone/monopack": "^1.1.0",
+    "@alcalzone/monopack": "^1.2.0",
     "@alcalzone/release-script": "~3.5.9",
     "@babel/core": "^7.19.0",
     "@babel/plugin-proposal-class-properties": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,16 +63,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@alcalzone/monopack@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@alcalzone/monopack@npm:1.1.0"
+"@alcalzone/monopack@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@alcalzone/monopack@npm:1.2.0"
   dependencies:
     "@alcalzone/pak": ^0.9.0
     fs-extra: ^10.1.0
     tar-stream: ^2.2.0
   bin:
     monopack: bin/cli.js
-  checksum: 3ed52431270fea849631d4fbffd4c01e32a52a3d6f73d99ca2b8c0be319c2a7f5f60bfda0886eb5557db38b56b418f2169455d18f4cf6eff8d860ca65c818687
+  checksum: 9db6c771f47776ca6a2c6ffec59cd11bc9ea575542a4b2c92ca7efd89e9bd03054ecb5b41fe5bad70f6d855f3e0e43887eb6f7ca1bf2f44bc167515255c7b0b2
   languageName: node
   linkType: hard
 
@@ -4689,7 +4689,7 @@ __metadata:
     "@actions/exec": ^1.1.1
     "@actions/github": ^5.0.3
     "@alcalzone/jsonl-db": ^2.5.3
-    "@alcalzone/monopack": ^1.1.0
+    "@alcalzone/monopack": ^1.2.0
     "@alcalzone/release-script": ~3.5.9
     "@babel/core": ^7.19.0
     "@babel/plugin-proposal-class-properties": "*"


### PR DESCRIPTION
needed for zwave-js-ui's Dockerfile.contrib fix