### PR TITLE
feat: support pre-filling the DSK and scanning DSK-only QRs

### DIFF
--- a/packages/core/api.md
+++ b/packages/core/api.md
@@ -2312,6 +2312,11 @@ export enum TransmitStatus {
     OK = 0
 }
 
+// Warning: (ae-missing-release-tag) "tryParseDSKFromQRCodeString" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function tryParseDSKFromQRCodeString(qr: string): string | undefined;
+
 // Warning: (ae-missing-release-tag) "TXReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,7 @@ export * from "./security/Manager";
 export * from "./security/Manager2";
 export * from "./security/QR";
 export * from "./security/SecurityClass";
+export * from "./security/shared_safe";
 export * from "./test/assertZWaveError";
 export * from "./util/crc";
 export * from "./util/date";

--- a/packages/core/src/index_safe.ts
+++ b/packages/core/src/index_safe.ts
@@ -15,6 +15,7 @@ export * from "./error/ZWaveError";
 export * from "./log/shared_safe";
 export * from "./security/DSK";
 export * from "./security/SecurityClass";
+export * from "./security/shared_safe";
 export * from "./util/crc";
 export * from "./util/graph";
 export * from "./util/misc";

--- a/packages/core/src/security/DSK.ts
+++ b/packages/core/src/security/DSK.ts
@@ -1,9 +1,6 @@
 import { padStart } from "alcalzone-shared/strings";
 import { ZWaveError, ZWaveErrorCodes } from "../error/ZWaveError";
