### PR TITLE
fix: skip queries for invalid enum members during interview

### DIFF
--- a/packages/cc/src/cc/BarrierOperatorCC.ts
+++ b/packages/cc/src/cc/BarrierOperatorCC.ts
@@ -13,7 +13,7 @@ import {
 	ZWaveErrorCodes,
 } from "@zwave-js/core/safe";
 import type { ZWaveApplicationHost, ZWaveHost } from "@zwave-js/host/safe";
-import { getEnumMemberName, pick } from "@zwave-js/shared/safe";
+import { getEnumMemberName, isEnumMember, pick } from "@zwave-js/shared/safe";
 import { validateArgs } from "@zwave-js/transformers";
 import {
 	CCAPI,
@@ -360,6 +360,10 @@ export class BarrierOperatorCC extends CommandClass {
 			) ?? [];
 
 		for (const subsystemType of supportedSubsystems) {
+			// Some devices report invalid subsystem types, but the CC API checks
+			// for valid values and throws otherwise.
+			if (!isEnumMember(SubsystemType, subsystemType)) continue;
+
 			applHost.controllerLog.logNode(node.id, {
 				message: `Querying event signaling state for subsystem ${getEnumMemberName(
 					SubsystemType,

--- a/packages/cc/src/cc/BinarySensorCC.ts
+++ b/packages/cc/src/cc/BinarySensorCC.ts
@@ -10,7 +10,7 @@ import {
 	ZWaveErrorCodes,
 } from "@zwave-js/core/safe";
 import type { ZWaveApplicationHost, ZWaveHost } from "@zwave-js/host/safe";
-import { getEnumMemberName } from "@zwave-js/shared/safe";
+import { getEnumMemberName, isEnumMember } from "@zwave-js/shared/safe";
 import { validateArgs } from "@zwave-js/transformers";
 import {
 	CCAPI,
@@ -229,6 +229,10 @@ export class BinarySensorCC extends CommandClass {
 				) ?? [];
 
 			for (const type of supportedSensorTypes) {
+				// Some devices report invalid sensor types, but the CC API checks
+				// for valid values and throws otherwise.
+				if (!isEnumMember(BinarySensorType, type)) continue;
+
 				const sensorName = getEnumMemberName(BinarySensorType, type);
 				applHost.controllerLog.logNode(node.id, {
 					endpoint: this.endpointIndex,

--- a/packages/cc/src/cc/ColorSwitchCC.ts
+++ b/packages/cc/src/cc/ColorSwitchCC.ts
@@ -17,7 +17,12 @@ import {
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
 import type { ZWaveApplicationHost, ZWaveHost } from "@zwave-js/host/safe";
-import { getEnumMemberName, keysOf, pick } from "@zwave-js/shared/safe";
+import {
+	getEnumMemberName,
+	isEnumMember,
+	keysOf,
+	pick,
+} from "@zwave-js/shared/safe";
 import { validateArgs } from "@zwave-js/transformers";
 import { clamp } from "alcalzone-shared/math";
 import { isObject } from "alcalzone-shared/typeguards";
@@ -606,6 +611,10 @@ export class ColorSwitchCC extends CommandClass {
 			) ?? [];
 
 		for (const color of supportedColors) {
+			// Some devices report invalid colors, but the CC API checks
+			// for valid values and throws otherwise.
+			if (!isEnumMember(ColorComponent, color)) continue;
+
 			const colorName = getEnumMemberName(ColorComponent, color);
 			applHost.controllerLog.logNode(node.id, {
 				endpoint: this.endpointIndex,

--- a/packages/shared/api.md
+++ b/packages/shared/api.md
@@ -133,6 +133,13 @@ export type IsAny<T> = 0 extends 1 & T ? true : false;
 // @public
 export function isDocker(): boolean;
 
+// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// Warning: (ae-missing-release-tag) "isEnumMember" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function isEnumMember(enumeration: unknown, value: number): boolean;
+
 // Warning: (ae-missing-release-tag) "isPrintableASCII" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -67,6 +67,16 @@ export function getEnumMemberName(enumeration: unknown, value: number): string {
 	return (enumeration as any)[value] || `unknown (${num2hex(value)})`;
 }
 
+/**
+ * Checks if the given value is a member of the given enum object.
+ *
+ * @param enumeration The enumeration object the value comes from
+ * @param value The enum value to be pretty-printed
+ */
+export function isEnumMember(enumeration: unknown, value: number): boolean {
+	return typeof (enumeration as any)[value] === "string";
+}
+
 /** Skips the first n bytes of a buffer and returns the rest */
 export function skipBytes(buf: Buffer, n: number): Buffer {
 	return Buffer.from(buf.slice(n));


### PR DESCRIPTION
fixes: #5463 