### PR TITLE
feat(config): add parameter 24 to Zooz ZEN32, FW 10.30+

### DIFF
--- a/packages/config/config/devices/0x027a/zen32.json
+++ b/packages/config/config/devices/0x027a/zen32.json
@@ -186,6 +186,13 @@
 			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
 			"label": "LED Settings Indicator",
 			"defaultValue": 0
+		},
+		{
+			"#": "24",
+			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
+			"$if": "firmwareVersion >= 10.30",
+			"label": "Scene Control for the Relay Button",
+			"defaultValue": 0
 		}
 	],
 	"compat": {

--- a/packages/config/config/devices/0x027a/zen32.json
+++ b/packages/config/config/devices/0x027a/zen32.json
@@ -191,7 +191,7 @@
 			"#": "24",
 			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
 			"$if": "firmwareVersion >= 10.30",
-			"label": "Scene Control for the Relay Button",
+			"label": "Scene Control (Relay)",
 			"defaultValue": 0
 		}
 	],


### PR DESCRIPTION
Firmware: 10.30
Added parameter 24 to disable scene control for the relay button and reduce the physical press delay for that button with scene control disabled

Parameter 24: Enable or disable scene control on the relay button. If scene control is disabled, the slight delay for physical press will be reduced but the relay button will no longer send central scene events to the hub. It's recommended to disable the feature only if using the relay button for direct electrical control of the connected load without any additional remote control functions.

Values: 0 – scene control enabled (default). 1 – scene control disabled.

Size: 1 byte dec

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

PR description here
