### PR TITLE
fix(config): allow higher pulse factor for NQ-9021

### DIFF
--- a/packages/config/config/devices/0x0096/nq-9021.json
+++ b/packages/config/config/devices/0x0096/nq-9021.json
@@ -19,10 +19,10 @@
 			"#": "1",
 			"label": "Pulse factor",
 			"description": "Impulse or Rotation factor per KWh * 10",
-			"valueSize": 2,
+			"valueSize": 4,
 			"minValue": 0,
-			"maxValue": 65535,
-			"defaultValue": 1024,
+			"maxValue": 1000000,
+			"defaultValue": 10000,
 			"unsigned": true
 		},
 		{

--- a/packages/config/config/devices/0x0096/nq-9021.json
+++ b/packages/config/config/devices/0x0096/nq-9021.json
@@ -17,6 +17,18 @@
 	"paramInformation": [
 		{
 			"#": "1",
+			"$if": "firmwareVersion < 3.24",
+			"label": "Pulse factor",
+			"description": "Impulse or Rotation factor per KWh * 10",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 65535,
+			"defaultValue": 1024,
+			"unsigned": true
+		},
+		{
+			"#": "1",
+			"$if": "firmwareVersion >= 3.24",
 			"label": "Pulse factor",
 			"description": "Impulse or Rotation factor per KWh * 10",
 			"valueSize": 4,


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

Pulse factor needs to be 100,000 for most electricity meters in Finland. According to below post the maximum is 1,000,000 for this device.

* https://forum.fibaro.com/topic/24261-northq-nq-9021-powermeter/
