### PR TITLE
fix: rename `label` property on `Endpoint` class to `endpointLabel`

### DIFF
--- a/docs/api/endpoint.md
+++ b/docs/api/endpoint.md
@@ -104,10 +104,10 @@ readonly index: number
 
 The index of this endpoint. 0 for the root device, 1+ otherwise.
 
-### `label`
+### `endpointLabel`
 
 ```ts
-readonly label: string | undefined;
+readonly endpointLabel: string | undefined;
 ```
 
 If the device config file contains a label for this endpoint, it is exposed here.

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -396,6 +396,7 @@ export class Endpoint implements IZWaveEndpoint {
     get deviceClass(): DeviceClass | undefined;
     protected set deviceClass(deviceClass: DeviceClass | undefined);
     protected readonly driver: Driver;
+    get endpointLabel(): string | undefined;
     // (undocumented)
     getCCs(): Iterable<[ccId: CommandClasses_2, info: CommandClassInfo]>;
     getCCVersion(cc: CommandClasses_2): number;
@@ -406,7 +407,6 @@ export class Endpoint implements IZWaveEndpoint {
     get installerIcon(): number | undefined;
     invokeCCAPI<CC extends CommandClasses_2, TMethod extends keyof TAPI, TAPI extends Record<string, (...args: any[]) => any> = CommandClasses_2 extends CC ? any : APIMethodsOf<CC>>(cc: CC, method: TMethod, ...args: Parameters<TAPI[TMethod]>): ReturnType<TAPI[TMethod]>;
     isCCSecure(cc: CommandClasses_2): boolean;
-    get label(): string | undefined;
     readonly nodeId: number;
     removeCC(cc: CommandClasses_2): void;
     protected reset(): void;

--- a/packages/zwave-js/src/lib/node/Endpoint.ts
+++ b/packages/zwave-js/src/lib/node/Endpoint.ts
@@ -82,7 +82,7 @@ export class Endpoint implements IZWaveEndpoint {
 	}
 
 	/** Can be used to distinguish multiple endpoints of a node */
-	public get label(): string | undefined {
+	public get endpointLabel(): string | undefined {
 		return this.getNodeUnsafe()?.deviceConfig?.endpoints?.get(this.index)
 			?.label;
 	}


### PR DESCRIPTION
We noticed that the `Node.label` property overrides the endpoint label for the root endpoint with the device label, so we avoid this in a patch before this feature gets widespread use.