### PR TITLE
fix(ci): use different command to generate random body delimiter

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -422,7 +422,7 @@ jobs:
         VERSION="${{ github.ref }}"
         VERSION=${VERSION##*/v}
         echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-        EOF=$(</dev/urandom tr -dc "A-Za-z0-9" | head -c 6)
+        EOF=$(od -An -N6 -x /dev/urandom | tr -d ' ')
         BODY=$(git show -s --format=%b)
         echo "BODY<<$EOF" >> $GITHUB_OUTPUT
         echo "$BODY" >> $GITHUB_OUTPUT


### PR DESCRIPTION
the other one caused deploys to fail with PIPEFAIL