### PR TITLE
feat: add new SerialAPI Setup commands

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -697,7 +697,12 @@ setPowerlevel(powerlevel: number, measured0dBm: number): Promise<boolean>;
 getPowerlevel(): Promise<{powerlevel: number, measured0dBm: number}>;
 ```
 
-Configure or read the TX powerlevel setting of the Z-Wave API. `powerlevel` is the normal powerlevel, `measured0dBm` the measured output power at 0 dBm. Both are in dBm and must be between -12.8 and +12.7.
+Configure or read the TX powerlevel setting of the Z-Wave API. `powerlevel` is the normal powerlevel, `measured0dBm` the measured output power at 0 dBm and serves as a calibration. Both are in dBm and must satisfy the following constraints:
+
+-   `powerlevel` between `-10` and either `+12.7`, `+14` or `+20` dBm (depending on the controller)
+-   `measured0dBm` between `-10` and `+10` or between `-12.8` and `+12.7` dBm (depending on the controller)
+
+Unfortunately there doesn't seem to be a way to determine which constrains apply for a given controller.
 
 > [!ATTENTION] Not all controllers support configuring the TX powerlevel. These methods will throw if they are not supported.
 

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -846,17 +846,25 @@ export enum SerialAPISetupCommand {
     // (undocumented)
     GetLRMaximumPayloadSize = 17,
     // (undocumented)
+    GetLRMaximumTxPower = 5,
+    // (undocumented)
     GetMaximumPayloadSize = 16,
     // (undocumented)
     GetPowerlevel = 8,
+    // (undocumented)
+    GetPowerlevel16Bit = 19,
     // (undocumented)
     GetRFRegion = 32,
     // (undocumented)
     GetSupportedCommands = 1,
     // (undocumented)
+    SetLRMaximumTxPower = 3,
+    // (undocumented)
     SetNodeIDType = 128,
     // (undocumented)
     SetPowerlevel = 4,
+    // (undocumented)
+    SetPowerlevel16Bit = 18,
     // (undocumented)
     SetRFRegion = 64,
     // (undocumented)

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -126,6 +126,8 @@ import {
 	SerialAPISetup_GetLRMaximumPayloadSizeResponse,
 	SerialAPISetup_GetMaximumPayloadSizeRequest,
 	SerialAPISetup_GetMaximumPayloadSizeResponse,
+	SerialAPISetup_GetPowerlevel16BitRequest,
+	SerialAPISetup_GetPowerlevel16BitResponse,
 	SerialAPISetup_GetPowerlevelRequest,
 	SerialAPISetup_GetPowerlevelResponse,
 	SerialAPISetup_GetRFRegionRequest,
@@ -134,6 +136,8 @@ import {
 	SerialAPISetup_GetSupportedCommandsResponse,
 	SerialAPISetup_SetNodeIDTypeRequest,
 	SerialAPISetup_SetNodeIDTypeResponse,
+	SerialAPISetup_SetPowerlevel16BitRequest,
+	SerialAPISetup_SetPowerlevel16BitResponse,
 	SerialAPISetup_SetPowerlevelRequest,
 	SerialAPISetup_SetPowerlevelResponse,
 	SerialAPISetup_SetRFRegionRequest,
@@ -4485,15 +4489,32 @@ ${associatedNodes.join(", ")}`,
 		powerlevel: number,
 		measured0dBm: number,
 	): Promise<boolean> {
-		const result = await this.driver.sendMessage<
-			| SerialAPISetup_SetPowerlevelResponse
-			| SerialAPISetup_CommandUnsupportedResponse
-		>(
-			new SerialAPISetup_SetPowerlevelRequest(this.driver, {
+		let request: Message;
+		if (
+			this.supportedSerialAPISetupCommands?.includes(
+				SerialAPISetupCommand.SetPowerlevel16Bit,
+			)
+		) {
+			request = new SerialAPISetup_SetPowerlevel16BitRequest(
+				this.driver,
+				{
+					powerlevel,
+					measured0dBm,
+				},
+			);
+		} else {
+			request = new SerialAPISetup_SetPowerlevelRequest(this.driver, {
 				powerlevel,
 				measured0dBm,
-			}),
-		);
+			});
+		}
+
+		const result = await this.driver.sendMessage<
+			| SerialAPISetup_SetPowerlevelResponse
+			| SerialAPISetup_SetPowerlevel16BitResponse
+			| SerialAPISetup_CommandUnsupportedResponse
+		>(request);
+
 		if (result instanceof SerialAPISetup_CommandUnsupportedResponse) {
 			throw new ZWaveError(
 				`Your hardware does not support setting the powerlevel!`,
@@ -4510,10 +4531,22 @@ ${associatedNodes.join(", ")}`,
 			"powerlevel" | "measured0dBm"
 		>
 	> {
+		let request: Message;
+		if (
+			this.supportedSerialAPISetupCommands?.includes(
+				SerialAPISetupCommand.GetPowerlevel16Bit,
+			)
+		) {
+			request = new SerialAPISetup_GetPowerlevel16BitRequest(this.driver);
+		} else {
+			request = new SerialAPISetup_GetPowerlevelRequest(this.driver);
+		}
 		const result = await this.driver.sendMessage<
 			| SerialAPISetup_GetPowerlevelResponse
+			| SerialAPISetup_GetPowerlevel16BitResponse
 			| SerialAPISetup_CommandUnsupportedResponse
-		>(new SerialAPISetup_GetPowerlevelRequest(this.driver));
+		>(request);
+
 		if (result instanceof SerialAPISetup_CommandUnsupportedResponse) {
 			throw new ZWaveError(
 				`Your hardware does not support getting the powerlevel!`,

--- a/packages/zwave-js/src/lib/serialapi/capability/SerialAPISetupMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/capability/SerialAPISetupMessages.ts
@@ -37,10 +37,16 @@ export enum SerialAPISetupCommand {
 	SetPowerlevel = 0x04,
 	GetPowerlevel = 0x08,
 	GetMaximumPayloadSize = 0x10,
-	GetLRMaximumPayloadSize = 0x11,
 	GetRFRegion = 0x20,
 	SetRFRegion = 0x40,
 	SetNodeIDType = 0x80,
+
+	// These are added "inbetween" the existing commands
+	SetLRMaximumTxPower = 0x03,
+	GetLRMaximumTxPower = 0x05,
+	GetLRMaximumPayloadSize = 0x11,
+	SetPowerlevel16Bit = 0x12,
+	GetPowerlevel16Bit = 0x13,
 }
 
 // We need to define the decorators for Requests and Responses separately
@@ -596,6 +602,264 @@ export class SerialAPISetup_SetPowerlevelRequest extends SerialAPISetupRequest {
 
 @subCommandResponse(SerialAPISetupCommand.SetPowerlevel)
 export class SerialAPISetup_SetPowerlevelResponse
+	extends SerialAPISetupResponse
+	implements SuccessIndicator
+{
+	public constructor(
+		host: ZWaveHost,
+		options: MessageDeserializationOptions,
+	) {
+		super(host, options);
+		this.success = this.payload[0] !== 0;
+	}
+
+	isOK(): boolean {
+		return this.success;
+	}
+
+	public readonly success: boolean;
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		const ret = { ...super.toLogEntry() };
+		const message = ret.message!;
+		message.success = this.success;
+		delete message.payload;
+		return ret;
+	}
+}
+
+// =============================================================================
+
+@subCommandRequest(SerialAPISetupCommand.GetPowerlevel16Bit)
+export class SerialAPISetup_GetPowerlevel16BitRequest extends SerialAPISetupRequest {
+	public constructor(host: ZWaveHost, options?: MessageOptions) {
+		super(host, options);
+		this.command = SerialAPISetupCommand.GetPowerlevel16Bit;
+	}
+}
+
+@subCommandResponse(SerialAPISetupCommand.GetPowerlevel16Bit)
+export class SerialAPISetup_GetPowerlevel16BitResponse extends SerialAPISetupResponse {
+	public constructor(
+		host: ZWaveHost,
+		options: MessageDeserializationOptions,
+	) {
+		super(host, options);
+		validatePayload(this.payload.length >= 4);
+		// The values are in 0.1 dBm, signed
+		this.powerlevel = this.payload.readInt16BE(0) / 10;
+		this.measured0dBm = this.payload.readInt16BE(2) / 10;
+	}
+
+	/** The configured normal powerlevel in dBm */
+	public readonly powerlevel: number;
+	/** The measured output power in dBm for a normal output powerlevel of 0 */
+	public readonly measured0dBm: number;
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		const ret = { ...super.toLogEntry() };
+		const message: MessageRecord = {
+			...ret.message!,
+			"normal powerlevel": `${this.powerlevel.toFixed(1)} dBm`,
+			"output power at 0 dBm": `${this.measured0dBm.toFixed(1)} dBm`,
+		};
+		delete message.payload;
+		ret.message = message;
+		return ret;
+	}
+}
+
+// =============================================================================
+
+export interface SerialAPISetup_SetPowerlevel16BitOptions
+	extends MessageBaseOptions {
+	powerlevel: number;
+	measured0dBm: number;
+}
+
+@subCommandRequest(SerialAPISetupCommand.SetPowerlevel16Bit)
+export class SerialAPISetup_SetPowerlevel16BitRequest extends SerialAPISetupRequest {
+	public constructor(
+		host: ZWaveHost,
+		options:
+			| MessageDeserializationOptions
+			| SerialAPISetup_SetPowerlevel16BitOptions,
+	) {
+		super(host, options);
+		this.command = SerialAPISetupCommand.SetPowerlevel16Bit;
+
+		if (gotDeserializationOptions(options)) {
+			throw new ZWaveError(
+				`${this.constructor.name}: deserialization not implemented`,
+				ZWaveErrorCodes.Deserialization_NotImplemented,
+			);
+		} else {
+			if (options.powerlevel < -10 || options.powerlevel > 20) {
+				throw new ZWaveError(
+					`The normal powerlevel must be between -10.0 and +20.0 dBm`,
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
+			if (options.measured0dBm < -10 || options.measured0dBm > 10) {
+				throw new ZWaveError(
+					`The measured output power at 0 dBm must be between -10.0 and +10.0 dBm`,
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
+			this.powerlevel = options.powerlevel;
+			this.measured0dBm = options.measured0dBm;
+		}
+	}
+
+	public powerlevel: number;
+	public measured0dBm: number;
+
+	public serialize(): Buffer {
+		this.payload = Buffer.allocUnsafe(4);
+		// The values are in 0.1 dBm
+		this.payload.writeInt16BE(Math.round(this.powerlevel * 10), 0);
+		this.payload.writeInt16BE(Math.round(this.measured0dBm * 10), 2);
+
+		return super.serialize();
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		const ret = { ...super.toLogEntry() };
+		const message: MessageRecord = {
+			...ret.message!,
+			"normal powerlevel": `${this.powerlevel.toFixed(1)} dBm`,
+			"output power at 0 dBm": `${this.measured0dBm.toFixed(1)} dBm`,
+		};
+		delete message.payload;
+		ret.message = message;
+		return ret;
+	}
+}
+
+@subCommandResponse(SerialAPISetupCommand.SetPowerlevel16Bit)
+export class SerialAPISetup_SetPowerlevel16BitResponse
+	extends SerialAPISetupResponse
+	implements SuccessIndicator
+{
+	public constructor(
+		host: ZWaveHost,
+		options: MessageDeserializationOptions,
+	) {
+		super(host, options);
+		this.success = this.payload[0] !== 0;
+	}
+
+	isOK(): boolean {
+		return this.success;
+	}
+
+	public readonly success: boolean;
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		const ret = { ...super.toLogEntry() };
+		const message = ret.message!;
+		message.success = this.success;
+		delete message.payload;
+		return ret;
+	}
+}
+
+// =============================================================================
+
+@subCommandRequest(SerialAPISetupCommand.GetLRMaximumTxPower)
+export class SerialAPISetup_GetLRMaximumTxPowerRequest extends SerialAPISetupRequest {
+	public constructor(host: ZWaveHost, options?: MessageOptions) {
+		super(host, options);
+		this.command = SerialAPISetupCommand.GetLRMaximumTxPower;
+	}
+}
+
+@subCommandResponse(SerialAPISetupCommand.GetLRMaximumTxPower)
+export class SerialAPISetup_GetLRMaximumTxPowerResponse extends SerialAPISetupResponse {
+	public constructor(
+		host: ZWaveHost,
+		options: MessageDeserializationOptions,
+	) {
+		super(host, options);
+		validatePayload(this.payload.length >= 2);
+		// The values are in 0.1 dBm, signed
+		this.limit = this.payload.readInt16BE(0) / 10;
+	}
+
+	/** The maximum LR TX power dBm */
+	public readonly limit: number;
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		const ret = { ...super.toLogEntry() };
+		const message: MessageRecord = {
+			...ret.message!,
+			"max. TX power (LR)": `${this.limit.toFixed(1)} dBm`,
+		};
+		delete message.payload;
+		ret.message = message;
+		return ret;
+	}
+}
+
+// =============================================================================
+
+export interface SerialAPISetup_SetLRMaximumTxPowerOptions
+	extends MessageBaseOptions {
+	limit: number;
+}
+
+@subCommandRequest(SerialAPISetupCommand.SetLRMaximumTxPower)
+export class SerialAPISetup_SetLRMaximumTxPowerRequest extends SerialAPISetupRequest {
+	public constructor(
+		host: ZWaveHost,
+		options:
+			| MessageDeserializationOptions
+			| SerialAPISetup_SetLRMaximumTxPowerOptions,
+	) {
+		super(host, options);
+		this.command = SerialAPISetupCommand.SetLRMaximumTxPower;
+
+		if (gotDeserializationOptions(options)) {
+			throw new ZWaveError(
+				`${this.constructor.name}: deserialization not implemented`,
+				ZWaveErrorCodes.Deserialization_NotImplemented,
+			);
+		} else {
+			if (options.limit < -10 || options.limit > 20) {
+				throw new ZWaveError(
+					`The maximum LR TX power must be between -10.0 and +20.0 dBm`,
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
+
+			this.limit = options.limit;
+		}
+	}
+
+	public limit: number;
+
+	public serialize(): Buffer {
+		this.payload = Buffer.allocUnsafe(2);
+		// The values are in 0.1 dBm
+		this.payload.writeInt16BE(Math.round(this.limit * 10), 0);
+
+		return super.serialize();
+	}
+
+	public toLogEntry(): MessageOrCCLogEntry {
+		const ret = { ...super.toLogEntry() };
+		const message: MessageRecord = {
+			...ret.message!,
+			"max. TX power (LR)": `${this.limit.toFixed(1)} dBm`,
+		};
+		delete message.payload;
+		ret.message = message;
+		return ret;
+	}
+}
+
+@subCommandResponse(SerialAPISetupCommand.SetLRMaximumTxPower)
+export class SerialAPISetup_SetLRMaximumTxPowerResponse
 	extends SerialAPISetupResponse
 	implements SuccessIndicator
 {


### PR DESCRIPTION
These were found in the Gecko SDK sources but are not documented yet. The controller methods now switch between the 8 and 16 bit variants of the get/set powerlevel methods depending on support. 