### PR TITLE
chore: add snippets for authoring config files to VSCode

### DIFF
--- a/.vscode/deviceSnippets.code-snippets
+++ b/.vscode/deviceSnippets.code-snippets
@@ -134,10 +134,55 @@
 		"prefix": ["Insert Compat Flag"],
 		"body": [
 			"\"compat\": {",
-			"$LINE_COMMENT This device incorrectly ${1:[problem]}",
-			"\"${2|disableBasicMapping,disableStrictEntryControlDataValidation,disableStrictMeasurementValidation,enableBasicSetMapping,forceNotificationIdleReset,mapRootReportsToEndpoint,preserveRootApplicationCCValueIDs,skipConfigurationNameQuery,skipConfigurationInfoQuery,treatBasicSetAsEvent,treatMultilevelSwitchSetAsEvent,treatDestinationEndpointAsSource|}\": true",
+			"\t$LINE_COMMENT This device incorrectly ${1:[problem]}",
+			"\t\"${2|disableBasicMapping,disableStrictEntryControlDataValidation,disableStrictMeasurementValidation,enableBasicSetMapping,forceNotificationIdleReset,mapRootReportsToEndpoint,preserveRootApplicationCCValueIDs,skipConfigurationNameQuery,skipConfigurationInfoQuery,treatBasicSetAsEvent,treatMultilevelSwitchSetAsEvent,treatDestinationEndpointAsSource|}\": true",
 			"},"
 		],
 		"description": "Insert parameter condition"
+	},
+	"disableSupervision": {
+		"scope": "json,jsonc",
+		"prefix": ["Disable Supverision CC"],
+		"body": [
+			"\"compat\": {",
+			"\t\"commandClasses\": {",
+			"\t\t\"remove\": {",
+			"\t\t\t$LINE_COMMENT The device seems to report support for Supervision but ignores the commands",
+			"\t\t\t\"0x6c\": {",
+			"\t\t\t\t\"endpoints\": \"*\"",
+			"\t\t\t}",
+			"\t\t}",
+			"\t}",
+			"}"
+		],
+		"description": "Disables Supverision CC via compat flag"
+	},
+	"removeCC": {
+		"scope": "json,jsonc",
+		"prefix": ["Remove CC"],
+		"body": [
+			"\"compat\": {",
+			"\t\"commandClasses\": {",
+			"\t\t\"remove\": {",
+			"\t\t\t$LINE_COMMENT The device seems to ${1:[Describe why the CC is being removed]}",
+			"\t\t\t\"0x${2:5d}\": {",
+			"\t\t\t\t\"endpoints\": ${3:\"*\" or [0, 2]}",
+			"\t\t\t}",
+			"\t\t}",
+			"\t}",
+			"}"
+		],
+		"description": "Disables Supverision CC via compat flag"
+	},
+	"preserveEndpoints": {
+		"scope": "json,jsonc",
+		"prefix": ["Preserve Endpoints"],
+		"body": [
+			"\"compat\": {",
+			"\t$LINE_COMMENT The device seems to ${1:[Describe why the endpoint is being preserved]}",
+			"\t\"preserveEndpoints\": ${3:\"*\" or [0, 2]}",
+			"}"
+		],
+		"description": "Preserve endpoints via compat flag"
 	}
 }

--- a/.vscode/deviceSnippets.code-snippets
+++ b/.vscode/deviceSnippets.code-snippets
@@ -3,7 +3,7 @@
 		"scope": "json,jsonc",
 		"prefix": ["Insert Master Template Reference from Clipboard"],
 		"body": [
-			"\"$import\": \"~/templates/master_template.json#$CLIPBOARD\","
+			"\"\\$import\": \"~/templates/master_template.json#$CLIPBOARD\","
 		],
 		"description": "Import reference for master template using the clipboard"
 	},
