### PR TITLE
feat: add special handling for the controller node in `node.isFirmwareUpdateInProgress`

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -888,6 +888,14 @@ To do so, the controller gets put in bootloader mode where a new firmware image 
 
 To keep track of the update progress, use the [`"firmware update progress"` and `"firmware update finished"` events](api/controller#quotfirmware-update-progressquot) of the controller.
 
+### `isFirmwareUpdateInProgress`
+
+```ts
+isFirmwareUpdateInProgress(): boolean;
+```
+
+Return whether a firmware update is in progress for the controller.
+
 ## Controller properties
 
 ### `nodes`

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -5155,7 +5155,8 @@ ${associatedNodes.join(", ")}`,
 	 */
 	public isAnyOTAFirmwareUpdateInProgress(): boolean {
 		for (const node of this._nodes.values()) {
-			if (node.isFirmwareUpdateInProgress()) return true;
+			if (!node.isControllerNode && node.isFirmwareUpdateInProgress())
+				return true;
 		}
 		return false;
 	}

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3689,7 +3689,11 @@ protocol version:      ${this.protocolVersion}`;
 	 * Returns whether a firmware update is in progress for this node.
 	 */
 	public isFirmwareUpdateInProgress(): boolean {
-		return this._firmwareUpdateInProgress;
+		return (
+			(this.isControllerNode &&
+				this.driver.controller.isFirmwareUpdateInProgress()) ||
+			this._firmwareUpdateInProgress
+		);
 	}
 
 	private _abortFirmwareUpdate: (() => Promise<void>) | undefined;

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3689,11 +3689,11 @@ protocol version:      ${this.protocolVersion}`;
 	 * Returns whether a firmware update is in progress for this node.
 	 */
 	public isFirmwareUpdateInProgress(): boolean {
-		return (
-			(this.isControllerNode &&
-				this.driver.controller.isFirmwareUpdateInProgress()) ||
-			this._firmwareUpdateInProgress
-		);
+		if (this.isControllerNode) {
+			return this.driver.controller.isFirmwareUpdateInProgress();
+		} else {
+			return this._firmwareUpdateInProgress;
+		}
 	}
 
 	private _abortFirmwareUpdate: (() => Promise<void>) | undefined;


### PR DESCRIPTION
Updates `Node.isFirmwareUpdateInProgress` to return the proper value when its the controller node and a controller node firmware update is in progress. Subsequently fixes `Controller.isAnyOTAFirmwareUpdateInProgress` so that it will not return true if an OTW controller firmware update is happening