### PR TITLE
feat(config): add configuration for Honeywell Thermostat TH6320ZW2007

### DIFF
--- a/packages/config/config/devices/0x041b/th6320zw2007.json
+++ b/packages/config/config/devices/0x041b/th6320zw2007.json
@@ -1,12 +1,12 @@
 {
 	"manufacturer": "Honeywell",
-	"manufacturerId": "0x0039",
-	"label": "TH6320ZW",
-	"description": "T6 Pro Z-Wave Programmable Thermostat",
+	"manufacturerId": "0x041b",
+	"label": "TH6320ZW2007",
+	"description": "T6 Pro Z-Wave Programmable Thermostat with SmartStart",
 	"devices": [
 		{
 			"productType": "0x0011",
-			"productId": "0x0008"
+			"productId": "0x0009"
 		}
 	],
 	"firmwareVersion": {
@@ -181,6 +181,18 @@
 		{
 			"#": "42",
 			"$import": "~/templates/honeywell_template.json#temperature_offset"
+		},
+		{
+			"#": "43",
+			"$import": "~/templates/honeywell_template.json#humidity_offset"
+		},
+		{
+			"#": "44",
+			"$import": "~/templates/honeywell_template.json#temperature_resolution"
+		},
+		{
+			"#": "45",
+			"$import": "~/templates/honeywell_template.json#humidity_resolution"
 		}
 	],
 	"compat": {

--- a/packages/config/config/devices/templates/honeywell_template.json
+++ b/packages/config/config/devices/templates/honeywell_template.json
@@ -44,7 +44,7 @@
 		"valueSize": 1,
 		"minValue": 0,
 		"maxValue": 65,
-		"defaultValue": 65,
+		"defaultValue": 0,
 		"unit": "°F",
 		"options": [
 			{
@@ -674,6 +674,88 @@
 		"minValue": -3,
 		"maxValue": 3,
 		"defaultValue": 0,
-		"unit": "°F"
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Off",
+				"value": 0
+			},
+			{
+				"label": "-1°F / -0.5°C",
+				"value": -1
+			},
+			{
+				"label": "-2°F / -1.0°C",
+				"value": -2
+			},
+			{
+				"label": "-3°F / -1.5°C",
+				"value": -3
+			},
+			{
+				"label": "+1°F / +0.5°C",
+				"value": 1
+			},
+			{
+				"label": "+2°F / +1.0°C",
+				"value": 2
+			},
+			{
+				"label": "+3°F / +1.5°C",
+				"value": 3
+			}
+		]
+	},
+	"humidity_offset": {
+		"label": "Humidity Offset",
+		"valueSize": 1,
+		"minValue": -12,
+		"maxValue": 12,
+		"defaultValue": 0,
+		"unit": "%"
+	},
+	"temperature_resolution": {
+		"label": "Temperature Resolution",
+		"description": "Min change before temperature is reported to the controller",
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 5,
+		"defaultValue": 1,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "0.5°F / 0.5°C",
+				"value": 0
+			},
+			{
+				"label": "1°F / 1.0°C",
+				"value": 1
+			},
+			{
+				"label": "2°F / 1.5°C",
+				"value": 2
+			},
+			{
+				"label": "3°F / 2.0°C",
+				"value": 3
+			},
+			{
+				"label": "4°F / 2.5°C",
+				"value": 4
+			},
+			{
+				"label": "5°F / 3.0°C",
+				"value": 5
+			}
+		]
+	},
+	"humidity_resolution": {
+		"label": "Humidity Resolution",
+		"description": "Min change before humidity is reported to the controller",
+		"valueSize": 1,
+		"minValue": 1,
+		"maxValue": 5,
+		"defaultValue": 1,
+		"unit": "%"
 	}
 }


### PR DESCRIPTION
Added support for TH6320ZW2007:
https://www.resideo.com/us/en/products/air/thermostats/programmable-thermostats/z-wave-t6-pro-programmable-thermostat-with-smartstart-th6320zw2007-u/

Tested by updating `devices` config for existing z-wave-server installation, restarting server, and pressing reinterview device in Home Assistant. All options have appeared in Home Assistant and are editable.

The config mostly blindly copied from th6320zw2003. I have quickly looked and it looks like at least configuration properties are at the same position as previous model th6320zw2003. New model TH6320ZW2007 has 3 more properties, I was able to trace one as humidity offset, but remaining 2 are unknown.
