### PR TITLE
fix: don't overwrite known Wake Up CC version

### DIFF
--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -2913,10 +2913,13 @@ protocol version:      ${this.protocolVersion}`;
 		// It can happen that the node has not told us that it supports the Wake Up CC
 		// https://sentry.io/share/issue/6a681729d7db46d591f1dcadabe8d02e/
 		// To avoid a crash, mark it as supported
-		this.addCC(CommandClasses["Wake Up"], {
-			isSupported: true,
-			version: 1,
-		});
+		// Only add if Wake Up CC is currently marked as unsupported
+		if (this.getCCVersion(CommandClasses["Wake Up"]) == 0) {
+			this.addCC(CommandClasses["Wake Up"], {
+				isSupported: true,
+				version: 1,
+			});
+		}
 
 		this.markAsAwake();
 

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -2913,8 +2913,7 @@ protocol version:      ${this.protocolVersion}`;
 		// It can happen that the node has not told us that it supports the Wake Up CC
 		// https://sentry.io/share/issue/6a681729d7db46d591f1dcadabe8d02e/
 		// To avoid a crash, mark it as supported
-		// Only add if Wake Up CC is currently marked as unsupported
-		if (this.getCCVersion(CommandClasses["Wake Up"]) == 0) {
+		if (this.getCCVersion(CommandClasses["Wake Up"]) === 0) {
 			this.addCC(CommandClasses["Wake Up"], {
 				isSupported: true,
 				version: 1,


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->
Every time a wake up notification is received from a node, the tracked version of `Wake Up CC` is set to `1`. This means devices that actually support version 2 or greater will be incorrectly shown to support only version 1. This PR adds a check to only add the `Wake Up CC` to a node if it isn't already known to support it.

fixes: #5262 