### PR TITLE
feat: region-specific firmware updates

### DIFF
--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -4578,6 +4578,7 @@ ${associatedNodes.join(", ")}`,
 					productType,
 					productId,
 					firmwareVersion,
+					rfRegion: this.rfRegion,
 				},
 				{
 					userAgent: this.driver.getUserAgentStringWithComponents(


### PR DESCRIPTION
This PR adds support for the `v3` endpoint of the firmware update service, which allows region-locking firmware updates.
