### PR TITLE
feat(config): clean up Zooz ZSE40 firmware version mess, add new parameters 9 and 10

### DIFF
--- a/packages/config/config/devices/0x027a/zse40.json
+++ b/packages/config/config/devices/0x027a/zse40.json
@@ -178,7 +178,7 @@
 			"$if": "firmwareVersion < 32.32",
 			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Basic Set Reports",
-			"defaultValue": 1			
+			"defaultValue": 1
 		},
 		{
 			"#": "9",

--- a/packages/config/config/devices/0x027a/zse40.json
+++ b/packages/config/config/devices/0x027a/zse40.json
@@ -172,6 +172,37 @@
 					"value": 3
 				}
 			]
+		},
+		{
+			"#": "8",
+			"$if": "firmwareVersion < 32.32",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Basic Set Reports",
+			"defaultValue": 1			
+		},
+		{
+			"#": "9",
+			"$if": "firmwareVersion < 32.32",
+			"label": "Temperature Offset",
+			"description": "Set the reporting offset on your temperature sensor. 0=-10, 100=0, 200=+10",
+			"valueSize": 1,
+			"unit": "0.1 °F/C",
+			"minValue": 0,
+			"maxValue": 200,
+			"defaultValue": 100,
+			"unsigned": true
+		},
+		{
+			"#": "10",
+			"$if": "firmwareVersion < 32.32",
+			"label": "Humidity Offset",
+			"description": "Set the reporting offset on your humidity sensor. 0=-10%, 100=0%, 200=+10%",
+			"valueSize": 1,
+			"unit": "0.1 %",
+			"minValue": 0,
+			"maxValue": 200,
+			"defaultValue": 100,
+			"unsigned": true
 		}
 	],
 	"metadata": {

--- a/packages/config/config/devices/0x027a/zse40.json
+++ b/packages/config/config/devices/0x027a/zse40.json
@@ -6,14 +6,14 @@
 // Conditionals:
 // version 1.0: firmwareVersion >= 16.9 && firmwareVersion < 24.16
 // version 2.0: firmwareVersion >= 24.16 && firmwareVersion < 32.32
-// version 3.0: firmwareVersion >= 32.32 || (firmwareVersion >= 1.10 && firmwareVersion < 16.9)
+// version 3.0: firmwareVersion >= 32.32 || firmwareVersion >= 1.10 && firmwareVersion < 16.9
 
 {
 	"manufacturer": "Zooz",
 	"manufacturerId": "0x027a",
 	"label": [
 		{
-			"$if": "firmwareVersion === 32.32 || (firmwareVersion >= 1.10 && firmwareVersion < 16.9)",
+			"$if": "firmwareVersion === 32.32 || firmwareVersion >= 1.10 && firmwareVersion < 16.9",
 			"value": "ZSE40 700"
 		},
 		// Fallback for non-700 series
@@ -38,7 +38,7 @@
 			"isLifeline": true
 		},
 		"2": {
-			"$if": "firmwareVersion >= 32.2 || (firmwareVersion >= 1.10 && firmwareVersion < 16.9)",
+			"$if": "firmwareVersion >= 32.2 || firmwareVersion >= 1.10 && firmwareVersion < 16.9",
 			"label": "Group 2",
 			"maxNodes": 5
 		}
@@ -190,7 +190,7 @@
 		{
 			"#": "7",
 			// Hardware version 3 has removed mode 4
-			"$if": "firmwareVersion >= 32.32 || (firmwareVersion >= 1.10 && firmwareVersion < 16.9)",
+			"$if": "firmwareVersion >= 32.32 || firmwareVersion >= 1.10 && firmwareVersion < 16.9",
 			"label": "LED Indicator Mode",
 			"valueSize": 1,
 			"defaultValue": 3,
@@ -239,7 +239,7 @@
 		{
 			"#": "8",
 			// Added in firmware version 32.2, still present in HW 3.0
-			"$if": "firmwareVersion >= 32.2 || (firmwareVersion >= 1.10 && firmwareVersion < 16.9)",
+			"$if": "firmwareVersion >= 32.2 || firmwareVersion >= 1.10 && firmwareVersion < 16.9",
 			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Basic Set Reports",
 			"defaultValue": 1

--- a/packages/config/config/devices/0x027a/zse40.json
+++ b/packages/config/config/devices/0x027a/zse40.json
@@ -1,7 +1,24 @@
+// The firmware versions on this device are a mess
+// 16.9 / 17.9: HW version 1.0, 500 series
+// 24.16 / 32.2 / 32.12: HW version 2.0, 500 series
+// 32.32 / 1.10+: HW version 3.0, 700 series, called ZSE40 700
+
+// Conditionals:
+// version 1.0: firmwareVersion >= 16.9 && firmwareVersion < 24.16
+// version 2.0: firmwareVersion >= 24.16 && firmwareVersion < 32.32
+// version 3.0: firmwareVersion >= 32.32 || (firmwareVersion >= 1.10 && firmwareVersion < 16.9)
+
 {
 	"manufacturer": "Zooz",
 	"manufacturerId": "0x027a",
-	"label": "ZSE40",
+	"label": [
+		{
+			"$if": "firmwareVersion === 32.32 || (firmwareVersion >= 1.10 && firmwareVersion < 16.9)",
+			"value": "ZSE40 700"
+		},
+		// Fallback for non-700 series
+		"ZSE40"
+	],
 	"description": "4-in-1 Sensor",
 	"devices": [
 		{
@@ -21,6 +38,7 @@
 			"isLifeline": true
 		},
 		"2": {
+			"$if": "firmwareVersion >= 32.2 || (firmwareVersion >= 1.10 && firmwareVersion < 16.9)",
 			"label": "Group 2",
 			"maxNodes": 5
 		}
@@ -59,7 +77,8 @@
 		},
 		{
 			"#": "5",
-			"$if": "firmwareVersion < 17.9",
+			// Initial release of HW version 1.0
+			"$if": "firmwareVersion >= 16.9 && firmwareVersion < 17.9",
 			"$import": "~/templates/master_template.json#base_1-255_nounit",
 			"label": "Re-trigger Interval",
 			"unit": "minutes",
@@ -67,7 +86,8 @@
 		},
 		{
 			"#": "5",
-			"$if": "firmwareVersion >= 17.9 && firmwareVersion < 24.2",
+			// Update 17.9 changed the unit to seconds
+			"$if": "firmwareVersion >= 17.9 && firmwareVersion < 24.16",
 			"label": "Re-trigger Interval",
 			"unit": "seconds",
 			"valueSize": 1,
@@ -78,7 +98,7 @@
 		},
 		{
 			"#": "5",
-			"$if": "firmwareVersion >= 24.2",
+			// Update 24.16 changed the range to 15-255, this also applies to HW version 1.0
 			"label": "Re-trigger Interval",
 			"unit": "seconds",
 			"valueSize": 1,
@@ -89,6 +109,8 @@
 		},
 		{
 			"#": "6",
+			// HW version 1.0, first release has default value 3
+			"$if": "firmwareVersion >= 16.9 && firmwareVersion < 17.9",
 			"label": "Motion Sensor Sensitivity",
 			"description": "Adjust sensitivity of the motion sensor.",
 			"valueSize": 1,
@@ -126,8 +148,71 @@
 			]
 		},
 		{
+			"#": "6",
+			// All other releases have default value 4
+			"$if": "firmwareVersion < 16.9 || firmwareVersion >= 17.9",
+			"label": "Motion Sensor Sensitivity",
+			"description": "Adjust sensitivity of the motion sensor.",
+			"valueSize": 1,
+			"defaultValue": 4,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "highest",
+					"value": 1
+				},
+				{
+					"label": "higher",
+					"value": 2
+				},
+				{
+					"label": "high",
+					"value": 3
+				},
+				{
+					"label": "normal",
+					"value": 4
+				},
+				{
+					"label": "low",
+					"value": 5
+				},
+				{
+					"label": "lower",
+					"value": 6
+				},
+				{
+					"label": "lowest",
+					"value": 7
+				}
+			]
+		},
+		{
 			"#": "7",
-			"$if": "firmwareVersion < 32.32",
+			// Hardware version 3 has removed mode 4
+			"$if": "firmwareVersion >= 32.32 || (firmwareVersion >= 1.10 && firmwareVersion < 16.9)",
+			"label": "LED Indicator Mode",
+			"valueSize": 1,
+			"defaultValue": 3,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Off",
+					"value": 1
+				},
+				{
+					"label": "Pulsing Temperature, Flashing Motion",
+					"value": 2
+				},
+				{
+					"label": "Flashing Temperature and Motion",
+					"value": 3
+				}
+			]
+		},
+		{
+			"#": "7",
+			// All other versions still have mode 4
 			"label": "LED Indicator Mode",
 			"valueSize": 1,
 			"defaultValue": 4,
@@ -152,37 +237,17 @@
 			]
 		},
 		{
-			"#": "7",
-			"$if": "firmwareVersion >= 32.32",
-			"label": "LED Indicator Mode",
-			"valueSize": 1,
-			"defaultValue": 3,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Off",
-					"value": 1
-				},
-				{
-					"label": "Pulsing Temperature, Flashing Motion",
-					"value": 2
-				},
-				{
-					"label": "Flashing Temperature and Motion",
-					"value": 3
-				}
-			]
-		},
-		{
 			"#": "8",
-			"$if": "firmwareVersion < 32.32",
+			// Added in firmware version 32.2, still present in HW 3.0
+			"$if": "firmwareVersion >= 32.2 || (firmwareVersion >= 1.10 && firmwareVersion < 16.9)",
 			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Basic Set Reports",
 			"defaultValue": 1
 		},
 		{
 			"#": "9",
-			"$if": "firmwareVersion < 32.32",
+			// Added with the switch to the new firmware versioning scheme
+			"$if": "firmwareVersion >= 1.10 && firmwareVersion < 16.9",
 			"label": "Temperature Offset",
 			"description": "Set the reporting offset on your temperature sensor. 0=-10, 100=0, 200=+10",
 			"valueSize": 1,
@@ -194,7 +259,8 @@
 		},
 		{
 			"#": "10",
-			"$if": "firmwareVersion < 32.32",
+			// Added with the switch to the new firmware versioning scheme
+			"$if": "firmwareVersion >= 1.10 && firmwareVersion < 16.9",
 			"label": "Humidity Offset",
 			"description": "Set the reporting offset on your humidity sensor. 0=-10%, 100=0%, 200=+10%",
 			"valueSize": 1,

--- a/packages/config/src/Logic.ts
+++ b/packages/config/src/Logic.ts
@@ -38,7 +38,11 @@ add_operation(
 );
 
 export function parseLogic(logic: string): RulesLogic {
-	return parse(logic);
+	try {
+		return parse(logic);
+	} catch (e: any) {
+		throw new Error(`Invalid logic: ${logic}\n${e.message}`);
+	}
 }
 
 export function evaluate(


### PR DESCRIPTION
feat: Add parameters 8,9 and 10

Not sure how to deal with the change in firmware naming convention.

ZSE40 700 (released 3/2022)
Firmware: 1.10

Firmware version changed to 1.10 to follow new naming convention for device firmware files

Added parameters 9 and 10 for temperature and humidity offset settings

Basic Set Reports
Parameter 8: Disable Basic Set reports sent to the hub when motion is detected to reduce Z-Wave activity from the sensor.

Values:

0 – Basic Set reports disabled.

1 – Basic Set reports enabled (default).

Size: 1 byte dec

Temperature Offset
Parameter 9: Set the reporting offset on your temperature sensor.

Values: 0 - 200 (degrees Fahrenheit, where value 0 equals -10 degrees, value 100 equals 0 degrees, and value 200 equals +10 degrees).

Default: 100.

Size: 1 byte dec

Humidity Offset
Parameter 10: Set the reporting offset on your humidity sensor.

Values: 0 - 200 (%, where value 0 equals -10%, value 100 equals 0%, and value 200 equals +10%). Default: 0.

Default: 100.

Size: 1 byte dec

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->


fixes: #5229 
fixes: #5322 