### PR TITLE
fix: use 700 series OTW method when already in bootloader mode

### DIFF
--- a/packages/flash/src/cli.ts
+++ b/packages/flash/src/cli.ts
@@ -88,8 +88,12 @@ async function flash() {
 		}
 	});
 
-	// eslint-disable-next-line @typescript-eslint/no-empty-function
-	await driver.controller.firmwareUpdateOTW(firmware).catch(() => {});
+	try {
+		await driver.controller.firmwareUpdateOTW(firmware);
+	} catch (e: any) {
+		console.error("Failed to update firmware:", e.message);
+		process.exit(1);
+	}
 }
 
 async function main() {

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -5424,7 +5424,8 @@ ${associatedNodes.join(", ")}`,
 			throw new ZWaveError(message, ZWaveErrorCodes.OTW_Update_Busy);
 		}
 
-		if (this.sdkVersionGte("7.0")) {
+		if (this.driver.isInBootloader() || this.sdkVersionGte("7.0")) {
+			// If the controller is stuck in bootloader mode, always use the 700 series update method
 			return this.firmwareUpdateOTW700(data);
 		} else if (
 			this.sdkVersionGte("6.50.0") &&


### PR DESCRIPTION
next fix for https://github.com/zwave-js/node-zwave-js/issues/5360