### PR TITLE
feat(config): zooz zen72 zen74 param 27, 28 and 29

### DIFF
--- a/packages/config/config/devices/0x027a/zen72.json
+++ b/packages/config/config/devices/0x027a/zen72.json
@@ -114,6 +114,21 @@
 			"#": "26",
 			"$if": "firmwareVersion >= 10.0",
 			"$import": "templates/zooz_template.json#local_programming"
+		},
+		{
+			"#": "27",
+			"$if": "firmwareVersion >= 10.10",
+			"$import": "templates/zooz_template.json#dimmer_off_ramp_rate"
+		},
+		{
+			"#": "28",
+			"$if": "firmwareVersion >= 10.10",
+			"$import": "templates/zooz_template.json#zwave_on_dimmer_ramp_rate"
+		},
+		{
+			"#": "29",
+			"$if": "firmwareVersion >= 10.10",
+			"$import": "templates/zooz_template.json#zwave_off_dimmer_ramp_rate"
 		}
 	],
 	"compat": {

--- a/packages/config/config/devices/0x027a/zen74.json
+++ b/packages/config/config/devices/0x027a/zen74.json
@@ -99,6 +99,21 @@
 			"#": "26",
 			"$if": "firmwareVersion >= 10.0",
 			"$import": "templates/zooz_template.json#local_programming"
+		},
+		{
+			"#": "27",
+			"$if": "firmwareVersion >= 10.10",
+			"$import": "templates/zooz_template.json#dimmer_off_ramp_rate"
+		},
+		{
+			"#": "28",
+			"$if": "firmwareVersion >= 10.10",
+			"$import": "templates/zooz_template.json#zwave_on_dimmer_ramp_rate"
+		},
+		{
+			"#": "29",
+			"$if": "firmwareVersion >= 10.10",
+			"$import": "templates/zooz_template.json#zwave_off_dimmer_ramp_rate"
 		}
 	],
 	"compat": {


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

Adding parameters 27, 28 and 29 to ZEN72 and ZEN74 firmware >= 10.10.  Partially closes issue [4786](https://github.com/zwave-js/node-zwave-js/issues/4786).  Note that ZEN77 hardware version 1.0 firmware 10.20 already resolved by PR [5006](https://github.com/zwave-js/node-zwave-js/pull/5006).  Firmware version 2.10 for ver. 2.0 hardware, and firmware 3.0 for ver. 3.0 hardware per issue [4786 ](https://github.com/zwave-js/node-zwave-js/issues/4786)not resolved. May require split of ZEN77 into three hardware classes.