### PR TITLE
feat: add support for managing priority (return) routes

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -550,7 +550,15 @@ The `repeaters` array contains the node IDs of the repeaters (max. 4) that shoul
 
 `routeSpeed` is the transmission speed to be used for the route. Make sure that all nodes in the route support this speed.
 
-<!-- #import ZWaveDataRate from "zwave-js" -->
+<!-- #import ZWaveDataRate from "@zwave-js/core" -->
+
+```ts
+enum ZWaveDataRate {
+	"9k6" = 0x01,
+	"40k" = 0x02,
+	"100k" = 0x03,
+}
+```
 
 > [!WARNING] While these methods are meant to improve the routing and latency in certain situations, they can easily make things worse by choosing the wrong or unreachable repeaters, or by selecting a route speed that is not supported by a node in the route.
 >

--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -493,6 +493,69 @@ type ReplaceNodeOptions =
 	  };
 ```
 
+### Managing routes
+
+The methods shown here can be used to manage routes between nodes. For the most part, these are not particularly relevant for applications or even end users, since they are used automatically by Z-Wave JS when necessary.
+
+```ts
+assignReturnRoute(nodeId: number, destinationNodeId: number): Promise<boolean>;
+deleteReturnRoute(nodeId: number): Promise<boolean>;
+
+assignSUCReturnRoute(nodeId: number): Promise<boolean>;
+deleteSUCReturnRoute(nodeId: number): Promise<boolean>;
+```
+
+-   `assignReturnRoute` instructs the controller to assign node `nodeId` a set of routes to node `destinationNodeId`. These routes are determined by the controller.
+-   `deleteReturnRoute` instructs node `nodeId` to delete all previously assigned routes.
+-   `assignSUCReturnRoute` works like `assignReturnRoute`, but the routes have the SUC as the destination.
+-   `deleteSUCReturnRoute` works like `deleteReturnRoute`, but for routes that have the SUC as the destination.
+
+In certain scenarios, the routing algorithm of Z-Wave can break down and produce subpar results. It is possible to manually assign priority routes which will always be attempted first instead of the automatically determined routes. This is done with the following methods:
+
+```ts
+setPriorityRoute(
+	destinationNodeId: number,
+	repeaters: number[],
+	routeSpeed: ZWaveDataRate,
+): Promise<boolean>
+
+getPriorityRoute(destinationNodeId: number): Promise<
+	| {
+			repeaters: number[];
+			routeSpeed: ZWaveDataRate;
+	  }
+	| undefined
+>;
+
+assignPriorityReturnRoute(
+	nodeId: number,
+	destinationNodeId: number,
+	repeaters: number[],
+	routeSpeed: ZWaveDataRate,
+): Promise<boolean>;
+
+assignPrioritySUCReturnRoute(
+	nodeId: number,
+	repeaters: number[],
+	routeSpeed: ZWaveDataRate,
+): Promise<boolean>
+```
+
+-   `setPriorityRoute` sets the priority route which will always be used for the first transmission attempt from the controller to the given node.
+-   `getPriorityRoute` returns the priority route to the given node. **Note:** if none is set, this will return the LWR or NLWR instead.
+-   `assignPriorityReturnRoute` sets the priority route from node `nodeId` to the destination node.
+-   `assignPrioritySUCReturnRoute` does the same, but with the SUC as the destination node.
+
+The `repeaters` array contains the node IDs of the repeaters (max. 4) that should be used for the route. An empty array means a direct connection.
+
+`routeSpeed` is the transmission speed to be used for the route. Make sure that all nodes in the route support this speed.
+
+<!-- #import ZWaveDataRate from "zwave-js" -->
+
+> [!WARNING] While these methods are meant to improve the routing and latency in certain situations, they can easily make things worse by choosing the wrong or unreachable repeaters, or by selecting a route speed that is not supported by a node in the route.
+>
+> Typically you'll want to use these methods to force a direct connection as the first attempt.
+
 ### Managing associations
 
 The following methods can be used to manage associations between nodes and/or endpoints. This only works AFTER the interview process!

--- a/packages/serial/api.md
+++ b/packages/serial/api.md
@@ -129,6 +129,10 @@ export enum FunctionType {
     // (undocumented)
     ApplicationUpdateRequest = 73,
     // (undocumented)
+    AssignPriorityReturnRoute = 79,
+    // (undocumented)
+    AssignPrioritySUCReturnRoute = 88,
+    // (undocumented)
     AssignReturnRoute = 70,
     // (undocumented)
     AssignSUCReturnRoute = 81,
@@ -209,6 +213,8 @@ export enum FunctionType {
     // (undocumented)
     GetNVMId = 41,
     // (undocumented)
+    GetPriorityRoute = 146,
+    // (undocumented)
     GetProtocolVersion = 9,
     // (undocumented)
     GetRoutingInfo = 128,
@@ -251,6 +257,8 @@ export enum FunctionType {
     // (undocumented)
     SetApplicationNodeInformation = 3,
     // (undocumented)
+    SetPriorityRoute = 147,
+    // (undocumented)
     SetRFReceiveMode = 16,
     // (undocumented)
     SetSerialApiTimeouts = 6,
@@ -258,8 +266,6 @@ export enum FunctionType {
     SetSUCNodeId = 84,
     // (undocumented)
     SoftReset = 8,
-    // (undocumented)
-    UNKNOWN_FUNC_AssignPrioritySUCReturnRoute = 88,
     // (undocumented)
     UNKNOWN_FUNC_ClearNetworkStats = 57,
     // (undocumented)
@@ -270,8 +276,6 @@ export enum FunctionType {
     UNKNOWN_FUNC_CLOCK_SET = 48,
     // (undocumented)
     UNKNOWN_FUNC_GET_LIBRARY_TYPE = 189,
-    // (undocumented)
-    UNKNOWN_FUNC_GET_PRIORITY_ROUTE = 146,
     // (undocumented)
     UNKNOWN_FUNC_GET_PROTOCOL_STATUS = 191,
     // (undocumented)
@@ -314,8 +318,6 @@ export enum FunctionType {
     UNKNOWN_FUNC_SEND_TEST_FRAME = 190,
     // (undocumented)
     UNKNOWN_FUNC_SERIAL_API_TEST = 149,
-    // (undocumented)
-    UNKNOWN_FUNC_SET_PRIORITY_ROUTE = 147,
     // (undocumented)
     UNKNOWN_FUNC_SET_SLEEP_MODE = 17,
     // (undocumented)

--- a/packages/serial/src/message/Constants.ts
+++ b/packages/serial/src/message/Constants.ts
@@ -93,6 +93,9 @@ export enum FunctionType {
 
 	FUNC_ID_ZW_CREATE_NEW_PRIMARY = 0x4c, // Control the createnewprimary process...start, stop, etc.
 	FUNC_ID_ZW_CONTROLLER_CHANGE = 0x4d, // Control the transferprimary process...start, stop, etc.
+
+	AssignPriorityReturnRoute = 0x4f, // Assign a priority route between two nodes
+
 	FUNC_ID_ZW_SET_LEARN_MODE = 0x50, // Put a controller into learn mode for replication/ receipt of configuration info
 	AssignSUCReturnRoute = 0x51, // Assign a return route to the SUC
 	FUNC_ID_ZW_ENABLE_SUC = 0x52, // Make a controller a Static Update Controller
@@ -102,7 +105,7 @@ export enum FunctionType {
 	GetSUCNodeId = 0x56, // Try to retrieve a Static Update Controller node id (zero if no SUC present)
 
 	UNKNOWN_FUNC_SEND_SUC_ID = 0x57,
-	UNKNOWN_FUNC_AssignPrioritySUCReturnRoute = 0x58,
+	AssignPrioritySUCReturnRoute = 0x58, // Assign a priority route from a node to the SUC
 	UNKNOWN_FUNC_REDISCOVERY_NEEDED = 0x59,
 
 	FUNC_ID_ZW_REQUEST_NODE_NEIGHBOR_UPDATE_OPTIONS = 0x5a, // Allow options for request node neighbor update
@@ -133,8 +136,8 @@ export enum FunctionType {
 
 	UNKNOWN_FUNC_LOCK_ROUTE_RESPONSE = 0x90, // ??
 	UNKNOWN_FUNC_SEND_DATA_ROUTE_DEMO = 0x91, // ??
-	UNKNOWN_FUNC_GET_PRIORITY_ROUTE = 0x92, // ??
-	UNKNOWN_FUNC_SET_PRIORITY_ROUTE = 0x93, // ??
+	GetPriorityRoute = 0x92, // Get the route that is used as the first routing attempty when transmitting to a node
+	SetPriorityRoute = 0x93, // Set the route that shall be used as the first routing attempty when transmitting to a node
 	UNKNOWN_FUNC_SERIAL_API_TEST = 0x95, // ??
 	UNKNOWN_FUNC_UNKNOWN_0x98 = 0x98, // ??
 

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -146,6 +146,7 @@ import { ValueType } from '@zwave-js/core/safe';
 import type { ValueUpdatedArgs } from '@zwave-js/core';
 import { ZWaveApiVersion } from '@zwave-js/core/safe';
 import type { ZWaveApplicationHost } from '@zwave-js/host';
+import { ZWaveDataRate } from '@zwave-js/core';
 import { ZWaveError } from '@zwave-js/core/safe';
 import { ZWaveErrorCodes } from '@zwave-js/core/safe';
 import type { ZWaveHost } from '@zwave-js/host';
@@ -964,6 +965,15 @@ export interface ZWaveController extends ControllerStatisticsHost {
 // @public (undocumented)
 export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks> {
     addAssociations(source: AssociationAddress, group: number, destinations: AssociationAddress[]): Promise<void>;
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    assignPriorityReturnRoute(nodeId: number, destinationNodeId: number, repeaters: number[], routeSpeed: ZWaveDataRate): Promise<boolean>;
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    assignPrioritySUCReturnRoute(nodeId: number, repeaters: number[], routeSpeed: ZWaveDataRate): Promise<boolean>;
     // (undocumented)
     assignReturnRoute(nodeId: number, destinationNodeId: number): Promise<boolean>;
     // (undocumented)
@@ -1026,6 +1036,11 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
     getNVMId(): Promise<NVMId>;
     // Warning: (ae-forgotten-export) The symbol "SerialAPISetup_GetPowerlevelResponse" needs to be exported by the entry point index.d.ts
     getPowerlevel(): Promise<Pick<SerialAPISetup_GetPowerlevelResponse, "powerlevel" | "measured0dBm">>;
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    getPriorityRoute(destinationNodeId: number): Promise<{
+        repeaters: number[];
+        routeSpeed: ZWaveDataRate;
+    } | undefined>;
     getProvisioningEntries(): SmartStartProvisioningEntry[];
     getProvisioningEntry(dskOrNodeId: string | number): Readonly<SmartStartProvisioningEntry> | undefined;
     getRFRegion(): Promise<RFRegion_2>;
@@ -1089,6 +1104,10 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
     sdkVersionLt(version: SDKVersion): boolean | undefined;
     sdkVersionLte(version: SDKVersion): boolean | undefined;
     setPowerlevel(powerlevel: number, measured0dBm: number): Promise<boolean>;
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    setPriorityRoute(destinationNodeId: number, repeaters: number[], routeSpeed: ZWaveDataRate): Promise<boolean>;
     setRFRegion(region: RFRegion_2): Promise<boolean>;
     stopExclusion(): Promise<boolean>;
     stopHealingNetwork(): boolean;

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -3999,7 +3999,7 @@ ${associatedNodes.join(", ")}`,
 	}
 
 	/**
-	 * Sets the priority route for a node, which is the first route that will be used for commands sent to it.
+	 * Sets the priority route which will always be used for the first transmission attempt from the controller to the given node.
 	 * @param destinationNodeId The ID of the node that should be reached via the priority route
 	 * @param repeaters The IDs of the nodes that should be used as repeaters, or an empty array for direct connection
 	 * @param routeSpeed The transmission speed to use for the route

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -47,6 +47,7 @@ import {
 	securityClassOrder,
 	SinglecastCC,
 	ValueDB,
+	ZWaveDataRate,
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
@@ -167,10 +168,16 @@ import {
 	computeNeighborDiscoveryTimeout,
 	EnableSmartStartListenRequest,
 } from "../serialapi/network-mgmt/AddNodeToNetworkRequest";
+import { AssignPriorityReturnRouteRequest } from "../serialapi/network-mgmt/AssignPriorityReturnRouteMessages";
+import { AssignPrioritySUCReturnRouteRequest } from "../serialapi/network-mgmt/AssignPrioritySUCReturnRouteMessages";
 import { AssignReturnRouteRequest } from "../serialapi/network-mgmt/AssignReturnRouteMessages";
 import { AssignSUCReturnRouteRequest } from "../serialapi/network-mgmt/AssignSUCReturnRouteMessages";
 import { DeleteReturnRouteRequest } from "../serialapi/network-mgmt/DeleteReturnRouteMessages";
 import { DeleteSUCReturnRouteRequest } from "../serialapi/network-mgmt/DeleteSUCReturnRouteMessages";
+import {
+	GetPriorityRouteRequest,
+	GetPriorityRouteResponse,
+} from "../serialapi/network-mgmt/GetPriorityRouteMessages";
 import {
 	GetRoutingInfoRequest,
 	GetRoutingInfoResponse,
@@ -208,6 +215,7 @@ import {
 	RequestNodeNeighborUpdateReport,
 	RequestNodeNeighborUpdateRequest,
 } from "../serialapi/network-mgmt/RequestNodeNeighborUpdateMessages";
+import { SetPriorityRouteRequest } from "../serialapi/network-mgmt/SetPriorityRouteMessages";
 import { SetSUCNodeIdRequest } from "../serialapi/network-mgmt/SetSUCNodeIDMessages";
 import {
 	ExtNVMReadLongBufferRequest,
@@ -3906,6 +3914,158 @@ ${associatedNodes.join(", ")}`,
 				"error",
 			);
 			return false;
+		}
+	}
+
+	/**
+	 * Assigns a priority route between two end nodes. This route will always be used for the first transmission attempt.
+	 * @param nodeId The ID of the source node of the route
+	 * @param destinationNodeId The ID of the destination node of the route
+	 * @param repeaters The IDs of the nodes that should be used as repeaters, or an empty array for direct connection
+	 * @param routeSpeed The transmission speed to use for the route
+	 */
+	public async assignPriorityReturnRoute(
+		nodeId: number,
+		destinationNodeId: number,
+		repeaters: number[],
+		routeSpeed: ZWaveDataRate,
+	): Promise<boolean> {
+		this.driver.controllerLog.logNode(nodeId, {
+			message: `Assigning priority return route to node ${destinationNodeId}...`,
+			direction: "outbound",
+		});
+
+		try {
+			const result = await this.driver.sendMessage<
+				Message & SuccessIndicator
+			>(
+				new AssignPriorityReturnRouteRequest(this.driver, {
+					nodeId,
+					destinationNodeId,
+					repeaters,
+					routeSpeed,
+				}),
+			);
+
+			return result.isOK();
+		} catch (e) {
+			this.driver.controllerLog.logNode(
+				nodeId,
+				`Assigning priority return route failed: ${getErrorMessage(e)}`,
+				"error",
+			);
+			return false;
+		}
+	}
+
+	/**
+	 * Assigns a priority route from an end node to the SUC. This route will always be used for the first transmission attempt.
+	 * @param nodeId The ID of the end node for which to assign the route
+	 * @param repeaters The IDs of the nodes that should be used as repeaters, or an empty array for direct connection
+	 * @param routeSpeed The transmission speed to use for the route
+	 */
+	public async assignPrioritySUCReturnRoute(
+		nodeId: number,
+		repeaters: number[],
+		routeSpeed: ZWaveDataRate,
+	): Promise<boolean> {
+		this.driver.controllerLog.logNode(nodeId, {
+			message: `Assigning priority SUC return route...`,
+			direction: "outbound",
+		});
+
+		try {
+			const result = await this.driver.sendMessage<
+				Message & SuccessIndicator
+			>(
+				new AssignPrioritySUCReturnRouteRequest(this.driver, {
+					nodeId,
+					repeaters,
+					routeSpeed,
+				}),
+			);
+
+			return result.isOK();
+		} catch (e) {
+			this.driver.controllerLog.logNode(
+				nodeId,
+				`Assigning priority SUC return route failed: ${getErrorMessage(
+					e,
+				)}`,
+				"error",
+			);
+			return false;
+		}
+	}
+
+	/**
+	 * Sets the priority route for a node, which is the first route that will be used for commands sent to it.
+	 * @param destinationNodeId The ID of the node that should be reached via the priority route
+	 * @param repeaters The IDs of the nodes that should be used as repeaters, or an empty array for direct connection
+	 * @param routeSpeed The transmission speed to use for the route
+	 */
+	public async setPriorityRoute(
+		destinationNodeId: number,
+		repeaters: number[],
+		routeSpeed: ZWaveDataRate,
+	): Promise<boolean> {
+		this.driver.controllerLog.print(
+			`Setting priority route to node ${destinationNodeId}...`,
+		);
+
+		try {
+			const result = await this.driver.sendMessage<
+				Message & SuccessIndicator
+			>(
+				new SetPriorityRouteRequest(this.driver, {
+					destinationNodeId,
+					repeaters,
+					routeSpeed,
+				}),
+			);
+
+			return result.isOK();
+		} catch (e) {
+			this.driver.controllerLog.print(
+				`Setting priority route failed: ${getErrorMessage(e)}`,
+				"error",
+			);
+			return false;
+		}
+	}
+
+	/**
+	 * Returns the priority route which is currently set for a node. If none is set, either the LWR or the NLWR is returned.
+	 * @param destinationNodeId The ID of the node for which the priority route should be returned
+	 */
+	public async getPriorityRoute(destinationNodeId: number): Promise<
+		| {
+				repeaters: number[];
+				routeSpeed: ZWaveDataRate;
+		  }
+		| undefined
+	> {
+		this.driver.controllerLog.print(
+			`Retrieving priority route to node ${destinationNodeId}...`,
+		);
+
+		try {
+			const result =
+				await this.driver.sendMessage<GetPriorityRouteResponse>(
+					new GetPriorityRouteRequest(this.driver, {
+						destinationNodeId,
+					}),
+				);
+
+			return {
+				repeaters: result.repeaters,
+				routeSpeed: result.routeSpeed,
+			};
+		} catch (e) {
+			this.driver.controllerLog.print(
+				`Retrieving priority route failed: ${getErrorMessage(e)}`,
+				"error",
+			);
 		}
 	}
 

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/AssignPriorityReturnRouteMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/AssignPriorityReturnRouteMessages.ts
@@ -1,0 +1,191 @@
+import {
+	MAX_NODES,
+	MAX_REPEATERS,
+	MessageOrCCLogEntry,
+	MessagePriority,
+	TransmitStatus,
+	ZWaveDataRate,
+	ZWaveError,
+	ZWaveErrorCodes,
+} from "@zwave-js/core";
+import type { ZWaveHost } from "@zwave-js/host";
+import {
+	expectedCallback,
+	expectedResponse,
+	FunctionType,
+	gotDeserializationOptions,
+	Message,
+	MessageBaseOptions,
+	MessageDeserializationOptions,
+	MessageOptions,
+	MessageType,
+	messageTypes,
+	priority,
+	SuccessIndicator,
+} from "@zwave-js/serial";
+import { getEnumMemberName } from "@zwave-js/shared";
+
+@messageTypes(MessageType.Request, FunctionType.AssignPriorityReturnRoute)
+@priority(MessagePriority.Normal)
+export class AssignPriorityReturnRouteRequestBase extends Message {
+	public constructor(host: ZWaveHost, options: MessageOptions) {
+		if (
+			gotDeserializationOptions(options) &&
+			(new.target as any) !== AssignPriorityReturnRouteCallback
+		) {
+			return new AssignPriorityReturnRouteCallback(host, options);
+		}
+		super(host, options);
+	}
+}
+
+export interface AssignPriorityReturnRouteRequestOptions
+	extends MessageBaseOptions {
+	nodeId: number;
+	destinationNodeId: number;
+	repeaters: number[];
+	routeSpeed: ZWaveDataRate;
+}
+
+@expectedResponse(FunctionType.AssignPriorityReturnRoute)
+@expectedCallback(FunctionType.AssignPriorityReturnRoute)
+export class AssignPriorityReturnRouteRequest extends AssignPriorityReturnRouteRequestBase {
+	public constructor(
+		host: ZWaveHost,
+		options:
+			| MessageDeserializationOptions
+			| AssignPriorityReturnRouteRequestOptions,
+	) {
+		super(host, options);
+		if (gotDeserializationOptions(options)) {
+			throw new ZWaveError(
+				`${this.constructor.name}: deserialization not implemented`,
+				ZWaveErrorCodes.Deserialization_NotImplemented,
+			);
+		} else {
+			if (options.nodeId === options.destinationNodeId) {
+				throw new ZWaveError(
+					`The source and destination node must not be identical`,
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
+			if (
+				options.repeaters.length > MAX_REPEATERS ||
+				options.repeaters.some((id) => id < 1 || id > MAX_NODES)
+			) {
+				throw new ZWaveError(
+					`The repeaters array must contain at most ${MAX_REPEATERS} node IDs between 1 and ${MAX_NODES}`,
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
+
+			this.nodeId = options.nodeId;
+			this.destinationNodeId = options.destinationNodeId;
+			this.repeaters = options.repeaters;
+			this.routeSpeed = options.routeSpeed;
+		}
+	}
+
+	public nodeId: number;
+	public destinationNodeId: number;
+	public repeaters: number[];
+	public routeSpeed: ZWaveDataRate;
+
+	public serialize(): Buffer {
+		this.payload = Buffer.from([
+			this.nodeId,
+			this.destinationNodeId,
+			this.repeaters[0] ?? 0,
+			this.repeaters[1] ?? 0,
+			this.repeaters[2] ?? 0,
+			this.repeaters[3] ?? 0,
+			this.routeSpeed,
+			this.callbackId,
+		]);
+
+		return super.serialize();
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: {
+				"source node ID": this.nodeId,
+				"destination node ID": this.destinationNodeId,
+				repeaters:
+					this.repeaters.length > 0
+						? this.repeaters.join(" -> ")
+						: "none",
+				"route speed": getEnumMemberName(
+					ZWaveDataRate,
+					this.routeSpeed,
+				),
+				"callback id": this.callbackId,
+			},
+		};
+	}
+}
+
+@messageTypes(MessageType.Response, FunctionType.AssignPriorityReturnRoute)
+export class AssignPriorityReturnRouteResponse
+	extends Message
+	implements SuccessIndicator
+{
+	public constructor(
+		host: ZWaveHost,
+		options: MessageDeserializationOptions,
+	) {
+		super(host, options);
+		this.hasStarted = this.payload[0] !== 0;
+	}
+
+	public isOK(): boolean {
+		return this.hasStarted;
+	}
+
+	public readonly hasStarted: boolean;
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: { "has started": this.hasStarted },
+		};
+	}
+}
+
+export class AssignPriorityReturnRouteCallback
+	extends AssignPriorityReturnRouteRequestBase
+	implements SuccessIndicator
+{
+	public constructor(
+		host: ZWaveHost,
+		options: MessageDeserializationOptions,
+	) {
+		super(host, options);
+
+		this.callbackId = this.payload[0];
+		this._transmitStatus = this.payload[1];
+	}
+
+	public isOK(): boolean {
+		return this._transmitStatus === TransmitStatus.OK;
+	}
+
+	private _transmitStatus: TransmitStatus;
+	public get transmitStatus(): TransmitStatus {
+		return this._transmitStatus;
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: {
+				"callback id": this.callbackId,
+				"transmit status": getEnumMemberName(
+					TransmitStatus,
+					this.transmitStatus,
+				),
+			},
+		};
+	}
+}

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/GetPriorityRouteMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/GetPriorityRouteMessages.ts
@@ -21,7 +21,7 @@ import {
 import { getEnumMemberName } from "@zwave-js/shared";
 
 export interface GetPriorityRouteRequestOptions extends MessageBaseOptions {
-	targetNodeId: number;
+	destinationNodeId: number;
 }
 
 @messageTypes(MessageType.Request, FunctionType.GetPriorityRoute)
@@ -39,14 +39,14 @@ export class GetPriorityRouteRequest extends Message {
 				ZWaveErrorCodes.Deserialization_NotImplemented,
 			);
 		} else {
-			this.targetNodeId = options.targetNodeId;
+			this.destinationNodeId = options.destinationNodeId;
 		}
 	}
 
