### PR TITLE
feat(config): add Fakro Solar ARZ Z-Wave/102

### DIFF
--- a/packages/config/config/devices/0x0085/arz_z-wave_solar.json
+++ b/packages/config/config/devices/0x0085/arz_z-wave_solar.json
@@ -8,6 +8,11 @@
 			// Solar variant of ARZ Z-Wave
 			"productType": "0x0003",
 			"productId": "0x0112"
+		},
+		{
+			// Solar variant of ARZ Z-Wave/102
+			"productType": "0x0003",
+			"productId": "0x0012"
 		}
 	],
 	"firmwareVersion": {

--- a/packages/config/config/devices/0x0085/arz_z-wave_solar.json
+++ b/packages/config/config/devices/0x0085/arz_z-wave_solar.json
@@ -5,14 +5,14 @@
 	"description": "Roller Shutter",
 	"devices": [
 		{
-			// Solar variant of ARZ Z-Wave
-			"productType": "0x0003",
-			"productId": "0x0112"
-		},
-		{
 			// Solar variant of ARZ Z-Wave/102
 			"productType": "0x0003",
 			"productId": "0x0012"
+		},
+		{
+			// Solar variant of ARZ Z-Wave
+			"productType": "0x0003",
+			"productId": "0x0112"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
Recently (2021) Fakro intoduced new version of ARZ Z-Wave roller shutter. It's labeled as ARZ Z-Wave/102 and productID has been changed from 0x0112 to 0x0012.
No other changes to the code or functionality.