### PR TITLE
feat: prevent parallel FW updates and soft/hard reset during ongoing FW updates

### DIFF
--- a/packages/core/api.md
+++ b/packages/core/api.md
@@ -2959,6 +2959,7 @@ export enum ZWaveErrorCodes {
     FirmwareUpdateCC_Busy = 1500,
     FirmwareUpdateCC_FailedToAbort = 1504,
     FirmwareUpdateCC_FailedToStart = 1503,
+    FirmwareUpdateCC_NetworkBusy = 1508,
     FirmwareUpdateCC_NotUpgradable = 1501,
     FirmwareUpdateCC_TargetNotFound = 1502,
     FirmwareUpdateCC_Timeout = 1505,

--- a/packages/core/src/error/ZWaveError.ts
+++ b/packages/core/src/error/ZWaveError.ts
@@ -158,7 +158,7 @@ export enum ZWaveErrorCodes {
 	/** Gets thrown when parsing an invalid QR code */
 	Security2CC_InvalidQRCode,
 
-	/** The firmware update process is already active */
+	/** The firmware update process is already active on this node */
 	FirmwareUpdateCC_Busy = 1500,
 	/** The selected firmware target is not upgradable */
 	FirmwareUpdateCC_NotUpgradable,
@@ -176,8 +176,8 @@ export enum ZWaveErrorCodes {
 	/** An firmware file with an unsupported format was provided */
 	Unsupported_Firmware_Format,
 
-	/** A firmware update is already in progress preventing this action from proceeding */
-	Firmware_Update_In_Progress_Error,
+	/** A firmware update is already in progress on the network preventing this action from proceeding */
+	FirmwareUpdateCC_NetworkBusy,
 
 	/** Unsupported target node for a powerlevel test */
 	PowerlevelCC_UnsupportedTestNode = 1600,

--- a/packages/core/src/error/ZWaveError.ts
+++ b/packages/core/src/error/ZWaveError.ts
@@ -176,6 +176,9 @@ export enum ZWaveErrorCodes {
 	/** An firmware file with an unsupported format was provided */
 	Unsupported_Firmware_Format,
 
+	/** A firmware update is already in progress preventing this action from proceeding */
+	Firmware_Update_In_Progress_Error,
+
 	/** Unsupported target node for a powerlevel test */
 	PowerlevelCC_UnsupportedTestNode = 1600,
 }

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -4591,6 +4591,16 @@ ${associatedNodes.join(", ")}`,
 		nodeId: number,
 		update: FirmwareUpdateFileInfo,
 	): Promise<void> {
+		// Don't let two firmware updates happen in parallel
+		if (this.isAnyOTAFirmwareUpdateInProgress()) {
+			const message =
+				"Failed to start the update: A firmware update is already in progress on this network!";
+			this.driver.controllerLog.print(message, "error");
+			throw new ZWaveError(
+				message,
+				ZWaveErrorCodes.Firmware_Update_In_Progress_Error,
+			);
+		}
 		const node = this.nodes.getOrThrow(nodeId);
 
 		let firmware: Firmware;
@@ -4647,6 +4657,17 @@ ${associatedNodes.join(", ")}`,
 			throw new ZWaveError(
 				`At least one update must be provided`,
 				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+
+		// Don't let two firmware updates happen in parallel
+		if (this.isAnyOTAFirmwareUpdateInProgress()) {
+			const message =
+				"Failed to start the update: A firmware update is already in progress on this network!";
+			this.driver.controllerLog.print(message, "error");
+			throw new ZWaveError(
+				message,
+				ZWaveErrorCodes.Firmware_Update_In_Progress_Error,
 			);
 		}
 

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -4593,8 +4593,7 @@ ${associatedNodes.join(", ")}`,
 	): Promise<void> {
 		// Don't let two firmware updates happen in parallel
 		if (this.isAnyOTAFirmwareUpdateInProgress()) {
-			const message =
-				"Failed to start the update: A firmware update is already in progress on this network!";
+			const message = `Failed to start the update: A firmware update is already in progress on this network!`;
 			this.driver.controllerLog.print(message, "error");
 			throw new ZWaveError(
 				message,
@@ -4662,8 +4661,7 @@ ${associatedNodes.join(", ")}`,
 
 		// Don't let two firmware updates happen in parallel
 		if (this.isAnyOTAFirmwareUpdateInProgress()) {
-			const message =
-				"Failed to start the update: A firmware update is already in progress on this network!";
+			const message = `Failed to start the update: A firmware update is already in progress on this network!`;
 			this.driver.controllerLog.print(message, "error");
 			throw new ZWaveError(
 				message,

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -4597,7 +4597,7 @@ ${associatedNodes.join(", ")}`,
 			this.driver.controllerLog.print(message, "error");
 			throw new ZWaveError(
 				message,
-				ZWaveErrorCodes.Firmware_Update_In_Progress_Error,
+				ZWaveErrorCodes.FirmwareUpdateCC_NetworkBusy,
 			);
 		}
 		const node = this.nodes.getOrThrow(nodeId);
@@ -4665,7 +4665,7 @@ ${associatedNodes.join(", ")}`,
 			this.driver.controllerLog.print(message, "error");
 			throw new ZWaveError(
 				message,
-				ZWaveErrorCodes.Firmware_Update_In_Progress_Error,
+				ZWaveErrorCodes.FirmwareUpdateCC_NetworkBusy,
 			);
 		}
 

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -2247,8 +2247,7 @@ export class Driver
 		}
 
 		if (this._controller!.isAnyOTAFirmwareUpdateInProgress()) {
-			const message =
-				"Failed to soft reset controller: A firmware update is in progress on this network.";
+			const message = `Failed to soft reset controller: A firmware update is in progress on this network.`;
 			this.controllerLog.print(message, "error");
 			throw new ZWaveError(
 				message,
@@ -2416,8 +2415,7 @@ export class Driver
 		this.ensureReady(true);
 
 		if (this._controller!.isAnyOTAFirmwareUpdateInProgress()) {
-			const message =
-				"Failed to hard reset controller: A firmware update is in progress on this network.";
+			const message = `Failed to hard reset controller: A firmware update is in progress on this network.`;
 			this.controllerLog.print(message, "error");
 			throw new ZWaveError(
 				message,

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -2246,6 +2246,16 @@ export class Driver
 			);
 		}
 
+		if (this._controller!.isAnyOTAFirmwareUpdateInProgress()) {
+			const message =
+				"Failed to soft reset controller: A firmware update is in progress on this network.";
+			this.controllerLog.print(message, "error");
+			throw new ZWaveError(
+				message,
+				ZWaveErrorCodes.Firmware_Update_In_Progress_Error,
+			);
+		}
+
 		return this.softResetInternal(true);
 	}
 
@@ -2404,6 +2414,16 @@ export class Driver
 	 */
 	public async hardReset(): Promise<void> {
 		this.ensureReady(true);
+
+		if (this._controller!.isAnyOTAFirmwareUpdateInProgress()) {
+			const message =
+				"Failed to hard reset controller: A firmware update is in progress on this network.";
+			this.controllerLog.print(message, "error");
+			throw new ZWaveError(
+				message,
+				ZWaveErrorCodes.Firmware_Update_In_Progress_Error,
+			);
+		}
 
 		// Update the controller NIF prior to hard resetting
 		await this._controller!.setControllerNIF();

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -2251,7 +2251,7 @@ export class Driver
 			this.controllerLog.print(message, "error");
 			throw new ZWaveError(
 				message,
-				ZWaveErrorCodes.Firmware_Update_In_Progress_Error,
+				ZWaveErrorCodes.FirmwareUpdateCC_NetworkBusy,
 			);
 		}
 
@@ -2419,7 +2419,7 @@ export class Driver
 			this.controllerLog.print(message, "error");
 			throw new ZWaveError(
 				message,
-				ZWaveErrorCodes.Firmware_Update_In_Progress_Error,
+				ZWaveErrorCodes.FirmwareUpdateCC_NetworkBusy,
 			);
 		}
 

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -2246,7 +2246,7 @@ export class Driver
 			);
 		}
 
-		if (this._controller!.isAnyOTAFirmwareUpdateInProgress()) {
+		if (this._controller?.isAnyOTAFirmwareUpdateInProgress()) {
 			const message = `Failed to soft reset controller: A firmware update is in progress on this network.`;
 			this.controllerLog.print(message, "error");
 			throw new ZWaveError(
@@ -2414,7 +2414,7 @@ export class Driver
 	public async hardReset(): Promise<void> {
 		this.ensureReady(true);
 
-		if (this._controller!.isAnyOTAFirmwareUpdateInProgress()) {
+		if (this.controller.isAnyOTAFirmwareUpdateInProgress()) {
 			const message = `Failed to hard reset controller: A firmware update is in progress on this network.`;
 			this.controllerLog.print(message, "error");
 			throw new ZWaveError(
@@ -2424,8 +2424,8 @@ export class Driver
 		}
 
 		// Update the controller NIF prior to hard resetting
-		await this._controller!.setControllerNIF();
-		await this._controller!.hardReset();
+		await this.controller.setControllerNIF();
+		await this.controller.hardReset();
 
 		// Clean up
 		this.rejectTransactions(() => true, `The controller was hard-reset`);

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3711,7 +3711,7 @@ protocol version:      ${this.protocolVersion}`;
 		if (this.driver.controller.isAnyOTAFirmwareUpdateInProgress()) {
 			throw new ZWaveError(
 				`Failed to start the update: A firmware update is already in progress on this network!`,
-				ZWaveErrorCodes.Firmware_Update_In_Progress_Error,
+				ZWaveErrorCodes.FirmwareUpdateCC_NetworkBusy,
 			);
 		}
 		this._firmwareUpdateInProgress = true;
@@ -3898,7 +3898,7 @@ protocol version:      ${this.protocolVersion}`;
 		if (this.driver.controller.isAnyOTAFirmwareUpdateInProgress()) {
 			throw new ZWaveError(
 				`Failed to start the update: A firmware update is already in progress on this network!`,
-				ZWaveErrorCodes.Firmware_Update_In_Progress_Error,
+				ZWaveErrorCodes.FirmwareUpdateCC_NetworkBusy,
 			);
 		}
 		this._firmwareUpdateInProgress = true;

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3709,11 +3709,8 @@ protocol version:      ${this.protocolVersion}`;
 
 		// Don't let two firmware updates happen in parallel
 		if (this.driver.controller.isAnyOTAFirmwareUpdateInProgress()) {
-			const message =
-				"Failed to start the update: A firmware update is already in progress on this network!";
-			this.driver.controllerLog.print(message, "error");
 			throw new ZWaveError(
-				message,
+				`Failed to start the update: A firmware update is already in progress on this network!`,
 				ZWaveErrorCodes.Firmware_Update_In_Progress_Error,
 			);
 		}
@@ -3899,11 +3896,8 @@ protocol version:      ${this.protocolVersion}`;
 
 		// Don't let two firmware updates happen in parallel
 		if (this.driver.controller.isAnyOTAFirmwareUpdateInProgress()) {
-			const message =
-				"Failed to start the update: A firmware update is already in progress on this network!";
-			this.driver.controllerLog.print(message, "error");
 			throw new ZWaveError(
-				message,
+				`Failed to start the update: A firmware update is already in progress on this network!`,
 				ZWaveErrorCodes.Firmware_Update_In_Progress_Error,
 			);
 		}

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3702,8 +3702,19 @@ protocol version:      ${this.protocolVersion}`;
 		// Don't start the process twice
 		if (this.isFirmwareUpdateInProgress()) {
 			throw new ZWaveError(
-				`Failed to start the update: A firmware upgrade is already in progress!`,
+				`Failed to start the update: A firmware upgrade for this node is already in progress!`,
 				ZWaveErrorCodes.FirmwareUpdateCC_Busy,
+			);
+		}
+
+		// Don't let two firmware updates happen in parallel
+		if (this.driver.controller.isAnyOTAFirmwareUpdateInProgress()) {
+			const message =
+				"Failed to start the update: A firmware update is already in progress on this network!";
+			this.driver.controllerLog.print(message, "error");
+			throw new ZWaveError(
+				message,
+				ZWaveErrorCodes.Firmware_Update_In_Progress_Error,
 			);
 		}
 		this._firmwareUpdateInProgress = true;
@@ -3883,6 +3894,17 @@ protocol version:      ${this.protocolVersion}`;
 			throw new ZWaveError(
 				`Failed to start the update: A firmware upgrade is already in progress!`,
 				ZWaveErrorCodes.FirmwareUpdateCC_Busy,
+			);
+		}
+
+		// Don't let two firmware updates happen in parallel
+		if (this.driver.controller.isAnyOTAFirmwareUpdateInProgress()) {
+			const message =
+				"Failed to start the update: A firmware update is already in progress on this network!";
+			this.driver.controllerLog.print(message, "error");
+			throw new ZWaveError(
+				message,
+				ZWaveErrorCodes.Firmware_Update_In_Progress_Error,
 			);
 		}
 		this._firmwareUpdateInProgress = true;


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

Per https://github.com/zwave-js/zwave-js-server/pull/772#discussion_r1028144666 , we won't let hard resets or soft resets occur while a firmware update is in progress. Al has also mentioned that two firmware updates should not happen in parallel (at least for now), so this PR protects against those as well