-	public targetNodeId: number;
+	public destinationNodeId: number;
 
 	public serialize(): Buffer {
-		this.payload = Buffer.from([this.targetNodeId]);
+		this.payload = Buffer.from([this.destinationNodeId]);
 
 		return super.serialize();
 	}
@@ -55,7 +55,7 @@ export class GetPriorityRouteRequest extends Message {
 		return {
 			...super.toLogEntry(),
 			message: {
-				"node ID": this.targetNodeId,
+				"node ID": this.destinationNodeId,
 			},
 		};
 	}
@@ -68,22 +68,22 @@ export class GetPriorityRouteResponse extends Message {
 		options: MessageDeserializationOptions,
 	) {
 		super(host, options);
-		this.targetNodeId = this.payload[0];
+		this.destinationNodeId = this.payload[0];
 		this.repeaters = [...this.payload.slice(1, 1 + MAX_REPEATERS)].filter(
 			(id) => id > 0,
 		);
 		this.routeSpeed = this.payload[1 + MAX_REPEATERS];
 	}
 
-	public readonly targetNodeId: number;
-	public readonly repeaters: readonly number[];
+	public readonly destinationNodeId: number;
+	public readonly repeaters: number[];
 	public readonly routeSpeed: ZWaveDataRate;
 
 	public toLogEntry(): MessageOrCCLogEntry {
 		return {
 			...super.toLogEntry(),
 			message: {
-				"node ID": this.targetNodeId,
+				"node ID": this.destinationNodeId,
 				repeaters:
 					this.repeaters.length > 0
 						? this.repeaters.join(" -> ")

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/GetPriorityRouteMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/GetPriorityRouteMessages.ts
@@ -1,0 +1,98 @@
+import {
+	MAX_REPEATERS,
+	MessageOrCCLogEntry,
+	MessagePriority,
+	ZWaveDataRate,
+	ZWaveError,
+	ZWaveErrorCodes,
+} from "@zwave-js/core";
+import type { ZWaveHost } from "@zwave-js/host";
+import {
+	expectedResponse,
+	FunctionType,
+	gotDeserializationOptions,
+	Message,
+	MessageBaseOptions,
+	MessageDeserializationOptions,
+	MessageType,
+	messageTypes,
+	priority,
+} from "@zwave-js/serial";
+import { getEnumMemberName } from "@zwave-js/shared";
+
+export interface GetPriorityRouteRequestOptions extends MessageBaseOptions {
+	targetNodeId: number;
+}
+
+@messageTypes(MessageType.Request, FunctionType.GetPriorityRoute)
+@priority(MessagePriority.Normal)
+@expectedResponse(FunctionType.GetPriorityRoute)
+export class GetPriorityRouteRequest extends Message {
+	public constructor(
+		host: ZWaveHost,
+		options: MessageDeserializationOptions | GetPriorityRouteRequestOptions,
+	) {
+		super(host, options);
+		if (gotDeserializationOptions(options)) {
+			throw new ZWaveError(
+				`${this.constructor.name}: deserialization not implemented`,
+				ZWaveErrorCodes.Deserialization_NotImplemented,
+			);
+		} else {
+			this.targetNodeId = options.targetNodeId;
+		}
+	}
+
+	public targetNodeId: number;
+
+	public serialize(): Buffer {
+		this.payload = Buffer.from([this.targetNodeId]);
+
+		return super.serialize();
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: {
+				"node ID": this.targetNodeId,
+			},
+		};
+	}
+}
+
+@messageTypes(MessageType.Response, FunctionType.GetPriorityRoute)
+export class GetPriorityRouteResponse extends Message {
+	public constructor(
+		host: ZWaveHost,
+		options: MessageDeserializationOptions,
+	) {
+		super(host, options);
+		this.targetNodeId = this.payload[0];
+		this.repeaters = [...this.payload.slice(1, 1 + MAX_REPEATERS)].filter(
+			(id) => id > 0,
+		);
+		this.routeSpeed = this.payload[1 + MAX_REPEATERS];
+	}
+
+	public readonly targetNodeId: number;
+	public readonly repeaters: readonly number[];
+	public readonly routeSpeed: ZWaveDataRate;
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: {
+				"node ID": this.targetNodeId,
+				repeaters:
+					this.repeaters.length > 0
+						? this.repeaters.join(" -> ")
+						: "none",
+				"route speed": getEnumMemberName(
+					ZWaveDataRate,
+					this.routeSpeed,
+				),
+			},
+		};
+	}
+}

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/SetPriorityRouteMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/SetPriorityRouteMessages.ts
@@ -1,0 +1,122 @@
+import {
+	MAX_NODES,
+	MAX_REPEATERS,
+	MessageOrCCLogEntry,
+	MessagePriority,
+	ZWaveDataRate,
+	ZWaveError,
+	ZWaveErrorCodes,
+} from "@zwave-js/core";
+import type { ZWaveHost } from "@zwave-js/host";
+import {
+	expectedResponse,
+	FunctionType,
+	gotDeserializationOptions,
+	Message,
+	MessageBaseOptions,
+	MessageDeserializationOptions,
+	MessageType,
+	messageTypes,
+	priority,
+	SuccessIndicator,
+} from "@zwave-js/serial";
+import { getEnumMemberName } from "@zwave-js/shared";
+
+export interface SetPriorityRouteRequestOptions extends MessageBaseOptions {
+	targetNodeId: number;
+	repeaters: number[];
+	routeSpeed: ZWaveDataRate;
+}
+
+@messageTypes(MessageType.Request, FunctionType.SetPriorityRoute)
+@priority(MessagePriority.Normal)
+@expectedResponse(FunctionType.SetPriorityRoute)
+export class SetPriorityRouteRequest extends Message {
+	public constructor(
+		host: ZWaveHost,
+		options: MessageDeserializationOptions | SetPriorityRouteRequestOptions,
+	) {
+		super(host, options);
+		if (gotDeserializationOptions(options)) {
+			throw new ZWaveError(
+				`${this.constructor.name}: deserialization not implemented`,
+				ZWaveErrorCodes.Deserialization_NotImplemented,
+			);
+		} else {
+			if (
+				options.repeaters.length > MAX_REPEATERS ||
+				options.repeaters.some((id) => id < 1 || id > MAX_NODES)
+			) {
+				throw new ZWaveError(
+					`The repeaters array must contain at most ${MAX_REPEATERS} node IDs between 1 and ${MAX_NODES}`,
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
+
+			this.targetNodeId = options.targetNodeId;
+			this.repeaters = options.repeaters;
+			this.routeSpeed = options.routeSpeed;
+		}
+	}
+
+	public targetNodeId: number;
+	public repeaters: number[];
+	public routeSpeed: ZWaveDataRate;
+
+	public serialize(): Buffer {
+		this.payload = Buffer.from([
+			this.targetNodeId,
+			this.repeaters[0] ?? 0,
+			this.repeaters[1] ?? 0,
+			this.repeaters[2] ?? 0,
+			this.repeaters[3] ?? 0,
+			this.routeSpeed,
+		]);
+
+		return super.serialize();
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: {
+				"node ID": this.targetNodeId,
+				repeaters:
+					this.repeaters.length > 0
+						? this.repeaters.join(" -> ")
+						: "none",
+				"route speed": getEnumMemberName(
+					ZWaveDataRate,
+					this.routeSpeed,
+				),
+			},
+		};
+	}
+}
+
+@messageTypes(MessageType.Response, FunctionType.SetPriorityRoute)
+export class SetPriorityRouteResponse
+	extends Message
+	implements SuccessIndicator
+{
+	public constructor(
+		host: ZWaveHost,
+		options: MessageDeserializationOptions,
+	) {
+		super(host, options);
+		this.success = this.payload[0] !== 0;
+	}
+
+	isOK(): boolean {
+		return this.success;
+	}
+
+	public readonly success: boolean;
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		return {
+			...super.toLogEntry(),
+			message: { success: this.success },
+		};
+	}
+}

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/SetPriorityRouteMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/SetPriorityRouteMessages.ts
@@ -23,7 +23,7 @@ import {
 import { getEnumMemberName } from "@zwave-js/shared";
 
 export interface SetPriorityRouteRequestOptions extends MessageBaseOptions {
-	targetNodeId: number;
+	destinationNodeId: number;
 	repeaters: number[];
 	routeSpeed: ZWaveDataRate;
 }
@@ -53,19 +53,19 @@ export class SetPriorityRouteRequest extends Message {
 				);
 			}
 
-			this.targetNodeId = options.targetNodeId;
+			this.destinationNodeId = options.destinationNodeId;
 			this.repeaters = options.repeaters;
 			this.routeSpeed = options.routeSpeed;
 		}
 	}
 
-	public targetNodeId: number;
+	public destinationNodeId: number;
 	public repeaters: number[];
 	public routeSpeed: ZWaveDataRate;
 
 	public serialize(): Buffer {
 		this.payload = Buffer.from([
-			this.targetNodeId,
+			this.destinationNodeId,
 			this.repeaters[0] ?? 0,
 			this.repeaters[1] ?? 0,
 			this.repeaters[2] ?? 0,
@@ -80,7 +80,7 @@ export class SetPriorityRouteRequest extends Message {
 		return {
 			...super.toLogEntry(),
 			message: {
-				"node ID": this.targetNodeId,
+				"node ID": this.destinationNodeId,
 				repeaters:
 					this.repeaters.length > 0
 						? this.repeaters.join(" -> ")


### PR DESCRIPTION
This PR adds support for managing priority routes to nodes, between nodes and to the controller. These can be used in scenarios where the automatic Z-Wave routing resolution produces subpar results.

fixes: #3544