### PR TITLE
fix: do not assume nodes to be asleep during re-interview if a wakeup triggered the re-interview

### DIFF
--- a/packages/zwave-js/src/lib/test/compliance/secureNodeSecureEndpoint.test.ts
+++ b/packages/zwave-js/src/lib/test/compliance/secureNodeSecureEndpoint.test.ts
@@ -31,7 +31,7 @@ import { integrationTest } from "../integrationTestSuite";
 integrationTest(
 	"Security S2: Communicate with endpoints of secure nodes securely, even if the endpoint does not list S2 as supported",
 	{
-		debug: true,
+		// debug: true,
 
 		clearMessageStatsBeforeTest: false,
 

--- a/packages/zwave-js/src/lib/test/driver/reInterviewAssumeAwake.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/reInterviewAssumeAwake.test.ts
@@ -1,0 +1,62 @@
+import { WakeUpCCWakeUpNotification } from "@zwave-js/cc";
+import { CommandClasses, InterviewStage } from "@zwave-js/core";
+import { createMockZWaveRequestFrame } from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import { integrationTest } from "../integrationTestSuite";
+
+integrationTest("Assume a node to be awake at the start of a re-interview", {
+	debug: true,
+
+	nodeCapabilities: {
+		isListening: false,
+		isFrequentListening: false,
+
+		commandClasses: [
+			{
+				ccId: CommandClasses["Wake Up"],
+				version: 1,
+				isSupported: true,
+			},
+		],
+	},
+
+	customSetup(driver, mockController, mockNode) {
+		driver.on("driver ready", async () => {
+			await wait(100);
+
+			// Send a WakeUpNotification to the node to trigger the interview
+			const cc = new WakeUpCCWakeUpNotification(mockNode.host, {
+				nodeId: mockController.host.ownNodeId,
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+		});
+		return Promise.resolve();
+	},
+
+	testBody: async (driver, node, mockController, mockNode) => {
+		// Wait for the assignReturnRoute command to be completed
+		await wait(500);
+		node.markAsAsleep();
+
+		// After the interview, do a re-interview
+		void node.refreshInfo({
+			waitForWakeup: true,
+		});
+
+		const cc = new WakeUpCCWakeUpNotification(mockNode.host, {
+			nodeId: mockController.host.ownNodeId,
+		});
+		await mockNode.sendToController(
+			createMockZWaveRequestFrame(cc, {
+				ackRequested: false,
+			}),
+		);
+		// This should not hang since the node just sent a wakeup notification
+		await wait(1000);
+		expect(node.interviewStage).not.toBe(InterviewStage.ProtocolInfo);
+	},
+});

--- a/packages/zwave-js/src/lib/test/driver/reInterviewAssumeAwake.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/reInterviewAssumeAwake.test.ts
@@ -5,7 +5,7 @@ import { wait } from "alcalzone-shared/async";
 import { integrationTest } from "../integrationTestSuite";
 
 integrationTest("Assume a node to be awake at the start of a re-interview", {
-	debug: true,
+	// debug: true,
 
 	nodeCapabilities: {
 		isListening: false,


### PR DESCRIPTION
fixes: https://github.com/zwave-js/node-zwave-js/issues/5026
fixes: https://github.com/zwave-js/node-zwave-js/issues/5251