### PR TITLE
fix: indicator identify command is v3

### DIFF
--- a/packages/cc/src/cc/IndicatorCC.ts
+++ b/packages/cc/src/cc/IndicatorCC.ts
@@ -303,7 +303,7 @@ export class IndicatorCCAPI extends CCAPI {
 	 * Instructs the node to identify itself. Available starting with V3 of this CC.
 	 */
 	public async identify(): Promise<SupervisionResult | undefined> {
-		if (this.version <= 3) {
+		if (this.version < 3) {
 			throw new ZWaveError(
 				`The identify command is only supported in Version 3 and above`,
 				ZWaveErrorCodes.CC_NotSupported,


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

CC API IndicatorCC.identify fails even for CC v3, this fixes the version check.
