### PR TITLE
fix(config): correct Zooz ZEN15 parameter 152 value size

### DIFF
--- a/packages/config/config/devices/0x027a/zen15.json
+++ b/packages/config/config/devices/0x027a/zen15.json
@@ -153,7 +153,7 @@
 		{
 			"#": "152",
 			"label": "Power Report Percentage Threshold",
-			"valueSize": 2,
+			"valueSize": 1,
 			"unit": "%",
 			"minValue": 0,
 			"maxValue": 255,


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

This PR changes the valueSize of parameter 152 on the Zooz ZEN15 from 2 to 1.

Zooz ZEN15 device config file currently has parameter 152 with a valueSize of 2, but the Zooz user manual for the ZEN15 says parameter 152 has a size of 1.

Ref: https://www.getzooz.com/downloads/zooz-z-wave-plus-power-switch-zen15-ver2-manual.pdf