@@ -11,7 +11,7 @@
 		"scope": "json,jsonc",
 		"prefix": ["Insert Master Template Reference"],
 		"body": [
-			"\"$import\": \"~/templates/master_template.json#${1:base_enable_disable}\","
+			"\"\\$import\": \"~/templates/master_template.json#${1:base_enable_disable}\","
 		],
 		"description": "Import reference for master template"
 	},
@@ -19,7 +19,7 @@
 		"scope": "json,jsonc",
 		"prefix": ["Insert Manufacturer Template Reference"],
 		"body": [
-			"\"$import\": \"templates/${1:manufacturer}_template.json#${template}\","
+			"\"\\$import\": \"templates/${1:manufacturer}_template.json#${template}\","
 		],
 		"description": "Import reference for master template"
 	},
@@ -27,7 +27,7 @@
 		"scope": "json,jsonc",
 		"prefix": ["Insert Manufacturer Template Reference from Clipboard"],
 		"body": [
-			"\"$import\": \"templates/${1:manufacturer}_template.json#$CLIPBOARD\","
+			"\"\\$import\": \"templates/${1:manufacturer}_template.json#$CLIPBOARD\","
 		],
 		"description": "Import reference for master template using the clipboard"
 	},

--- a/.vscode/deviceSnippets.code-snippets
+++ b/.vscode/deviceSnippets.code-snippets
@@ -1,0 +1,145 @@
+{
+	"masterTemplateClipboard": {
+		"scope": "json,jsonc",
+		"prefix": ["zwavejs: Insert Master Template Reference from Clipboard"],
+		"body": [
+			"\"$import\": \"~/templates/master_template.json#$CLIPBOARD\","
+		],
+		"description": "Import reference for master template using the clipboard"
+	},
+	"masterTemplate": {
+		"scope": "json,jsonc",
+		"prefix": ["zwavejs: Insert Master Template Reference"],
+		"body": [
+			"\"$import\": \"~/templates/master_template.json#${1:base_enable_disable}\","
+		],
+		"description": "Import reference for master template"
+	},
+	"manufacturerTemplate": {
+		"scope": "json,jsonc",
+		"prefix": ["zwavejs: Insert Manufacturer Template Reference"],
+		"body": [
+			"\"$import\": \"templates/${1:manufacturer}_template.json#${template}\","
+		],
+		"description": "Import reference for master template"
+	},
+	"manufacturerTemplateClipboard": {
+		"scope": "json,jsonc",
+		"prefix": [
+			"zwavejs: Insert Manufacturer Template Reference from Clipboard"
+		],
+		"body": [
+			"\"$import\": \"templates/${1:manufacturer}_template.json#$CLIPBOARD\","
+		],
+		"description": "Import reference for master template using the clipboard"
+	},
+	"allowManualEntryScaffold": {
+		"scope": "json,jsonc",
+		"prefix": ["zwavejs: Insert allowManualEntry scaffold"],
+		"body": [
+			"\"allowManualEntry\": false,",
+			"\"options\": [",
+			"\t{",
+			"\t\t\"label\": \"${1:Disable}\",",
+			"\t\t\"value\": 0",
+			"\t},",
+			"\t{",
+			"\t\t\"label\": \"${2:Option Name}\",",
+			"\t\t\"value\": 1",
+			"\t}",
+			"]"
+		],
+		"description": "Insert allowManualEntry = false scaffold"
+	},
+	"helperOption": {
+		"scope": "json,jsonc",
+		"prefix": ["zwavejs: Insert Option Helper"],
+		"body": [
+			"\"options\": [",
+			"\t{",
+			"\t\t\"label\": \"${1:Disable}\",",
+			"\t\t\"value\": 0",
+			"\t}",
+			"]"
+		],
+		"description": "Insert allowManualEntry = false scaffold"
+	},
+	"newParameterDropdown": {
+		"scope": "json,jsonc",
+		"prefix": ["zwavejs: Insert New Parameter (Drop Down)"],
+		"body": [
+			"{",
+			"\t\"#\": \"${1:1}\",",
+			"\t\"label\": \"${2:Parameter Name}\",",
+			"\t\"valueSize\": ${3:1},",
+			"\t\"defaultValue\": ${4:0},",
+			"\t\"allowManualEntry\": false,",
+			"\t\"options\": [",
+			"\t\t{",
+			"\t\t\t\"label\": \"${5:Disable}\",",
+			"\t\t\t\"value\": 0",
+			"\t\t},",
+			"\t\t{",
+			"\t\t\t\"label\": \"${6:Option Name}\",",
+			"\t\t\t\"value\": 1",
+			"\t\t}",
+			"\t]",
+			"},"
+		],
+		"description": "Insert new paramter - no manual entry"
+	},
+	"newParameterManual": {
+		"scope": "json,jsonc",
+		"prefix": ["zwavejs: Insert New Parameter (Manual Entry)"],
+		"body": [
+			"{",
+			"\t\"#\": \"${1:1}\",",
+			"\t\"label\": \"${2:Parameter Name}\",",
+			"\t\"valueSize\": ${3:1},",
+			"\t\"minValue\": ${4:0},",
+			"\t\"maxValue\": ${5:655350},",
+			"\t\"defaultValue\": ${6:0},",
+			"\t\"allowManualEntry\": false,",
+			"\t\"options\": [",
+			"\t\t{",
+			"\t\t\t\"label\": \"${7:Disable}\",",
+			"\t\t\t\"value\": 0",
+			"\t\t},",
+			"\t\t{",
+			"\t\t\t\"label\": \"${8:Option Name}\",",
+			"\t\t\t\"value\": 1",
+			"\t\t}",
+			"\t]",
+			"},"
+		],
+		"description": "Insert new paramter - no manual entry"
+	},
+	"deviceEntry": {
+		"scope": "json,jsonc",
+		"prefix": ["zwavejs: Insert Device Entry"],
+		"body": [
+			"{",
+			"\t\"productType\": \"0x${1:0000}\",",
+			"\t\"productId\": \"0x${2:0000}\"",
+			"}"
+		],
+		"description": "Import reference for master template"
+	},
+	"firmwareCondition": {
+		"scope": "json,jsonc",
+		"prefix": ["zwavejs: Insert Parameter Condition"],
+		"body": ["\"$if\": \"firmwareVersion >= ${1:1.0}\","],
+		"description": "Import parameter condition"
+	},
+	"insertCompat": {
+		"scope": "json,jsonc",
+		"prefix": ["zwavejs: Insert Compat Flag"],
+		"body": [
+			"\"compat\": {",
+			"$LINE_COMMENT This device incorrectly ${1:[problem]}",
+			"\"${2|disableBasicMapping,disableStrictEntryControlDataValidation,disableStrictMeasurementValidation,enableBasicSetMapping,forceNotificationIdleReset,mapRootReportsToEndpoint,preserveRootApplicationCCValueIDs,skipConfigurationNameQuery,skipConfigurationInfoQuery,treatBasicSetAsEvent,treatMultilevelSwitchSetAsEvent,treatDestinationEndpointAsSource|}\": true",
+			"},"
+		],
+		"description": "Insert parameter condition"
+	}
+}

