### PR TITLE
fix(config): correct config params for Logic Group ZSO7300

### DIFF
--- a/packages/config/config/devices/0x0234/templates/logic_group_template.json
+++ b/packages/config/config/devices/0x0234/templates/logic_group_template.json
@@ -491,7 +491,7 @@
 		"label": "Power Change Threshold",
 		"valueSize": 2,
 		"unit": "W",
-		"minValue": 0,
+		"minValue": 1,
 		"maxValue": 500,
 		"defaultValue": 50,
 		"unsigned": true
@@ -500,7 +500,7 @@
 		"label": "Power Overload Limit",
 		"valueSize": 2,
 		"unit": "W",
-		"minValue": 0,
+		"minValue": 1,
 		"maxValue": 3000,
 		"defaultValue": 2900,
 		"unsigned": true
@@ -522,7 +522,7 @@
 				"value": 1
 			},
 			{
-				"label": "LED set by parameters 6 and 7",
+				"label": "Colors set by parameters 6 and 7",
 				"value": 2
 			}
 		]

--- a/packages/config/config/devices/0x0234/zso7300.json
+++ b/packages/config/config/devices/0x0234/zso7300.json
@@ -35,15 +35,15 @@
 	"paramInformation": [
 		{
 			"#": "1",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Button 2 Controls Relay 1"
+		},
+		{
+			"#": "2",
 			"$import": "~/templates/master_template.json#base_0-255_nounit",
 			"label": "Meter Report Time",
 			"description": "Values 1-127 = seconds; 128-255 = minutes (minus 127)",
 			"defaultValue": 60
-		},
-		{
-			"#": "2",
-			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Button 2 Controls Relay 1"
 		},
 		{
 			"#": "3",

--- a/packages/config/config/devices/0x0234/zso7300.json
+++ b/packages/config/config/devices/0x0234/zso7300.json
@@ -67,31 +67,31 @@
 		},
 		{
 			"#": "6[0xff0000]",
-			"$import": "#6[0xff000000]",
+			"$import": "#paramInformation/6[0xff000000]",
 			"label": "LED Indicator (On): Green",
 			"defaultValue": 255
 		},
 		{
 			"#": "6[0xff00]",
-			"$import": "#6[0xff000000]",
+			"$import": "#paramInformation/6[0xff000000]",
 			"label": "LED Indicator (On): Blue",
 			"defaultValue": 0
 		},
 		{
 			"#": "7[0xff000000]",
-			"$import": "#6[0xff000000]",
+			"$import": "#paramInformation/6[0xff000000]",
 			"label": "LED Indicator (Off): Red",
 			"defaultValue": 143
 		},
 		{
 			"#": "7[0xff0000]",
-			"$import": "#6[0xff000000]",
+			"$import": "#paramInformation/6[0xff000000]",
 			"label": "LED Indicator (Off): Green",
 			"defaultValue": 0
 		},
 		{
 			"#": "7[0xff00]",
-			"$import": "#6[0xff000000]",
+			"$import": "#paramInformation/6[0xff000000]",
 			"label": "LED Indicator (Off): Blue",
 			"defaultValue": 255
 		},

--- a/packages/config/config/devices/0x0234/zso7300.json
+++ b/packages/config/config/devices/0x0234/zso7300.json
@@ -35,8 +35,7 @@
 	"paramInformation": [
 		{
 			"#": "1",
-			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Startup relay state"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		{
 			"#": "2",
@@ -59,44 +58,41 @@
 		},
 		{
 			"#": "6[0xff000000]",
-			"$import": "templates/logic_group_template.json#led_indicator",
 			"label": "LED Indicator (On): Red",
 			"valueSize": 4,
-			"defaultValue": 0
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"unsigned": true
 		},
 		{
 			"#": "6[0xff0000]",
-			"$import": "templates/logic_group_template.json#led_indicator",
+			"$import": "#6[0xff000000]",
 			"label": "LED Indicator (On): Green",
-			"valueSize": 4,
 			"defaultValue": 255
 		},
 		{
 			"#": "6[0xff00]",
-			"$import": "templates/logic_group_template.json#led_indicator",
+			"$import": "#6[0xff000000]",
 			"label": "LED Indicator (On): Blue",
-			"valueSize": 4,
 			"defaultValue": 0
 		},
 		{
 			"#": "7[0xff000000]",
-			"$import": "templates/logic_group_template.json#led_indicator",
+			"$import": "#6[0xff000000]",
 			"label": "LED Indicator (Off): Red",
-			"valueSize": 4,
 			"defaultValue": 143
 		},
 		{
 			"#": "7[0xff0000]",
-			"$import": "templates/logic_group_template.json#led_indicator",
+			"$import": "#6[0xff000000]",
 			"label": "LED Indicator (Off): Green",
-			"valueSize": 4,
 			"defaultValue": 0
 		},
 		{
 			"#": "7[0xff00]",
-			"$import": "templates/logic_group_template.json#led_indicator",
+			"$import": "#6[0xff000000]",
 			"label": "LED Indicator (Off): Blue",
-			"valueSize": 4,
 			"defaultValue": 255
 		},
 		{

--- a/packages/config/config/devices/0x0234/zso7300.json
+++ b/packages/config/config/devices/0x0234/zso7300.json
@@ -36,7 +36,7 @@
 		{
 			"#": "1",
 			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Button 2 Controls Relay 1"
+			"label": "Startup relay state"
 		},
 		{
 			"#": "2",


### PR DESCRIPTION
The order of parameter 1 and 2 was reversed.

See the manual for the correct order of parameters: https://logic-group.com/download/9307/
