### PR TITLE
fix(config): add new product ID for 46201/ZW4008

### DIFF
--- a/packages/config/config/devices/0x0063/46201_zw4008.json
+++ b/packages/config/config/devices/0x0063/46201_zw4008.json
@@ -8,6 +8,11 @@
 			"productType": "0x4952",
 			"productId": "0x3135",
 			"zwaveAllianceId": 4143
+		},
+    {
+			"productType": "0x4952",
+			"productId": "0x3036",
+			"zwaveAllianceId": 4143
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

Adding support for the GE/Enbrighten In-Wall Paddle Switch, ZW4008 /42601-2, with the product ID of `0x3036`. 

Logs to show productId when interviewing the device:

```
received response for manufacturer information:
                                    manufacturer: GE/Jasco (0x63)
                                    product type: 0x4952
                                    product id:   0x3036
```