--- a/.vscode/deviceSnippets.code-snippets
+++ b/.vscode/deviceSnippets.code-snippets
@@ -1,7 +1,7 @@
 {
 	"masterTemplateClipboard": {
 		"scope": "json,jsonc",
-		"prefix": ["zwavejs: Insert Master Template Reference from Clipboard"],
+		"prefix": ["Insert Master Template Reference from Clipboard"],
 		"body": [
 			"\"$import\": \"~/templates/master_template.json#$CLIPBOARD\","
 		],
@@ -9,7 +9,7 @@
 	},
 	"masterTemplate": {
 		"scope": "json,jsonc",
-		"prefix": ["zwavejs: Insert Master Template Reference"],
+		"prefix": ["Insert Master Template Reference"],
 		"body": [
 			"\"$import\": \"~/templates/master_template.json#${1:base_enable_disable}\","
 		],
@@ -17,7 +17,7 @@
 	},
 	"manufacturerTemplate": {
 		"scope": "json,jsonc",
-		"prefix": ["zwavejs: Insert Manufacturer Template Reference"],
+		"prefix": ["Insert Manufacturer Template Reference"],
 		"body": [
 			"\"$import\": \"templates/${1:manufacturer}_template.json#${template}\","
 		],
@@ -25,9 +25,7 @@
 	},
 	"manufacturerTemplateClipboard": {
 		"scope": "json,jsonc",
-		"prefix": [
-			"zwavejs: Insert Manufacturer Template Reference from Clipboard"
-		],
+		"prefix": ["Insert Manufacturer Template Reference from Clipboard"],
 		"body": [
 			"\"$import\": \"templates/${1:manufacturer}_template.json#$CLIPBOARD\","
 		],
@@ -35,7 +33,7 @@
 	},
 	"allowManualEntryScaffold": {
 		"scope": "json,jsonc",
-		"prefix": ["zwavejs: Insert allowManualEntry scaffold"],
+		"prefix": ["Insert allowManualEntry scaffold"],
 		"body": [
 			"\"allowManualEntry\": false,",
 			"\"options\": [",
@@ -53,7 +51,7 @@
 	},
 	"helperOption": {
 		"scope": "json,jsonc",
-		"prefix": ["zwavejs: Insert Option Helper"],
+		"prefix": ["Insert Option Helper"],
 		"body": [
 			"\"options\": [",
 			"\t{",
@@ -66,7 +64,7 @@
 	},
 	"newParameterDropdown": {
 		"scope": "json,jsonc",
-		"prefix": ["zwavejs: Insert New Parameter (Drop Down)"],
+		"prefix": ["Insert New Parameter (Drop Down)"],
 		"body": [
 			"{",
 			"\t\"#\": \"${1:1}\",",
@@ -90,7 +88,7 @@
 	},
 	"newParameterManual": {
 		"scope": "json,jsonc",
-		"prefix": ["zwavejs: Insert New Parameter (Manual Entry)"],
+		"prefix": ["Insert New Parameter (Manual Entry)"],
 		"body": [
 			"{",
 			"\t\"#\": \"${1:1}\",",
@@ -116,7 +114,7 @@
 	},
 	"deviceEntry": {
 		"scope": "json,jsonc",
-		"prefix": ["zwavejs: Insert Device Entry"],
+		"prefix": ["Insert Device Entry"],
 		"body": [
 			"{",
 			"\t\"productType\": \"0x${1:0000}\",",
@@ -127,13 +125,13 @@
 	},
 	"firmwareCondition": {
 		"scope": "json,jsonc",
-		"prefix": ["zwavejs: Insert Parameter Condition"],
+		"prefix": ["Insert Parameter Condition"],
 		"body": ["\"$if\": \"firmwareVersion >= ${1:1.0}\","],
 		"description": "Import parameter condition"
 	},
 	"insertCompat": {
 		"scope": "json,jsonc",
-		"prefix": ["zwavejs: Insert Compat Flag"],
+		"prefix": ["Insert Compat Flag"],
 		"body": [
 			"\"compat\": {",
 			"$LINE_COMMENT This device incorrectly ${1:[problem]}",


### PR DESCRIPTION
Because I can never remember how to add an import, I've created a set of snippets that insert various things:
- Add device entry
- Conditional parameters
- Import from master device file (with and without using the clipboard contents as the template name
- Import from manufacturer device file (with and without using the clipboard contents as the template name
- New Parameters (with manual entry)
- New Parameters (without manual entry)
- Insert allowManualEntry scaffold with two options
- Insert a Disable option (for when manual entry is allowed)
- Insert compat section, with all of the true/false compat flags in a drop-down

Hitting tab jumps you from piece to piece where you'd need to change things.

Someday maybe I'll get around to writing an extension, but for now this is helpful (to me at least).
