### PR TITLE
fix: always use S2 for endpoint communication if node uses S2

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,23 @@
 		{
 			"type": "node",
 			"request": "launch",
+			"name": "Launch current test file",
+			"runtimeExecutable": "yarn",
+			"runtimeArgs": [
+				"node",
+				"--async-stack-traces",
+				"--inspect-brk",
+				"node_modules/jest/bin/jest.js",
+				"${relativeFile}"
+			],
+			"console": "integratedTerminal",
+			"skipFiles": ["<node_internals>/**"],
+			"sourceMaps": true,
+			"preLaunchTask": "npm: build"
+		},
+		{
+			"type": "node",
+			"request": "launch",
 			"name": "Debug locally",
 			"port": 9229,
 			"runtimeExecutable": "yarn",

--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -10356,7 +10356,8 @@ export class MultiChannelCCCapabilityGet extends MultiChannelCC {
 //
 // @public (undocumented)
 export class MultiChannelCCCapabilityReport extends MultiChannelCC implements ApplicationNodeInformation {
-    constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
+    // Warning: (ae-forgotten-export) The symbol "MultiChannelCCCapabilityReportOptions" needs to be exported by the entry point index.d.ts
+    constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions | MultiChannelCCCapabilityReportOptions);
     // (undocumented)
     readonly endpointIndex: number;
     // (undocumented)
@@ -10365,6 +10366,8 @@ export class MultiChannelCCCapabilityReport extends MultiChannelCC implements Ap
     readonly isDynamic: boolean;
     // (undocumented)
     persistValues(applHost: ZWaveApplicationHost): boolean;
+    // (undocumented)
+    serialize(): Buffer;
     // (undocumented)
     readonly specificDeviceClass: number;
     // (undocumented)
@@ -10413,21 +10416,24 @@ export class MultiChannelCCEndPointFind extends MultiChannelCC {
 //
 // @public (undocumented)
 export class MultiChannelCCEndPointFindReport extends MultiChannelCC {
-    constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
+    // Warning: (ae-forgotten-export) The symbol "MultiChannelCCEndPointFindReportOptions" needs to be exported by the entry point index.d.ts
+    constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions | MultiChannelCCEndPointFindReportOptions);
     // (undocumented)
     expectMoreMessages(): boolean;
     // (undocumented)
-    get foundEndpoints(): readonly number[];
+    foundEndpoints: number[];
     // (undocumented)
-    get genericClass(): number;
+    genericClass: number;
     // (undocumented)
     getPartialCCSessionId(): Record<string, any> | undefined;
     // (undocumented)
     mergePartialCCs(applHost: ZWaveApplicationHost, partials: MultiChannelCCEndPointFindReport[]): void;
     // (undocumented)
-    get reportsToFollow(): number;
+    reportsToFollow: number;
     // (undocumented)
-    get specificClass(): number;
+    serialize(): Buffer;
+    // (undocumented)
+    specificClass: number;
     // (undocumented)
     toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
 }
@@ -10442,15 +10448,18 @@ export class MultiChannelCCEndPointGet extends MultiChannelCC {
 //
 // @public (undocumented)
 export class MultiChannelCCEndPointReport extends MultiChannelCC {
-    constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
+    // Warning: (ae-forgotten-export) The symbol "MultiChannelCCEndPointReportOptions" needs to be exported by the entry point index.d.ts
+    constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions | MultiChannelCCEndPointReportOptions);
     // (undocumented)
-    readonly aggregatedCount: number | undefined;
+    aggregatedCount: number | undefined;
     // (undocumented)
-    readonly countIsDynamic: boolean;
+    countIsDynamic: boolean;
     // (undocumented)
-    readonly identicalCapabilities: boolean;
+    identicalCapabilities: boolean;
     // (undocumented)
-    readonly individualCount: number;
+    individualCount: number;
+    // (undocumented)
+    serialize(): Buffer;
     // (undocumented)
     toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
 }
@@ -13551,7 +13560,10 @@ export class Security2CCCommandsSupportedGet extends Security2CC {
 //
 // @public (undocumented)
 export class Security2CCCommandsSupportedReport extends Security2CC {
-    constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
+    // Warning: (ae-forgotten-export) The symbol "Security2CCCommandsSupportedReportOptions" needs to be exported by the entry point index.d.ts
+    constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions | Security2CCCommandsSupportedReportOptions);
+    // (undocumented)
+    serialize(): Buffer;
     // (undocumented)
     readonly supportedCCs: CommandClasses_2[];
     // (undocumented)

--- a/packages/core/api.md
+++ b/packages/core/api.md
@@ -785,6 +785,11 @@ export enum EncapsulationFlags {
     Supervision = 1
 }
 
+// Warning: (ae-missing-release-tag) "encodeApplicationNodeInformation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function encodeApplicationNodeInformation(nif: ApplicationNodeInformation): Buffer;
+
 // Warning: (ae-missing-release-tag) "encodeBitMask" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public

--- a/packages/core/src/capabilities/NodeInfo.ts
+++ b/packages/core/src/capabilities/NodeInfo.ts
@@ -19,6 +19,16 @@ export function parseApplicationNodeInformation(
 	};
 }
 
+export function encodeApplicationNodeInformation(
+	nif: ApplicationNodeInformation,
+): Buffer {
+	const ccList = encodeCCList(nif.supportedCCs, []);
+	return Buffer.concat([
+		Buffer.from([nif.genericDeviceClass, nif.specificDeviceClass]),
+		ccList,
+	]);
+}
+
 export interface NodeUpdatePayload extends ApplicationNodeInformation {
 	nodeId: number;
 	basicDeviceClass: number;

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -2070,7 +2070,12 @@ protocol version:      ${this.protocolVersion}`;
 				this.supportsCC(CommandClasses["Security 2"]) &&
 				!endpoint.supportsCC(CommandClasses["Security 2"]);
 			if (endpointMissingS2) {
-				endpoint.addCC(CommandClasses["Security 2"], { secure: true });
+				endpoint.addCC(
+					CommandClasses["Security 2"],
+					this.implementedCommandClasses.get(
+						CommandClasses["Security 2"],
+					)!,
+				);
 			}
 
 			// Always interview Security first because it changes the interview order

--- a/packages/zwave-js/src/lib/test/compliance/secureNodeSecureEndpoint.test.ts
+++ b/packages/zwave-js/src/lib/test/compliance/secureNodeSecureEndpoint.test.ts
@@ -1,0 +1,372 @@
+import {
+	InvalidCC,
+	MultiChannelCCCapabilityGet,
+	MultiChannelCCCapabilityReport,
+	MultiChannelCCCommandEncapsulation,
+	MultiChannelCCEndPointFind,
+	MultiChannelCCEndPointFindReport,
+	MultiChannelCCEndPointGet,
+	MultiChannelCCEndPointReport,
+	Security2CC,
+	Security2CCCommandsSupportedGet,
+	Security2CCCommandsSupportedReport,
+	Security2CCMessageEncapsulation,
+	Security2CCNonceGet,
+	Security2CCNonceReport,
+	ZWavePlusCCGet,
+} from "@zwave-js/cc";
+import {
+	CommandClasses,
+	SecurityClass,
+	SecurityManager2,
+	ZWaveErrorCodes,
+} from "@zwave-js/core";
+import {
+	createMockZWaveRequestFrame,
+	MockZWaveFrameType,
+	type MockNodeBehavior,
+} from "@zwave-js/testing";
+import { integrationTest } from "../integrationTestSuite";
+
+integrationTest(
+	"Security S2: Communicate with endpoints of secure nodes securely, even if the endpoint does not list S2 as supported",
+	{
+		debug: true,
+
+		clearMessageStatsBeforeTest: false,
+
+		nodeCapabilities: {
+			// The node supports S2
+			commandClasses: [
+				{
+					ccId: CommandClasses["Z-Wave Plus Info"],
+					isSupported: true,
+					version: 1,
+					secure: true,
+				},
+				{
+					ccId: CommandClasses["Security 2"],
+					isSupported: true,
+					version: 1,
+					secure: true,
+				},
+				{
+					ccId: CommandClasses["Multi Channel"],
+					isSupported: true,
+					version: 2,
+					secure: true,
+				},
+			],
+			// But its endpoints don't list the CC
+			endpoints: [
+				{
+					commandClasses: [
+						{
+							ccId: CommandClasses["Z-Wave Plus Info"],
+							isSupported: true,
+							version: 1,
+						},
+					],
+				},
+				{
+					commandClasses: [
+						{
+							ccId: CommandClasses["Z-Wave Plus Info"],
+							isSupported: true,
+							version: 1,
+						},
+					],
+				},
+			],
+		},
+
+		// We need the cache to skip the CC interviews and mark S2 as supported
+		// provisioningDirectory: path.join(__dirname, "fixtures/securityS2"),
+
+		customSetup: async (driver, controller, mockNode) => {
+			// Create a security manager for the node
+			const smNode = new SecurityManager2();
+			// Copy keys from the driver
+			// smNode.setKey(
+			// 	SecurityClass.S2_AccessControl,
+			// 	driver.options.securityKeys!.S2_AccessControl!,
+			// );
+			// smNode.setKey(
+			// 	SecurityClass.S2_Authenticated,
+			// 	driver.options.securityKeys!.S2_Authenticated!,
+			// );
+			smNode.setKey(
+				SecurityClass.S2_Unauthenticated,
+				driver.options.securityKeys!.S2_Unauthenticated!,
+			);
+			mockNode.host.securityManager2 = smNode;
+			mockNode.host.getHighestSecurityClass = () =>
+				SecurityClass.S2_Unauthenticated;
+
+			// Create a security manager for the controller
+			const smCtrlr = new SecurityManager2();
+			// Copy keys from the driver
+			smCtrlr.setKey(
+				SecurityClass.S2_AccessControl,
+				driver.options.securityKeys!.S2_AccessControl!,
+			);
+			smCtrlr.setKey(
+				SecurityClass.S2_Authenticated,
+				driver.options.securityKeys!.S2_Authenticated!,
+			);
+			smCtrlr.setKey(
+				SecurityClass.S2_Unauthenticated,
+				driver.options.securityKeys!.S2_Unauthenticated!,
+			);
+			controller.host.securityManager2 = smCtrlr;
+			controller.host.getHighestSecurityClass = () =>
+				SecurityClass.S2_Unauthenticated;
+
+			// Respond to Nonce Get
+			const respondToNonceGet: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof Security2CCNonceGet
+					) {
+						const nonce = smNode.generateNonce(
+							controller.host.ownNodeId,
+						);
+						const cc = new Security2CCNonceReport(self.host, {
+							nodeId: controller.host.ownNodeId,
+							SOS: true,
+							MOS: false,
+							receiverEI: nonce,
+						});
+						await self.sendToController(
+							createMockZWaveRequestFrame(cc, {
+								ackRequested: false,
+							}),
+						);
+						return true;
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(respondToNonceGet);
+
+			// Handle decode errors
+			const handleInvalidCC: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof InvalidCC
+					) {
+						if (
+							frame.payload.reason ===
+								ZWaveErrorCodes.Security2CC_CannotDecode ||
+							frame.payload.reason ===
+								ZWaveErrorCodes.Security2CC_NoSPAN
+						) {
+							const nonce = smNode.generateNonce(
+								controller.host.ownNodeId,
+							);
+							const cc = new Security2CCNonceReport(self.host, {
+								nodeId: controller.host.ownNodeId,
+								SOS: true,
+								MOS: false,
+								receiverEI: nonce,
+							});
+							await self.sendToController(
+								createMockZWaveRequestFrame(cc, {
+									ackRequested: false,
+								}),
+							);
+							return true;
+						}
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(handleInvalidCC);
+
+			// The node was granted the S2_Unauthenticated key
+			const respondToS2CommandsSupportedGet: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof
+							Security2CCMessageEncapsulation &&
+						frame.payload.encapsulated instanceof
+							Security2CCCommandsSupportedGet
+					) {
+						const isHighestGranted = frame.payload["key"]?.equals(
+							smNode.getKeysForSecurityClass(
+								self.host.getHighestSecurityClass(self.id)!,
+							).keyCCM,
+						);
+
+						const cc = Security2CC.encapsulate(
+							self.host,
+							new Security2CCCommandsSupportedReport(self.host, {
+								nodeId: controller.host.ownNodeId,
+								supportedCCs: isHighestGranted
+									? [...mockNode.implementedCCs.entries()]
+											.filter(
+												([ccId, info]) =>
+													info.secure &&
+													ccId !==
+														CommandClasses[
+															"Security 2"
+														],
+											)
+											.map(([ccId]) => ccId)
+									: [],
+							}),
+						);
+						await self.sendToController(
+							createMockZWaveRequestFrame(cc, {
+								ackRequested: false,
+							}),
+						);
+						return true;
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(respondToS2CommandsSupportedGet);
+
+			const respondToS2MultiChannelCCEndPointGet: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof
+							Security2CCMessageEncapsulation &&
+						frame.payload.encapsulated instanceof
+							MultiChannelCCEndPointGet
+					) {
+						const cc = Security2CC.encapsulate(
+							self.host,
+							new MultiChannelCCEndPointReport(self.host, {
+								nodeId: controller.host.ownNodeId,
+								countIsDynamic: false,
+								identicalCapabilities: false,
+								individualCount: self.endpoints.size,
+							}),
+						);
+						await self.sendToController(
+							createMockZWaveRequestFrame(cc, {
+								ackRequested: false,
+							}),
+						);
+						return true;
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(respondToS2MultiChannelCCEndPointGet);
+
+			const respondToS2MultiChannelCCEndPointFind: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof
+							Security2CCMessageEncapsulation &&
+						frame.payload.encapsulated instanceof
+							MultiChannelCCEndPointFind
+					) {
+						const request = frame.payload.encapsulated;
+						const cc = Security2CC.encapsulate(
+							self.host,
+							new MultiChannelCCEndPointFindReport(self.host, {
+								nodeId: controller.host.ownNodeId,
+								genericClass: request.genericClass,
+								specificClass: request.specificClass,
+								foundEndpoints: [...self.endpoints.keys()],
+								reportsToFollow: 0,
+							}),
+						);
+						await self.sendToController(
+							createMockZWaveRequestFrame(cc, {
+								ackRequested: false,
+							}),
+						);
+						return true;
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(respondToS2MultiChannelCCEndPointFind);
+
+			const respondToS2MultiChannelCCCapabilityGet: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof
+							Security2CCMessageEncapsulation &&
+						frame.payload.encapsulated instanceof
+							MultiChannelCCCapabilityGet
+					) {
+						const endpoint = self.endpoints.get(
+							frame.payload.encapsulated.requestedEndpoint,
+						)!;
+						const cc = Security2CC.encapsulate(
+							self.host,
+							new MultiChannelCCCapabilityReport(self.host, {
+								nodeId: controller.host.ownNodeId,
+								endpointIndex: endpoint.index,
+								genericDeviceClass:
+									endpoint?.capabilities.genericDeviceClass ??
+									self.capabilities.genericDeviceClass,
+								specificDeviceClass:
+									endpoint?.capabilities
+										.specificDeviceClass ??
+									self.capabilities.specificDeviceClass,
+								isDynamic: false,
+								wasRemoved: false,
+								supportedCCs: [
+									...endpoint.implementedCCs.keys(),
+								],
+							}),
+						);
+						await self.sendToController(
+							createMockZWaveRequestFrame(cc, {
+								ackRequested: false,
+							}),
+						);
+						return true;
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(respondToS2MultiChannelCCCapabilityGet);
+		},
+
+		testBody: async (driver, node, mockController, mockNode) => {
+			// The interview should request Z-Wave+ info from both endpoints securely
+			mockNode.assertReceivedControllerFrame(
+				(msg) =>
+					msg.type === MockZWaveFrameType.Request &&
+					msg.payload instanceof Security2CCMessageEncapsulation &&
+					msg.payload.encapsulated instanceof
+						MultiChannelCCCommandEncapsulation &&
+					msg.payload.encapsulated.destination === 1 &&
+					msg.payload.encapsulated.encapsulated instanceof
+						ZWavePlusCCGet,
+				{
+					errorMessage:
+						"Expected communication with endpoint 1 to be secure",
+				},
+			);
+			mockNode.assertReceivedControllerFrame(
+				(msg) =>
+					msg.type === MockZWaveFrameType.Request &&
+					msg.payload instanceof Security2CCMessageEncapsulation &&
+					msg.payload.encapsulated instanceof
+						MultiChannelCCCommandEncapsulation &&
+					msg.payload.encapsulated.destination === 2 &&
+					msg.payload.encapsulated.encapsulated instanceof
+						ZWavePlusCCGet,
+				{
+					errorMessage:
+						"Expected communication with endpoint 2 to be secure",
+				},
+			);
+		},
+	},
+);


### PR DESCRIPTION
This PR does what https://github.com/zwave-js/node-zwave-js/pull/5310 failed to do.

fixes: https://github.com/zwave-js/node-zwave-js/issues/5302