### PR TITLE
fix(config): update Zooz ZSE44 parameters

### DIFF
--- a/packages/config/config/devices/0x027a/zse44.json
+++ b/packages/config/config/devices/0x027a/zse44.json
@@ -331,7 +331,7 @@
 			"minValue": 0,
 			"maxValue": 480,
 			"defaultValue": 240,
-			"unsigned": true
+			"unsigned": true,
 			"options": [
 				{
 					"label": "Disable",
@@ -347,7 +347,7 @@
 			"minValue": 0,
 			"maxValue": 480,
 			"defaultValue": 240,
-			"unsigned": true
+			"unsigned": true,
 			"options": [
 				{
 					"label": "Disable",

--- a/packages/config/config/devices/0x027a/zse44.json
+++ b/packages/config/config/devices/0x027a/zse44.json
@@ -39,6 +39,7 @@
 	"paramInformation": [
 		{
 			"#": "1",
+			"$if": "firmwareVersion < 1.20",
 			"$import": "templates/zooz_template.json#battery_report_threshold",
 			"label": "Battery Report Threshold",
 			"maxValue": 10,
@@ -327,20 +328,32 @@
 			"label": "Temperature Reporting Interval",
 			"valueSize": 2,
 			"unit": "minutes",
-			"minValue": 1,
+			"minValue": 0,
 			"maxValue": 480,
 			"defaultValue": 240,
 			"unsigned": true
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
 		},
 		{
 			"#": "17",
 			"label": "Humidity Reporting Interval",
 			"valueSize": 2,
 			"unit": "minutes",
-			"minValue": 1,
+			"minValue": 0,
 			"maxValue": 480,
 			"defaultValue": 240,
 			"unsigned": true
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
 		}
 	],
 	"metadata": {


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

Per the Zooz documentation parameters 16 and 17 are disabled with a value of 0. Added option for 0.
Also parameter 1 was removed with firmware >= 1.20

https://www.support.getzooz.com/kb/article/853-zse44-temperature-humidity-xs-sensor-advanced-settings/ https://www.support.getzooz.com/kb/article/912-zse44-temperature-humidity-xs-sensor-change-log/
