### PR TITLE
feat(config): add DragonTech WD-100 In-Wall Dimmer

### DIFF
--- a/packages/config/config/devices/0x0184/WD-100.json
+++ b/packages/config/config/devices/0x0184/WD-100.json
@@ -25,7 +25,7 @@
 		},
 		{
 			"#": "8",
-			"$import": "templates/master_template.json#dimming_timing",
+			"$import": "~/templates/master_template.json#dimming_timing",
 			"label": "Remote Dimming Step Duration"
 		},
 		{
@@ -35,7 +35,7 @@
 		},
 		{
 			"#": "10",
-			"$import": "templates/master_template.json#dimming_timing",
+			"$import": "~/templates/master_template.json#dimming_timing",
 			"label": "Local Dimming Step Duration"
 		}
 	],

--- a/packages/config/config/devices/0x0184/WD-100.json
+++ b/packages/config/config/devices/0x0184/WD-100.json
@@ -1,0 +1,58 @@
+{
+	"manufacturer": "Dragon Tech Industrial, Ltd.",
+	"manufacturerId": "0x0184",
+	"label": "WD-100",
+	"description": "In-Wall Dimmer Switch",
+	"devices": [
+		{
+			"productType": "0x4447",
+			"productId": "0x3034"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"paramInformation": [
+		{
+			"#": "4",
+			"$import": "~/templates/master_template.json#orientation"
+		},
+		{
+			"#": "7",
+			"$import": "~/templates/master_template.json#base_1-99_nounit",
+			"label": "Remote Dimming Level Increment"
+		},
+		{
+			"#": "8",
+			"$import": "templates/master_template.json#dimming_timing",
+			"label": "Remote Dimming Step Duration"
+		},
+		{
+			"#": "9",
+			"$import": "~/templates/master_template.json#base_1-99_nounit",
+			"label": "Local Dimming Level Increment"
+		},
+		{
+			"#": "10",
+			"$import": "templates/master_template.json#dimming_timing",
+			"label": "Local Dimming Step Duration"
+		}
+	],
+	"compat": {
+		"commandClasses": {
+			"remove": {
+				"0x6c": {
+					// The device does not support supervision although it is mandatory for the device type
+					"endpoints": "*"
+				}
+			}
+		}
+	},
+	"metadata": {
+		"inclusion": "1. Turn the connected lights ON/OFF by tapping the switch. Tapping and releasing the upper part of the rocker turns the appliance ON. Tapping and releasing the lower part of the rocker turns the appliance OFF.\n2. Add(Include) the module to/from your Z-Wave network with your primary controller. Please refer to the instructions manual of your gateway or remote controller for details and procedures on how these actions can be done. \n3. Normally, the sequence is as follows: when the inclusion process is prompted by your primary controller, single click and release the rocker switch to ON or OFF position. The controller should show that the action was successful. If the controller shows it was a fail, repeat the procedure",
+		"exclusion": "1. Turn the connected appliance ON/OFF by tapping the switch. Tapping and releasing the upper part of the rocker turns the appliance ON. Tapping and releasing the lower part of the rocker turns the appliance OFF.\n2. Delete(Exclude) the module to/from your Z-Wave network with your primary controller. Please refer to the instructions manual of your gateway or remote controller for details and procedures on how these actions can be done. \n3. Normally, the sequence is as follows: when the exclusion process is prompted by your primary controller, single click and release the rocker switch. The controller should show that the action was successful. If the controller shows it was a fail, repeat the procedure",
+		"reset": "Please use this procedure only in the event that the network primary controller is lost or otherwise inoperable.\n\nAll Configuration Parameters can all be restored to their factory default settings by using your primary controller to delete/reset the device. \nTo manually reset, tap the ON button twice quickly and then tap the OFF button twice quickly. Repeat the procedure to restore the settings to the factory default.",
+		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/2563/HS-WD100-Manual-v1_1a.pdf"
+	}
+}

--- a/packages/config/config/devices/0x0184/wd-100.json
+++ b/packages/config/config/devices/0x0184/wd-100.json
@@ -6,7 +6,8 @@
 	"devices": [
 		{
 			"productType": "0x4447",
-			"productId": "0x3034"
+			"productId": "0x3034",
+			"zwaveAllianceId": 2031
 		}
 	],
 	"firmwareVersion": {
@@ -53,6 +54,6 @@
 		"inclusion": "1. Turn the connected lights ON/OFF by tapping the switch. Tapping and releasing the upper part of the rocker turns the appliance ON. Tapping and releasing the lower part of the rocker turns the appliance OFF.\n2. Add(Include) the module to/from your Z-Wave network with your primary controller. Please refer to the instructions manual of your gateway or remote controller for details and procedures on how these actions can be done. \n3. Normally, the sequence is as follows: when the inclusion process is prompted by your primary controller, single click and release the rocker switch to ON or OFF position. The controller should show that the action was successful. If the controller shows it was a fail, repeat the procedure",
 		"exclusion": "1. Turn the connected appliance ON/OFF by tapping the switch. Tapping and releasing the upper part of the rocker turns the appliance ON. Tapping and releasing the lower part of the rocker turns the appliance OFF.\n2. Delete(Exclude) the module to/from your Z-Wave network with your primary controller. Please refer to the instructions manual of your gateway or remote controller for details and procedures on how these actions can be done. \n3. Normally, the sequence is as follows: when the exclusion process is prompted by your primary controller, single click and release the rocker switch. The controller should show that the action was successful. If the controller shows it was a fail, repeat the procedure",
 		"reset": "Please use this procedure only in the event that the network primary controller is lost or otherwise inoperable.\n\nAll Configuration Parameters can all be restored to their factory default settings by using your primary controller to delete/reset the device. \nTo manually reset, tap the ON button twice quickly and then tap the OFF button twice quickly. Repeat the procedure to restore the settings to the factory default.",
-		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/2563/HS-WD100-Manual-v1_1a.pdf"
+		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/2031/WD-100_UG_updated%2007212016.pdf"
 	}
 }


### PR DESCRIPTION
Add support for DragonTech WD-100 In-Wall Dimmer switch: x0184:0x4447:0x3034

Product info here: https://products.z-wavealliance.org/products/2031
Command Classes: https://products.z-wavealliance.org/products/2031/configs

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

PR description here
