### PR TITLE
fix(docs): correct link to Aeotec updating guide

### DIFF
--- a/docs/troubleshooting/otw-upgrade.md
+++ b/docs/troubleshooting/otw-upgrade.md
@@ -10,5 +10,5 @@ https://github.com/kpine/zwave-js-server-docker/wiki/700-series-Controller-Firmw
 
 ## Windows
 
--   Aeotec - https://help.aeotec.com/support/solutions/articles/6000252296-update-z-stick-7-with-windows
+-   Aeotec - https://aeotec.freshdesk.com/support/solutions/articles/6000252296-update-z-stick-7-with-windows
 -   Zooz - https://www.support.getzooz.com/kb/article/931-how-to-perform-an-ota-firmware-update-on-your-zst10-700-z-wave-stick/


### PR DESCRIPTION
Aeotec changed the URI of their support page. Manuals & FAQ also links to aetec.freshdesk.com, so it is their support page.