### PR TITLE
fix: some more NVM conversion logic fixes

### DIFF
--- a/packages/nvmedit/api.md
+++ b/packages/nvmedit/api.md
@@ -39,7 +39,7 @@ export function json700To500(json: NVMJSON): NVM500JSON;
 // Warning: (ae-missing-release-tag) "jsonToNVM" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-export function jsonToNVM(json: Required<NVMJSON>, protocolVersion: string): Buffer;
+export function jsonToNVM(json: Required<NVMJSON>, targetSDKVersion: string): Buffer;
 
 // Warning: (ae-missing-release-tag) "jsonToNVM500" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/packages/nvmedit/src/convert.test.ts
+++ b/packages/nvmedit/src/convert.test.ts
@@ -183,7 +183,9 @@ test("700 to 700 migration shortcut", async (t) => {
 	const fixturesDir = path.join(__dirname, "../test/fixtures/nvm_700_binary");
 
 	const nvmSource = await fs.readFile(
-		path.join(fixturesDir, "ctrlr_backup_700_7.11.bin"),
+		// cannot use 7.11.bin because it has an invalid combination of protocol
+		// and application version
+		path.join(fixturesDir, "ctrlr_backup_700_7.12.bin"),
 	);
 	const nvmTarget = await fs.readFile(
 		path.join(fixturesDir, "ctrlr_backup_700_7.16_1.bin"),


### PR DESCRIPTION
There were a few logical errors in the previous revision of the updated NVM conversion logic, which this PR fixes:
- binary migration is only skipped if both the source and target NVM are in a valid state (applVersion >= protocolVersion)
- 700 series jsonToNVM uses the application version to decide on a format, not protocol version
- 255.x application versions are fixed after checking if migration can be skipped
- since the 700 series target protocol version is derived from the application version, overwriting the application version with the protocol version in case of a mismatch didn't make sense and would have prevented downgrading the NVM