### PR TITLE
fix: move serialport mock to `/mock` subpath export

### DIFF
--- a/packages/serial/api.md
+++ b/packages/serial/api.md
@@ -6,7 +6,6 @@
 
 /// <reference types="node" />
 
-import type { BindingPortInterface } from '@serialport/bindings-interface';
 import type { DataDirection } from '@zwave-js/core/safe';
 import { DataDirection as DataDirection_2 } from '@zwave-js/core';
 import { Duplex } from 'stream';
@@ -17,18 +16,11 @@ import type { LogContext } from '@zwave-js/core/safe';
 import { MessageOrCCLogEntry } from '@zwave-js/core';
 import { MessagePriority } from '@zwave-js/core';
 import * as net from 'net';
-import type { OpenOptions } from '@serialport/bindings-interface';
 import { PassThrough } from 'stream';
-import type { PortInfo } from '@serialport/bindings-interface';
-import type { PortStatus } from '@serialport/bindings-interface';
 import { SerialPort } from 'serialport';
-import type { SetOptions } from '@serialport/bindings-interface';
-import { default as sinon_2 } from 'sinon';
 import { Transform } from 'stream';
 import { TransformCallback } from 'stream';
 import type { TypedClassDecorator } from '@zwave-js/shared/safe';
-import { TypedEventEmitter } from '@zwave-js/shared';
-import type { UpdateOptions } from '@serialport/bindings-interface';
 import type { ZWaveApplicationHost } from '@zwave-js/host';
 import type { ZWaveHost } from '@zwave-js/host';
 import { ZWaveLogContainer } from '@zwave-js/core';
@@ -94,14 +86,6 @@ export class BootloaderScreenParser extends Transform {
     // (undocumented)
     _transform(chunk: any, encoding: string, callback: TransformCallback): void;
 }
-
-// Warning: (ae-missing-release-tag) "createAndOpenMockedZWaveSerialPort" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export function createAndOpenMockedZWaveSerialPort(path: string): Promise<{
-    port: ZWaveSerialPort;
-    binding: MockPortBinding;
-}>;
 
 // Warning: (ae-missing-release-tag) "DeserializingMessageConstructor" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -586,57 +570,6 @@ export enum MessageType {
 // @public
 export const messageTypes: <TTarget extends Message>(messageType: MessageType, functionType: FunctionType) => TypedClassDecorator<TTarget>;
 
-// Warning: (ae-missing-release-tag) "MockSerialPort" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "MockSerialPort" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export interface MockSerialPort {
-    // (undocumented)
-    addListener<TEvent extends MockSerialPortEvents>(event: TEvent, callback: MockSerialPortEventCallbacks[TEvent]): this;
-    // (undocumented)
-    emit<TEvent extends MockSerialPortEvents>(event: TEvent, ...args: Parameters<MockSerialPortEventCallbacks[TEvent]>): boolean;
-    // (undocumented)
-    off<TEvent extends MockSerialPortEvents>(event: TEvent, callback: MockSerialPortEventCallbacks[TEvent]): this;
-    // Warning: (ae-forgotten-export) The symbol "MockSerialPortEvents" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "MockSerialPortEventCallbacks" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    on<TEvent extends MockSerialPortEvents>(event: TEvent, callback: MockSerialPortEventCallbacks[TEvent]): this;
-    // (undocumented)
-    once<TEvent extends MockSerialPortEvents>(event: TEvent, callback: MockSerialPortEventCallbacks[TEvent]): this;
-    // (undocumented)
-    removeAllListeners(event?: MockSerialPortEvents): this;
-    // (undocumented)
-    removeListener<TEvent extends MockSerialPortEvents>(event: TEvent, callback: MockSerialPortEventCallbacks[TEvent]): this;
-}
-
-// @public (undocumented)
-export class MockSerialPort extends ZWaveSerialPort {
-    constructor(port: string, loggers: ZWaveLogContainer);
-    // (undocumented)
-    close(): Promise<void>;
-    // (undocumented)
-    readonly closeStub: sinon_2.SinonStub<any[], any>;
-    // (undocumented)
-    static getInstance(port: string): MockSerialPort | undefined;
-    // (undocumented)
-    get isOpen(): boolean;
-    // (undocumented)
-    get lastWrite(): string | number[] | Buffer | undefined;
-    // (undocumented)
-    open(): Promise<void>;
-    // (undocumented)
-    readonly openStub: sinon_2.SinonStub<any[], any>;
-    // (undocumented)
-    raiseError(err: Error): void;
-    // (undocumented)
-    receiveData(data: Buffer): void;
-    // (undocumented)
-    writeAsync(data: Buffer): Promise<void>;
-    // (undocumented)
-    readonly writeStub: sinon_2.SinonStub<any[], any>;
-}
-
 // Warning: (ae-missing-release-tag) "MultiStageCallback" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
