### PR TITLE
fix(config): correct LED Indicator param for Honeywell 39337 / 39444 / ZW4103

### DIFF
--- a/packages/config/config/devices/0x0039/39337_39444_zw4103.json
+++ b/packages/config/config/devices/0x0039/39337_39444_zw4103.json
@@ -17,23 +17,22 @@
 	"paramInformation": [
 		{
 			"#": "3",
-			"label": "Led Light",
-			"description": "Led light off when device is turned off (default)",
+			"label": "LED Indicator",
 			"valueSize": 1,
 			"defaultValue": 0,
 			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Default: LED Light ON when Device is OFF",
+					"label": "LED on when device is off",
 					"value": 0
 				},
 				{
-					"label": "LED Light ON when Device is ON",
+					"label": "LED on when device is on",
 					"value": 1
 				},
 				{
-					"label": "LED light always OFF",
+					"label": "Always off",
 					"value": 2
 				}
 			]

--- a/packages/config/config/devices/0x0039/39337_39444_zw4103.json
+++ b/packages/config/config/devices/0x0039/39337_39444_zw4103.json
@@ -25,11 +25,15 @@
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Led light on when device is on",
+					"label": "Default: LED Light ON when Device is OFF",
+					"value": 0
+				},
+				{
+					"label": "LED Light ON when Device is ON",
 					"value": 1
 				},
 				{
-					"label": "Led light always on",
+					"label": "LED light always OFF",
 					"value": 2
 				}
 			]


### PR DESCRIPTION
From instruction manual linked in "manual":
LED Light
When shipped from the factory, the LED is set to turn ON when the connected light is turned OFF. This is the default setting and can be changed if your primary controller supports the node configuration function. To make the LED turn ON when the light is turned ON, change parameter 3’s value to “1”. To turn the LED OFF at all times, change parameter 3’s value to 2.
• Parameter No: 3
• Length: 1 Byte
• Valid Values = 0, 1 or 2 (default 0)

Updating the descriptions and adding the default value 0 back

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

PR description here
