### PR TITLE
fix: add resiliency to import config routines

### DIFF
--- a/packages/config/maintenance/importConfig.ts
+++ b/packages/config/maintenance/importConfig.ts
@@ -1560,11 +1560,9 @@ async function parseZWAProduct(
 	let output = "";
 	if (
 		newConfig.devices.filter(
-			(d) =>
-				d.productType === "0x9999" ||
-				d.productId === "0x9999" ||
-				d.manufacturerIdHex === "0x9999",
-		)
+			(d) => d.productType === "0x9999" || d.productType === "0x9999",
+		).length > 0 ||
+		newConfig.manufacturerIdHex === "0x9999"
 	) {
 		output = `// TODO: This file contains a placeholder for a productType, productID, or manufacturerId (0x9999) that must be corrected. 
 ${JSONC.stringify(normalizeConfig(newConfig), null, "\t") + "\n"}`;

--- a/packages/config/maintenance/importConfig.ts
+++ b/packages/config/maintenance/importConfig.ts
@@ -1560,10 +1560,13 @@ async function parseZWAProduct(
 	let output = "";
 	if (
 		newConfig.devices.filter(
-			(d) => d.productType === "0x9999" || d.productId === "0x9999",
+			(d) =>
+				d.productType === "0x9999" ||
+				d.productId === "0x9999" ||
+				d.manufacturerIdHex === "0x9999",
 		)
 	) {
-		output = `// TODO: This file contains a placeholder for the ProductType or Product ID (0x9999) that must be corrected. 
+		output = `// TODO: This file contains a placeholder for a productType, productID, or manufacturerId (0x9999) that must be corrected. 
 ${JSONC.stringify(normalizeConfig(newConfig), null, "\t") + "\n"}`;
 	} else {
 		output = JSONC.stringify(normalizeConfig(newConfig), null, "\t") + "\n";

--- a/packages/config/maintenance/importConfig.ts
+++ b/packages/config/maintenance/importConfig.ts
@@ -406,17 +406,6 @@ function normalizeConfig(config: Record<string, any>): Record<string, any> {
 		config[l] = temp;
 	}
 
-	// Sort parameters
-	if (config.paramInformation) {
-		config.paramInformation = config.paramInformation.sort(
-			(a: Record<string, any>, b: Record<string, any>) => {
-				const aNum = parseInt(a["#"], 10);
-				const bNum = parseInt(b["#"], 10);
-				return aNum - bNum;
-			},
-		);
-	}
-
 	// Remove empty arrays and objects
 	for (const prop of Object.keys(disallowEmpty)) {
 		if (prop in config) {

--- a/packages/config/maintenance/importConfig.ts
+++ b/packages/config/maintenance/importConfig.ts
@@ -1560,7 +1560,7 @@ async function parseZWAProduct(
 	let output = "";
 	if (
 		newConfig.devices.filter(
-			(d) => d.productType === "0x9999" || d.productType === "0x9999",
+			(d) => d.productType === "0x9999" || d.productId === "0x9999",
 		).length > 0 ||
 		newConfig.manufacturerIdHex === "0x9999"
 	) {

--- a/packages/config/maintenance/importConfig.ts
+++ b/packages/config/maintenance/importConfig.ts
@@ -854,7 +854,7 @@ async function parseZWAFiles(): Promise<void> {
 		}
 
 		if (!device.Brand) {
-			device.ManufacturerId = "Unknown";
+			device.Brand = "Unknown";
 		}
 
 		if (!device.ProductTypeId) {
@@ -884,16 +884,15 @@ async function parseZWAFiles(): Promise<void> {
 		const manufacturerName =
 			configManager.lookupManufacturer(manufacturerId);
 
-		if (file.ManufacturerId != "0x9999") {
-			// Add the manufacturer to our manufacturers.json if it is missing
-			if (Number.isNaN(manufacturerId)) {
-			} else if (
-				manufacturerName === undefined &&
-				file.Brand !== undefined
-			) {
-				console.log(`Adding missing manufacturer: ${file.Brand}`);
-				configManager.setManufacturer(manufacturerId, file.Brand);
-			}
+		// Add the manufacturer to our manufacturers.json if it is missing
+		if (
+			!Number.isNaN(manufacturerId) &&
+			file.ManufacturerId != "0x9999" &&
+			manufacturerName === undefined &&
+			file.Brand !== undefined
+		) {
+			console.log(`Adding missing manufacturer: ${file.Brand}`);
+			configManager.setManufacturer(manufacturerId, file.Brand);
 		}
 
 		/**
@@ -1557,17 +1556,16 @@ async function parseZWAProduct(
 	await fs.ensureDir(manufacturerDir);
 
 	// Insert a TODO comment if necessary
-	let output = "";
+	let output = JSONC.stringify(normalizeConfig(newConfig), null, "\t") + "\n";
 	if (
 		newConfig.devices.filter(
 			(d) => d.productType === "0x9999" || d.productId === "0x9999",
 		).length > 0 ||
 		newConfig.manufacturerIdHex === "0x9999"
 	) {
-		output = `// TODO: This file contains a placeholder for a productType, productID, or manufacturerId (0x9999) that must be corrected. 
-${JSONC.stringify(normalizeConfig(newConfig), null, "\t") + "\n"}`;
-	} else {
-		output = JSONC.stringify(normalizeConfig(newConfig), null, "\t") + "\n";
+		output =
+			"// TODO: This file contains a placeholder for a productType, productID, or manufacturerId (0x9999) that must be corrected.\n" +
+			output;
 	}
 
 	// Write the file

--- a/packages/config/maintenance/importConfig.ts
+++ b/packages/config/maintenance/importConfig.ts
@@ -406,6 +406,17 @@ function normalizeConfig(config: Record<string, any>): Record<string, any> {
 		config[l] = temp;
 	}
 
+	// Sort parameters
+	if (config.paramInformation) {
+		config.paramInformation = config.paramInformation.sort(
+			(a: Record<string, any>, b: Record<string, any>) => {
+				const aNum = parseInt(a["#"], 10);
+				const bNum = parseInt(b["#"], 10);
+				return aNum - bNum;
+			},
+		);
+	}
+
 	// Remove empty arrays and objects
 	for (const prop of Object.keys(disallowEmpty)) {
 		if (prop in config) {

--- a/packages/config/maintenance/importConfig.ts
+++ b/packages/config/maintenance/importConfig.ts
@@ -887,7 +887,7 @@ async function parseZWAFiles(): Promise<void> {
 		// Add the manufacturer to our manufacturers.json if it is missing
 		if (
 			!Number.isNaN(manufacturerId) &&
-			file.ManufacturerId != "0x9999" &&
+			file.ManufacturerId !== "0x9999" &&
 			manufacturerName === undefined &&
 			file.Brand !== undefined
 		) {
@@ -1555,8 +1555,9 @@ async function parseZWAProduct(
 	const manufacturerDir = path.join(processedDir, manufacturerIdHex);
 	await fs.ensureDir(manufacturerDir);
 
-	// Insert a TODO comment if necessary
 	let output = JSONC.stringify(normalizeConfig(newConfig), null, "\t") + "\n";
+
+	// Insert a TODO comment if necessary
 	if (
 		newConfig.devices.filter(
 			(d) => d.productType === "0x9999" || d.productId === "0x9999",

--- a/packages/config/maintenance/importConfig.ts
+++ b/packages/config/maintenance/importConfig.ts
@@ -393,6 +393,20 @@ function normalizeConfig(config: Record<string, any>): Record<string, any> {
 	 * Standardize things
 	 ********************/
 
+	// Sort parameters in only new files
+	if (config.isNewFile) {
+		if (config.paramInformation) {
+			config.paramInformation = config.paramInformation.sort(
+				(a: Record<string, any>, b: Record<string, any>) => {
+					const aNum = parseInt(a["#"], 10);
+					const bNum = parseInt(b["#"], 10);
+					return aNum - bNum;
+				},
+			);
+		}
+	}
+	delete config.isNewFile;
+
 	// Enforce top-level order
 	for (const l of topOrder) {
 		if (typeof config[l] === "undefined") {
@@ -1309,6 +1323,7 @@ async function parseZWAProduct(
 	}
 
 	const newConfig: Record<string, any> = {
+		isNewFile: typeof existingDevice === "undefined",
 		manufacturer,
 		manufacturerId: manufacturerIdHex,
 		label: productLabel,


### PR DESCRIPTION
Recently introduced corrupt entries at the Z-Wave Alliance DB cause importConfig to fail in some instances. These changes add 0x9999 placeholders to missing productId or productType entries, and if present, inserts a TODO warning in a comment at the top of the device file.

I went with a placeholder instead of putting "Unknown" or something there, as using a string would require a bunch of refactoring due to the number of different places we enforce the format and use that value to lookup manufacturer names and such. 

![Screen Shot 2022-10-08 at 1 52 47 PM](https://user-images.githubusercontent.com/33612110/194720863-81361755-44a8-4b66-8505-3d823e8068c8.png)


