### PR TITLE
feat: allow configuring the number of kept logfiles

### DIFF
--- a/packages/core/api.md
+++ b/packages/core/api.md
@@ -1271,6 +1271,8 @@ export interface LogConfig {
     // (undocumented)
     logToFile: boolean;
     // (undocumented)
+    maxFiles: number;
+    // (undocumented)
     nodeFilter?: number[];
     // (undocumented)
     transports: Transport[];

--- a/packages/core/src/log/shared.ts
+++ b/packages/core/src/log/shared.ts
@@ -48,7 +48,7 @@ export class ZWaveLogContainer extends winston.Container {
 		enabled: true,
 		level: getTransportLoglevel(),
 		logToFile: !!process.env.LOGTOFILE,
-		numLogFiles: 7,
+		maxFiles: 7,
 		nodeFilter: stringToNodeList(process.env.LOG_NODES),
 		transports: undefined as any,
 		filename: require.main
@@ -102,18 +102,18 @@ export class ZWaveLogContainer extends winston.Container {
 			config.filename != undefined &&
 			config.filename !== this.logConfig.filename;
 
-		if (config.numLogFiles != undefined) {
+		if (config.maxFiles != undefined) {
 			if (
-				typeof config.numLogFiles !== "number" ||
-				config.numLogFiles < 1 ||
-				config.numLogFiles > 365
+				typeof config.maxFiles !== "number" ||
+				config.maxFiles < 1 ||
+				config.maxFiles > 365
 			) {
-				delete config.numLogFiles;
+				delete config.maxFiles;
 			}
 		}
-		const changedNumLogFiles =
-			config.numLogFiles != undefined &&
-			config.numLogFiles !== this.logConfig.numLogFiles;
+		const changedMaxFiles =
+			config.maxFiles != undefined &&
+			config.maxFiles !== this.logConfig.maxFiles;
 
 		this.logConfig = Object.assign(this.logConfig, config);
 
@@ -130,7 +130,7 @@ export class ZWaveLogContainer extends winston.Container {
 				this.consoleTransport == undefined) ||
 			changedLoggingTarget ||
 			changedFilename ||
-			changedNumLogFiles;
+			changedMaxFiles;
 
 		if (recreateInternalTransports) {
 			this.fileTransport?.destroy();
@@ -240,7 +240,7 @@ export class ZWaveLogContainer extends winston.Container {
 				.basename(this.logConfig.filename)
 				.replace(`_%DATE%`, "_current"),
 			zippedArchive: true,
-			maxFiles: `${this.logConfig.numLogFiles}d`,
+			maxFiles: `${this.logConfig.maxFiles}d`,
 			format: createDefaultTransportFormat(false, false),
 			silent: this.isFileTransportSilent(),
 		});

--- a/packages/core/src/log/shared_safe.ts
+++ b/packages/core/src/log/shared_safe.ts
@@ -88,7 +88,7 @@ export interface LogConfig {
 	level: string | number;
 	transports: Transport[];
 	logToFile: boolean;
-	numLogFiles: number;
+	maxFiles: number;
 	nodeFilter?: number[];
 	filename: string;
 	forceConsole: boolean;

--- a/packages/core/src/log/shared_safe.ts
+++ b/packages/core/src/log/shared_safe.ts
@@ -88,6 +88,7 @@ export interface LogConfig {
 	level: string | number;
 	transports: Transport[];
 	logToFile: boolean;
+	numLogFiles: number;
 	nodeFilter?: number[];
 	filename: string;
 	forceConsole: boolean;


### PR DESCRIPTION
fixes: #5268 

This PR adds the property `maxFiles` to the `LogConfig` interface, which allows configuring a number of kept logfiles between 1 and 365 (default 7).

@robertsLando we might want to expose this option in zwave-js-ui