### PR TITLE
fix: update workaround for SerialAPISetupCommand encoding error in pre-7.19.1 firmwares

### DIFF
--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -913,6 +913,15 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 					new SerialAPISetup_GetSupportedCommandsRequest(this.driver),
 				);
 			this._supportedSerialAPISetupCommands = setupCaps.supportedCommands;
+
+			// According to the Host API specification, the first bit (bit 0) should be GetSupportedCommands
+			// However, before Z-Wave SDK 7.19.1, the entire bitmask is shifted by 1 bit and
+			// GetSupportedCommands is encoded in the second bit (bit 1)
+			if (this.sdkVersionLt("7.19.1")) {
+				this._supportedSerialAPISetupCommands =
+					this._supportedSerialAPISetupCommands.map((cmd) => cmd - 1);
+			}
+
 			this.driver.controllerLog.print(
 				`supported serial API setup commands:${this._supportedSerialAPISetupCommands
 					.map(

--- a/packages/zwave-js/src/lib/serialapi/capability/SerialAPISetupMessages.test.ts
+++ b/packages/zwave-js/src/lib/serialapi/capability/SerialAPISetupMessages.test.ts
@@ -7,7 +7,7 @@ const host = createTestingHost();
 describe("SerialAPISetupMessages", () => {
 	it("GetSupportedCommandsResponse with extended bitmask parses correctly", () => {
 		const data = Buffer.from(
-			"0116010b01fe160103000100000001000000000000000109",
+			"0116010b01ff8b8001800000008000000000000000800097",
 			"hex",
 		);
 

--- a/packages/zwave-js/src/lib/serialapi/capability/SerialAPISetupMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/capability/SerialAPISetupMessages.ts
@@ -198,12 +198,7 @@ export class SerialAPISetup_GetSupportedCommandsResponse extends SerialAPISetupR
 			// Parse it as a bitmask
 			this.supportedCommands = parseBitMask(
 				this.payload.slice(1),
-				// According to the Host API specification, the first bit (bit 0) should be GetSupportedCommands
-				// However, at least in Z-Wave SDK 7.15, the entire bitmask is shifted by 1 bit and
-				// GetSupportedCommands is encoded in the second bit (bit 1)
-
-				// TODO: When this is fixed, make the start value dependent on the SDK version
-				SerialAPISetupCommand.Unsupported,
+				SerialAPISetupCommand.GetSupportedCommands,
 			);
 		} else {
 			// This module only uses the single byte power-of-2 bitmask. Decode it manually
@@ -234,6 +229,7 @@ export class SerialAPISetup_GetSupportedCommandsResponse extends SerialAPISetupR
 		}
 	}
 
+	/** **WARNING:** In SDK versions < 7.19.1, all entries in this array need to be reduced by 1 due to an encoding error. */
 	public readonly supportedCommands: SerialAPISetupCommand[];
 }
 


### PR DESCRIPTION
fixes: https://github.com/zwave-js/node-zwave-js/issues/5407