### PR TITLE
feat(cc): add support for enums in Notification CC event parameters

### DIFF
--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -11668,7 +11668,7 @@ export class NotificationCCReport extends NotificationCC {
     // (undocumented)
     alarmType: number | undefined;
     // (undocumented)
-    eventParameters: Buffer | Duration | Record<string, number> | undefined;
+    eventParameters: Buffer | Duration | Record<string, number> | number | undefined;
     // (undocumented)
     notificationEvent: number | undefined;
     // (undocumented)

--- a/packages/cc/src/cc/NotificationCC.ts
+++ b/packages/cc/src/cc/NotificationCC.ts
@@ -2,6 +2,7 @@ import {
 	Notification,
 	NotificationParameterWithCommandClass,
 	NotificationParameterWithDuration,
+	NotificationParameterWithEnum,
 	NotificationParameterWithValue,
 	NotificationValueDefinition,
 } from "@zwave-js/config";
@@ -291,6 +292,32 @@ export class NotificationCCAPI extends PhysicalCCAPI {
 	}
 }
 
+function getNotificationEnumBehavior(
+	notificationConfig: Notification,
+	valueConfig: NotificationValueDefinition & { type: "state" },
+): "none" | "extend" | "replace" {
+	const variable = notificationConfig.variables.find((v) =>
+		v.states.has(valueConfig.value),
+	);
+	if (!variable) return "none";
+	const numStatesWithEnums = [...variable.states.values()].filter(
+		(val) => val.parameter instanceof NotificationParameterWithEnum,
+	).length;
+	if (numStatesWithEnums === 0) return "none";
+	// An enum value replaces the original value if there is only a single possible state
+	// which also has an enum parameter
+	if (numStatesWithEnums === 1 && variable.states.size === 1)
+		return "replace";
+	return "extend";
+}
+
+export function getNotificationStateValueWithEnum(
+	stateValue: number,
+	enumValue: number,
+): number {
+	return (stateValue << 8) | enumValue;
+}
+
 /**
  * Returns the metadata to use for a known notification value.
  * Can be used to extend a previously defined metadata,
@@ -312,7 +339,21 @@ export function getNotificationValueMetadata(
 	if (valueConfig.idle) {
 		metadata.states![0] = "idle";
 	}
-	metadata.states![valueConfig.value] = valueConfig.label;
+	const enumBehavior = getNotificationEnumBehavior(
+		notificationConfig,
+		valueConfig,
+	);
+	if (enumBehavior !== "replace") {
+		metadata.states![valueConfig.value] = valueConfig.label;
+	}
+	if (valueConfig.parameter instanceof NotificationParameterWithEnum) {
+		for (const [value, label] of valueConfig.parameter.values) {
+			metadata.states![
+				getNotificationStateValueWithEnum(valueConfig.value, value)
+			] = label;
+		}
+	}
+
 	return metadata;
 }
 
@@ -854,6 +895,7 @@ export class NotificationCCReport extends NotificationCC {
 		| Buffer
 		| Duration
 		| Record<string, number>
+		| number
 		| undefined;
 
 	public sequenceNumber: number | undefined;
@@ -867,8 +909,8 @@ export class NotificationCCReport extends NotificationCC {
 			};
 		}
 
+		let valueConfig: NotificationValueDefinition | undefined;
 		if (this.notificationType) {
-			let valueConfig: NotificationValueDefinition | undefined;
 			try {
 				valueConfig = applHost.configManager
 					.lookupNotification(this.notificationType)
@@ -911,7 +953,25 @@ export class NotificationCCReport extends NotificationCC {
 			message["sequence number"] = this.sequenceNumber;
 		}
 		if (this.eventParameters != undefined) {
-			if (Buffer.isBuffer(this.eventParameters)) {
+			if (typeof this.eventParameters === "number") {
+				// Try to look up the enum label
+				let found = false;
+				if (
+					valueConfig?.parameter instanceof
+					NotificationParameterWithEnum
+				) {
+					const label = valueConfig.parameter.values.get(
+						this.eventParameters,
+					);
+					if (label) {
+						message["state parameters"] = label;
+						found = true;
+					}
+				}
+				if (!found) {
+					message["state parameters"] = num2hex(this.eventParameters);
+				}
+			} else if (Buffer.isBuffer(this.eventParameters)) {
 				message["event parameters"] = buffer2hex(this.eventParameters);
 			} else if (this.eventParameters instanceof Duration) {
 				message["event parameters"] = this.eventParameters.toString();
@@ -1046,6 +1106,14 @@ export class NotificationCCReport extends NotificationCC {
 						this.eventParameters.length,
 					),
 			};
+		} else if (
+			valueConfig.parameter instanceof NotificationParameterWithEnum
+		) {
+			// The parameters may contain an enum value
+			this.eventParameters =
+				this.eventParameters.length === 1
+					? this.eventParameters[0]
+					: undefined;
 		}
 	}
 

--- a/packages/config/api.md
+++ b/packages/config/api.md
@@ -788,9 +788,18 @@ export class NotificationParameterWithDuration {
     constructor(_definition: JSONObject);
 }
 
+// Warning: (ae-missing-release-tag) "NotificationParameterWithEnum" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export class NotificationParameterWithEnum {
+    constructor(definition: JSONObject);
+    // (undocumented)
+    readonly values: ReadonlyMap<number, string>;
+}
+
 // Warning: (ae-missing-release-tag) "NotificationParameterWithValue" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public
 export class NotificationParameterWithValue {
     constructor(definition: JSONObject);
     // (undocumented)

--- a/packages/config/config/notifications.json
+++ b/packages/config/config/notifications.json
@@ -82,9 +82,7 @@
 				"states": {
 					"0x03": {
 						"label": "Carbon monoxide test",
-						// TODO: The event parameter buffer has different meanings. Implement parsing!
 						"params": {
-							// TODO: type "enum" replaces the actual value
 							"type": "enum",
 							"values": {
 								"0x01": "Test OK",
@@ -411,8 +409,9 @@
 						"params": {
 							"type": "enum",
 							"values": {
-								"0x00": "Open in regular position",
-								"0x01": "Open in tilt position"
+								// These values extend the existing states, so they need to be named in a similar fashion
+								"0x00": "Window/door is open in regular position",
+								"0x01": "Window/door is open in tilt position"
 							}
 						}
 					},
@@ -1070,7 +1069,6 @@
 						"label": "Volatile Organic Compound level",
 						"idle": false,
 						"params": {
-							// TODO: type "enum" replaces the actual value
 							"type": "enum",
 							"values": {
 								"0x01": "Clean",
@@ -1088,7 +1086,6 @@
 					"0x07": {
 						"label": "Sleep apnea detected",
 						"params": {
-							// TODO: type "enum" replaces the actual value
 							"type": "enum",
 							"values": {
 								"0x01": "Low breath",
@@ -1149,7 +1146,6 @@
 					"0x01": {
 						"label": "Valve operation",
 						"params": {
-							// TODO: type "enum" replaces the actual value
 							"type": "enum",
 							"values": {
 								"0x00": "Off / Closed",
@@ -1166,7 +1162,6 @@
 					"0x02": {
 						"label": "Master valve operation",
 						"params": {
-							// TODO: type "enum" replaces the actual value
 							"type": "enum",
 							"values": {
 								"0x00": "Off / Closed",
@@ -1198,7 +1193,6 @@
 					"0x05": {
 						"label": "Valve current alarm",
 						"params": {
-							// TODO: type "enum" replaces the actual value
 							"type": "enum",
 							"values": {
 								"0x01": "No data",
@@ -1216,7 +1210,6 @@
 					"0x06": {
 						"label": "Master valve current alarm",
 						"params": {
-							// TODO: type "enum" replaces the actual value
 							"type": "enum",
 							"values": {
 								"0x01": "No data",

--- a/packages/config/src/Notifications.ts
+++ b/packages/config/src/Notifications.ts
@@ -219,8 +219,7 @@ export class NotificationParameter {
 			case "value":
 				return new NotificationParameterWithValue(definition);
 			case "enum":
-				// TODO
-				break;
+				return new NotificationParameterWithEnum(definition);
 		}
 	}
 }
@@ -239,6 +238,7 @@ export class NotificationParameterWithCommandClass {
 	}
 }
 
+/** Marks a notification that contains a named value */
 export class NotificationParameterWithValue {
 	public constructor(definition: JSONObject) {
 		if (typeof definition.name !== "string") {
@@ -250,4 +250,39 @@ export class NotificationParameterWithValue {
 		this.propertyName = definition.name;
 	}
 	public readonly propertyName: string;
+}
+
+/** Marks a notification that contains an enumeration of values */
+export class NotificationParameterWithEnum {
+	public constructor(definition: JSONObject) {
+		if (!isObject(definition.values)) {
+			throwInvalidConfig(
+				"notifications",
+				`Found a non-object definition for enum values`,
+			);
+		}
+
+		const values = new Map<number, string>();
+		for (const [enumValue, enumLabel] of Object.entries(
+			definition.values,
+		)) {
+			if (!hexKeyRegexNDigits.test(enumValue)) {
+				throwInvalidConfig(
+					"notifications",
+					`found invalid enum value "${enumValue}". All enum values must be defined in hexadecimal.`,
+				);
+			} else if (typeof enumLabel !== "string") {
+				throwInvalidConfig(
+					"notifications",
+					`found invalid label for enum value "${enumValue}". All enum labels must be defined as strings.`,
+				);
+			}
+
+			values.set(parseInt(enumValue, 16), enumLabel);
+		}
+
+		this.values = values;
+	}
+
+	public readonly values: ReadonlyMap<number, string>;
 }

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -60,6 +60,7 @@ import {
 } from "@zwave-js/cc/MultilevelSwitchCC";
 import { NodeNamingAndLocationCCValues } from "@zwave-js/cc/NodeNamingCC";
 import {
+	getNotificationStateValueWithEnum,
 	getNotificationValueMetadata,
 	NotificationCC,
 	NotificationCCReport,
@@ -3490,7 +3491,17 @@ protocol version:      ${this.protocolVersion}`;
 					}
 				}
 			}
-			this.valueDB.setValue(valueId, value);
+			if (typeof command.eventParameters === "number") {
+				// This notification contains an enum value. We set "fake" values for these to distinguish them
+				// from states without enum values
+				const valueWithEnum = getNotificationStateValueWithEnum(
+					value,
+					command.eventParameters,
+				);
+				this.valueDB.setValue(valueId, valueWithEnum);
+			} else {
+				this.valueDB.setValue(valueId, value);
+			}
 
 			// Nodes before V8 (and some misbehaving V8 ones) don't necessarily reset the notification to idle.
 			// The specifications advise to auto-reset the variables, but it has been found that this interferes

--- a/packages/zwave-js/src/lib/test/cc-specific/notificationEnums.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/notificationEnums.test.ts
@@ -1,0 +1,230 @@
+import {
+	NotificationCCEventSupportedGet,
+	NotificationCCEventSupportedReport,
+	NotificationCCReport,
+	NotificationCCSupportedGet,
+	NotificationCCSupportedReport,
+	NotificationCCValues,
+} from "@zwave-js/cc/NotificationCC";
+import { CommandClasses, ValueMetadataNumeric } from "@zwave-js/core";
+import {
+	createMockZWaveRequestFrame,
+	MockZWaveFrameType,
+	type MockNodeBehavior,
+} from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import { integrationTest } from "../integrationTestSuite";
+
+integrationTest(
+	"Notifications with enum event parameters are evaluated correctly",
+	{
+		// debug: true,
+
+		nodeCapabilities: {
+			commandClasses: [CommandClasses.Notification],
+		},
+
+		customSetup: async (driver, controller, mockNode) => {
+			// Node supports the Water Valve notifications Valve Operation Status
+			const respondToNotificationSupportedGet: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof NotificationCCSupportedGet
+					) {
+						const cc = new NotificationCCSupportedReport(
+							self.host,
+							{
+								nodeId: controller.host.ownNodeId,
+								supportsV1Alarm: false,
+								supportedNotificationTypes: [0x0f],
+							},
+						);
+						await self.sendToController(
+							createMockZWaveRequestFrame(cc, {
+								ackRequested: false,
+							}),
+						);
+						return true;
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(respondToNotificationSupportedGet);
+
+			const respondToNotificationEventSupportedGet: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof
+							NotificationCCEventSupportedGet &&
+						frame.payload.notificationType === 0x0f
+					) {
+						const cc = new NotificationCCEventSupportedReport(
+							self.host,
+							{
+								nodeId: controller.host.ownNodeId,
+								notificationType: 0x0f,
+								supportedEvents: [0x01],
+							},
+						);
+						await self.sendToController(
+							createMockZWaveRequestFrame(cc, {
+								ackRequested: false,
+							}),
+						);
+						return true;
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(respondToNotificationEventSupportedGet);
+		},
+
+		testBody: async (driver, node, mockController, mockNode) => {
+			await node.commandClasses.Notification.getSupportedEvents(0x0f);
+
+			const valveOperationStatusId =
+				NotificationCCValues.notificationVariable(
+					"Water Valve",
+					"Valve operation status",
+				).id;
+
+			const states = (
+				node.getValueMetadata(
+					valveOperationStatusId,
+				) as ValueMetadataNumeric
+			).states;
+			expect(states).toStrictEqual({
+				// For the valve operation status variable, the embedded enum replaces its possible states
+				// since there is only one meaningless state, so it doesn't make sense to preserve it
+				// This is different from the "Door state" value which has multiple states AND enums
+				[0x0100]: "Off / Closed",
+				[0x0101]: "On / Open",
+			});
+
+			// Send notifications to the node
+			let cc = new NotificationCCReport(mockNode.host, {
+				nodeId: mockController.host.ownNodeId,
+				notificationType: 0x0f,
+				notificationEvent: 0x01,
+				eventParameters: Buffer.from([0x00]), // Off / Closed
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			// wait a bit for the value to be updated
+			await wait(100);
+
+			let value = node.getValue(valveOperationStatusId);
+			expect(value).toBe(0x0100);
+
+			cc = new NotificationCCReport(mockNode.host, {
+				nodeId: mockController.host.ownNodeId,
+				notificationType: 0x0f,
+				notificationEvent: 0x01,
+				eventParameters: Buffer.from([0x01]), // On / Open
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			await wait(100);
+
+			value = node.getValue(valveOperationStatusId);
+			expect(value).toBe(0x0101);
+		},
+	},
+);
+
+integrationTest(
+	"Notification types multiple states and optional enums merge/extend states for all of them",
+	{
+		// debug: true,
+
+		nodeCapabilities: {
+			commandClasses: [CommandClasses.Notification],
+		},
+
+		customSetup: async (driver, controller, mockNode) => {
+			// Node supports the Access Control notifications Window open and Window closed
+			const respondToNotificationSupportedGet: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof NotificationCCSupportedGet
+					) {
+						const cc = new NotificationCCSupportedReport(
+							self.host,
+							{
+								nodeId: controller.host.ownNodeId,
+								supportsV1Alarm: false,
+								supportedNotificationTypes: [0x06],
+							},
+						);
+						await self.sendToController(
+							createMockZWaveRequestFrame(cc, {
+								ackRequested: false,
+							}),
+						);
+						return true;
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(respondToNotificationSupportedGet);
+
+			const respondToNotificationEventSupportedGet: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof
+							NotificationCCEventSupportedGet &&
+						frame.payload.notificationType === 0x06
+					) {
+						const cc = new NotificationCCEventSupportedReport(
+							self.host,
+							{
+								nodeId: controller.host.ownNodeId,
+								notificationType: 0x06,
+								supportedEvents: [0x16, 0x17],
+							},
+						);
+						await self.sendToController(
+							createMockZWaveRequestFrame(cc, {
+								ackRequested: false,
+							}),
+						);
+						return true;
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(respondToNotificationEventSupportedGet);
+		},
+
+		testBody: async (driver, node, _mockController, _mockNode) => {
+			await node.commandClasses.Notification.getSupportedEvents(0x06);
+
+			const states = (
+				node.getValueMetadata(
+					NotificationCCValues.notificationVariable(
+						"Access Control",
+						"Door state",
+					).id,
+				) as ValueMetadataNumeric
+			).states;
+			expect(states).toStrictEqual({
+				[0x16]: "Window/door is open",
+				[0x17]: "Window/door is closed",
+				// The Door state notification type has an enum for the "open" state
+				// We add synthetic values for these (optional!) states in addition to the actual values
+				[0x1600]: "Window/door is open in regular position",
+				[0x1601]: "Window/door is open in tilt position",
+			});
+		},
+	},
+);

--- a/packages/zwave-js/src/lib/test/cc-specific/notificationMultipleEventsMetadata.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/notificationMultipleEventsMetadata.test.ts
@@ -27,7 +27,7 @@ integrationTest(
 		},
 
 		customSetup: async (driver, controller, mockNode) => {
-			// Node supports the Access Control notifications Window open and Window closed
+			// Node supports the Smoke Alarm notifications Smoke alarm test, Alarm silenced (and idle)
 			const respondToNotificationSupportedGet: MockNodeBehavior = {
 				async onControllerFrame(controller, self, frame) {
 					if (
@@ -39,7 +39,7 @@ integrationTest(
 							{
 								nodeId: controller.host.ownNodeId,
 								supportsV1Alarm: false,
-								supportedNotificationTypes: [0x06],
+								supportedNotificationTypes: [0x01],
 							},
 						);
 						await self.sendToController(
@@ -60,14 +60,14 @@ integrationTest(
 						frame.type === MockZWaveFrameType.Request &&
 						frame.payload instanceof
 							NotificationCCEventSupportedGet &&
-						frame.payload.notificationType === 0x06
+						frame.payload.notificationType === 0x01
 					) {
 						const cc = new NotificationCCEventSupportedReport(
 							self.host,
 							{
 								nodeId: controller.host.ownNodeId,
-								notificationType: 0x06,
-								supportedEvents: [0x16, 0x17],
+								notificationType: 0x01,
+								supportedEvents: [0x03, 0x06],
 							},
 						);
 						await self.sendToController(
@@ -84,19 +84,20 @@ integrationTest(
 		},
 
 		testBody: async (driver, node, _mockController, _mockNode) => {
-			await node.commandClasses.Notification.getSupportedEvents(0x06);
+			await node.commandClasses.Notification.getSupportedEvents(0x01);
 
 			const states = (
 				node.getValueMetadata(
 					NotificationCCValues.notificationVariable(
-						"Access Control",
-						"Door state",
+						"Smoke Alarm",
+						"Alarm status",
 					).id,
 				) as ValueMetadataNumeric
 			).states;
 			expect(states).toStrictEqual({
-				22: "Window/door is open",
-				23: "Window/door is closed",
+				[0x00]: "idle",
+				[0x03]: "Smoke alarm test",
+				[0x06]: "Alarm silenced",
 			});
 		},
 	},


### PR DESCRIPTION
This PR finally adds support for enums in Notification CC event parameters, which is necessary for devices like Zooz ZAC36.
For those kinds of notifications, we now combine the notification value with the enum value, so it is possible that some notifications have their values changed, although all of them but one were incorrect before.
The `Door/window state` of devices which do send an enum value for the open state is possibly influenced by this though:

**Before:**
* 22: Window/door is open
* 23: Window/door is closed

**After:**
* 22: Window/door is open **(possibly unused)**
* 23: Window/door is closed
* 5632: Window/door is open in regular position
* 5633: Window/door is open in tilt position

fixes: #264