### PR TITLE
feat(compat): add flag to override report timeout for single devices

### DIFF
--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -401,6 +401,10 @@ Many devices unnecessarily use endpoints when they could (or do) provide all fun
 
 The Z-Wave+ specs mandate that the root endpoint must **mirror** the application functionality of endpoint 1 (and potentially others). For this reason, `zwave-js` hides these superfluous values. However, some legacy devices offer additional functionality through the root endpoint, which should not be hidden. To achieve this, set `preserveRootApplicationCCValueIDs` to `true`.
 
+### `reportTimeout`
+
+By default, the driver determines the time to wait for a response from a node using the RTT of the request (including nonce exchange if needed) and adds `1s` to it. While `1s` is recommended by the specs and a good default, some devices have been found to sometimes respond slower. Instead of increasing the timeout for all devices with the driver option, the `reportTimeout` compat flag can be used to increase the timeout for a specific device.
+
 ### `skipConfigurationNameQuery`
 
 Some devices spam the network with lots of `ConfigurationCC::NameReport`s in response to the `NameGet` command. Set this flag to `true` to skip this query for affected devices.

--- a/maintenance/schemas/device-config.json
+++ b/maintenance/schemas/device-config.json
@@ -634,6 +634,11 @@
 						}
 					}
 				},
+				"reportTimeout": {
+					"type": "number",
+					"minimum": 1000,
+					"maximum": 10000
+				},
 				"skipConfigurationNameQuery": {
 					"const": true
 				},

--- a/packages/config/api.md
+++ b/packages/config/api.md
@@ -150,6 +150,8 @@ export class ConditionalCompatConfig implements ConditionalItem<CompatConfig> {
     // (undocumented)
     readonly removeCCs?: ReadonlyMap<CommandClasses, "*" | readonly number[]>;
     // (undocumented)
+    readonly reportTimeout?: number;
+    // (undocumented)
     readonly skipConfigurationInfoQuery?: boolean;
     // (undocumented)
     readonly skipConfigurationNameQuery?: boolean;

--- a/packages/config/src/devices/CompatConfig.ts
+++ b/packages/config/src/devices/CompatConfig.ts
@@ -271,6 +271,30 @@ compat option manualValueRefreshDelayMs must be a non-negative integer!`,
 				definition.manualValueRefreshDelayMs;
 		}
 
+		if (definition.reportTimeout != undefined) {
+			if (typeof definition.reportTimeout !== "number") {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+compat option reportTimeout must be a number!`,
+				);
+			}
+
+			if (
+				definition.reportTimeout % 1 !== 0 ||
+				definition.reportTimeout < 1000 ||
+				definition.reportTimeout > 10000
+			) {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+compat option reportTimeout must be an integer between 1000 and 10000!`,
+				);
+			}
+
+			this.reportTimeout = definition.reportTimeout;
+		}
+
 		if (definition.mapRootReportsToEndpoint != undefined) {
 			if (typeof definition.mapRootReportsToEndpoint !== "number") {
 				throwInvalidConfig(
@@ -505,6 +529,7 @@ compat option alarmMapping must be an array where all items are objects!`,
 	};
 	public readonly preserveRootApplicationCCValueIDs?: boolean;
 	public readonly preserveEndpoints?: "*" | readonly number[];
+	public readonly reportTimeout?: number;
 	public readonly skipConfigurationNameQuery?: boolean;
 	public readonly skipConfigurationInfoQuery?: boolean;
 	public readonly treatBasicSetAsEvent?: boolean;
@@ -538,6 +563,7 @@ compat option alarmMapping must be an array where all items are objects!`,
 			"manualValueRefreshDelayMs",
 			"mapRootReportsToEndpoint",
 			"overrideFloatEncoding",
+			"reportTimeout",
 			"preserveRootApplicationCCValueIDs",
 			"preserveEndpoints",
 			"skipConfigurationNameQuery",

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -290,6 +290,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> implements Z
     readonly getNextSupervisionSessionId: () => number;
     // (undocumented)
     getNodeUnsafe(msg: Message): ZWaveNode | undefined;
+    getReportTimeout(msg: Message): number;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -4667,6 +4667,18 @@ ${handlers.length} left`,
 		return msg.command.getMaxPayloadLength(msg.getMaxPayloadLength());
 	}
 
+	/** Determines time in milliseconds to wait for a report from a node */
+	public getReportTimeout(msg: Message): number {
+		const node = this.getNodeUnsafe(msg);
+
+		// If the node has a compat flag to override the timeout, use that,
+		// otherwise use the driver option
+		return (
+			node?.deviceConfig?.compat?.reportTimeout ??
+			this.options.timeouts.report
+		);
+	}
+
 	/** Returns the preferred constructor to use for singlecast SendData commands */
 	public getSendDataSinglecastConstructor():
 		| typeof SendDataRequest

--- a/packages/zwave-js/src/lib/driver/MessageGenerators.ts
+++ b/packages/zwave-js/src/lib/driver/MessageGenerators.ts
@@ -108,7 +108,7 @@ export const simpleMessageGenerator: MessageGeneratorImplementation =
 			// ReportTime timeout SHOULD be set to CommandTime + 1 second.
 			const timeout =
 				commandTimeMs +
-				driver.options.timeouts.report +
+				driver.getReportTimeout(msg) +
 				additionalCommandTimeoutMs;
 			return waitForNodeUpdate(driver, msg, timeout);
 		}


### PR DESCRIPTION
We already have a driver option for this, which is necessary for devices that respond slowly before being identified.
This compat option is the same, but for individual (identified) devices. This should make communication with slow devices more reliable without introducing unnecessary delays globally.