### PR TITLE
fix(config): disable Supervision for Zooz ZSE29

### DIFF
--- a/packages/config/config/devices/0x027a/zse29.json
+++ b/packages/config/config/devices/0x027a/zse29.json
@@ -141,5 +141,15 @@
 		"exclusion": "1. Bring the sensor within direct range of your Z-Wave\ngateway (hub).\n2. Put the Z-Wave hub into exclusion mode (not sure\nhow to do that? ask@getzooz.com).\n3. Press and release the tamper switch 3 times quickly.\n4. Your hub will confirm exclusion and the sensor will\ndisappear from your controller's device list",
 		"reset": "When your network’s primary controller is missing or otherwise inoperable, you may need to reset the device to factory settings manually. In order to complete the process, make sure the sensor is powered, then CLICKCLICK-CLICK-CLICK’N’HOLD the tamper switch for AT LEAST 5 SECONDS. The LED indicator will turn off to\nindicate successful reset. The sensor will then enter auto-inclusion mode for 4 minutes.\nNOTE: All previously recorded activity and custom settings will be erased from the device’s memory.",
 		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/3081/zooz-z-wave-plus-s2-outdoor-motion-sensor-zse29-manual.pdf"
+	},
+	"compat": {
+		"commandClasses": {
+			"remove": {
+				// Supervised commands always result in a status of "Fail"
+				"0x6c": {
+					"endpoints": "*"
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
fixes: #5157

The ZSE29 fails to respond to supervised commands.  Copied the "compat" attribute from the neighboring zse19.json config file.  This solved the problem when loaded as a custom device config file on my Home Assistant server. 
