### PR TITLE
fix(config): allow higher minimum dim level for Inovelli LZW31-SN, FW 1.57+

### DIFF
--- a/packages/config/config/devices/0x031e/lzw31-sn.json
+++ b/packages/config/config/devices/0x031e/lzw31-sn.json
@@ -89,7 +89,7 @@
 		},
 		{
 			"#": "5",
-			"$if": " firmwareVersion < 1.57",
+			"$if": "firmwareVersion < 1.57",
 			"label": "Minimum Dim Level",
 			"unit": "%",
 			"valueSize": 1,
@@ -99,7 +99,7 @@
 		},
 		{
 			"#": "5",
-			"$if": " firmwareVersion >= 1.57",
+			"$if": "firmwareVersion >= 1.57",
 			"label": "Minimum Dim Level",
 			"unit": "%",
 			"valueSize": 1,

--- a/packages/config/config/devices/0x031e/lzw31-sn.json
+++ b/packages/config/config/devices/0x031e/lzw31-sn.json
@@ -89,11 +89,22 @@
 		},
 		{
 			"#": "5",
+			"$if": " firmwareVersion < 1.57",
 			"label": "Minimum Dim Level",
 			"unit": "%",
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 45,
+			"defaultValue": 1
+		},
+		{
+			"#": "5",
+			"$if": " firmwareVersion >= 1.57",
+			"label": "Minimum Dim Level",
+			"unit": "%",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 98,
 			"defaultValue": 1
 		},
 		{


### PR DESCRIPTION
Per: https://community.inovelli.com/t/maximum-mininum-level-of-45/2727/13

Only applies to FW v 1.57+, please confirm applied properly.
