### PR TITLE
fix(config): fix typo in configuration options for Greenwave GWPN1

### DIFF
--- a/packages/config/config/devices/0x0099/gwpn1.json
+++ b/packages/config/config/devices/0x0099/gwpn1.json
@@ -48,7 +48,7 @@
 		{
 			"#": "1",
 			"label": "No communication light",
-			"description": "Minutes after which the device will flash if controller communicate is lost",
+			"description": "Minutes after which the device will flash if controller communication is lost",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 255,


### PR DESCRIPTION
change 'communicate' to 'communication'

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

PR description here
