### PR TITLE
fix(config): correct Aeotec Multisensor 7, param 2

### DIFF
--- a/packages/config/config/devices/0x0371/zwa024.json
+++ b/packages/config/config/devices/0x0371/zwa024.json
@@ -70,12 +70,19 @@
 		{
 			"#": "2",
 			"label": "Motion Retrigger Timeout",
+			"description": "Allowable range: 0, 30-3600. Values 1-29 are equivalent to 30.",
 			"valueSize": 2,
 			"unit": "seconds",
 			"minValue": 0,
-			"maxValue": 30,
+			"maxValue": 3600,
 			"defaultValue": 30,
-			"unsigned": true
+			"unsigned": true,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
 		},
 		{
 			"#": "3",

--- a/packages/config/config/devices/0x0371/zwa024.json
+++ b/packages/config/config/devices/0x0371/zwa024.json
@@ -72,8 +72,8 @@
 			"label": "Motion Retrigger Timeout",
 			"valueSize": 2,
 			"unit": "seconds",
-			"minValue": 30,
-			"maxValue": 3600,
+			"minValue": 0,
+			"maxValue": 30,
 			"defaultValue": 30,
 			"unsigned": true
 		},


### PR DESCRIPTION
parameter 2 should have a range of 0 to 30 seconds not 30 to 3600 seconds

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

PR description here
