### PR TITLE
fix: handle all commands contained in a Multi Command CC

### DIFF
--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -2358,7 +2358,7 @@ export class BinarySwitchCCGet extends BinarySwitchCC {
 // @public (undocumented)
 export class BinarySwitchCCReport extends BinarySwitchCC {
     // Warning: (ae-forgotten-export) The symbol "BinarySwitchCCReportOptions" needs to be exported by the entry point index.d.ts
-    constructor(host: ZWaveHost_2, options: BinarySwitchCCReportOptions);
+    constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions | BinarySwitchCCReportOptions);
     // (undocumented)
     readonly currentValue: Maybe<boolean> | undefined;
     // (undocumented)

--- a/packages/cc/src/cc/BinarySwitchCC.ts
+++ b/packages/cc/src/cc/BinarySwitchCC.ts
@@ -334,7 +334,12 @@ export type BinarySwitchCCReportOptions = CCCommandOptions & {
 
 @CCCommand(BinarySwitchCommand.Report)
 export class BinarySwitchCCReport extends BinarySwitchCC {
-	public constructor(host: ZWaveHost, options: BinarySwitchCCReportOptions) {
+	public constructor(
+		host: ZWaveHost,
+		options:
+			| CommandClassDeserializationOptions
+			| BinarySwitchCCReportOptions,
+	) {
 		super(host, options);
 
 		if (gotDeserializationOptions(options)) {

--- a/packages/cc/src/cc/MultiCommandCC.ts
+++ b/packages/cc/src/cc/MultiCommandCC.ts
@@ -96,7 +96,7 @@ interface MultiCommandCCCommandEncapsulationOptions extends CCCommandOptions {
 }
 
 @CCCommand(MultiCommandCommand.CommandEncapsulation)
-// TODO: This probably expects multiple commands in return
+// When sending commands encapsulated in this CC, responses to GET-type commands likely won't be encapsulated
 export class MultiCommandCCCommandEncapsulation extends MultiCommandCC {
 	public constructor(
 		host: ZWaveHost,

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -3803,10 +3803,7 @@ ${handlers.length} left`,
 		) {
 			const unwrapped = msg.command.encapsulated;
 			if (isArray(unwrapped)) {
-				this.driverLog.print(
-					`Received a command that contains multiple CommandClasses. This is not supported yet! Discarding the message...`,
-					"warn",
-				);
+				// Multi Command CC cannot be further unwrapped
 				return;
 			}
 

--- a/packages/zwave-js/src/lib/log/Driver.ts
+++ b/packages/zwave-js/src/lib/log/Driver.ts
@@ -3,6 +3,7 @@ import {
 	CommandClass,
 	isCommandClassContainer,
 	isEncapsulatingCommandClass,
+	isMultiEncapsulatingCommandClass,
 } from "@zwave-js/cc";
 import {
 	DataDirection,
@@ -140,10 +141,10 @@ export class DriverLogger extends ZWaveLoggerBase<DriverLogContext> {
 				// Remove the default payload message and draw a bracket
 				msg = msg.filter((line) => !line.startsWith("│ payload:"));
 
-				let indent = 0;
-				let cc: CommandClass = message.command;
-				while (true) {
-					const isEncapCC = isEncapsulatingCommandClass(cc);
+				const logCC = (cc: CommandClass, indent: number = 0) => {
+					const isEncapCC =
+						isEncapsulatingCommandClass(cc) ||
+						isMultiEncapsulatingCommandClass(cc);
 					const loggedCC = cc.toLogEntry(this.driver);
 					msg.push(
 						" ".repeat(indent * 2) + "└─" + tagify(loggedCC.tags),
@@ -162,11 +163,15 @@ export class DriverLogger extends ZWaveLoggerBase<DriverLogContext> {
 					}
 					// If this is an encap CC, continue
 					if (isEncapsulatingCommandClass(cc)) {
-						cc = cc.encapsulated;
-					} else {
-						break;
+						logCC(cc.encapsulated, indent);
+					} else if (isMultiEncapsulatingCommandClass(cc)) {
+						for (const encap of cc.encapsulated) {
+							logCC(encap, indent);
+						}
 					}
-				}
+				};
+
+				logCC(message.command);
 			}
 
 			this.logger.log({

--- a/packages/zwave-js/src/lib/node/Node.test.ts
+++ b/packages/zwave-js/src/lib/node/Node.test.ts
@@ -1939,7 +1939,7 @@ describe("lib/node/Node", () => {
 				},
 			);
 
-			node.handleCommand(command);
+			await node.handleCommand(command);
 
 			const calls = spy.mock.calls;
 			expect(calls.length).toBe(1);

--- a/packages/zwave-js/src/lib/test/compliance/fixtures/handleMultiCommandPayload/7e570001.jsonl
+++ b/packages/zwave-js/src/lib/test/compliance/fixtures/handleMultiCommandPayload/7e570001.jsonl
@@ -1,0 +1,19 @@
+{"k":"cacheFormat","v":1}
+{"k":"node.1.isListening","v":true}
+{"k":"node.1.isFrequentListening","v":false}
+{"k":"node.1.isRouting","v":true}
+{"k":"node.1.supportedDataRates","v":[40000,9600,100000]}
+{"k":"node.1.protocolVersion","v":3}
+{"k":"node.1.nodeType","v":"Controller"}
+{"k":"node.1.supportsSecurity","v":false}
+{"k":"node.1.supportsBeaming","v":true}
+{"k":"node.1.deviceClass","v":{"basic":2,"generic":2,"specific":7}}
+{"k":"node.1.endpoint.0.commandClass.0x72","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x86","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x20","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x60","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.interviewStage","v":"Complete"}
+{"k":"node.2.hasSUCReturnRoute","v":true}
+
+// Define some base functionality for node 2 so we can skip the interview of these CCs
+{"k":"node.2.endpoint.0.commandClass.0x5e","v":{"isSupported":true,"isControlled":false,"secure":false,"version":2}}

--- a/packages/zwave-js/src/lib/test/compliance/fixtures/handleMultiCommandPayload/7e570001.values.jsonl
+++ b/packages/zwave-js/src/lib/test/compliance/fixtures/handleMultiCommandPayload/7e570001.values.jsonl
@@ -1,0 +1,1 @@
+{"k":"{\"nodeId\":2,\"commandClass\":94,\"endpoint\":0,\"property\":\"interviewComplete\"}","v":true}

--- a/packages/zwave-js/src/lib/test/compliance/handleMultiCommandPayload.test.ts
+++ b/packages/zwave-js/src/lib/test/compliance/handleMultiCommandPayload.test.ts
@@ -1,0 +1,67 @@
+import {
+	MultiCommandCC,
+	SceneActivationCCSet,
+	SceneActivationCCValues,
+	ZWavePlusCCGet,
+	ZWavePlusCCReport,
+} from "@zwave-js/cc";
+import {
+	createMockZWaveRequestFrame,
+	MockZWaveFrameType,
+} from "@zwave-js/testing";
+import path from "path";
+import { integrationTest } from "../integrationTestSuite";
+
+integrationTest("All CCs contained in a Multi Command CC are handled", {
+	// debug: true,
+	provisioningDirectory: path.join(
+		__dirname,
+		"fixtures/handleMultiCommandPayload",
+	),
+
+	// nodeCapabilities: {
+	// 	commandClasses: [
+	// 		{
+	// 			ccId: CommandClasses["Z-Wave Plus Info"],
+	// 			isSupported: true,
+	// 			version: 2,
+	// 		},
+	// 	],
+	// },
+
+	testBody: async (driver, node, mockController, mockNode) => {
+		// This one requires a response
+		const zwpRequest = new ZWavePlusCCGet(mockNode.host, {
+			nodeId: mockController.host.ownNodeId,
+		});
+		// This one updates a value
+		const scaSet = new SceneActivationCCSet(mockNode.host, {
+			nodeId: mockController.host.ownNodeId,
+			sceneId: 7,
+		});
+		const cc = MultiCommandCC.encapsulate(mockNode.host, [
+			zwpRequest,
+			scaSet,
+		]);
+		await mockNode.sendToController(createMockZWaveRequestFrame(cc));
+
+		const expectResponse = mockNode.expectControllerFrame(
+			1000,
+			(msg): msg is any =>
+				msg.type === MockZWaveFrameType.Request &&
+				msg.payload instanceof ZWavePlusCCReport,
+		);
+
+		const scaValue = SceneActivationCCValues.sceneId;
+		const valueNotification = new Promise((resolve) => {
+			node.on("value notification", (node, args) => {
+				if (scaValue.is(args)) {
+					resolve(args.value);
+				}
+			});
+		});
+		const expectNotification = expect(valueNotification).resolves.toBe(7);
+
+		await Promise.all([expectResponse, expectNotification]);
+	},
+});


### PR DESCRIPTION
fixes: #5270

also adds logging for the Multi Command CC, so we can see what's in it.