### PR TITLE
feat: add readonly `rfRegion` property to `Controller` class

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -971,6 +971,15 @@ enum InclusionState {
 }
 ```
 
+### `rfRegion`
+
+```ts
+readonly rfRegion: RFRegion | undefined
+```
+
+Which RF region the controller is currently set to, or `undefined` if it could not be determined (yet).
+This value is cached and updated automatically when using [`getRFRegion` or `setRFRegion`](#configure-rf-region).
+
 ## Controller events
 
 The `Controller` class inherits from the Node.js [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) and thus also supports its methods like `on`, `removeListener`, etc. The available events are available:

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -1028,6 +1028,8 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "zwave-js" does not have an export "restoreNVM"
     restoreNVMRaw(nvmData: Buffer, onProgress?: (bytesWritten: number, total: number) => void): Promise<void>;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "zwave-js" does not have an export "setRFRegion"
+    get rfRegion(): RFRegion_2 | undefined;
     // (undocumented)
     get sdkVersion(): string | undefined;
     sdkVersionGt(version: SDKVersion): boolean | undefined;

--- a/test/run.ts
+++ b/test/run.ts
@@ -1,9 +1,7 @@
-import { wait } from "alcalzone-shared/async";
-import fs from "fs/promises";
 import os from "os";
 import path from "path";
 import "reflect-metadata";
-import { Driver, extractFirmware, guessFirmwareFileFormat } from "zwave-js";
+import { Driver } from "zwave-js";
 
 process.on("unhandledRejection", (_r) => {
 	debugger;
@@ -38,42 +36,7 @@ const driver = new Driver(port, {
 })
 	.on("error", console.error)
 	.once("driver ready", async () => {
-		const node = driver.controller.nodes.getOrThrow(8);
-		node.once("ready", async () => {
-			await wait(2000);
-			const fwFilename =
-				"/home/dominic/Repositories/zwavejs2mqtt/MultiSensor_OTA_Security_ZW050x_EU_A_V1_13_hex__TargetZwave__.bin";
-			const fwData = await fs.readFile(fwFilename);
-			const format = guessFirmwareFileFormat(
-				path.basename(fwFilename),
-				fwData,
-			);
-			const fw = extractFirmware(fwData, format);
-
-			await node.beginFirmwareUpdate(fw.data, fw.firmwareTarget);
-			await wait(2000);
-			await node.abortFirmwareUpdate();
-		});
-		// setTimeout(
-		// 	() => driver.controller.nodes.getOrThrow(2).refreshInfo(),
-		// 	2500,
-		// );
-		// Test code
-		// await wait(1000);
-		// const updates = await driver.controller.getAvailableFirmwareUpdates(10);
-		// console.log("Found updates:");
-		// console.dir(updates, { depth: Infinity });
-		// await wait(1000);
-		// try {
-		// 	console.log(`Installing update ${updates[0].version}...`);
-		// 	await wait(1000);
-		// 	await driver.controller.beginOTAFirmwareUpdate(
-		// 		2,
-		// 		updates[0].files[0],
-		// 	);
-		// } catch (e) {
-		// 	console.error(e);
-		// }
+		// Test code goes here
 	});
 void driver.start();
 // driver.enableStatistics({


### PR DESCRIPTION
This PR adds the `rfRegion` property to the `Controller` class. This automatically gets queried during the controller identification phase now and updated when using `setRFRegion` or `getRFRegion`.

Outside of these, the RF region of the controller isn't going to change, so applications can now display/use the RF region without having to query it and handle errors.