@@ -837,10 +770,6 @@ export class ZWaveSocket extends ZWaveSerialPortBase {
 //
 // @public (undocumented)
 export type ZWaveSocketOptions = Omit<net.TcpSocketConnectOpts, "onread"> | Omit<net.IpcSocketConnectOpts, "onread">;
-
-// Warnings were encountered during analysis:
-//
-// src/MockSerialPort.ts:110:2 - (ae-forgotten-export) The symbol "MockPortBinding" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/serial/src/index.ts
+++ b/packages/serial/src/index.ts
@@ -5,7 +5,6 @@ export * from "./message/INodeQuery";
 export * from "./message/Message";
 export * from "./message/SuccessIndicator";
 export * from "./MessageHeaders";
-export * from "./MockSerialPort";
 export * from "./parsers/BootloaderParsers";
 export * from "./parsers/SerialAPIParser";
 export * from "./ZWaveSerialPort";

--- a/packages/serial/src/index_mock.ts
+++ b/packages/serial/src/index_mock.ts
@@ -1,2 +1,3 @@
+export * from "./MockSerialPort";
 export * from "./SerialPortBindingMock";
 export * from "./SerialPortMock";

--- a/packages/zwave-js/src/lib/driver/Driver.unit.test.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.unit.test.ts
@@ -1,10 +1,6 @@
 import { assertZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
-import {
-	Message,
-	MessageType,
-	messageTypes,
-	MockSerialPort,
-} from "@zwave-js/serial";
+import { Message, MessageType, messageTypes } from "@zwave-js/serial";
+import { MockSerialPort } from "@zwave-js/serial/mock";
 import { createAndStartDriver, PORT_ADDRESS } from "../test/utils";
 import { Driver } from "./Driver";
 

--- a/packages/zwave-js/src/lib/node/VirtualEndpoint.test.ts
+++ b/packages/zwave-js/src/lib/node/VirtualEndpoint.test.ts
@@ -5,8 +5,8 @@ import {
 	CommandClasses,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
-import type { MockSerialPort } from "@zwave-js/serial";
 import { FunctionType } from "@zwave-js/serial";
+import type { MockSerialPort } from "@zwave-js/serial/mock";
 import type { ThrowingMap } from "@zwave-js/shared";
 import { wait } from "alcalzone-shared/async";
 import { ZWaveController } from "../controller/Controller";

--- a/packages/zwave-js/src/lib/test/driver/handleUnsolicited.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/handleUnsolicited.test.ts
@@ -1,5 +1,6 @@
 import { BasicCCValues } from "@zwave-js/cc/BasicCC";
-import { MessageHeaders, MockSerialPort } from "@zwave-js/serial";
+import { MessageHeaders } from "@zwave-js/serial";
+import type { MockSerialPort } from "@zwave-js/serial/mock";
 import { createThrowingMap, ThrowingMap } from "@zwave-js/shared";
 import { wait } from "alcalzone-shared/async";
 import type { Driver } from "../../driver/Driver";

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepBlockNonceReport.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepBlockNonceReport.test.ts
@@ -1,5 +1,6 @@
 import { CommandClasses, SecurityManager } from "@zwave-js/core";
-import { MessageHeaders, MockSerialPort } from "@zwave-js/serial";
+import { MessageHeaders } from "@zwave-js/serial";
+import type { MockSerialPort } from "@zwave-js/serial/mock";
 import type { ThrowingMap } from "@zwave-js/shared";
 import { wait } from "alcalzone-shared/async";
 import type { Driver } from "../../driver/Driver";

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepMessageOrder.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepMessageOrder.test.ts
@@ -1,4 +1,5 @@
-import { MessageHeaders, MockSerialPort } from "@zwave-js/serial";
+import { MessageHeaders } from "@zwave-js/serial";
+import type { MockSerialPort } from "@zwave-js/serial/mock";
 import type { ThrowingMap } from "@zwave-js/shared";
 import { wait } from "alcalzone-shared/async";
 import type { Driver } from "../../driver/Driver";

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepNoReject.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepNoReject.test.ts
@@ -1,6 +1,7 @@
 import { BasicCCSet } from "@zwave-js/cc";
 import { MessagePriority } from "@zwave-js/core";
-import { MessageHeaders, MockSerialPort } from "@zwave-js/serial";
+import { MessageHeaders } from "@zwave-js/serial";
+import type { MockSerialPort } from "@zwave-js/serial/mock";
 import type { ThrowingMap } from "@zwave-js/shared";
 import { wait } from "alcalzone-shared/async";
 import type { Driver } from "../../driver/Driver";

--- a/packages/zwave-js/src/lib/test/driver/receiveApplicationCommandHandlerBridge.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/receiveApplicationCommandHandlerBridge.test.ts
@@ -1,5 +1,6 @@
 import { CommandClasses, SecurityManager } from "@zwave-js/core";
-import { MessageHeaders, MockSerialPort } from "@zwave-js/serial";
+import { MessageHeaders } from "@zwave-js/serial";
+import type { MockSerialPort } from "@zwave-js/serial/mock";
 import type { ThrowingMap } from "@zwave-js/shared";
 import { wait } from "alcalzone-shared/async";
 import type { Driver } from "../../driver/Driver";

--- a/packages/zwave-js/src/lib/test/driver/sendDataFailThrow.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/sendDataFailThrow.test.ts
@@ -1,5 +1,6 @@
 import { BasicCCSet } from "@zwave-js/cc";
-import { MessageHeaders, MockSerialPort } from "@zwave-js/serial";
+import { MessageHeaders } from "@zwave-js/serial";
+import type { MockSerialPort } from "@zwave-js/serial/mock";
 import type { ThrowingMap } from "@zwave-js/shared";
 import { wait } from "alcalzone-shared/async";
 import type { Driver } from "../../driver/Driver";

--- a/packages/zwave-js/src/lib/test/driver/successfulPingChangeNodeStatus.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/successfulPingChangeNodeStatus.test.ts
@@ -1,4 +1,5 @@
-import { FunctionType, MessageHeaders, MockSerialPort } from "@zwave-js/serial";
+import { FunctionType, MessageHeaders } from "@zwave-js/serial";
+import type { MockSerialPort } from "@zwave-js/serial/mock";
 import { getEnumMemberName, ThrowingMap } from "@zwave-js/shared";
 import { wait } from "alcalzone-shared/async";
 import type { Driver } from "../../driver/Driver";

--- a/packages/zwave-js/src/lib/test/utils.ts
+++ b/packages/zwave-js/src/lib/test/utils.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 
-import { MockSerialPort } from "@zwave-js/serial";
+import { MockSerialPort } from "@zwave-js/serial/mock";
 import type { DeepPartial } from "@zwave-js/shared";
 import { Driver } from "../driver/Driver";
 import type { ZWaveOptions } from "../driver/ZWaveOptions";
@@ -11,7 +11,7 @@ jest.mock("@zwave-js/serial", () => {
 		jest.requireActual("@zwave-js/serial");
 	return {
 		...mdl,
-		ZWaveSerialPort: mdl.MockSerialPort,
+		ZWaveSerialPort: MockSerialPort,
 	};
 });
 


### PR DESCRIPTION
Somehow this slipped through the tests. The serialport mocks should not end up in the "main" exports, because they use dev-dependencies.