### PR TITLE
fix(config): support hardware version 2.0 for Zooz ZEN71, add parameter 17

### DIFF
--- a/packages/config/config/devices/0x027a/zen71.json
+++ b/packages/config/config/devices/0x027a/zen71.json
@@ -76,7 +76,7 @@
 		},
 		{
 			"#": "17",
-			"$if": "firmwareVersion >= 10.0",
+			"$if": "firmwareVersion >= 2.0",
 			"$import": "templates/zooz_template.json#local_programming"
 		}
 	],

--- a/packages/config/config/devices/0x027a/zen71.json
+++ b/packages/config/config/devices/0x027a/zen71.json
@@ -76,6 +76,7 @@
 		},
 		{
 			"#": "17",
+			// This parameter was added in firmware 10.0, which the 2.0 firmware is based on
 			"$if": "firmwareVersion >= 2.0",
 			"$import": "templates/zooz_template.json#local_programming"
 		}


### PR DESCRIPTION
The hardware version 2.0 of the switch uses different versioning. Can this be changed to support the different firmware versioning?

"$if": "firmwareVersion >= 10.0",
to
"$if": "firmwareVersion >= 2.0",

Hardware Version 1.0 is currently Firmware Version 10.10 Hardware Version 2.0 is currently Firmware Version 2.10 (>= 2.0 has the parameter 17)

This would capture both hardware versions without showing the parameter for those on FW version 1.0 or 1.01

https://www.support.getzooz.com/kb/article/1102-zen71-700-series-on-off-switch-change-log/