-
-export function isValidDSK(dsk: string): boolean {
-	return /^(\d{5}-){7}\d{5}$/.test(dsk);
-}
+import { isValidDSK } from "./shared_safe";
 
 export function dskToString(dsk: Buffer): string {
 	if (dsk.length !== 16) {

--- a/packages/core/src/security/QR.ts
+++ b/packages/core/src/security/QR.ts
@@ -2,7 +2,7 @@ import { createHash } from "crypto";
 import { Protocols } from "../capabilities/Protocols";
 import { ZWaveError, ZWaveErrorCodes } from "../error/ZWaveError";
 import { parseBitMask } from "../values/Primitive";
-import { dskToString, isValidDSK } from "./DSK";
+import { dskToString } from "./DSK";
 import { SecurityClass } from "./SecurityClass";
 
 function readNumber(qr: string, offset: number, length: number): number {
@@ -215,21 +215,6 @@ function parseTLV(qr: string): {
 		entry,
 		charsRead: offset,
 	};
-}
-
-/**
- * Tries to extract a DSK from a scanned QR code. If the string is a valid DSK (prefixed with "zws2dsk:" or unprefixed), the DSK will be returned.
- * This can then be used to initiate an S2 inclusion with pre-filled DSK.
- */
-export function tryParseDSKFromQRCodeString(qr: string): string | undefined {
-	// Trim off whitespace that might have been copied by accident
-	qr = qr.trim();
-	if (qr.startsWith("zws2dsk:")) {
-		qr = qr.slice("zws2dsk:".length);
-	}
-	if (isValidDSK(qr)) {
-		return qr;
-	}
 }
 
 /** Parses a string that has been decoded from a Z-Wave (S2 or SmartStart) QR code */

--- a/packages/core/src/security/QR.ts
+++ b/packages/core/src/security/QR.ts
@@ -2,7 +2,7 @@ import { createHash } from "crypto";
 import { Protocols } from "../capabilities/Protocols";
 import { ZWaveError, ZWaveErrorCodes } from "../error/ZWaveError";
 import { parseBitMask } from "../values/Primitive";
-import { dskToString } from "./DSK";
+import { dskToString, isValidDSK } from "./DSK";
 import { SecurityClass } from "./SecurityClass";
 
 function readNumber(qr: string, offset: number, length: number): number {
@@ -215,6 +215,21 @@ function parseTLV(qr: string): {
 		entry,
 		charsRead: offset,
 	};
+}
+
+/**
+ * Tries to extract a DSK from a scanned QR code. If the string is a valid DSK (prefixed with "zws2dsk:" or unprefixed), the DSK will be returned.
+ * This can then be used to initiate an S2 inclusion with pre-filled DSK.
+ */
+export function tryParseDSKFromQRCodeString(qr: string): string | undefined {
+	// Trim off whitespace that might have been copied by accident
+	qr = qr.trim();
+	if (qr.startsWith("zws2dsk:")) {
+		qr = qr.slice("zws2dsk:".length);
+	}
+	if (isValidDSK(qr)) {
+		return qr;
+	}
 }
 
 /** Parses a string that has been decoded from a Z-Wave (S2 or SmartStart) QR code */

--- a/packages/core/src/security/shared_safe.ts
+++ b/packages/core/src/security/shared_safe.ts
@@ -1,0 +1,18 @@
+/**
+ * Tries to extract a DSK from a scanned QR code. If the string is a valid DSK (prefixed with "zws2dsk:" or unprefixed), the DSK will be returned.
+ * This can then be used to initiate an S2 inclusion with pre-filled DSK.
+ */
+export function tryParseDSKFromQRCodeString(qr: string): string | undefined {
+	// Trim off whitespace that might have been copied by accident
+	qr = qr.trim();
+	if (qr.startsWith("zws2dsk:")) {
+		qr = qr.slice("zws2dsk:".length);
+	}
+	if (isValidDSK(qr)) {
+		return qr;
+	}
+}
+
+export function isValidDSK(dsk: string): boolean {
+	return /^(\d{5}-){7}\d{5}$/.test(dsk);
+}

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -526,6 +526,7 @@ export type InclusionOptions = {
     forceSecurity?: boolean;
 } | {
     strategy: InclusionStrategy.Security_S2;
+    dsk?: string;
     userCallbacks?: InclusionUserCallbacks;
 } | {
     strategy: InclusionStrategy.Security_S2;

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -34,6 +34,7 @@ import {
 	indexDBsByNode,
 	isRecoverableZWaveError,
 	isTransmissionError,
+	isValidDSK,
 	isZWaveError,
 	NodeType,
 	NODE_ID_BROADCAST,
@@ -2493,13 +2494,23 @@ supported CCs: ${nodeInfo.supportedCCs
 				const tai2RemainingMs =
 					inclusionTimeouts.TAI2 - (Date.now() - timerStartTAI2);
 
-				const pinResult = await Promise.race([
-					wait(tai2RemainingMs, true).then(() => false as const),
-					userCallbacks
-						.validateDSKAndEnterPIN(dsk)
-						// ignore errors in application callbacks
-						.catch(() => false as const),
-				]);
+				let pinResult: string | false;
+				if (
+					"dsk" in inclusionOptions &&
+					typeof inclusionOptions.dsk === "string" &&
+					isValidDSK(inclusionOptions.dsk)
+				) {
+					pinResult = inclusionOptions.dsk.slice(0, 5);
+				} else {
+					pinResult = await Promise.race([
+						wait(tai2RemainingMs, true).then(() => false as const),
+						userCallbacks
+							.validateDSKAndEnterPIN(dsk)
+							// ignore errors in application callbacks
+							.catch(() => false as const),
+					]);
+				}
+
 				if (
 					typeof pinResult !== "string" ||
 					!/^\d{5}$/.test(pinResult)

--- a/packages/zwave-js/src/lib/controller/Inclusion.ts
+++ b/packages/zwave-js/src/lib/controller/Inclusion.ts
@@ -107,6 +107,11 @@ export type InclusionOptions =
 	| {
 			strategy: InclusionStrategy.Security_S2;
 			/**
+			 * Allows pre-filling the DSK, e.g. when a DSK-only QR code has been scanned.
+			 * If this is given, the `validateDSKAndEnterPIN` callback will not be called.
+			 */
+			dsk?: string;
+			/**
 			 * Allows overriding the user callbacks for this inclusion.
 			 * If not given, the inclusion user callbacks of the driver options will be used.
 			 */


### PR DESCRIPTION
@raman325 @robertsLando 

This is an attempt at supporting QR codes that only include the DSK (prefixed or unprefixed). I tried to add this functionality to the API without breaking changes - doing this as part of `parseQRCodeString` would require changes to the return type which in turn would require application-level checks to decide what to do with the info.

The downside is that after scanning, applications need to first check if the QR code string is a valid DSK (`tryParseDSKFromQRCodeString`) and if yes use the S2 inclusion strategy with pre-filled DSK.
If not, attempt to parse the encoded info from the QR code string as they do now.

Thoughts?

fixes: #5205