### PR TITLE
feat: add `stateful` and `secret` flags to `ValueMetadata`

### DIFF
--- a/docs/api/valueid.md
+++ b/docs/api/valueid.md
@@ -55,6 +55,8 @@ interface ValueMetadataAny {
 	label?: string;
 	ccSpecific?: Record<string, any>;
 	valueChangeOptions?: (keyof ValueChangeOptions)[];
+	stateful: boolean;
+	secret: boolean;
 }
 ```
 
@@ -65,6 +67,8 @@ interface ValueMetadataAny {
 -   `label`: A human-readable label for the property
 -   `ccSpecific`: CC specific information to help identify this value [(see below)](#CC-specific-fields)
 -   `valueChangeOptions`: Parameters that can be passed as `options` to the [`setValue`](api/node.md#setvalue) command for this value.
+-   `stateful`: Whether this value represents a state (`true`) or a notification/event (`false`).
+-   `secret`: Whether this value should be omitted or obfuscated in logs.
 
 ### Value types
 

--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -27,8 +27,8 @@ import type { GenericDeviceClass } from '@zwave-js/config';
 import { ICommandClass } from '@zwave-js/core';
 import { IVirtualEndpoint } from '@zwave-js/core';
 import { IVirtualEndpoint as IVirtualEndpoint_2 } from '@zwave-js/core/safe';
-import { IZWaveEndpoint } from '@zwave-js/core/safe';
-import { IZWaveEndpoint as IZWaveEndpoint_2 } from '@zwave-js/core';
+import { IZWaveEndpoint } from '@zwave-js/core';
+import { IZWaveEndpoint as IZWaveEndpoint_2 } from '@zwave-js/core/safe';
 import { IZWaveNode } from '@zwave-js/core/safe';
 import { IZWaveNode as IZWaveNode_2 } from '@zwave-js/core';
 import { JSONObject } from '@zwave-js/shared';
@@ -72,8 +72,8 @@ import { ValueID } from '@zwave-js/core';
 import { ValueID as ValueID_2 } from '@zwave-js/core/safe';
 import { ValueMetadata } from '@zwave-js/core';
 import { ValueMetadata as ValueMetadata_2 } from '@zwave-js/core/safe';
-import type { ZWaveApplicationHost } from '@zwave-js/host/safe';
-import type { ZWaveApplicationHost as ZWaveApplicationHost_2 } from '@zwave-js/host';
+import type { ZWaveApplicationHost } from '@zwave-js/host';
+import type { ZWaveApplicationHost as ZWaveApplicationHost_2 } from '@zwave-js/host/safe';
 import { ZWaveDataRate } from '@zwave-js/core';
 import { ZWaveDataRate as ZWaveDataRate_2 } from '@zwave-js/core/safe';
 import { ZWaveErrorCodes } from '@zwave-js/core';
@@ -84,7 +84,7 @@ import { ZWaveLibraryTypes } from '@zwave-js/core/safe';
 // Warning: (ae-missing-release-tag) "addAssociations" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-function addAssociations(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, group: number, destinations: AssociationAddress[]): Promise<void>;
+function addAssociations(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2, group: number, destinations: AssociationAddress[]): Promise<void>;
 
 // Warning: (ae-missing-release-tag) "AlarmSensorCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -93,11 +93,11 @@ export class AlarmSensorCC extends CommandClass {
     // (undocumented)
     ccCommand: AlarmSensorCommand;
     // (undocumented)
-    protected createMetadataForSensorType(applHost: ZWaveApplicationHost, sensorType: AlarmSensorType): void;
+    protected createMetadataForSensorType(applHost: ZWaveApplicationHost_2, sensorType: AlarmSensorType): void;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "AlarmSensorCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -111,7 +111,7 @@ export class AlarmSensorCCGet extends AlarmSensorCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "AlarmSensorCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -122,7 +122,7 @@ export class AlarmSensorCCReport extends AlarmSensorCC {
     // (undocumented)
     readonly duration: number | undefined;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     readonly sensorType: AlarmSensorType;
     // (undocumented)
@@ -130,7 +130,7 @@ export class AlarmSensorCCReport extends AlarmSensorCC {
     // (undocumented)
     readonly state: boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "AlarmSensorCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -145,11 +145,11 @@ export class AlarmSensorCCSupportedGet extends AlarmSensorCC {
 export class AlarmSensorCCSupportedReport extends AlarmSensorCC {
     constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     get supportedSensorTypes(): readonly AlarmSensorType[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "AlarmSensorCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -173,9 +173,9 @@ export const AlarmSensorCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -188,11 +188,6 @@ export const AlarmSensorCCValues: Readonly<{
             readonly property: "duration";
             readonly propertyKey: AlarmSensorType;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Alarm Sensor"];
-            property: "duration";
-            propertyKey: AlarmSensorType;
-        };
         readonly meta: {
             readonly unit: "s";
             readonly label: `${string} duration`;
@@ -203,6 +198,11 @@ export const AlarmSensorCCValues: Readonly<{
             readonly writeable: false;
             readonly type: "number";
             readonly readable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Alarm Sensor"];
+            property: "duration";
+            propertyKey: AlarmSensorType;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -222,11 +222,6 @@ export const AlarmSensorCCValues: Readonly<{
             readonly property: "severity";
             readonly propertyKey: AlarmSensorType;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Alarm Sensor"];
-            property: "severity";
-            propertyKey: AlarmSensorType;
-        };
         readonly meta: {
             readonly min: 1;
             readonly max: 100;
@@ -238,6 +233,11 @@ export const AlarmSensorCCValues: Readonly<{
             readonly writeable: false;
             readonly type: "number";
             readonly readable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Alarm Sensor"];
+            property: "severity";
+            propertyKey: AlarmSensorType;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -257,11 +257,6 @@ export const AlarmSensorCCValues: Readonly<{
             readonly property: "state";
             readonly propertyKey: AlarmSensorType;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Alarm Sensor"];
-            property: "state";
-            propertyKey: AlarmSensorType;
-        };
         readonly meta: {
             readonly label: `${string} state`;
             readonly description: "Whether the alarm is active";
@@ -271,6 +266,11 @@ export const AlarmSensorCCValues: Readonly<{
             readonly writeable: false;
             readonly type: "boolean";
             readonly readable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Alarm Sensor"];
+            property: "state";
+            propertyKey: AlarmSensorType;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -337,7 +337,7 @@ export const API: <TTarget extends CCAPI>(cc: CommandClasses_2) => TypedClassDec
 // Warning: (ae-missing-release-tag) "APIConstructor" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export type APIConstructor<T extends CCAPI = CCAPI> = new (applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2 | IVirtualEndpoint) => T;
+export type APIConstructor<T extends CCAPI = CCAPI> = new (applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint | IVirtualEndpoint) => T;
 
 // Warning: (ae-missing-release-tag) "APIMethodsOf" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -368,13 +368,13 @@ export class AssociationCC extends CommandClass {
     ccCommand: AssociationCommand;
     // (undocumented)
     determineRequiredCCInterviews(): readonly CommandClasses[];
-    static getAllDestinationsCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): ReadonlyMap<number, readonly AssociationAddress[]>;
-    static getGroupCountCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): number;
-    static getMaxNodesCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, groupId: number): number;
+    static getAllDestinationsCached(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): ReadonlyMap<number, readonly AssociationAddress[]>;
+    static getGroupCountCached(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): number;
+    static getMaxNodesCached(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2, groupId: number): number;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "AssociationCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -388,7 +388,7 @@ export class AssociationCCGet extends AssociationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "AssociationCCRemove" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -404,7 +404,7 @@ export class AssociationCCRemove extends AssociationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "AssociationCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -421,13 +421,13 @@ export class AssociationCCReport extends AssociationCC {
     // (undocumented)
     get maxNodes(): number;
     // (undocumented)
-    mergePartialCCs(applHost: ZWaveApplicationHost, partials: AssociationCCReport[]): void;
+    mergePartialCCs(applHost: ZWaveApplicationHost_2, partials: AssociationCCReport[]): void;
     // (undocumented)
     get nodeIds(): readonly number[];
     // (undocumented)
     get reportsToFollow(): number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "AssociationCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -443,7 +443,7 @@ export class AssociationCCSet extends AssociationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "AssociationCCSupportedGroupingsGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -460,7 +460,7 @@ export class AssociationCCSupportedGroupingsReport extends AssociationCC {
     // (undocumented)
     get groupCount(): number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "AssociationCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -474,22 +474,22 @@ export const AssociationCCValues: Readonly<{
             readonly property: "nodeIds";
             readonly propertyKey: number;
         };
-        readonly id: {
-            commandClass: CommandClasses.Association;
-            property: "nodeIds";
-            propertyKey: number;
-        };
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
             readonly writeable: true;
         };
+        readonly id: {
+            commandClass: CommandClasses.Association;
+            property: "nodeIds";
+            propertyKey: number;
+        };
     }) & {
         is: (valueId: ValueID_2) => boolean;
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -502,22 +502,22 @@ export const AssociationCCValues: Readonly<{
             readonly property: "maxNodes";
             readonly propertyKey: number;
         };
-        readonly id: {
-            commandClass: CommandClasses.Association;
-            property: "maxNodes";
-            propertyKey: number;
-        };
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
             readonly writeable: true;
         };
+        readonly id: {
+            commandClass: CommandClasses.Association;
+            property: "maxNodes";
+            propertyKey: number;
+        };
     }) & {
         is: (valueId: ValueID_2) => boolean;
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -540,9 +540,9 @@ export const AssociationCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -565,9 +565,9 @@ export const AssociationCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -614,14 +614,14 @@ export class AssociationGroupInfoCC extends CommandClass {
     // (undocumented)
     determineRequiredCCInterviews(): readonly CommandClasses[];
     // (undocumented)
-    static findGroupsForIssuedCommand(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, ccId: CommandClasses, command: number): number[];
-    static getGroupNameCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, groupId: number): string | undefined;
-    static getGroupProfileCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, groupId: number): AssociationGroupInfoProfile | undefined;
-    static getIssuedCommandsCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, groupId: number): ReadonlyMap<CommandClasses, readonly number[]> | undefined;
+    static findGroupsForIssuedCommand(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2, ccId: CommandClasses, command: number): number[];
+    static getGroupNameCached(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2, groupId: number): string | undefined;
+    static getGroupProfileCached(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2, groupId: number): AssociationGroupInfoProfile | undefined;
+    static getIssuedCommandsCached(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2, groupId: number): ReadonlyMap<CommandClasses, readonly number[]> | undefined;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "AssociationGroupInfoCCCommandListGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -637,7 +637,7 @@ export class AssociationGroupInfoCCCommandListGet extends AssociationGroupInfoCC
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "AssociationGroupInfoCCCommandListReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -650,7 +650,7 @@ export class AssociationGroupInfoCCCommandListReport extends AssociationGroupInf
     // (undocumented)
     readonly groupId: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "AssociationGroupInfoCCInfoGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -668,7 +668,7 @@ export class AssociationGroupInfoCCInfoGet extends AssociationGroupInfoCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "AssociationGroupInfoCCInfoReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -685,9 +685,9 @@ export class AssociationGroupInfoCCInfoReport extends AssociationGroupInfoCC {
     // (undocumented)
     readonly isListMode: boolean;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "AssociationGroupInfoCCNameGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -701,7 +701,7 @@ export class AssociationGroupInfoCCNameGet extends AssociationGroupInfoCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "AssociationGroupInfoCCNameReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -714,9 +714,9 @@ export class AssociationGroupInfoCCNameReport extends AssociationGroupInfoCC {
     // (undocumented)
     readonly name: string;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "AssociationGroupInfoCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -730,22 +730,22 @@ export const AssociationGroupInfoCCValues: Readonly<{
             readonly property: "issuedCommands";
             readonly propertyKey: number;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Association Group Information"];
-            property: "issuedCommands";
-            propertyKey: number;
-        };
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
             readonly writeable: true;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Association Group Information"];
+            property: "issuedCommands";
+            propertyKey: number;
+        };
     }) & {
         is: (valueId: ValueID_2) => boolean;
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -758,22 +758,22 @@ export const AssociationGroupInfoCCValues: Readonly<{
             readonly property: "info";
             readonly propertyKey: number;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Association Group Information"];
-            property: "info";
-            propertyKey: number;
-        };
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
             readonly writeable: true;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Association Group Information"];
+            property: "info";
+            propertyKey: number;
+        };
     }) & {
         is: (valueId: ValueID_2) => boolean;
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -786,22 +786,22 @@ export const AssociationGroupInfoCCValues: Readonly<{
             readonly property: "name";
             readonly propertyKey: number;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Association Group Information"];
-            property: "name";
-            propertyKey: number;
-        };
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
             readonly writeable: true;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Association Group Information"];
+            property: "name";
+            propertyKey: number;
+        };
     }) & {
         is: (valueId: ValueID_2) => boolean;
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -824,9 +824,9 @@ export const AssociationGroupInfoCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -1211,9 +1211,9 @@ export class BarrierOperatorCC extends CommandClass {
     // (undocumented)
     ccCommand: BarrierOperatorCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "BarrierOperatorCCEventSignalingGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1227,7 +1227,7 @@ export class BarrierOperatorCCEventSignalingGet extends BarrierOperatorCC {
     // (undocumented)
     subsystemType: SubsystemType;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "BarrierOperatorCCEventSignalingReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1236,13 +1236,13 @@ export class BarrierOperatorCCEventSignalingGet extends BarrierOperatorCC {
 export class BarrierOperatorCCEventSignalingReport extends BarrierOperatorCC {
     constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     readonly subsystemState: SubsystemState;
     // (undocumented)
     readonly subsystemType: SubsystemType;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "BarrierOperatorCCEventSignalingSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1258,7 +1258,7 @@ export class BarrierOperatorCCEventSignalingSet extends BarrierOperatorCC {
     // (undocumented)
     subsystemType: SubsystemType;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "BarrierOperatorCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1277,7 +1277,7 @@ export class BarrierOperatorCCReport extends BarrierOperatorCC {
     // (undocumented)
     readonly position: number | undefined;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "BarrierOperatorCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1291,7 +1291,7 @@ export class BarrierOperatorCCSet extends BarrierOperatorCC {
     // (undocumented)
     targetState: BarrierState.Open | BarrierState.Closed;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "BarrierOperatorCCSignalingCapabilitiesGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1308,7 +1308,7 @@ export class BarrierOperatorCCSignalingCapabilitiesReport extends BarrierOperato
     // (undocumented)
     readonly supportedSubsystemTypes: readonly SubsystemType[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "BarrierOperatorCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1322,11 +1322,6 @@ export const BarrierOperatorCCValues: Readonly<{
             readonly property: "signalingState";
             readonly propertyKey: SubsystemType;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Barrier Operator"];
-            property: "signalingState";
-            propertyKey: SubsystemType;
-        };
         readonly meta: {
             readonly label: `Signaling State (${string})`;
             readonly states: {
@@ -1337,6 +1332,11 @@ export const BarrierOperatorCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Barrier Operator"];
+            property: "signalingState";
+            propertyKey: SubsystemType;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -1457,9 +1457,9 @@ export const BarrierOperatorCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -1512,9 +1512,9 @@ export class BasicCC extends CommandClass {
     // (undocumented)
     ccCommand: BasicCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "BasicCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1534,13 +1534,13 @@ export class BasicCCReport extends BasicCC {
     // (undocumented)
     readonly duration: Duration | undefined;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
     readonly targetValue: number | undefined;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "BasicCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1554,7 +1554,7 @@ export class BasicCCSet extends BasicCC {
     // (undocumented)
     targetValue: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "BasicCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1582,11 +1582,11 @@ export const BasicCCValues: Readonly<{
         };
         readonly options: {
             readonly internal: false;
-            readonly minVersion: 1;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly stateful: false;
-            readonly autoCreate: (applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint) => boolean;
+            readonly autoCreate: (applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2) => boolean;
         };
     };
     restorePrevious: {
@@ -1720,9 +1720,9 @@ export class BatteryCC extends CommandClass {
     // (undocumented)
     ccCommand: BatteryCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "BatteryCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1745,11 +1745,11 @@ export class BatteryCCHealthReport extends BatteryCC {
     // (undocumented)
     readonly maximumCapacity: number | undefined;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     readonly temperature: number | undefined;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "BatteryCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1781,7 +1781,7 @@ export class BatteryCCReport extends BatteryCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "BatteryCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2165,11 +2165,11 @@ export class BinarySensorCC extends CommandClass {
     // (undocumented)
     ccCommand: BinarySensorCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    setMappedBasicValue(applHost: ZWaveApplicationHost, value: number): boolean;
+    setMappedBasicValue(applHost: ZWaveApplicationHost_2, value: number): boolean;
 }
 
 // Warning: (ae-missing-release-tag) "BinarySensorCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2183,7 +2183,7 @@ export class BinarySensorCCGet extends BinarySensorCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "BinarySensorCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2192,9 +2192,9 @@ export class BinarySensorCCGet extends BinarySensorCC {
 export class BinarySensorCCReport extends BinarySensorCC {
     constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     get type(): BinarySensorType;
     // (undocumented)
@@ -2215,7 +2215,7 @@ export class BinarySensorCCSupportedReport extends BinarySensorCC {
     // (undocumented)
     readonly supportedSensorTypes: readonly BinarySensorType[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "BinarySensorCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2228,10 +2228,6 @@ export const BinarySensorCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: string;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Binary Sensor"];
-            property: string;
-        };
         readonly meta: {
             readonly label: `Sensor state (${string})`;
             readonly ccSpecific: {
@@ -2240,6 +2236,10 @@ export const BinarySensorCCValues: Readonly<{
             readonly writeable: false;
             readonly type: "boolean";
             readonly readable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Binary Sensor"];
+            property: string;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -2269,9 +2269,9 @@ export const BinarySensorCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -2343,11 +2343,11 @@ export class BinarySwitchCC extends CommandClass {
     // (undocumented)
     ccCommand: BinarySwitchCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    setMappedBasicValue(applHost: ZWaveApplicationHost, value: number): boolean;
+    setMappedBasicValue(applHost: ZWaveApplicationHost_2, value: number): boolean;
 }
 
 // Warning: (ae-missing-release-tag) "BinarySwitchCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2371,7 +2371,7 @@ export class BinarySwitchCCReport extends BinarySwitchCC {
     // (undocumented)
     readonly targetValue: boolean | undefined;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "BinarySwitchCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2387,7 +2387,7 @@ export class BinarySwitchCCSet extends BinarySwitchCC {
     // (undocumented)
     targetValue: boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "BinarySwitchCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2496,19 +2496,19 @@ export class CCAPI {
     protected [POLL_VALUE]: PollValueImplementation | undefined;
     // (undocumented)
     protected [SET_VALUE]: SetValueImplementation | undefined;
-    constructor(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2 | IVirtualEndpoint);
+    constructor(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint | IVirtualEndpoint);
     // (undocumented)
-    protected readonly applHost: ZWaveApplicationHost_2;
+    protected readonly applHost: ZWaveApplicationHost;
     // (undocumented)
-    protected assertPhysicalEndpoint(endpoint: IZWaveEndpoint_2 | IVirtualEndpoint): asserts endpoint is IZWaveEndpoint_2;
+    protected assertPhysicalEndpoint(endpoint: IZWaveEndpoint | IVirtualEndpoint): asserts endpoint is IZWaveEndpoint;
     // (undocumented)
     protected assertSupportsCommand(commandEnum: unknown, command: number): void;
     readonly ccId: CommandClasses_2;
     protected get commandOptions(): SendCommandOptions;
     // (undocumented)
-    static create<T extends CommandClasses_2>(ccId: T, applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2 | IVirtualEndpoint, requireSupport?: boolean): CommandClasses_2 extends T ? CCAPI : CCToAPI<T>;
+    static create<T extends CommandClasses_2>(ccId: T, applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint | IVirtualEndpoint, requireSupport?: boolean): CommandClasses_2 extends T ? CCAPI : CCToAPI<T>;
     // (undocumented)
-    protected readonly endpoint: IZWaveEndpoint_2 | IVirtualEndpoint;
+    protected readonly endpoint: IZWaveEndpoint | IVirtualEndpoint;
     getNode(): IZWaveNode_2 | undefined;
     protected getValueDB(): ValueDB;
     // (undocumented)
@@ -2526,7 +2526,7 @@ export class CCAPI {
     isSetValueOptimistic(valueId: ValueID): boolean;
     // (undocumented)
     protected isSinglecast(): this is this & {
-        endpoint: IZWaveEndpoint_2;
+        endpoint: IZWaveEndpoint;
     };
     isSupported(): boolean;
     get pollValue(): PollValueImplementation | undefined;
@@ -2844,6 +2844,18 @@ export function ccValue<TTarget extends CommandClass>(value: StaticCCValue): Typ
 // @public (undocumented)
 export function ccValue<TTarget extends CommandClass, TArgs extends any[]>(value: DynamicCCValue<TArgs>, getArgs: (self: TTarget) => Readonly<TArgs>): TypedPropertyDecorator<TTarget>;
 
+// Warning: (ae-missing-release-tag) "CCValueOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface CCValueOptions {
+    autoCreate?: boolean | ((applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint) => boolean);
+    internal?: boolean;
+    minVersion?: number;
+    secret?: boolean;
+    stateful?: boolean;
+    supportsEndpoints?: boolean;
+}
+
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
 // Warning: (ae-missing-release-tag) "ccValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -2859,7 +2871,7 @@ export class CentralSceneCC extends CommandClass {
     // (undocumented)
     determineRequiredCCInterviews(): readonly CommandClasses[];
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
     skipEndpointInterview(): boolean;
 }
@@ -2878,7 +2890,7 @@ export class CentralSceneCCConfigurationReport extends CentralSceneCC {
     // (undocumented)
     readonly slowRefresh: boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "CentralSceneCCConfigurationSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2892,7 +2904,7 @@ export class CentralSceneCCConfigurationSet extends CentralSceneCC {
     // (undocumented)
     slowRefresh: boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "CentralSceneCCNotification" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2903,7 +2915,7 @@ export class CentralSceneCCNotification extends CentralSceneCC {
     // (undocumented)
     readonly keyAttribute: CentralSceneKeys;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     readonly sceneNumber: number;
     // (undocumented)
@@ -2911,7 +2923,7 @@ export class CentralSceneCCNotification extends CentralSceneCC {
     // (undocumented)
     readonly slowRefresh: boolean | undefined;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "CentralSceneCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2926,7 +2938,7 @@ export class CentralSceneCCSupportedGet extends CentralSceneCC {
 export class CentralSceneCCSupportedReport extends CentralSceneCC {
     constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     readonly sceneCount: number;
     // (undocumented)
@@ -2934,7 +2946,7 @@ export class CentralSceneCCSupportedReport extends CentralSceneCC {
     // (undocumented)
     readonly supportsSlowRefresh: boolean | undefined;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "CentralSceneCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2948,11 +2960,6 @@ export const CentralSceneCCValues: Readonly<{
             readonly property: "scene";
             readonly propertyKey: string;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Central Scene"];
-            property: "scene";
-            propertyKey: string;
-        };
         readonly meta: {
             readonly label: `Scene ${string}`;
             readonly writeable: false;
@@ -2960,6 +2967,11 @@ export const CentralSceneCCValues: Readonly<{
             readonly max: 255;
             readonly type: "number";
             readonly readable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Central Scene"];
+            property: "scene";
+            propertyKey: string;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -3016,9 +3028,9 @@ export const CentralSceneCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -3041,9 +3053,9 @@ export const CentralSceneCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -3066,9 +3078,9 @@ export const CentralSceneCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -3136,7 +3148,7 @@ export class ClimateControlScheduleCCChangedReport extends ClimateControlSchedul
     // (undocumented)
     readonly changeCounter: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ClimateControlScheduleCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -3148,7 +3160,7 @@ export class ClimateControlScheduleCCGet extends ClimateControlScheduleCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     weekday: Weekday;
 }
@@ -3169,7 +3181,7 @@ export class ClimateControlScheduleCCOverrideReport extends ClimateControlSchedu
     // (undocumented)
     readonly overrideType: ScheduleOverrideType;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ClimateControlScheduleCCOverrideSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -3185,7 +3197,7 @@ export class ClimateControlScheduleCCOverrideSet extends ClimateControlScheduleC
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ClimateControlScheduleCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -3196,7 +3208,7 @@ export class ClimateControlScheduleCCReport extends ClimateControlScheduleCC {
     // (undocumented)
     readonly schedule: readonly Switchpoint[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     readonly weekday: Weekday;
 }
@@ -3212,7 +3224,7 @@ export class ClimateControlScheduleCCSet extends ClimateControlScheduleCC {
     // (undocumented)
     switchPoints: Switchpoint[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     weekday: Weekday;
 }
@@ -3228,16 +3240,16 @@ export const ClimateControlScheduleCCValues: Readonly<{
             readonly property: "schedule";
             readonly propertyKey: Weekday;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Climate Control Schedule"];
-            property: "schedule";
-            propertyKey: Weekday;
-        };
         readonly meta: {
             readonly label: `Schedule (${string})`;
             readonly type: "any";
             readonly readable: true;
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Climate Control Schedule"];
+            property: "schedule";
+            propertyKey: Weekday;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -3337,9 +3349,9 @@ export class ClockCC extends CommandClass {
     // (undocumented)
     ccCommand: ClockCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "ClockCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -3358,7 +3370,7 @@ export class ClockCCReport extends ClockCC {
     // (undocumented)
     readonly minute: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     readonly weekday: Weekday;
 }
@@ -3376,7 +3388,7 @@ export class ClockCCSet extends ClockCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     weekday: Weekday;
 }
@@ -3444,11 +3456,11 @@ export class ColorSwitchCC extends CommandClass {
     // (undocumented)
     ccCommand: ColorSwitchCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    translatePropertyKey(applHost: ZWaveApplicationHost, property: string | number, propertyKey: string | number): string | undefined;
+    translatePropertyKey(applHost: ZWaveApplicationHost_2, property: string | number, propertyKey: string | number): string | undefined;
 }
 
 // Warning: (ae-missing-release-tag) "ColorSwitchCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -3463,7 +3475,7 @@ export class ColorSwitchCCGet extends ColorSwitchCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "ColorSwitchCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -3478,11 +3490,11 @@ export class ColorSwitchCCReport extends ColorSwitchCC {
     // (undocumented)
     readonly duration: Duration_2 | undefined;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     readonly targetValue: number | undefined;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "ColorSwitchCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -3498,7 +3510,7 @@ export class ColorSwitchCCSet extends ColorSwitchCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "ColorSwitchCCStartLevelChange" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -3520,7 +3532,7 @@ export class ColorSwitchCCStartLevelChange extends ColorSwitchCC {
     // (undocumented)
     startLevel: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "ColorSwitchCCStopLevelChange" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -3534,7 +3546,7 @@ export class ColorSwitchCCStopLevelChange extends ColorSwitchCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "ColorSwitchCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -3551,7 +3563,7 @@ export class ColorSwitchCCSupportedReport extends ColorSwitchCC {
     // (undocumented)
     readonly supportedColorComponents: readonly ColorComponent[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "ColorSwitchCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -3565,11 +3577,6 @@ export const ColorSwitchCCValues: Readonly<{
             readonly property: "targetColor";
             readonly propertyKey: ColorComponent;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses_2)["Color Switch"];
-            property: "targetColor";
-            propertyKey: ColorComponent;
-        };
         readonly meta: {
             readonly label: `Target value (${string})`;
             readonly description: `The target value of the ${string} channel.`;
@@ -3579,6 +3586,11 @@ export const ColorSwitchCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses_2)["Color Switch"];
+            property: "targetColor";
+            propertyKey: ColorComponent;
         };
     }) & {
         is: (valueId: ValueID) => boolean;
@@ -3598,11 +3610,6 @@ export const ColorSwitchCCValues: Readonly<{
             readonly property: "currentColor";
             readonly propertyKey: ColorComponent;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses_2)["Color Switch"];
-            property: "currentColor";
-            propertyKey: ColorComponent;
-        };
         readonly meta: {
             readonly label: `Current value (${string})`;
             readonly description: `The current value of the ${string} channel.`;
@@ -3611,6 +3618,11 @@ export const ColorSwitchCCValues: Readonly<{
             readonly max: 255;
             readonly type: "number";
             readonly readable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses_2)["Color Switch"];
+            property: "currentColor";
+            propertyKey: ColorComponent;
         };
     }) & {
         is: (valueId: ValueID) => boolean;
@@ -3748,9 +3760,9 @@ export const ColorSwitchCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -3773,9 +3785,9 @@ export const ColorSwitchCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -3819,7 +3831,7 @@ export class CommandClass implements ICommandClass {
     // (undocumented)
     get ccName(): string;
     protected computeEncapsulationOverhead(): number;
-    static createInstanceUnchecked<T extends CommandClass>(host: ZWaveHost, endpoint: IZWaveEndpoint_2, cc: CommandClasses_2 | CCConstructor<T>): T | undefined;
+    static createInstanceUnchecked<T extends CommandClass>(host: ZWaveHost, endpoint: IZWaveEndpoint, cc: CommandClasses_2 | CCConstructor<T>): T | undefined;
     protected deserialize(data: Buffer): {
         ccId: CommandClasses_2;
         ccCommand: number;
@@ -3835,7 +3847,7 @@ export class CommandClass implements ICommandClass {
     endpointIndex: number;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (ae-forgotten-export) The symbol "CCValue" needs to be exported by the entry point index.d.ts
-    protected ensureMetadata(applHost: ZWaveApplicationHost_2, ccValue: CCValue, meta?: ValueMetadata): void;
+    protected ensureMetadata(applHost: ZWaveApplicationHost, ccValue: CCValue, meta?: ValueMetadata): void;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     expectMoreMessages(_session: CommandClass[]): boolean;
     expectsCCResponse(): boolean;
@@ -3844,59 +3856,59 @@ export class CommandClass implements ICommandClass {
     protected getCCValue(valueId: ValueID): StaticCCValue | DynamicCCValue | undefined;
     static getCommandClass(data: Buffer): CommandClasses_2;
     static getConstructor(ccData: Buffer): CCConstructor<CommandClass>;
-    getDefinedValueIDs(applHost: ZWaveApplicationHost_2): ValueID[];
+    getDefinedValueIDs(applHost: ZWaveApplicationHost): ValueID[];
     getEncapsulatingCC(ccId: CommandClasses_2, ccCommand?: number): CommandClass | undefined;
     // (undocumented)
-    getEndpoint(applHost: ZWaveApplicationHost_2): IZWaveEndpoint_2 | undefined;
+    getEndpoint(applHost: ZWaveApplicationHost): IZWaveEndpoint | undefined;
     getMaxPayloadLength(baseLength: number): number;
-    protected getMetadata<T extends ValueMetadata>(applHost: ZWaveApplicationHost_2, ccValue: CCValue): T | undefined;
-    getNode(applHost: ZWaveApplicationHost_2): IZWaveNode_2 | undefined;
+    protected getMetadata<T extends ValueMetadata>(applHost: ZWaveApplicationHost, ccValue: CCValue): T | undefined;
+    getNode(applHost: ZWaveApplicationHost): IZWaveNode_2 | undefined;
     getPartialCCSessionId(): Record<string, any> | undefined;
-    protected getValue<T>(applHost: ZWaveApplicationHost_2, ccValue: CCValue): T | undefined;
-    protected getValueDB(applHost: ZWaveApplicationHost_2): ValueDB;
+    protected getValue<T>(applHost: ZWaveApplicationHost, ccValue: CCValue): T | undefined;
+    protected getValueDB(applHost: ZWaveApplicationHost): ValueDB;
     // (undocumented)
     protected host: ZWaveHost;
-    interview(_applHost: ZWaveApplicationHost_2): Promise<void>;
+    interview(_applHost: ZWaveApplicationHost): Promise<void>;
     isEncapsulatedWith(ccId: CommandClasses_2, ccCommand?: number): boolean;
     // (undocumented)
     isExpectedCCResponse(received: CommandClass): boolean;
     isExtended(): boolean;
     isInternalValue(properties: ValueIDProperties): boolean;
-    isInterviewComplete(applHost: ZWaveApplicationHost_2): boolean;
+    isInterviewComplete(applHost: ZWaveApplicationHost): boolean;
     // (undocumented)
     isMulticast(): this is MulticastCC<this>;
     isSecretValue(properties: ValueIDProperties): boolean;
     // (undocumented)
     isSinglecast(): this is SinglecastCC<this>;
     isStatefulValue(properties: ValueIDProperties): boolean;
-    mergePartialCCs(_applHost: ZWaveApplicationHost_2, _partials: CommandClass[]): void;
+    mergePartialCCs(_applHost: ZWaveApplicationHost, _partials: CommandClass[]): void;
     nodeId: number | MulticastDestination;
     // (undocumented)
     payload: Buffer;
     // Warning: (tsdoc-characters-after-block-tag) The token "@ccValue" looks like a TSDoc tag but contains an invalid character "."; if it is not a tag, use a backslash to escape the "@"
-    persistValues(applHost: ZWaveApplicationHost_2): boolean;
-    refreshValues(_applHost: ZWaveApplicationHost_2): Promise<void>;
-    protected removeMetadata(applHost: ZWaveApplicationHost_2, ccValue: CCValue): void;
-    protected removeValue(applHost: ZWaveApplicationHost_2, ccValue: CCValue): void;
+    persistValues(applHost: ZWaveApplicationHost): boolean;
+    refreshValues(_applHost: ZWaveApplicationHost): Promise<void>;
+    protected removeMetadata(applHost: ZWaveApplicationHost, ccValue: CCValue): void;
+    protected removeValue(applHost: ZWaveApplicationHost, ccValue: CCValue): void;
     serialize(): Buffer;
     setEncapsulationFlag(flag: EncapsulationFlags, active: boolean): void;
-    setInterviewComplete(applHost: ZWaveApplicationHost_2, complete: boolean): void;
+    setInterviewComplete(applHost: ZWaveApplicationHost, complete: boolean): void;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    setMappedBasicValue(_applHost: ZWaveApplicationHost_2, _value: number): boolean;
+    setMappedBasicValue(_applHost: ZWaveApplicationHost, _value: number): boolean;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    protected setMetadata(applHost: ZWaveApplicationHost_2, ccValue: CCValue, meta?: ValueMetadata): void;
-    protected setValue(applHost: ZWaveApplicationHost_2, ccValue: CCValue, value: unknown): void;
+    protected setMetadata(applHost: ZWaveApplicationHost, ccValue: CCValue, meta?: ValueMetadata): void;
+    protected setValue(applHost: ZWaveApplicationHost, ccValue: CCValue, value: unknown): void;
     skipEndpointInterview(): boolean;
     // (undocumented)
     protected throwMissingCriticalInterviewResponse(): never;
     toJSON(): JSONObject;
-    toLogEntry(_applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
+    toLogEntry(_applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    translateProperty(_applHost: ZWaveApplicationHost_2, property: string | number, _propertyKey?: string | number): string;
+    translateProperty(_applHost: ZWaveApplicationHost, property: string | number, _propertyKey?: string | number): string;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    translatePropertyKey(_applHost: ZWaveApplicationHost_2, _property: string | number, propertyKey: string | number): string | undefined;
+    translatePropertyKey(_applHost: ZWaveApplicationHost, _property: string | number, propertyKey: string | number): string | undefined;
     version: number;
 }
 
@@ -3932,25 +3944,25 @@ export type CommandClassOptions = CommandClassCreationOptions | CommandClassDese
 export class ConfigurationCC extends CommandClass {
     // (undocumented)
     ccCommand: ConfigurationCommand;
-    composePartialParamValue(applHost: ZWaveApplicationHost, parameter: number, bitMask: number, partialValue: number): number;
-    composePartialParamValues(applHost: ZWaveApplicationHost, parameter: number, partials: {
+    composePartialParamValue(applHost: ZWaveApplicationHost_2, parameter: number, bitMask: number, partialValue: number): number;
+    composePartialParamValues(applHost: ZWaveApplicationHost_2, parameter: number, partials: {
         bitMask: number;
         partialValue: number;
     }[]): number;
-    deserializeParamInformationFromConfig(applHost: ZWaveApplicationHost, config: ParamInfoMap): void;
-    getPartialParamInfos(applHost: ZWaveApplicationHost, parameter: number): (ValueID_2 & {
+    deserializeParamInformationFromConfig(applHost: ZWaveApplicationHost_2, config: ParamInfoMap): void;
+    getPartialParamInfos(applHost: ZWaveApplicationHost_2, parameter: number): (ValueID_2 & {
         metadata: ConfigurationMetadata;
     })[];
-    getQueriedParamInfos(applHost: ZWaveApplicationHost): Record<number, ConfigurationMetadata>;
+    getQueriedParamInfos(applHost: ZWaveApplicationHost_2): Record<number, ConfigurationMetadata>;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
-    protected isParamInformationFromConfig(applHost: ZWaveApplicationHost): boolean;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
+    protected isParamInformationFromConfig(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    translateProperty(applHost: ZWaveApplicationHost, property: string | number, propertyKey?: string | number): string;
+    translateProperty(applHost: ZWaveApplicationHost_2, property: string | number, propertyKey?: string | number): string;
     // (undocumented)
-    translatePropertyKey(applHost: ZWaveApplicationHost, property: string | number, propertyKey?: string | number): string | undefined;
+    translatePropertyKey(applHost: ZWaveApplicationHost_2, property: string | number, propertyKey?: string | number): string | undefined;
 }
 
 // Warning: (ae-missing-release-tag) "ConfigurationCCBulkGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -3964,7 +3976,7 @@ export class ConfigurationCCBulkGet extends ConfigurationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ConfigurationCCBulkReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -3981,11 +3993,11 @@ export class ConfigurationCCBulkReport extends ConfigurationCC {
     // (undocumented)
     get isHandshakeResponse(): boolean;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     get reportsToFollow(): number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     get values(): ReadonlyMap<number, ConfigValue>;
     // (undocumented)
@@ -4007,7 +4019,7 @@ export class ConfigurationCCBulkSet extends ConfigurationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     get valueFormat(): ConfigValueFormat;
     // (undocumented)
@@ -4035,7 +4047,7 @@ export class ConfigurationCCGet extends ConfigurationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ConfigurationCCInfoGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -4048,7 +4060,7 @@ export class ConfigurationCCInfoGet extends ConfigurationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ConfigurationCCInfoReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -4063,15 +4075,15 @@ export class ConfigurationCCInfoReport extends ConfigurationCC {
     // (undocumented)
     get info(): string;
     // (undocumented)
-    mergePartialCCs(applHost: ZWaveApplicationHost, partials: ConfigurationCCInfoReport[]): void;
+    mergePartialCCs(applHost: ZWaveApplicationHost_2, partials: ConfigurationCCInfoReport[]): void;
     // (undocumented)
     get parameter(): number;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     get reportsToFollow(): number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ConfigurationCCNameGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -4084,7 +4096,7 @@ export class ConfigurationCCNameGet extends ConfigurationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ConfigurationCCNameReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -4097,17 +4109,17 @@ export class ConfigurationCCNameReport extends ConfigurationCC {
     // (undocumented)
     getPartialCCSessionId(): Record<string, any> | undefined;
     // (undocumented)
-    mergePartialCCs(applHost: ZWaveApplicationHost, partials: ConfigurationCCNameReport[]): void;
+    mergePartialCCs(applHost: ZWaveApplicationHost_2, partials: ConfigurationCCNameReport[]): void;
     // (undocumented)
     get name(): string;
     // (undocumented)
     get parameter(): number;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     get reportsToFollow(): number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ConfigurationCCPropertiesGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -4120,7 +4132,7 @@ export class ConfigurationCCPropertiesGet extends ConfigurationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ConfigurationCCPropertiesReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -4147,9 +4159,9 @@ export class ConfigurationCCPropertiesReport extends ConfigurationCC {
     // (undocumented)
     get parameter(): number;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     get valueFormat(): ConfigValueFormat;
     // (undocumented)
@@ -4164,9 +4176,9 @@ export class ConfigurationCCReport extends ConfigurationCC {
     // (undocumented)
     get parameter(): number;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     get value(): ConfigValue;
     // (undocumented)
@@ -4186,7 +4198,7 @@ export class ConfigurationCCSet extends ConfigurationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     value: ConfigValue | undefined;
     // (undocumented)
@@ -4206,23 +4218,23 @@ export const ConfigurationCCValues: Readonly<{
             readonly property: number;
             readonly propertyKey: number | undefined;
         };
-        readonly id: {
-            commandClass: CommandClasses.Configuration;
-            property: number;
-            propertyKey: number | undefined;
-        };
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
             readonly writeable: true;
         };
+        readonly id: {
+            commandClass: CommandClasses.Configuration;
+            property: number;
+            propertyKey: number | undefined;
+        };
     }) & {
         is: (valueId: ValueID_2) => boolean;
         readonly options: {
             readonly internal: false;
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly supportsEndpoints: false;
         };
@@ -4244,9 +4256,9 @@ export const ConfigurationCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly internal: true;
             readonly supportsEndpoints: false;
@@ -4289,7 +4301,7 @@ export enum ConfigurationCommand {
 // Warning: (ae-missing-release-tag) "configureLifelineAssociations" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-function configureLifelineAssociations(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): Promise<void>;
+function configureLifelineAssociations(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): Promise<void>;
 
 export { ConfigValue }
 
@@ -4316,7 +4328,7 @@ export class CRC16CCCommandEncapsulation extends CRC16CC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "CRC16Command" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -4331,6 +4343,18 @@ export enum CRC16Command {
 //
 // @public (undocumented)
 export function dataRate2ZWaveDataRate(dataRate: DataRate_2): ZWaveDataRate_2;
+
+// Warning: (ae-missing-release-tag) "defaultCCValueOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const defaultCCValueOptions: {
+    readonly internal: false;
+    readonly minVersion: 1;
+    readonly secret: false;
+    readonly stateful: true;
+    readonly supportsEndpoints: true;
+    readonly autoCreate: true;
+};
 
 // Warning: (ae-missing-release-tag) "DeviceIdType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -4380,9 +4404,9 @@ export class DoorLockCC extends CommandClass {
     // (undocumented)
     ccCommand: DoorLockCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "DoorLockCCCapabilitiesGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -4417,7 +4441,7 @@ export class DoorLockCCCapabilitiesReport extends DoorLockCC {
     // (undocumented)
     readonly supportedOutsideHandles: DoorHandleStatus;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     readonly twistAssistSupported: boolean;
 }
@@ -4448,7 +4472,7 @@ export class DoorLockCCConfigurationReport extends DoorLockCC {
     // (undocumented)
     readonly outsideHandlesCanOpenDoorConfiguration: DoorHandleStatus;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     readonly twistAssist?: boolean;
 }
@@ -4476,7 +4500,7 @@ export class DoorLockCCConfigurationSet extends DoorLockCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     twistAssist?: boolean;
 }
@@ -4509,11 +4533,11 @@ export class DoorLockCCOperationReport extends DoorLockCC {
     // (undocumented)
     readonly outsideHandlesCanOpenDoor: DoorHandleStatus;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     readonly targetMode?: DoorLockMode;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "DoorLockCCOperationSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -4527,7 +4551,7 @@ export class DoorLockCCOperationSet extends DoorLockCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "DoorLockCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -4577,9 +4601,9 @@ export const DoorLockCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -4628,9 +4652,9 @@ export const DoorLockCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -4679,9 +4703,9 @@ export const DoorLockCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -5255,9 +5279,9 @@ export class DoorLockLoggingCC extends CommandClass {
     // (undocumented)
     ccCommand: DoorLockLoggingCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "DoorLockLoggingCCRecordGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -5271,7 +5295,7 @@ export class DoorLockLoggingCCRecordGet extends DoorLockLoggingCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "DoorLockLoggingCCRecordReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -5284,7 +5308,7 @@ export class DoorLockLoggingCCRecordReport extends DoorLockLoggingCC {
     // (undocumented)
     readonly recordNumber: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "DoorLockLoggingCCRecordsSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -5301,7 +5325,7 @@ export class DoorLockLoggingCCRecordsSupportedReport extends DoorLockLoggingCC {
     // (undocumented)
     readonly recordsCount: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "DoorLockLoggingCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -5325,9 +5349,9 @@ export const DoorLockLoggingCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -5512,9 +5536,9 @@ export type EncapsulatingCommandClass = CommandClass & {
 // @public
 export interface EncapsulatingCommandClassStatic {
     // (undocumented)
-    new (applHost: ZWaveApplicationHost_2, options: CommandClassOptions): EncapsulatingCommandClass;
+    new (applHost: ZWaveApplicationHost, options: CommandClassOptions): EncapsulatingCommandClass;
     // (undocumented)
-    encapsulate(applHost: ZWaveApplicationHost_2, cc: CommandClass): EncapsulatingCommandClass;
+    encapsulate(applHost: ZWaveApplicationHost, cc: CommandClass): EncapsulatingCommandClass;
 }
 
 // Warning: (ae-missing-release-tag) "EndpointAddress" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -5534,9 +5558,9 @@ export class EntryControlCC extends CommandClass {
     // (undocumented)
     ccCommand: EntryControlCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "EntryControlCCConfigurationGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -5555,7 +5579,7 @@ export class EntryControlCCConfigurationReport extends EntryControlCC {
     // (undocumented)
     readonly keyCacheTimeout: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "EntryControlCCConfigurationSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -5571,7 +5595,7 @@ export class EntryControlCCConfigurationSet extends EntryControlCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "EntryControlCCEventSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -5594,13 +5618,13 @@ export class EntryControlCCEventSupportedReport extends EntryControlCC {
     // (undocumented)
     readonly minKeyCacheTimeout: number;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     readonly supportedDataTypes: readonly EntryControlDataTypes[];
     // (undocumented)
     readonly supportedEventTypes: readonly EntryControlEventTypes[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "EntryControlCCKeySupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -5617,7 +5641,7 @@ export class EntryControlCCKeySupportedReport extends EntryControlCC {
     // (undocumented)
     readonly supportedKeys: readonly number[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "EntryControlCCNotification" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -5634,7 +5658,7 @@ export class EntryControlCCNotification extends EntryControlCC {
     // (undocumented)
     readonly sequenceNumber: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "EntryControlCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -5658,9 +5682,9 @@ export const EntryControlCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -5683,9 +5707,9 @@ export const EntryControlCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -5708,9 +5732,9 @@ export const EntryControlCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -5898,9 +5922,9 @@ export class FibaroCC extends ManufacturerProprietaryCC {
     // (undocumented)
     fibaroCCId?: number;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
     serialize(): Buffer;
 }
@@ -5931,9 +5955,9 @@ export class FibaroVenetianBlindCC extends FibaroCC {
     // (undocumented)
     fibaroCCId: FibaroCCIDs.VenetianBlind;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "FibaroVenetianBlindCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -5949,13 +5973,13 @@ export class FibaroVenetianBlindCCGet extends FibaroVenetianBlindCC {
 export class FibaroVenetianBlindCCReport extends FibaroVenetianBlindCC {
     constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     get position(): Maybe<number> | undefined;
     // (undocumented)
     get tilt(): Maybe<number> | undefined;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "FibaroVenetianBlindCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -5971,7 +5995,7 @@ export class FibaroVenetianBlindCCSet extends FibaroVenetianBlindCC {
     // (undocumented)
     tilt: number | undefined;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "FirmwareDownloadStatus" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -6070,7 +6094,7 @@ export class FirmwareUpdateMetaDataCC extends CommandClass {
     // (undocumented)
     ccCommand: FirmwareUpdateMetaDataCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
     skipEndpointInterview(): boolean;
 }
@@ -6093,7 +6117,7 @@ export class FirmwareUpdateMetaDataCCActivationReport extends FirmwareUpdateMeta
     // (undocumented)
     readonly manufacturerId: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCActivationSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -6115,7 +6139,7 @@ export class FirmwareUpdateMetaDataCCActivationSet extends FirmwareUpdateMetaDat
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -6128,7 +6152,7 @@ export class FirmwareUpdateMetaDataCCGet extends FirmwareUpdateMetaDataCC {
     // (undocumented)
     readonly reportNumber: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCMetaDataGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -6161,7 +6185,7 @@ export class FirmwareUpdateMetaDataCCMetaDataReport extends FirmwareUpdateMetaDa
     // (undocumented)
     readonly supportsActivation: Maybe<boolean>;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCPrepareGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -6183,7 +6207,7 @@ export class FirmwareUpdateMetaDataCCPrepareGet extends FirmwareUpdateMetaDataCC
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCPrepareReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -6196,7 +6220,7 @@ export class FirmwareUpdateMetaDataCCPrepareReport extends FirmwareUpdateMetaDat
     // (undocumented)
     readonly status: FirmwareDownloadStatus;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -6214,7 +6238,7 @@ export class FirmwareUpdateMetaDataCCReport extends FirmwareUpdateMetaDataCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCRequestGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -6240,7 +6264,7 @@ export class FirmwareUpdateMetaDataCCRequestGet extends FirmwareUpdateMetaDataCC
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCRequestReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -6251,7 +6275,7 @@ export class FirmwareUpdateMetaDataCCRequestReport extends FirmwareUpdateMetaDat
     // (undocumented)
     readonly status: FirmwareUpdateRequestStatus;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCStatusReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -6262,7 +6286,7 @@ export class FirmwareUpdateMetaDataCCStatusReport extends FirmwareUpdateMetaData
     // (undocumented)
     readonly status: FirmwareUpdateStatus;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     readonly waitTime?: number;
 }
 
@@ -6287,9 +6311,9 @@ export const FirmwareUpdateMetaDataCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -6312,9 +6336,9 @@ export const FirmwareUpdateMetaDataCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -6337,9 +6361,9 @@ export const FirmwareUpdateMetaDataCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -6362,9 +6386,9 @@ export const FirmwareUpdateMetaDataCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -6482,12 +6506,12 @@ export function FLiRS2WakeUpTime(value: FLiRS_2): WakeUpTime;
 // Warning: (ae-missing-release-tag) "getAllAssociationGroups" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-function getAllAssociationGroups(applHost: ZWaveApplicationHost, node: IZWaveNode): ReadonlyMap<number, ReadonlyMap<number, AssociationGroup>>;
+function getAllAssociationGroups(applHost: ZWaveApplicationHost_2, node: IZWaveNode): ReadonlyMap<number, ReadonlyMap<number, AssociationGroup>>;
 
 // Warning: (ae-missing-release-tag) "getAllAssociations" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-function getAllAssociations(applHost: ZWaveApplicationHost, node: IZWaveNode): ReadonlyObjectKeyMap<AssociationAddress, ReadonlyMap<number, readonly AssociationAddress[]>>;
+function getAllAssociations(applHost: ZWaveApplicationHost_2, node: IZWaveNode): ReadonlyObjectKeyMap<AssociationAddress, ReadonlyMap<number, readonly AssociationAddress[]>>;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
 // Warning: (ae-missing-release-tag) "getAPI" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -6498,12 +6522,12 @@ export function getAPI(cc: CommandClasses_2): APIConstructor | undefined;
 // Warning: (ae-missing-release-tag) "getAssociationGroups" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-function getAssociationGroups(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): ReadonlyMap<number, AssociationGroup>;
+function getAssociationGroups(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): ReadonlyMap<number, AssociationGroup>;
 
 // Warning: (ae-missing-release-tag) "getAssociations" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-function getAssociations(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): ReadonlyMap<number, readonly AssociationAddress[]>;
+function getAssociations(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): ReadonlyMap<number, readonly AssociationAddress[]>;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
 // Warning: (ae-missing-release-tag) "getCCCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -6674,9 +6698,9 @@ export class HumidityControlModeCC extends CommandClass {
     // (undocumented)
     ccCommand: HumidityControlModeCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "HumidityControlModeCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -6693,7 +6717,7 @@ export class HumidityControlModeCCReport extends HumidityControlModeCC {
     // (undocumented)
     readonly mode: HumidityControlMode;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "HumidityControlModeCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -6707,7 +6731,7 @@ export class HumidityControlModeCCSet extends HumidityControlModeCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "HumidityControlModeCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -6722,11 +6746,11 @@ export class HumidityControlModeCCSupportedGet extends HumidityControlModeCC {
 export class HumidityControlModeCCSupportedReport extends HumidityControlModeCC {
     constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     get supportedModes(): readonly HumidityControlMode[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "HumidityControlModeCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -6750,9 +6774,9 @@ export const HumidityControlModeCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -6826,9 +6850,9 @@ export class HumidityControlOperatingStateCC extends CommandClass {
     // (undocumented)
     ccCommand: HumidityControlOperatingStateCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "HumidityControlOperatingStateCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -6845,7 +6869,7 @@ export class HumidityControlOperatingStateCCReport extends HumidityControlOperat
     // (undocumented)
     readonly state: HumidityControlOperatingState;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "HumidityControlOperatingStateCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -6916,11 +6940,11 @@ export class HumidityControlSetpointCC extends CommandClass {
     // (undocumented)
     ccCommand: HumidityControlSetpointCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    translatePropertyKey(applHost: ZWaveApplicationHost, property: string | number, propertyKey: string | number): string | undefined;
+    translatePropertyKey(applHost: ZWaveApplicationHost_2, property: string | number, propertyKey: string | number): string | undefined;
 }
 
 // Warning: (ae-missing-release-tag) "HumidityControlSetpointCCCapabilitiesGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -6934,7 +6958,7 @@ export class HumidityControlSetpointCCCapabilitiesGet extends HumidityControlSet
     // (undocumented)
     setpointType: HumidityControlSetpointType;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "HumidityControlSetpointCCCapabilitiesReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -6951,9 +6975,9 @@ export class HumidityControlSetpointCCCapabilitiesReport extends HumidityControl
     // (undocumented)
     get minValueScale(): number;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     get type(): HumidityControlSetpointType;
 }
@@ -6969,7 +6993,7 @@ export class HumidityControlSetpointCCGet extends HumidityControlSetpointCC {
     // (undocumented)
     setpointType: HumidityControlSetpointType;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "HumidityControlSetpointCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -6978,11 +7002,11 @@ export class HumidityControlSetpointCCGet extends HumidityControlSetpointCC {
 export class HumidityControlSetpointCCReport extends HumidityControlSetpointCC {
     constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     readonly scale: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     get type(): HumidityControlSetpointType;
     // (undocumented)
@@ -7000,7 +7024,7 @@ export class HumidityControlSetpointCCScaleSupportedGet extends HumidityControlS
     // (undocumented)
     setpointType: HumidityControlSetpointType;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "HumidityControlSetpointCCScaleSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -7011,7 +7035,7 @@ export class HumidityControlSetpointCCScaleSupportedReport extends HumidityContr
     // (undocumented)
     readonly supportedScales: readonly number[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "HumidityControlSetpointCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -7027,7 +7051,7 @@ export class HumidityControlSetpointCCSet extends HumidityControlSetpointCC {
     // (undocumented)
     setpointType: HumidityControlSetpointType;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     value: number;
 }
@@ -7046,7 +7070,7 @@ export class HumidityControlSetpointCCSupportedReport extends HumidityControlSet
     // (undocumented)
     readonly supportedSetpointTypes: readonly HumidityControlSetpointType[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "HumidityControlSetpointCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -7060,11 +7084,6 @@ export const HumidityControlSetpointCCValues: Readonly<{
             readonly property: "setpointScale";
             readonly propertyKey: number;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Humidity Control Setpoint"];
-            property: "setpointScale";
-            propertyKey: number;
-        };
         readonly meta: {
             readonly label: `Setpoint scale (${string})`;
             readonly writeable: false;
@@ -7072,6 +7091,11 @@ export const HumidityControlSetpointCCValues: Readonly<{
             readonly max: 255;
             readonly type: "number";
             readonly readable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Humidity Control Setpoint"];
+            property: "setpointScale";
+            propertyKey: number;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -7091,11 +7115,6 @@ export const HumidityControlSetpointCCValues: Readonly<{
             readonly property: "setpoint";
             readonly propertyKey: number;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Humidity Control Setpoint"];
-            property: "setpoint";
-            propertyKey: number;
-        };
         readonly meta: {
             readonly label: `Setpoint (${string})`;
             readonly ccSpecific: {
@@ -7104,6 +7123,11 @@ export const HumidityControlSetpointCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Humidity Control Setpoint"];
+            property: "setpoint";
+            propertyKey: number;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -7133,9 +7157,9 @@ export const HumidityControlSetpointCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -7235,7 +7259,7 @@ export class InclusionControllerCCComplete extends InclusionControllerCC {
     // (undocumented)
     step: InclusionControllerStep;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "InclusionControllerCCInitiate" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -7251,7 +7275,7 @@ export class InclusionControllerCCInitiate extends InclusionControllerCC {
     // (undocumented)
     step: InclusionControllerStep;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "InclusionControllerCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -7311,15 +7335,15 @@ export class IndicatorCC extends CommandClass {
     // (undocumented)
     ccCommand: IndicatorCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    protected supportsV2Indicators(applHost: ZWaveApplicationHost): boolean;
+    protected supportsV2Indicators(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
-    translateProperty(applHost: ZWaveApplicationHost, property: string | number, propertyKey?: string | number): string;
+    translateProperty(applHost: ZWaveApplicationHost_2, property: string | number, propertyKey?: string | number): string;
     // (undocumented)
-    translatePropertyKey(applHost: ZWaveApplicationHost, property: string | number, propertyKey: string | number): string | undefined;
+    translatePropertyKey(applHost: ZWaveApplicationHost_2, property: string | number, propertyKey: string | number): string | undefined;
 }
 
 // Warning: (ae-missing-release-tag) "IndicatorCCDescriptionGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -7333,7 +7357,7 @@ export class IndicatorCCDescriptionGet extends IndicatorCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "IndicatorCCDescriptionReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -7346,9 +7370,9 @@ export class IndicatorCCDescriptionReport extends IndicatorCC {
     // (undocumented)
     indicatorId: number;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "IndicatorCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -7362,7 +7386,7 @@ export class IndicatorCCGet extends IndicatorCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "IndicatorCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -7371,9 +7395,9 @@ export class IndicatorCCGet extends IndicatorCC {
 export class IndicatorCCReport extends IndicatorCC {
     constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     readonly value: number | undefined;
     // Warning: (ae-forgotten-export) The symbol "IndicatorObject" needs to be exported by the entry point index.d.ts
@@ -7393,7 +7417,7 @@ export class IndicatorCCSet extends IndicatorCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     values: IndicatorObject[] | undefined;
 }
@@ -7409,7 +7433,7 @@ export class IndicatorCCSupportedGet extends IndicatorCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "IndicatorCCSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -7422,11 +7446,11 @@ export class IndicatorCCSupportedReport extends IndicatorCC {
     // (undocumented)
     readonly nextIndicatorId: number;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     readonly supportedProperties: readonly number[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "IndicatorCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -7439,14 +7463,14 @@ export const IndicatorCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: number;
         };
-        readonly id: {
-            commandClass: CommandClasses.Indicator;
-            property: number;
-        };
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Indicator;
+            property: number;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -7466,11 +7490,6 @@ export const IndicatorCCValues: Readonly<{
             readonly property: number;
             readonly propertyKey: number;
         };
-        readonly id: {
-            commandClass: CommandClasses.Indicator;
-            property: number;
-            propertyKey: number;
-        };
         readonly meta: {
             readonly ccSpecific: {
                 indicatorId: number;
@@ -7479,6 +7498,11 @@ export const IndicatorCCValues: Readonly<{
             readonly type: "any";
             readonly readable: true;
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Indicator;
+            property: number;
+            propertyKey: number;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -7498,22 +7522,22 @@ export const IndicatorCCValues: Readonly<{
             readonly property: "supportedPropertyIDs";
             readonly propertyKey: number;
         };
-        readonly id: {
-            commandClass: CommandClasses.Indicator;
-            property: "supportedPropertyIDs";
-            propertyKey: number;
-        };
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
             readonly writeable: true;
         };
+        readonly id: {
+            commandClass: CommandClasses.Indicator;
+            property: "supportedPropertyIDs";
+            propertyKey: number;
+        };
     }) & {
         is: (valueId: ValueID_2) => boolean;
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -7593,9 +7617,9 @@ export const IndicatorCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -7662,15 +7686,15 @@ export interface InvalidCCCreationOptions extends CommandClassCreationOptions {
 export class IrrigationCC extends CommandClass {
     // (undocumented)
     ccCommand: IrrigationCommand;
-    static getMaxValveTableSizeCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): number | undefined;
-    static getNumValvesCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): number | undefined;
+    static getMaxValveTableSizeCached(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): number | undefined;
+    static getNumValvesCached(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): number | undefined;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
-    static supportsMasterValveCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): boolean;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
+    static supportsMasterValveCached(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): boolean;
     // (undocumented)
-    translateProperty(applHost: ZWaveApplicationHost, property: string | number, propertyKey?: string | number): string;
+    translateProperty(applHost: ZWaveApplicationHost_2, property: string | number, propertyKey?: string | number): string;
 }
 
 // Warning: (ae-missing-release-tag) "IrrigationCCSystemConfigGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -7695,7 +7719,7 @@ export class IrrigationCCSystemConfigReport extends IrrigationCC {
     // (undocumented)
     readonly rainSensorPolarity?: IrrigationSensorPolarity;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "IrrigationCCSystemConfigSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -7716,7 +7740,7 @@ export class IrrigationCCSystemConfigSet extends IrrigationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "IrrigationCCSystemConfigSetOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -7750,7 +7774,7 @@ export class IrrigationCCSystemInfoReport extends IrrigationCC {
     // (undocumented)
     readonly supportsMasterValve: boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "IrrigationCCSystemShutoff" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -7764,7 +7788,7 @@ export class IrrigationCCSystemShutoff extends IrrigationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "IrrigationCCSystemStatusGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -7809,7 +7833,7 @@ export class IrrigationCCSystemStatusReport extends IrrigationCC {
     // (undocumented)
     systemVoltage: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "IrrigationCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -7823,16 +7847,16 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "startStop";
         };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "startStop";
-        };
         readonly meta: {
             readonly label: `${string}: Start/Stop`;
             readonly type: "boolean";
             readonly readable: true;
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "startStop";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -7852,11 +7876,6 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "duration";
         };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "duration";
-        };
         readonly meta: {
             readonly label: `${string}: Run duration`;
             readonly min: 1;
@@ -7865,6 +7884,11 @@ export const IrrigationCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "duration";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -7884,16 +7908,16 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "useMoistureSensor";
         };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "useMoistureSensor";
-        };
         readonly meta: {
             readonly label: `${string}: Use moisture sensor`;
             readonly type: "boolean";
             readonly readable: true;
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "useMoistureSensor";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -7913,16 +7937,16 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "useRainSensor";
         };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "useRainSensor";
-        };
         readonly meta: {
             readonly label: `${string}: Use rain sensor`;
             readonly type: "boolean";
             readonly readable: true;
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "useRainSensor";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -7942,16 +7966,16 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "errorLowFlow";
         };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "errorLowFlow";
-        };
         readonly meta: {
             readonly label: `${string}: Error - Flow below high threshold`;
             readonly writeable: false;
             readonly type: "boolean";
             readonly readable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "errorLowFlow";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -7971,11 +7995,6 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "lowFlowThreshold";
         };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "lowFlowThreshold";
-        };
         readonly meta: {
             readonly label: `${string}: Low flow threshold`;
             readonly min: 0;
@@ -7983,6 +8002,11 @@ export const IrrigationCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "lowFlowThreshold";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -8002,16 +8026,16 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "errorHighFlow";
         };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "errorHighFlow";
-        };
         readonly meta: {
             readonly label: `${string}: Error - Flow above high threshold`;
             readonly writeable: false;
             readonly type: "boolean";
             readonly readable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "errorHighFlow";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -8031,11 +8055,6 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "highFlowThreshold";
         };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "highFlowThreshold";
-        };
         readonly meta: {
             readonly label: `${string}: High flow threshold`;
             readonly min: 0;
@@ -8043,6 +8062,11 @@ export const IrrigationCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "highFlowThreshold";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -8062,16 +8086,16 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "errorMaximumFlow";
         };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "errorMaximumFlow";
-        };
         readonly meta: {
             readonly label: `${string}: Error - Maximum flow detected`;
             readonly writeable: false;
             readonly type: "boolean";
             readonly readable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "errorMaximumFlow";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -8091,11 +8115,6 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "maximumFlow";
         };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "maximumFlow";
-        };
         readonly meta: {
             readonly label: `${string}: Maximum flow`;
             readonly min: 0;
@@ -8103,6 +8122,11 @@ export const IrrigationCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "maximumFlow";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -8122,16 +8146,16 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "errorLowCurrent";
         };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "errorLowCurrent";
-        };
         readonly meta: {
             readonly label: `${string}: Error - Current below low threshold`;
             readonly writeable: false;
             readonly type: "boolean";
             readonly readable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "errorLowCurrent";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -8151,16 +8175,16 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "errorHighCurrent";
         };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "errorHighCurrent";
-        };
         readonly meta: {
             readonly label: `${string}: Error - Current above high threshold`;
             readonly writeable: false;
             readonly type: "boolean";
             readonly readable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "errorHighCurrent";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -8180,16 +8204,16 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "errorShortCircuit";
         };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "errorShortCircuit";
-        };
         readonly meta: {
             readonly label: `${string}: Error - Short circuit detected`;
             readonly writeable: false;
             readonly type: "boolean";
             readonly readable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "errorShortCircuit";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -8209,11 +8233,6 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "nominalCurrentLowThreshold";
         };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "nominalCurrentLowThreshold";
-        };
         readonly meta: {
             readonly label: `${string}: Nominal current - low threshold`;
             readonly min: 0;
@@ -8222,6 +8241,11 @@ export const IrrigationCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "nominalCurrentLowThreshold";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -8241,11 +8265,6 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "nominalCurrentHighThreshold";
         };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "nominalCurrentHighThreshold";
-        };
         readonly meta: {
             readonly label: `${string}: Nominal current - high threshold`;
             readonly min: 0;
@@ -8254,6 +8273,11 @@ export const IrrigationCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "nominalCurrentHighThreshold";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -8273,17 +8297,17 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "nominalCurrent";
         };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "nominalCurrent";
-        };
         readonly meta: {
             readonly label: `${string}: Nominal current`;
             readonly unit: "mA";
             readonly writeable: false;
             readonly type: "boolean";
             readonly readable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "nominalCurrent";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -8303,16 +8327,16 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "valveConnected";
         };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "valveConnected";
-        };
         readonly meta: {
             readonly label: `${string}: Connected`;
             readonly writeable: false;
             readonly type: "boolean";
             readonly readable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "valveConnected";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -8912,9 +8936,9 @@ export const IrrigationCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -8937,9 +8961,9 @@ export const IrrigationCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -8962,9 +8986,9 @@ export const IrrigationCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -8987,9 +9011,9 @@ export const IrrigationCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -9006,7 +9030,7 @@ export class IrrigationCCValveConfigGet extends IrrigationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     valveId: ValveId;
 }
@@ -9027,9 +9051,9 @@ export class IrrigationCCValveConfigReport extends IrrigationCC {
     // (undocumented)
     nominalCurrentLowThreshold: number;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     useMoistureSensor: boolean;
     // (undocumented)
@@ -9056,7 +9080,7 @@ export class IrrigationCCValveConfigSet extends IrrigationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     useMoistureSensor: boolean;
     // (undocumented)
@@ -9088,7 +9112,7 @@ export class IrrigationCCValveInfoGet extends IrrigationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     valveId: ValveId;
 }
@@ -9115,9 +9139,9 @@ export class IrrigationCCValveInfoReport extends IrrigationCC {
     // (undocumented)
     readonly nominalCurrent: number;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     readonly valveId: ValveId;
 }
@@ -9133,7 +9157,7 @@ export class IrrigationCCValveRun extends IrrigationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     valveId: ValveId;
 }
@@ -9149,7 +9173,7 @@ export class IrrigationCCValveTableGet extends IrrigationCC {
     // (undocumented)
     tableId: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "IrrigationCCValveTableReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -9162,7 +9186,7 @@ export class IrrigationCCValveTableReport extends IrrigationCC {
     // (undocumented)
     readonly tableId: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "IrrigationCCValveTableRun" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -9176,7 +9200,7 @@ export class IrrigationCCValveTableRun extends IrrigationCC {
     // (undocumented)
     tableIDs: number[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "IrrigationCCValveTableSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -9192,7 +9216,7 @@ export class IrrigationCCValveTableSet extends IrrigationCC {
     // (undocumented)
     tableId: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "IrrigationCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -9250,7 +9274,7 @@ export enum IrrigationSensorPolarity {
 // Warning: (ae-missing-release-tag) "isAssociationAllowed" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-function isAssociationAllowed(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, group: number, destination: AssociationAddress): boolean;
+function isAssociationAllowed(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2, group: number, destination: AssociationAddress): boolean;
 
 // Warning: (ae-missing-release-tag) "isCommandClassContainer" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -9330,9 +9354,9 @@ export class LanguageCC extends CommandClass {
     // (undocumented)
     ccCommand: LanguageCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "LanguageCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -9351,7 +9375,7 @@ export class LanguageCCReport extends LanguageCC {
     // (undocumented)
     readonly language: string;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "LanguageCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -9369,7 +9393,7 @@ export class LanguageCCSet extends LanguageCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "LanguageCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -9471,9 +9495,9 @@ export class LockCC extends CommandClass {
     // (undocumented)
     ccCommand: LockCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "LockCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -9490,7 +9514,7 @@ export class LockCCReport extends LockCC {
     // (undocumented)
     readonly locked: boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "LockCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -9504,7 +9528,7 @@ export class LockCCSet extends LockCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "LockCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -9575,11 +9599,11 @@ export class ManufacturerProprietaryCC extends CommandClass {
     // (undocumented)
     createSpecificInstance(): ManufacturerProprietaryCC | undefined;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
     manufacturerId?: number;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
     serialize(): Buffer;
 }
@@ -9593,7 +9617,7 @@ export class ManufacturerSpecificCC extends CommandClass {
     // (undocumented)
     determineRequiredCCInterviews(): readonly CommandClasses[];
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "ManufacturerSpecificCCDeviceSpecificGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -9607,7 +9631,7 @@ export class ManufacturerSpecificCCDeviceSpecificGet extends ManufacturerSpecifi
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ManufacturerSpecificCCDeviceSpecificReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -9618,7 +9642,7 @@ export class ManufacturerSpecificCCDeviceSpecificReport extends ManufacturerSpec
     // (undocumented)
     readonly deviceId: string;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     readonly type: DeviceIdType;
 }
@@ -9641,7 +9665,7 @@ export class ManufacturerSpecificCCReport extends ManufacturerSpecificCC {
     // (undocumented)
     readonly productType: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ManufacturerSpecificCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -9655,16 +9679,16 @@ export const ManufacturerSpecificCCValues: Readonly<{
             readonly property: "deviceId";
             readonly propertyKey: string;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Manufacturer Specific"];
-            property: "deviceId";
-            propertyKey: string;
-        };
         readonly meta: {
             readonly label: string;
             readonly writeable: false;
             readonly type: "string";
             readonly readable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Manufacturer Specific"];
+            property: "deviceId";
+            propertyKey: string;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -9698,9 +9722,9 @@ export const ManufacturerSpecificCCValues: Readonly<{
         };
         readonly options: {
             readonly internal: false;
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly supportsEndpoints: false;
         };
@@ -9726,9 +9750,9 @@ export const ManufacturerSpecificCCValues: Readonly<{
         };
         readonly options: {
             readonly internal: false;
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly supportsEndpoints: false;
         };
@@ -9754,9 +9778,9 @@ export const ManufacturerSpecificCCValues: Readonly<{
         };
         readonly options: {
             readonly internal: false;
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly supportsEndpoints: false;
         };
@@ -9792,11 +9816,11 @@ export class MeterCC extends CommandClass {
     // (undocumented)
     ccCommand: MeterCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    translatePropertyKey(applHost: ZWaveApplicationHost, property: string | number, propertyKey: string | number): string | undefined;
+    translatePropertyKey(applHost: ZWaveApplicationHost_2, property: string | number, propertyKey: string | number): string | undefined;
 }
 
 // Warning: (ae-missing-release-tag) "MeterCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -9812,7 +9836,7 @@ export class MeterCCGet extends MeterCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MeterCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -9823,7 +9847,7 @@ export class MeterCCReport extends MeterCC {
     // (undocumented)
     get deltaTime(): Maybe<number>;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     get previousValue(): number | undefined;
     // (undocumented)
@@ -9831,7 +9855,7 @@ export class MeterCCReport extends MeterCC {
     // (undocumented)
     readonly scale: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     get type(): number;
     // (undocumented)
@@ -9849,7 +9873,7 @@ export class MeterCCReset extends MeterCC {
     // (undocumented)
     targetValue: number | undefined;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     type: number | undefined;
 }
@@ -9866,7 +9890,7 @@ export class MeterCCSupportedGet extends MeterCC {
 export class MeterCCSupportedReport extends MeterCC {
     constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     readonly supportedRateTypes: readonly RateType[];
     // (undocumented)
@@ -9874,7 +9898,7 @@ export class MeterCCSupportedReport extends MeterCC {
     // (undocumented)
     readonly supportsReset: boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     readonly type: number;
 }
@@ -9890,11 +9914,6 @@ export const MeterCCValues: Readonly<{
             readonly property: "value";
             readonly propertyKey: number;
         };
-        readonly id: {
-            commandClass: CommandClasses.Meter;
-            property: "value";
-            propertyKey: number;
-        };
         readonly meta: {
             readonly ccSpecific: {
                 readonly meterType: number;
@@ -9904,6 +9923,11 @@ export const MeterCCValues: Readonly<{
             readonly writeable: false;
             readonly type: "number";
             readonly readable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Meter;
+            property: "value";
+            propertyKey: number;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -9923,11 +9947,6 @@ export const MeterCCValues: Readonly<{
             readonly property: "reset";
             readonly propertyKey: number;
         };
-        readonly id: {
-            commandClass: CommandClasses.Meter;
-            property: "reset";
-            propertyKey: number;
-        };
         readonly meta: {
             readonly label: `Reset (${string})`;
             readonly ccSpecific: {
@@ -9936,6 +9955,11 @@ export const MeterCCValues: Readonly<{
             readonly readable: false;
             readonly type: "boolean";
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Meter;
+            property: "reset";
+            propertyKey: number;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -9991,9 +10015,9 @@ export const MeterCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -10016,9 +10040,9 @@ export const MeterCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -10041,9 +10065,9 @@ export const MeterCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -10066,9 +10090,9 @@ export const MeterCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -10151,13 +10175,13 @@ export class MultiChannelAssociationCC extends CommandClass {
     ccCommand: MultiChannelAssociationCommand;
     // (undocumented)
     determineRequiredCCInterviews(): readonly CommandClasses[];
-    static getAllDestinationsCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): ReadonlyMap<number, readonly AssociationAddress[]>;
-    static getGroupCountCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): number;
-    static getMaxNodesCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, groupId: number): number;
+    static getAllDestinationsCached(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): ReadonlyMap<number, readonly AssociationAddress[]>;
+    static getGroupCountCached(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): number;
+    static getMaxNodesCached(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2, groupId: number): number;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "MultiChannelAssociationCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -10171,7 +10195,7 @@ export class MultiChannelAssociationCCGet extends MultiChannelAssociationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultiChannelAssociationCCRemove" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -10189,7 +10213,7 @@ export class MultiChannelAssociationCCRemove extends MultiChannelAssociationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultiChannelAssociationCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -10208,13 +10232,13 @@ export class MultiChannelAssociationCCReport extends MultiChannelAssociationCC {
     // (undocumented)
     readonly maxNodes: number;
     // (undocumented)
-    mergePartialCCs(applHost: ZWaveApplicationHost, partials: MultiChannelAssociationCCReport[]): void;
+    mergePartialCCs(applHost: ZWaveApplicationHost_2, partials: MultiChannelAssociationCCReport[]): void;
     // (undocumented)
     get nodeIds(): readonly number[];
     // (undocumented)
     readonly reportsToFollow: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultiChannelAssociationCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -10232,7 +10256,7 @@ export class MultiChannelAssociationCCSet extends MultiChannelAssociationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultiChannelAssociationCCSupportedGroupingsGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -10249,7 +10273,7 @@ export class MultiChannelAssociationCCSupportedGroupingsReport extends MultiChan
     // (undocumented)
     readonly groupCount: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultiChannelAssociationCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -10263,22 +10287,22 @@ export const MultiChannelAssociationCCValues: Readonly<{
             readonly property: "endpoints";
             readonly propertyKey: number;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Multi Channel Association"];
-            property: "endpoints";
-            propertyKey: number;
-        };
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
             readonly writeable: true;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Multi Channel Association"];
+            property: "endpoints";
+            propertyKey: number;
+        };
     }) & {
         is: (valueId: ValueID_2) => boolean;
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -10291,22 +10315,22 @@ export const MultiChannelAssociationCCValues: Readonly<{
             readonly property: "nodeIds";
             readonly propertyKey: number;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Multi Channel Association"];
-            property: "nodeIds";
-            propertyKey: number;
-        };
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
             readonly writeable: true;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Multi Channel Association"];
+            property: "nodeIds";
+            propertyKey: number;
+        };
     }) & {
         is: (valueId: ValueID_2) => boolean;
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -10319,22 +10343,22 @@ export const MultiChannelAssociationCCValues: Readonly<{
             readonly property: "maxNodes";
             readonly propertyKey: number;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Multi Channel Association"];
-            property: "maxNodes";
-            propertyKey: number;
-        };
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
             readonly writeable: true;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Multi Channel Association"];
+            property: "maxNodes";
+            propertyKey: number;
+        };
     }) & {
         is: (valueId: ValueID_2) => boolean;
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -10357,9 +10381,9 @@ export const MultiChannelAssociationCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -10393,7 +10417,7 @@ export class MultiChannelCC extends CommandClass {
     ccCommand: MultiChannelCommand;
     static encapsulate(host: ZWaveHost_2, cc: CommandClass): MultiChannelCCCommandEncapsulation | MultiChannelCCV1CommandEncapsulation;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     static requiresEncapsulation(cc: CommandClass): boolean;
     // (undocumented)
     skipEndpointInterview(): boolean;
@@ -10410,7 +10434,7 @@ export class MultiChannelCCAggregatedMembersGet extends MultiChannelCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultiChannelCCAggregatedMembersReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -10423,7 +10447,7 @@ export class MultiChannelCCAggregatedMembersReport extends MultiChannelCC {
     // (undocumented)
     readonly members: readonly number[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultiChannelCCCapabilityGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -10437,7 +10461,7 @@ export class MultiChannelCCCapabilityGet extends MultiChannelCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultiChannelCCCapabilityReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -10453,7 +10477,7 @@ export class MultiChannelCCCapabilityReport extends MultiChannelCC implements Ap
     // (undocumented)
     readonly isDynamic: boolean;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
@@ -10461,7 +10485,7 @@ export class MultiChannelCCCapabilityReport extends MultiChannelCC implements Ap
     // (undocumented)
     readonly supportedCCs: CommandClasses[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     readonly wasRemoved: boolean;
 }
@@ -10481,7 +10505,7 @@ export class MultiChannelCCCommandEncapsulation extends MultiChannelCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultiChannelCCEndPointFind" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -10497,7 +10521,7 @@ export class MultiChannelCCEndPointFind extends MultiChannelCC {
     // (undocumented)
     specificClass: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultiChannelCCEndPointFindReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -10515,7 +10539,7 @@ export class MultiChannelCCEndPointFindReport extends MultiChannelCC {
     // (undocumented)
     getPartialCCSessionId(): Record<string, any> | undefined;
     // (undocumented)
-    mergePartialCCs(applHost: ZWaveApplicationHost, partials: MultiChannelCCEndPointFindReport[]): void;
+    mergePartialCCs(applHost: ZWaveApplicationHost_2, partials: MultiChannelCCEndPointFindReport[]): void;
     // (undocumented)
     reportsToFollow: number;
     // (undocumented)
@@ -10523,7 +10547,7 @@ export class MultiChannelCCEndPointFindReport extends MultiChannelCC {
     // (undocumented)
     specificClass: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultiChannelCCEndPointGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -10549,7 +10573,7 @@ export class MultiChannelCCEndPointReport extends MultiChannelCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultiChannelCCV1CommandEncapsulation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -10565,7 +10589,7 @@ export class MultiChannelCCV1CommandEncapsulation extends MultiChannelCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultiChannelCCV1Get" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -10579,7 +10603,7 @@ export class MultiChannelCCV1Get extends MultiChannelCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultiChannelCCV1Report" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -10592,7 +10616,7 @@ export class MultiChannelCCV1Report extends MultiChannelCC {
     // (undocumented)
     readonly requestedCC: CommandClasses;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultiChannelCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -10606,22 +10630,22 @@ export const MultiChannelCCValues: Readonly<{
             readonly property: "members";
             readonly propertyKey: number;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Multi Channel"];
-            property: "members";
-            propertyKey: number;
-        };
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
             readonly writeable: true;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Multi Channel"];
+            property: "members";
+            propertyKey: number;
+        };
     }) & {
         is: (valueId: ValueID_2) => boolean;
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -10644,9 +10668,9 @@ export const MultiChannelCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -10669,9 +10693,9 @@ export const MultiChannelCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -10694,9 +10718,9 @@ export const MultiChannelCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly internal: true;
             readonly supportsEndpoints: false;
@@ -10719,9 +10743,9 @@ export const MultiChannelCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly internal: true;
             readonly supportsEndpoints: false;
@@ -10744,9 +10768,9 @@ export const MultiChannelCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly internal: true;
             readonly supportsEndpoints: false;
@@ -10769,9 +10793,9 @@ export const MultiChannelCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly internal: true;
             readonly supportsEndpoints: false;
@@ -10794,9 +10818,9 @@ export const MultiChannelCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly internal: true;
             readonly supportsEndpoints: false;
@@ -10856,7 +10880,7 @@ export class MultiCommandCCCommandEncapsulation extends MultiCommandCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultiCommandCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -10882,9 +10906,9 @@ export interface MultiEncapsulatingCommandClass {
 // @public
 export interface MultiEncapsulatingCommandClassStatic {
     // (undocumented)
-    new (applHost: ZWaveApplicationHost_2, options: CommandClassOptions): MultiEncapsulatingCommandClass;
+    new (applHost: ZWaveApplicationHost, options: CommandClassOptions): MultiEncapsulatingCommandClass;
     // (undocumented)
-    encapsulate(applHost: ZWaveApplicationHost_2, CCs: CommandClass[]): MultiEncapsulatingCommandClass;
+    encapsulate(applHost: ZWaveApplicationHost, CCs: CommandClass[]): MultiEncapsulatingCommandClass;
     // (undocumented)
     requiresEncapsulation(cc: CommandClass): boolean;
 }
@@ -10896,11 +10920,11 @@ export class MultilevelSensorCC extends CommandClass {
     // (undocumented)
     ccCommand: MultilevelSensorCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    translatePropertyKey(applHost: ZWaveApplicationHost, property: string | number, propertyKey: string | number): string | undefined;
+    translatePropertyKey(applHost: ZWaveApplicationHost_2, property: string | number, propertyKey: string | number): string | undefined;
 }
 
 // Warning: (ae-missing-release-tag) "MultilevelSensorCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -10916,7 +10940,7 @@ export class MultilevelSensorCCGet extends MultilevelSensorCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultilevelSensorCCGetSupportedScale" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -10930,7 +10954,7 @@ export class MultilevelSensorCCGetSupportedScale extends MultilevelSensorCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultilevelSensorCCGetSupportedSensor" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -10945,13 +10969,13 @@ export class MultilevelSensorCCGetSupportedSensor extends MultilevelSensorCC {
 export class MultilevelSensorCCReport extends MultilevelSensorCC {
     constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions | MultilevelSensorCCReportOptions);
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     scale: number;
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     type: number;
     // (undocumented)
@@ -10980,7 +11004,7 @@ export class MultilevelSensorCCSupportedScaleReport extends MultilevelSensorCC {
     // (undocumented)
     readonly supportedScales: readonly number[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultilevelSensorCCSupportedSensorReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -10991,7 +11015,7 @@ export class MultilevelSensorCCSupportedSensorReport extends MultilevelSensorCC 
     // (undocumented)
     readonly supportedSensorTypes: readonly number[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultilevelSensorCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -11004,15 +11028,15 @@ export const MultilevelSensorCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: string;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Multilevel Sensor"];
-            property: string;
-        };
         readonly meta: {
             readonly label: string;
             readonly writeable: false;
             readonly type: "number";
             readonly readable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Multilevel Sensor"];
+            property: string;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -11032,22 +11056,22 @@ export const MultilevelSensorCCValues: Readonly<{
             readonly property: "supportedScales";
             readonly propertyKey: number;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Multilevel Sensor"];
-            property: "supportedScales";
-            propertyKey: number;
-        };
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
             readonly writeable: true;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Multilevel Sensor"];
+            property: "supportedScales";
+            propertyKey: number;
+        };
     }) & {
         is: (valueId: ValueID_2) => boolean;
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -11070,9 +11094,9 @@ export const MultilevelSensorCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -11125,13 +11149,13 @@ export class MultilevelSwitchCC extends CommandClass {
     // (undocumented)
     ccCommand: MultilevelSwitchCommand;
     // (undocumented)
-    protected createMetadataForLevelChangeActions(applHost: ZWaveApplicationHost, switchType?: SwitchType): void;
+    protected createMetadataForLevelChangeActions(applHost: ZWaveApplicationHost_2, switchType?: SwitchType): void;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    setMappedBasicValue(applHost: ZWaveApplicationHost, value: number): boolean;
+    setMappedBasicValue(applHost: ZWaveApplicationHost_2, value: number): boolean;
 }
 
 // Warning: (ae-missing-release-tag) "MultilevelSwitchCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -11150,11 +11174,11 @@ export class MultilevelSwitchCCReport extends MultilevelSwitchCC {
     // (undocumented)
     readonly duration: Duration | undefined;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     readonly targetValue: number | undefined;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultilevelSwitchCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -11170,7 +11194,7 @@ export class MultilevelSwitchCCSet extends MultilevelSwitchCC {
     // (undocumented)
     targetValue: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultilevelSwitchCCStartLevelChange" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -11190,7 +11214,7 @@ export class MultilevelSwitchCCStartLevelChange extends MultilevelSwitchCC {
     // (undocumented)
     startLevel: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultilevelSwitchCCStopLevelChange" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -11211,11 +11235,11 @@ export class MultilevelSwitchCCSupportedGet extends MultilevelSwitchCC {
 export class MultilevelSwitchCCSupportedReport extends MultilevelSwitchCC {
     constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     readonly switchType: SwitchType;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "MultilevelSwitchCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -11228,10 +11252,6 @@ export const MultilevelSwitchCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: string;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Multilevel Switch"];
-            property: string;
-        };
         readonly meta: {
             readonly label: `Perform a level change (${string})`;
             readonly valueChangeOptions: readonly ["transitionDuration"];
@@ -11241,6 +11261,10 @@ export const MultilevelSwitchCCValues: Readonly<{
             readonly readable: false;
             readonly type: "boolean";
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Multilevel Switch"];
+            property: string;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -11259,10 +11283,6 @@ export const MultilevelSwitchCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: string;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Multilevel Switch"];
-            property: string;
-        };
         readonly meta: {
             readonly label: `Perform a level change (${string})`;
             readonly valueChangeOptions: readonly ["transitionDuration"];
@@ -11272,6 +11292,10 @@ export const MultilevelSwitchCCValues: Readonly<{
             readonly readable: false;
             readonly type: "boolean";
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Multilevel Switch"];
+            property: string;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -11301,9 +11325,9 @@ export const MultilevelSwitchCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly internal: true;
             readonly supportsEndpoints: false;
@@ -11326,9 +11350,9 @@ export const MultilevelSwitchCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -11355,11 +11379,11 @@ export const MultilevelSwitchCCValues: Readonly<{
         };
         readonly options: {
             readonly internal: false;
-            readonly minVersion: 1;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly stateful: false;
-            readonly autoCreate: (applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint) => boolean;
+            readonly autoCreate: (applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2) => boolean;
         };
     };
     restorePrevious: {
@@ -11529,9 +11553,9 @@ export class NodeNamingAndLocationCC extends CommandClass {
     // (undocumented)
     ccCommand: NodeNamingAndLocationCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
     skipEndpointInterview(): boolean;
 }
@@ -11550,7 +11574,7 @@ export class NodeNamingAndLocationCCLocationReport extends NodeNamingAndLocation
     // (undocumented)
     readonly location: string;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "NodeNamingAndLocationCCLocationSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -11564,7 +11588,7 @@ export class NodeNamingAndLocationCCLocationSet extends NodeNamingAndLocationCC 
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "NodeNamingAndLocationCCNameGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -11581,7 +11605,7 @@ export class NodeNamingAndLocationCCNameReport extends NodeNamingAndLocationCC {
     // (undocumented)
     readonly name: string;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "NodeNamingAndLocationCCNameSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -11595,7 +11619,7 @@ export class NodeNamingAndLocationCCNameSet extends NodeNamingAndLocationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "NodeNamingAndLocationCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -11621,9 +11645,9 @@ export const NodeNamingAndLocationCCValues: Readonly<{
         };
         readonly options: {
             readonly internal: false;
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly supportsEndpoints: false;
         };
@@ -11647,9 +11671,9 @@ export const NodeNamingAndLocationCCValues: Readonly<{
         };
         readonly options: {
             readonly internal: false;
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly supportsEndpoints: false;
         };
@@ -11690,11 +11714,11 @@ export class NotificationCC extends CommandClass {
     ccCommand: NotificationCommand;
     // (undocumented)
     determineRequiredCCInterviews(): readonly CommandClasses[];
-    static getNotificationMode(applHost: ZWaveApplicationHost, node: IZWaveNode): "push" | "pull" | undefined;
+    static getNotificationMode(applHost: ZWaveApplicationHost_2, node: IZWaveNode): "push" | "pull" | undefined;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "NotificationCCEventSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -11708,7 +11732,7 @@ export class NotificationCCEventSupportedGet extends NotificationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "NotificationCCEventSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -11720,13 +11744,13 @@ export class NotificationCCEventSupportedReport extends NotificationCC {
     // (undocumented)
     notificationType: number;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
     supportedEvents: number[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "NotificationCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -11742,7 +11766,7 @@ export class NotificationCCGet extends NotificationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "NotificationCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -11764,13 +11788,13 @@ export class NotificationCCReport extends NotificationCC {
     // (undocumented)
     notificationType: number | undefined;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     sequenceNumber: number | undefined;
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     readonly zensorNetSourceNodeId: number | undefined;
 }
@@ -11788,7 +11812,7 @@ export class NotificationCCSet extends NotificationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "NotificationCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -11810,7 +11834,7 @@ export class NotificationCCSupportedReport extends NotificationCC {
     // (undocumented)
     supportsV1Alarm: boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "NotificationCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -11824,15 +11848,15 @@ export const NotificationCCValues: Readonly<{
             readonly property: string;
             readonly propertyKey: string;
         };
-        readonly id: {
-            commandClass: CommandClasses.Notification;
-            property: string;
-            propertyKey: string;
-        };
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Notification;
+            property: string;
+            propertyKey: string;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -11852,11 +11876,6 @@ export const NotificationCCValues: Readonly<{
             readonly property: string;
             readonly propertyKey: "unknown";
         };
-        readonly id: {
-            commandClass: CommandClasses.Notification;
-            property: string;
-            propertyKey: "unknown";
-        };
         readonly meta: {
             readonly label: `${string}: Unknown value`;
             readonly ccSpecific: {
@@ -11867,6 +11886,11 @@ export const NotificationCCValues: Readonly<{
             readonly max: 255;
             readonly type: "number";
             readonly readable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Notification;
+            property: string;
+            propertyKey: "unknown";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -11885,10 +11909,6 @@ export const NotificationCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: string;
         };
-        readonly id: {
-            commandClass: CommandClasses.Notification;
-            property: string;
-        };
         readonly meta: {
             readonly label: `Unknown notification (${string})`;
             readonly ccSpecific: {
@@ -11899,6 +11919,10 @@ export const NotificationCCValues: Readonly<{
             readonly max: 255;
             readonly type: "number";
             readonly readable: true;
+        };
+        readonly id: {
+            commandClass: CommandClasses.Notification;
+            property: string;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -11918,22 +11942,22 @@ export const NotificationCCValues: Readonly<{
             readonly property: "supportedNotificationEvents";
             readonly propertyKey: number;
         };
-        readonly id: {
-            commandClass: CommandClasses.Notification;
-            property: "supportedNotificationEvents";
-            propertyKey: number;
-        };
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
             readonly writeable: true;
         };
+        readonly id: {
+            commandClass: CommandClasses.Notification;
+            property: "supportedNotificationEvents";
+            propertyKey: number;
+        };
     }) & {
         is: (valueId: ValueID_2) => boolean;
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly internal: true;
             readonly supportsEndpoints: false;
@@ -12012,9 +12036,9 @@ export const NotificationCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly internal: true;
             readonly supportsEndpoints: false;
@@ -12037,9 +12061,9 @@ export const NotificationCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly internal: true;
             readonly supportsEndpoints: false;
@@ -12062,9 +12086,9 @@ export const NotificationCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly internal: true;
             readonly supportsEndpoints: false;
@@ -12115,9 +12139,9 @@ export function parseWakeUpTime(value: number): WakeUpTime;
 //
 // @public
 export class PhysicalCCAPI extends CCAPI {
-    constructor(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2 | IVirtualEndpoint);
+    constructor(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint | IVirtualEndpoint);
     // (undocumented)
-    protected readonly endpoint: IZWaveEndpoint_2;
+    protected readonly endpoint: IZWaveEndpoint;
 }
 
 // Warning: (ae-missing-release-tag) "POLL_VALUE" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -12180,7 +12204,7 @@ export class PowerlevelCCReport extends PowerlevelCC {
     // (undocumented)
     readonly timeout?: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "PowerlevelCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -12196,7 +12220,7 @@ export class PowerlevelCCSet extends PowerlevelCC {
     // (undocumented)
     timeout?: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "PowerlevelCCTestNodeGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -12217,7 +12241,7 @@ export class PowerlevelCCTestNodeReport extends PowerlevelCC {
     // (undocumented)
     readonly testNodeId: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "PowerlevelCCTestNodeSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -12235,7 +12259,7 @@ export class PowerlevelCCTestNodeSet extends PowerlevelCC {
     // (undocumented)
     testNodeId: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "PowerlevelCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -12275,9 +12299,9 @@ export class ProtectionCC extends CommandClass {
     // (undocumented)
     ccCommand: ProtectionCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "ProtectionCCExclusiveControlGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -12294,7 +12318,7 @@ export class ProtectionCCExclusiveControlReport extends ProtectionCC {
     // (undocumented)
     readonly exclusiveControlNodeId: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ProtectionCCExclusiveControlSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -12308,7 +12332,7 @@ export class ProtectionCCExclusiveControlSet extends ProtectionCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ProtectionCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -12327,7 +12351,7 @@ export class ProtectionCCReport extends ProtectionCC {
     // (undocumented)
     readonly rf?: RFProtectionState;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ProtectionCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -12343,7 +12367,7 @@ export class ProtectionCCSet extends ProtectionCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ProtectionCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -12358,7 +12382,7 @@ export class ProtectionCCSupportedGet extends ProtectionCC {
 export class ProtectionCCSupportedReport extends ProtectionCC {
     constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     readonly supportedLocalStates: LocalProtectionState[];
     // (undocumented)
@@ -12368,7 +12392,7 @@ export class ProtectionCCSupportedReport extends ProtectionCC {
     // (undocumented)
     readonly supportsTimeout: boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ProtectionCCTimeoutGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -12385,7 +12409,7 @@ export class ProtectionCCTimeoutReport extends ProtectionCC {
     // (undocumented)
     readonly timeout: Timeout;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ProtectionCCTimeoutSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -12399,7 +12423,7 @@ export class ProtectionCCTimeoutSet extends ProtectionCC {
     // (undocumented)
     timeout: Timeout;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ProtectionCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -12423,9 +12447,9 @@ export const ProtectionCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -12448,9 +12472,9 @@ export const ProtectionCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -12473,9 +12497,9 @@ export const ProtectionCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -12498,9 +12522,9 @@ export const ProtectionCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -12665,7 +12689,7 @@ export enum RateType {
 // Warning: (ae-missing-release-tag) "removeAssociations" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-function removeAssociations(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, group: number, destinations: AssociationAddress[]): Promise<void>;
+function removeAssociations(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2, group: number, destinations: AssociationAddress[]): Promise<void>;
 
 // Warning: (ae-missing-release-tag) "RFProtectionState" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -12700,7 +12724,7 @@ export class SceneActivationCCSet extends SceneActivationCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "SceneActivationCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -12755,8 +12779,8 @@ export const SceneActivationCCValues: Readonly<{
         };
         readonly options: {
             readonly internal: false;
-            readonly minVersion: 1;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly stateful: false;
@@ -12779,7 +12803,7 @@ export class SceneActuatorConfigurationCC extends CommandClass {
     // (undocumented)
     ccCommand: SceneActuatorConfigurationCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "SceneActuatorConfigurationCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -12793,7 +12817,7 @@ export class SceneActuatorConfigurationCCGet extends SceneActuatorConfigurationC
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "SceneActuatorConfigurationCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -12806,11 +12830,11 @@ export class SceneActuatorConfigurationCCReport extends SceneActuatorConfigurati
     // (undocumented)
     readonly level?: number;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     readonly sceneId: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "SceneActuatorConfigurationCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -12828,7 +12852,7 @@ export class SceneActuatorConfigurationCCSet extends SceneActuatorConfigurationC
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "SceneActuatorConfigurationCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -12842,16 +12866,16 @@ export const SceneActuatorConfigurationCCValues: Readonly<{
             readonly property: "dimmingDuration";
             readonly propertyKey: number;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Scene Actuator Configuration"];
-            property: "dimmingDuration";
-            propertyKey: number;
-        };
         readonly meta: {
             readonly label: `Dimming duration (${number})`;
             readonly type: "duration";
             readonly readable: true;
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Scene Actuator Configuration"];
+            property: "dimmingDuration";
+            propertyKey: number;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -12871,11 +12895,6 @@ export const SceneActuatorConfigurationCCValues: Readonly<{
             readonly property: "level";
             readonly propertyKey: number;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Scene Actuator Configuration"];
-            property: "level";
-            propertyKey: number;
-        };
         readonly meta: {
             readonly label: `Level (${number})`;
             readonly valueChangeOptions: readonly ["transitionDuration"];
@@ -12884,6 +12903,11 @@ export const SceneActuatorConfigurationCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Scene Actuator Configuration"];
+            property: "level";
+            propertyKey: number;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -12918,11 +12942,11 @@ export class SceneControllerConfigurationCC extends CommandClass {
     ccCommand: SceneControllerConfigurationCommand;
     // (undocumented)
     determineRequiredCCInterviews(): readonly CommandClasses[];
-    static getGroupCountCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): number;
+    static getGroupCountCached(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): number;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "SceneControllerConfigurationCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -12936,7 +12960,7 @@ export class SceneControllerConfigurationCCGet extends SceneControllerConfigurat
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "SceneControllerConfigurationCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -12949,11 +12973,11 @@ export class SceneControllerConfigurationCCReport extends SceneControllerConfigu
     // (undocumented)
     readonly groupId: number;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     readonly sceneId: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "SceneControllerConfigurationCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -12971,7 +12995,7 @@ export class SceneControllerConfigurationCCSet extends SceneControllerConfigurat
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "SceneControllerConfigurationCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -12985,16 +13009,16 @@ export const SceneControllerConfigurationCCValues: Readonly<{
             readonly property: "dimmingDuration";
             readonly propertyKey: number;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Scene Controller Configuration"];
-            property: "dimmingDuration";
-            propertyKey: number;
-        };
         readonly meta: {
             readonly label: `Dimming duration (${number})`;
             readonly type: "duration";
             readonly readable: true;
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Scene Controller Configuration"];
+            property: "dimmingDuration";
+            propertyKey: number;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -13014,11 +13038,6 @@ export const SceneControllerConfigurationCCValues: Readonly<{
             readonly property: "sceneId";
             readonly propertyKey: number;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Scene Controller Configuration"];
-            property: "sceneId";
-            propertyKey: number;
-        };
         readonly meta: {
             readonly label: `Associated Scene ID (${number})`;
             readonly valueChangeOptions: readonly ["transitionDuration"];
@@ -13027,6 +13046,11 @@ export const SceneControllerConfigurationCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Scene Controller Configuration"];
+            property: "sceneId";
+            propertyKey: number;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -13059,11 +13083,11 @@ export enum SceneControllerConfigurationCommand {
 export class ScheduleEntryLockCC extends CommandClass {
     // (undocumented)
     ccCommand: ScheduleEntryLockCommand;
-    static getNumDailyRepeatingSlotsCached(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): number;
-    static getNumWeekDaySlotsCached(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): number;
-    static getNumYearDaySlotsCached(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): number;
+    static getNumDailyRepeatingSlotsCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): number;
+    static getNumWeekDaySlotsCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): number;
+    static getNumYearDaySlotsCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): number;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
+    interview(applHost: ZWaveApplicationHost): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "ScheduleEntryLockCCDailyRepeatingScheduleGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -13077,7 +13101,7 @@ export class ScheduleEntryLockCCDailyRepeatingScheduleGet extends ScheduleEntryL
     // (undocumented)
     slotId: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
     // (undocumented)
     userId: number;
 }
@@ -13101,7 +13125,7 @@ export class ScheduleEntryLockCCDailyRepeatingScheduleReport extends ScheduleEnt
     // (undocumented)
     startMinute?: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
     // (undocumented)
     userId: number;
     // (undocumented)
@@ -13128,7 +13152,7 @@ export class ScheduleEntryLockCCDailyRepeatingScheduleSet extends ScheduleEntryL
     // (undocumented)
     startMinute?: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
     // (undocumented)
     userId: number;
     // (undocumented)
@@ -13156,7 +13180,7 @@ export class ScheduleEntryLockCCEnableAllSet extends ScheduleEntryLockCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "ScheduleEntryLockCCEnableSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -13170,7 +13194,7 @@ export class ScheduleEntryLockCCEnableSet extends ScheduleEntryLockCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
     // (undocumented)
     userId: number;
 }
@@ -13196,7 +13220,7 @@ export class ScheduleEntryLockCCSupportedReport extends ScheduleEntryLockCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "ScheduleEntryLockCCTimeOffsetGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -13218,7 +13242,7 @@ export class ScheduleEntryLockCCTimeOffsetReport extends ScheduleEntryLockCC {
     // (undocumented)
     standardOffset: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "ScheduleEntryLockCCTimeOffsetSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -13234,7 +13258,7 @@ export class ScheduleEntryLockCCTimeOffsetSet extends ScheduleEntryLockCC {
     // (undocumented)
     standardOffset: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "ScheduleEntryLockCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -13258,9 +13282,9 @@ export const ScheduleEntryLockCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -13283,9 +13307,9 @@ export const ScheduleEntryLockCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -13308,9 +13332,9 @@ export const ScheduleEntryLockCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -13329,7 +13353,7 @@ export class ScheduleEntryLockCCWeekDayScheduleGet extends ScheduleEntryLockCC {
     // (undocumented)
     slotId: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
     // (undocumented)
     userId: number;
 }
@@ -13353,7 +13377,7 @@ export class ScheduleEntryLockCCWeekDayScheduleReport extends ScheduleEntryLockC
     // (undocumented)
     stopMinute?: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
     // (undocumented)
     userId: number;
     // (undocumented)
@@ -13380,7 +13404,7 @@ export class ScheduleEntryLockCCWeekDayScheduleSet extends ScheduleEntryLockCC {
     // (undocumented)
     stopMinute?: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
     // (undocumented)
     userId: number;
     // (undocumented)
@@ -13408,7 +13432,7 @@ export class ScheduleEntryLockCCYearDayScheduleGet extends ScheduleEntryLockCC {
     // (undocumented)
     slotId: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
     // (undocumented)
     userId: number;
 }
@@ -13444,7 +13468,7 @@ export class ScheduleEntryLockCCYearDayScheduleReport extends ScheduleEntryLockC
     // (undocumented)
     stopYear?: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
     // (undocumented)
     userId: number;
 }
@@ -13481,7 +13505,7 @@ export class ScheduleEntryLockCCYearDayScheduleSet extends ScheduleEntryLockCC {
     // (undocumented)
     stopYear?: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
     // (undocumented)
     userId: number;
 }
@@ -13662,7 +13686,7 @@ export class Security2CC extends CommandClass {
     ccCommand: Security2Command;
     static encapsulate(host: ZWaveHost_2, cc: CommandClass, securityClass?: SecurityClass): Security2CCMessageEncapsulation;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     static requiresEncapsulation(cc: CommandClass): boolean;
 }
 
@@ -13683,7 +13707,7 @@ export class Security2CCCommandsSupportedReport extends Security2CC {
     // (undocumented)
     readonly supportedCCs: CommandClasses_2[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "Security2CCKEXFail" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -13697,7 +13721,7 @@ export class Security2CCKEXFail extends Security2CC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "Security2CCKEXGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -13725,7 +13749,7 @@ export class Security2CCKEXReport extends Security2CC {
     // (undocumented)
     readonly supportedKEXSchemes: readonly KEXSchemes[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "Security2CCKEXSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -13747,7 +13771,7 @@ export class Security2CCKEXSet extends Security2CC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "Security2CCMessageEncapsulation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -13770,7 +13794,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
     // (undocumented)
     unsetSequenceNumber(): void;
 }
@@ -13786,7 +13810,7 @@ export class Security2CCNetworkKeyGet extends Security2CC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "Security2CCNetworkKeyReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -13802,7 +13826,7 @@ export class Security2CCNetworkKeyReport extends Security2CC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "Security2CCNetworkKeyVerify" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -13824,7 +13848,7 @@ export class Security2CCNonceGet extends Security2CC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "Security2CCNonceReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -13847,7 +13871,7 @@ export class Security2CCNonceReport extends Security2CC {
     // (undocumented)
     readonly SOS: boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "Security2CCPublicKeyReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -13863,7 +13887,7 @@ export class Security2CCPublicKeyReport extends Security2CC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "Security2CCTransferEnd" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -13879,7 +13903,7 @@ export class Security2CCTransferEnd extends Security2CC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "Security2Command" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -13954,7 +13978,7 @@ export class SecurityCC extends CommandClass {
         securityManager: SecurityManager;
     };
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
     nodeId: number;
     static requiresEncapsulation(cc: CommandClass): boolean;
@@ -13975,7 +13999,7 @@ export class SecurityCCCommandEncapsulation extends SecurityCC {
     // (undocumented)
     getPartialCCSessionId(): Record<string, any> | undefined;
     // (undocumented)
-    mergePartialCCs(applHost: ZWaveApplicationHost, partials: SecurityCCCommandEncapsulation[]): void;
+    mergePartialCCs(applHost: ZWaveApplicationHost_2, partials: SecurityCCCommandEncapsulation[]): void;
     // (undocumented)
     nonce: Buffer | undefined;
     // (undocumented)
@@ -13983,7 +14007,7 @@ export class SecurityCCCommandEncapsulation extends SecurityCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "SecurityCCCommandEncapsulationNonceGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -14010,13 +14034,13 @@ export class SecurityCCCommandsSupportedReport extends SecurityCC {
     // (undocumented)
     getPartialCCSessionId(): Record<string, any> | undefined;
     // (undocumented)
-    mergePartialCCs(applHost: ZWaveApplicationHost, partials: SecurityCCCommandsSupportedReport[]): void;
+    mergePartialCCs(applHost: ZWaveApplicationHost_2, partials: SecurityCCCommandsSupportedReport[]): void;
     // (undocumented)
     readonly reportsToFollow: number;
     // (undocumented)
     get supportedCCs(): CommandClasses_2[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "SecurityCCNetworkKeySet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -14054,7 +14078,7 @@ export class SecurityCCNonceReport extends SecurityCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "SecurityCCSchemeGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -14065,7 +14089,7 @@ export class SecurityCCSchemeGet extends SecurityCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "SecurityCCSchemeInherit" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -14076,7 +14100,7 @@ export class SecurityCCSchemeInherit extends SecurityCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "SecurityCCSchemeReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -14165,7 +14189,7 @@ export class SoundSwitchCC extends CommandClass {
     // (undocumented)
     ccCommand: SoundSwitchCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "SoundSwitchCCConfigurationGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -14187,7 +14211,7 @@ export class SoundSwitchCCConfigurationReport extends SoundSwitchCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "SoundSwitchCCConfigurationSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -14203,7 +14227,7 @@ export class SoundSwitchCCConfigurationSet extends SoundSwitchCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "SoundSwitchCCToneInfoGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -14215,7 +14239,7 @@ export class SoundSwitchCCToneInfoGet extends SoundSwitchCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     toneId: number;
 }
@@ -14233,7 +14257,7 @@ export class SoundSwitchCCToneInfoReport extends SoundSwitchCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     readonly toneId: number;
 }
@@ -14250,7 +14274,7 @@ export class SoundSwitchCCTonePlayGet extends SoundSwitchCC {
 export class SoundSwitchCCTonePlayReport extends SoundSwitchCC {
     constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     readonly toneId: ToneId | number;
     // (undocumented)
@@ -14266,7 +14290,7 @@ export class SoundSwitchCCTonePlaySet extends SoundSwitchCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     toneId: ToneId | number;
     // (undocumented)
@@ -14288,7 +14312,7 @@ export class SoundSwitchCCTonesNumberReport extends SoundSwitchCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     toneCount: number;
 }
@@ -14484,13 +14508,13 @@ export class SupervisionCC extends CommandClass {
     // (undocumented)
     ccCommand: SupervisionCommand;
     static encapsulate(host: ZWaveHost_2, cc: CommandClass, requestStatusUpdates?: boolean): SupervisionCCGet;
-    static getCCSupportedWithSupervision(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, ccId: CommandClasses): boolean;
+    static getCCSupportedWithSupervision(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2, ccId: CommandClasses): boolean;
     static getSessionId(command: CommandClass): number | undefined;
-    static mayUseSupervision<T extends CommandClass>(applHost: ZWaveApplicationHost, command: T): command is SinglecastCC_2<T>;
+    static mayUseSupervision<T extends CommandClass>(applHost: ZWaveApplicationHost_2, command: T): command is SinglecastCC_2<T>;
     // (undocumented)
     nodeId: number;
     static requiresEncapsulation(cc: CommandClass): boolean;
-    static setCCSupportedWithSupervision(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, ccId: CommandClasses, supported: boolean): void;
+    static setCCSupportedWithSupervision(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2, ccId: CommandClasses, supported: boolean): void;
 }
 
 // Warning: (ae-missing-release-tag) "SupervisionCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -14510,7 +14534,7 @@ export class SupervisionCCGet extends SupervisionCC {
     // (undocumented)
     sessionId: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "SupervisionCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -14532,7 +14556,7 @@ export class SupervisionCCReport extends SupervisionCC {
     // (undocumented)
     readonly status: SupervisionStatus;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "SupervisionCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -14546,22 +14570,22 @@ export const SupervisionCCValues: Readonly<{
             readonly property: "ccSupported";
             readonly propertyKey: CommandClasses;
         };
-        readonly id: {
-            commandClass: CommandClasses.Supervision;
-            property: "ccSupported";
-            propertyKey: CommandClasses;
-        };
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
             readonly writeable: true;
         };
+        readonly id: {
+            commandClass: CommandClasses.Supervision;
+            property: "ccSupported";
+            propertyKey: CommandClasses;
+        };
     }) & {
         is: (valueId: ValueID_2) => boolean;
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly internal: true;
             readonly supportsEndpoints: false;
@@ -14650,9 +14674,9 @@ export class ThermostatFanModeCC extends CommandClass {
     // (undocumented)
     ccCommand: ThermostatFanModeCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "ThermostatFanModeCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -14671,7 +14695,7 @@ export class ThermostatFanModeCCReport extends ThermostatFanModeCC {
     // (undocumented)
     readonly off: boolean | undefined;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ThermostatFanModeCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -14687,7 +14711,7 @@ export class ThermostatFanModeCCSet extends ThermostatFanModeCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ThermostatFanModeCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -14702,11 +14726,11 @@ export class ThermostatFanModeCCSupportedGet extends ThermostatFanModeCC {
 export class ThermostatFanModeCCSupportedReport extends ThermostatFanModeCC {
     constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     readonly supportedModes: ThermostatFanMode[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ThermostatFanModeCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -14730,9 +14754,9 @@ export const ThermostatFanModeCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -14844,9 +14868,9 @@ export class ThermostatFanStateCC extends CommandClass {
     // (undocumented)
     ccCommand: ThermostatFanStateCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "ThermostatFanStateCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -14863,7 +14887,7 @@ export class ThermostatFanStateCCReport extends ThermostatFanStateCC {
     // (undocumented)
     readonly state: ThermostatFanState;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ThermostatFanStateCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -14958,9 +14982,9 @@ export class ThermostatModeCC extends CommandClass {
     // (undocumented)
     ccCommand: ThermostatModeCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "ThermostatModeCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -14979,9 +15003,9 @@ export class ThermostatModeCCReport extends ThermostatModeCC {
     // (undocumented)
     readonly mode: ThermostatMode;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ThermostatModeCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -14997,7 +15021,7 @@ export class ThermostatModeCCSet extends ThermostatModeCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ThermostatModeCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -15012,11 +15036,11 @@ export class ThermostatModeCCSupportedGet extends ThermostatModeCC {
 export class ThermostatModeCCSupportedReport extends ThermostatModeCC {
     constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     readonly supportedModes: ThermostatMode[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ThermostatModeCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -15040,9 +15064,9 @@ export const ThermostatModeCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -15160,9 +15184,9 @@ export class ThermostatOperatingStateCC extends CommandClass {
     // (undocumented)
     ccCommand: ThermostatOperatingStateCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "ThermostatOperatingStateCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -15179,7 +15203,7 @@ export class ThermostatOperatingStateCCReport extends ThermostatOperatingStateCC
     // (undocumented)
     readonly state: ThermostatOperatingState;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ThermostatOperatingStateCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -15236,9 +15260,9 @@ export class ThermostatSetbackCC extends CommandClass {
     // (undocumented)
     ccCommand: ThermostatSetbackCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "ThermostatSetbackCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -15257,7 +15281,7 @@ export class ThermostatSetbackCCReport extends ThermostatSetbackCC {
     // (undocumented)
     readonly setbackType: SetbackType;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ThermostatSetbackCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -15272,7 +15296,7 @@ export class ThermostatSetbackCCSet extends ThermostatSetbackCC {
     // (undocumented)
     setbackType: SetbackType;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ThermostatSetbackCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -15368,11 +15392,11 @@ export class ThermostatSetpointCC extends CommandClass {
     // (undocumented)
     ccCommand: ThermostatSetpointCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    translatePropertyKey(applHost: ZWaveApplicationHost, property: string | number, propertyKey: string | number): string | undefined;
+    translatePropertyKey(applHost: ZWaveApplicationHost_2, property: string | number, propertyKey: string | number): string | undefined;
 }
 
 // Warning: (ae-missing-release-tag) "ThermostatSetpointCCCapabilitiesGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -15386,7 +15410,7 @@ export class ThermostatSetpointCCCapabilitiesGet extends ThermostatSetpointCC {
     // (undocumented)
     setpointType: ThermostatSetpointType;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ThermostatSetpointCCCapabilitiesReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -15403,9 +15427,9 @@ export class ThermostatSetpointCCCapabilitiesReport extends ThermostatSetpointCC
     // (undocumented)
     get minValueScale(): number;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     get type(): ThermostatSetpointType;
 }
@@ -15421,7 +15445,7 @@ export class ThermostatSetpointCCGet extends ThermostatSetpointCC {
     // (undocumented)
     setpointType: ThermostatSetpointType;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ThermostatSetpointCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -15430,11 +15454,11 @@ export class ThermostatSetpointCCGet extends ThermostatSetpointCC {
 export class ThermostatSetpointCCReport extends ThermostatSetpointCC {
     constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     readonly scale: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     get type(): ThermostatSetpointType;
     // (undocumented)
@@ -15454,7 +15478,7 @@ export class ThermostatSetpointCCSet extends ThermostatSetpointCC {
     // (undocumented)
     setpointType: ThermostatSetpointType;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     value: number;
 }
@@ -15473,7 +15497,7 @@ export class ThermostatSetpointCCSupportedReport extends ThermostatSetpointCC {
     // (undocumented)
     readonly supportedSetpointTypes: readonly ThermostatSetpointType[];
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "ThermostatSetpointCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -15487,22 +15511,22 @@ export const ThermostatSetpointCCValues: Readonly<{
             readonly property: "setpointScale";
             readonly propertyKey: ThermostatSetpointType;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Thermostat Setpoint"];
-            property: "setpointScale";
-            propertyKey: ThermostatSetpointType;
-        };
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
             readonly writeable: true;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Thermostat Setpoint"];
+            property: "setpointScale";
+            propertyKey: ThermostatSetpointType;
+        };
     }) & {
         is: (valueId: ValueID_2) => boolean;
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -15515,11 +15539,6 @@ export const ThermostatSetpointCCValues: Readonly<{
             readonly property: "setpoint";
             readonly propertyKey: ThermostatSetpointType;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Thermostat Setpoint"];
-            property: "setpoint";
-            propertyKey: ThermostatSetpointType;
-        };
         readonly meta: {
             readonly label: `Setpoint (${string})`;
             readonly ccSpecific: {
@@ -15528,6 +15547,11 @@ export const ThermostatSetpointCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Thermostat Setpoint"];
+            property: "setpoint";
+            propertyKey: ThermostatSetpointType;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -15557,9 +15581,9 @@ export const ThermostatSetpointCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -15582,9 +15606,9 @@ export const ThermostatSetpointCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -15688,7 +15712,7 @@ export class TimeCC extends CommandClass {
     // (undocumented)
     ccCommand: TimeCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "TimeCCDateGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -15710,7 +15734,7 @@ export class TimeCCDateReport extends TimeCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
     // (undocumented)
     year: number;
 }
@@ -15744,7 +15768,7 @@ export class TimeCCTimeOffsetReport extends TimeCC {
     // (undocumented)
     standardOffset: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "TimeCCTimeOffsetSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -15764,7 +15788,7 @@ export class TimeCCTimeOffsetSet extends TimeCC {
     // (undocumented)
     standardOffset: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "TimeCCTimeReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -15782,7 +15806,7 @@ export class TimeCCTimeReport extends TimeCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "TimeCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -15812,7 +15836,7 @@ export class TimeParametersCC extends CommandClass {
     // (undocumented)
     ccCommand: TimeParametersCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "TimeParametersCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -15829,9 +15853,9 @@ export class TimeParametersCCReport extends TimeParametersCC {
     // (undocumented)
     get dateAndTime(): Date;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "TimeParametersCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -15843,11 +15867,11 @@ export class TimeParametersCCSet extends TimeParametersCC {
     // (undocumented)
     dateAndTime: Date;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
 // Warning: (ae-missing-release-tag) "TimeParametersCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -15958,7 +15982,7 @@ export class TransportServiceCCFirstSegment extends TransportServiceCC {
     // (undocumented)
     sessionId: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "TransportServiceCCSegmentComplete" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -15972,7 +15996,7 @@ export class TransportServiceCCSegmentComplete extends TransportServiceCC {
     // (undocumented)
     sessionId: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "TransportServiceCCSegmentRequest" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -15988,7 +16012,7 @@ export class TransportServiceCCSegmentRequest extends TransportServiceCC {
     // (undocumented)
     sessionId: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "TransportServiceCCSegmentWait" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -16002,7 +16026,7 @@ export class TransportServiceCCSegmentWait extends TransportServiceCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "TransportServiceCCSubsequentSegment" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -16029,7 +16053,7 @@ export class TransportServiceCCSubsequentSegment extends TransportServiceCC {
     // (undocumented)
     headerExtension: Buffer | undefined;
     // (undocumented)
-    mergePartialCCs(applHost: ZWaveApplicationHost, partials: [
+    mergePartialCCs(applHost: ZWaveApplicationHost_2, partials: [
     TransportServiceCCFirstSegment,
     ...TransportServiceCCSubsequentSegment[]
     ]): void;
@@ -16040,7 +16064,7 @@ export class TransportServiceCCSubsequentSegment extends TransportServiceCC {
     // (undocumented)
     sessionId: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "TransportServiceCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -16074,16 +16098,16 @@ export const TransportServiceTimeouts: {
 export class UserCodeCC extends CommandClass {
     // (undocumented)
     ccCommand: UserCodeCommand;
-    static getSupportedASCIICharsCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): string | undefined;
-    static getSupportedKeypadModesCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): KeypadMode[] | undefined;
-    static getSupportedUserIDStatusesCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): UserIDStatus[] | undefined;
-    static getSupportedUsersCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): number | undefined;
+    static getSupportedASCIICharsCached(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): string | undefined;
+    static getSupportedKeypadModesCached(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): KeypadMode[] | undefined;
+    static getSupportedUserIDStatusesCached(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): UserIDStatus[] | undefined;
+    static getSupportedUsersCached(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): number | undefined;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
-    refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
-    static supportsMasterCodeDeactivationCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): boolean;
-    static supportsMultipleUserCodeSetCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): boolean;
+    refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
+    static supportsMasterCodeDeactivationCached(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): boolean;
+    static supportsMultipleUserCodeSetCached(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): boolean;
 }
 
 // Warning: (ae-missing-release-tag) "UserCodeCCCapabilitiesGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -16114,7 +16138,7 @@ export class UserCodeCCCapabilitiesReport extends UserCodeCC {
     // (undocumented)
     readonly supportsUserCodeChecksum: boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "UserCodeCCExtendedUserCodeGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -16128,7 +16152,7 @@ export class UserCodeCCExtendedUserCodeGet extends UserCodeCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     userId: number;
 }
@@ -16141,9 +16165,9 @@ export class UserCodeCCExtendedUserCodeReport extends UserCodeCC {
     // (undocumented)
     readonly nextUserId: number;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // Warning: (ae-forgotten-export) The symbol "UserCode" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -16159,7 +16183,7 @@ export class UserCodeCCExtendedUserCodeSet extends UserCodeCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // Warning: (ae-forgotten-export) The symbol "UserCodeCCSetOptions" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -16175,7 +16199,7 @@ export class UserCodeCCGet extends UserCodeCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     userId: number;
 }
@@ -16194,9 +16218,9 @@ export class UserCodeCCKeypadModeReport extends UserCodeCC {
     // (undocumented)
     readonly keypadMode: KeypadMode;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "UserCodeCCKeypadModeSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -16210,7 +16234,7 @@ export class UserCodeCCKeypadModeSet extends UserCodeCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "UserCodeCCMasterCodeGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -16227,7 +16251,7 @@ export class UserCodeCCMasterCodeReport extends UserCodeCC {
     // (undocumented)
     readonly masterCode: string;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "UserCodeCCMasterCodeSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -16241,7 +16265,7 @@ export class UserCodeCCMasterCodeSet extends UserCodeCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-forgotten-export) The symbol "NotificationEventPayload" needs to be exported by the entry point index.d.ts
@@ -16251,9 +16275,9 @@ export class UserCodeCCMasterCodeSet extends UserCodeCC {
 export class UserCodeCCReport extends UserCodeCC implements NotificationEventPayload {
     constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     toNotificationEventParameters(): {
         userId: number;
@@ -16274,7 +16298,7 @@ export class UserCodeCCSet extends UserCodeCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     userCode: string | Buffer;
     // (undocumented)
@@ -16295,7 +16319,7 @@ export class UserCodeCCUserCodeChecksumGet extends UserCodeCC {
 export class UserCodeCCUserCodeChecksumReport extends UserCodeCC {
     constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     readonly userCodeChecksum: number;
 }
@@ -16314,7 +16338,7 @@ export class UserCodeCCUsersNumberReport extends UserCodeCC {
     // (undocumented)
     readonly supportedUsers: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "UserCodeCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -16328,22 +16352,22 @@ export const UserCodeCCValues: Readonly<{
             readonly property: "userCode";
             readonly propertyKey: number;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["User Code"];
-            property: "userCode";
-            propertyKey: number;
-        };
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
             readonly writeable: true;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["User Code"];
+            property: "userCode";
+            propertyKey: number;
+        };
     }) & {
         is: (valueId: ValueID_2) => boolean;
         readonly options: {
             readonly internal: false;
-            readonly minVersion: 1;
             readonly stateful: true;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly secret: true;
@@ -16356,16 +16380,16 @@ export const UserCodeCCValues: Readonly<{
             readonly property: "userIdStatus";
             readonly propertyKey: number;
         };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["User Code"];
-            property: "userIdStatus";
-            propertyKey: number;
-        };
         readonly meta: {
             readonly label: `User ID status (${number})`;
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["User Code"];
+            property: "userIdStatus";
+            propertyKey: number;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -16449,9 +16473,9 @@ export const UserCodeCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -16474,9 +16498,9 @@ export const UserCodeCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -16499,9 +16523,9 @@ export const UserCodeCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -16524,9 +16548,9 @@ export const UserCodeCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -16549,9 +16573,9 @@ export const UserCodeCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -16574,9 +16598,9 @@ export const UserCodeCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -16599,9 +16623,9 @@ export const UserCodeCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -16624,9 +16648,9 @@ export const UserCodeCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -16649,9 +16673,9 @@ export const UserCodeCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -16674,9 +16698,9 @@ export const UserCodeCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -16803,7 +16827,7 @@ export class VersionCC extends CommandClass {
     // (undocumented)
     determineRequiredCCInterviews(): readonly CommandClasses[];
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "VersionCCCapabilitiesGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -16820,7 +16844,7 @@ export class VersionCCCapabilitiesReport extends VersionCC {
     // (undocumented)
     readonly supportsZWaveSoftwareGet: boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "VersionCCCommandClassGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -16834,7 +16858,7 @@ export class VersionCCCommandClassGet extends VersionCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "VersionCCCommandClassReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -16847,7 +16871,7 @@ export class VersionCCCommandClassReport extends VersionCC {
     // (undocumented)
     get requestedCC(): CommandClasses;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "VersionCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -16870,7 +16894,7 @@ export class VersionCCReport extends VersionCC {
     // (undocumented)
     readonly protocolVersion: string;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
 // Warning: (ae-missing-release-tag) "VersionCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -17181,9 +17205,9 @@ export const VersionCCValues: Readonly<{
         };
         readonly options: {
             readonly internal: false;
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly supportsEndpoints: false;
         };
@@ -17210,9 +17234,9 @@ export const VersionCCValues: Readonly<{
         };
         readonly options: {
             readonly internal: false;
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly supportsEndpoints: false;
         };
@@ -17236,9 +17260,9 @@ export const VersionCCValues: Readonly<{
         };
         readonly options: {
             readonly internal: false;
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly supportsEndpoints: false;
         };
@@ -17271,7 +17295,7 @@ export class VersionCCZWaveSoftwareReport extends VersionCC {
     // (undocumented)
     readonly sdkVersion: string;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     readonly zWaveProtocolBuildNumber: number;
     // (undocumented)
@@ -17307,7 +17331,7 @@ export class WakeUpCC extends CommandClass {
     // (undocumented)
     ccCommand: WakeUpCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "WakeUpCCIntervalCapabilitiesGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -17328,9 +17352,9 @@ export class WakeUpCCIntervalCapabilitiesReport extends WakeUpCC {
     // (undocumented)
     readonly minWakeUpInterval: number;
     // (undocumented)
-    persistValues(applHost: ZWaveApplicationHost): boolean;
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     readonly wakeUpIntervalSteps: number;
     // (undocumented)
@@ -17351,7 +17375,7 @@ export class WakeUpCCIntervalReport extends WakeUpCC {
     // (undocumented)
     readonly controllerNodeId: number;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     readonly wakeUpInterval: number;
 }
@@ -17367,7 +17391,7 @@ export class WakeUpCCIntervalSet extends WakeUpCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     wakeUpInterval: number;
 }
@@ -17428,9 +17452,9 @@ export const WakeUpCCValues: Readonly<{
         };
         readonly options: {
             readonly internal: false;
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly supportsEndpoints: false;
         };
@@ -17454,9 +17478,9 @@ export const WakeUpCCValues: Readonly<{
         };
         readonly options: {
             readonly internal: false;
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly supportsEndpoints: false;
         };
@@ -17557,7 +17581,7 @@ export class ZWavePlusCC extends CommandClass {
     // (undocumented)
     ccCommand: ZWavePlusCommand;
     // (undocumented)
-    interview(applHost: ZWaveApplicationHost): Promise<void>;
+    interview(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "ZWavePlusCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -17581,7 +17605,7 @@ export class ZWavePlusCCReport extends ZWavePlusCC {
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
-    toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry_2;
+    toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
     // (undocumented)
     userIcon: number;
     // (undocumented)
@@ -17609,9 +17633,9 @@ export const ZWavePlusCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -17634,9 +17658,9 @@ export const ZWavePlusCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly supportsEndpoints: true;
             readonly autoCreate: true;
             readonly internal: true;
@@ -17659,9 +17683,9 @@ export const ZWavePlusCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly supportsEndpoints: false;
             readonly internal: true;
@@ -17684,9 +17708,9 @@ export const ZWavePlusCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly supportsEndpoints: false;
             readonly internal: true;
@@ -17709,9 +17733,9 @@ export const ZWavePlusCCValues: Readonly<{
             readonly writeable: true;
         };
         readonly options: {
-            readonly minVersion: 1;
             readonly stateful: true;
             readonly secret: false;
+            readonly minVersion: 1;
             readonly autoCreate: true;
             readonly supportsEndpoints: false;
             readonly internal: true;

--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -188,6 +188,11 @@ export const AlarmSensorCCValues: Readonly<{
             readonly property: "duration";
             readonly propertyKey: AlarmSensorType;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Alarm Sensor"];
+            property: "duration";
+            propertyKey: AlarmSensorType;
+        };
         readonly meta: {
             readonly unit: "s";
             readonly label: `${string} duration`;
@@ -198,11 +203,6 @@ export const AlarmSensorCCValues: Readonly<{
             readonly writeable: false;
             readonly type: "number";
             readonly readable: true;
-        };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Alarm Sensor"];
-            property: "duration";
-            propertyKey: AlarmSensorType;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -222,6 +222,11 @@ export const AlarmSensorCCValues: Readonly<{
             readonly property: "severity";
             readonly propertyKey: AlarmSensorType;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Alarm Sensor"];
+            property: "severity";
+            propertyKey: AlarmSensorType;
+        };
         readonly meta: {
             readonly min: 1;
             readonly max: 100;
@@ -233,11 +238,6 @@ export const AlarmSensorCCValues: Readonly<{
             readonly writeable: false;
             readonly type: "number";
             readonly readable: true;
-        };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Alarm Sensor"];
-            property: "severity";
-            propertyKey: AlarmSensorType;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -257,6 +257,11 @@ export const AlarmSensorCCValues: Readonly<{
             readonly property: "state";
             readonly propertyKey: AlarmSensorType;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Alarm Sensor"];
+            property: "state";
+            propertyKey: AlarmSensorType;
+        };
         readonly meta: {
             readonly label: `${string} state`;
             readonly description: "Whether the alarm is active";
@@ -266,11 +271,6 @@ export const AlarmSensorCCValues: Readonly<{
             readonly writeable: false;
             readonly type: "boolean";
             readonly readable: true;
-        };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Alarm Sensor"];
-            property: "state";
-            propertyKey: AlarmSensorType;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -474,15 +474,15 @@ export const AssociationCCValues: Readonly<{
             readonly property: "nodeIds";
             readonly propertyKey: number;
         };
-        readonly meta: {
-            readonly type: "any";
-            readonly readable: true;
-            readonly writeable: true;
-        };
         readonly id: {
             commandClass: CommandClasses.Association;
             property: "nodeIds";
             propertyKey: number;
+        };
+        readonly meta: {
+            readonly type: "any";
+            readonly readable: true;
+            readonly writeable: true;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -502,15 +502,15 @@ export const AssociationCCValues: Readonly<{
             readonly property: "maxNodes";
             readonly propertyKey: number;
         };
-        readonly meta: {
-            readonly type: "any";
-            readonly readable: true;
-            readonly writeable: true;
-        };
         readonly id: {
             commandClass: CommandClasses.Association;
             property: "maxNodes";
             propertyKey: number;
+        };
+        readonly meta: {
+            readonly type: "any";
+            readonly readable: true;
+            readonly writeable: true;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -730,15 +730,15 @@ export const AssociationGroupInfoCCValues: Readonly<{
             readonly property: "issuedCommands";
             readonly propertyKey: number;
         };
-        readonly meta: {
-            readonly type: "any";
-            readonly readable: true;
-            readonly writeable: true;
-        };
         readonly id: {
             commandClass: (typeof CommandClasses)["Association Group Information"];
             property: "issuedCommands";
             propertyKey: number;
+        };
+        readonly meta: {
+            readonly type: "any";
+            readonly readable: true;
+            readonly writeable: true;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -758,15 +758,15 @@ export const AssociationGroupInfoCCValues: Readonly<{
             readonly property: "info";
             readonly propertyKey: number;
         };
-        readonly meta: {
-            readonly type: "any";
-            readonly readable: true;
-            readonly writeable: true;
-        };
         readonly id: {
             commandClass: (typeof CommandClasses)["Association Group Information"];
             property: "info";
             propertyKey: number;
+        };
+        readonly meta: {
+            readonly type: "any";
+            readonly readable: true;
+            readonly writeable: true;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -786,15 +786,15 @@ export const AssociationGroupInfoCCValues: Readonly<{
             readonly property: "name";
             readonly propertyKey: number;
         };
-        readonly meta: {
-            readonly type: "any";
-            readonly readable: true;
-            readonly writeable: true;
-        };
         readonly id: {
             commandClass: (typeof CommandClasses)["Association Group Information"];
             property: "name";
             propertyKey: number;
+        };
+        readonly meta: {
+            readonly type: "any";
+            readonly readable: true;
+            readonly writeable: true;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -1322,6 +1322,11 @@ export const BarrierOperatorCCValues: Readonly<{
             readonly property: "signalingState";
             readonly propertyKey: SubsystemType;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Barrier Operator"];
+            property: "signalingState";
+            propertyKey: SubsystemType;
+        };
         readonly meta: {
             readonly label: `Signaling State (${string})`;
             readonly states: {
@@ -1332,11 +1337,6 @@ export const BarrierOperatorCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Barrier Operator"];
-            property: "signalingState";
-            propertyKey: SubsystemType;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -2228,6 +2228,10 @@ export const BinarySensorCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: string;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Binary Sensor"];
+            property: string;
+        };
         readonly meta: {
             readonly label: `Sensor state (${string})`;
             readonly ccSpecific: {
@@ -2236,10 +2240,6 @@ export const BinarySensorCCValues: Readonly<{
             readonly writeable: false;
             readonly type: "boolean";
             readonly readable: true;
-        };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Binary Sensor"];
-            property: string;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -2960,6 +2960,11 @@ export const CentralSceneCCValues: Readonly<{
             readonly property: "scene";
             readonly propertyKey: string;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Central Scene"];
+            property: "scene";
+            propertyKey: string;
+        };
         readonly meta: {
             readonly label: `Scene ${string}`;
             readonly writeable: false;
@@ -2967,11 +2972,6 @@ export const CentralSceneCCValues: Readonly<{
             readonly max: 255;
             readonly type: "number";
             readonly readable: true;
-        };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Central Scene"];
-            property: "scene";
-            propertyKey: string;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -3240,16 +3240,16 @@ export const ClimateControlScheduleCCValues: Readonly<{
             readonly property: "schedule";
             readonly propertyKey: Weekday;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Climate Control Schedule"];
+            property: "schedule";
+            propertyKey: Weekday;
+        };
         readonly meta: {
             readonly label: `Schedule (${string})`;
             readonly type: "any";
             readonly readable: true;
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Climate Control Schedule"];
-            property: "schedule";
-            propertyKey: Weekday;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -3577,6 +3577,11 @@ export const ColorSwitchCCValues: Readonly<{
             readonly property: "targetColor";
             readonly propertyKey: ColorComponent;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses_2)["Color Switch"];
+            property: "targetColor";
+            propertyKey: ColorComponent;
+        };
         readonly meta: {
             readonly label: `Target value (${string})`;
             readonly description: `The target value of the ${string} channel.`;
@@ -3586,11 +3591,6 @@ export const ColorSwitchCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: (typeof CommandClasses_2)["Color Switch"];
-            property: "targetColor";
-            propertyKey: ColorComponent;
         };
     }) & {
         is: (valueId: ValueID) => boolean;
@@ -3610,6 +3610,11 @@ export const ColorSwitchCCValues: Readonly<{
             readonly property: "currentColor";
             readonly propertyKey: ColorComponent;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses_2)["Color Switch"];
+            property: "currentColor";
+            propertyKey: ColorComponent;
+        };
         readonly meta: {
             readonly label: `Current value (${string})`;
             readonly description: `The current value of the ${string} channel.`;
@@ -3618,11 +3623,6 @@ export const ColorSwitchCCValues: Readonly<{
             readonly max: 255;
             readonly type: "number";
             readonly readable: true;
-        };
-        readonly id: {
-            commandClass: (typeof CommandClasses_2)["Color Switch"];
-            property: "currentColor";
-            propertyKey: ColorComponent;
         };
     }) & {
         is: (valueId: ValueID) => boolean;
@@ -4218,15 +4218,15 @@ export const ConfigurationCCValues: Readonly<{
             readonly property: number;
             readonly propertyKey: number | undefined;
         };
-        readonly meta: {
-            readonly type: "any";
-            readonly readable: true;
-            readonly writeable: true;
-        };
         readonly id: {
             commandClass: CommandClasses.Configuration;
             property: number;
             propertyKey: number | undefined;
+        };
+        readonly meta: {
+            readonly type: "any";
+            readonly readable: true;
+            readonly writeable: true;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -7084,6 +7084,11 @@ export const HumidityControlSetpointCCValues: Readonly<{
             readonly property: "setpointScale";
             readonly propertyKey: number;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Humidity Control Setpoint"];
+            property: "setpointScale";
+            propertyKey: number;
+        };
         readonly meta: {
             readonly label: `Setpoint scale (${string})`;
             readonly writeable: false;
@@ -7091,11 +7096,6 @@ export const HumidityControlSetpointCCValues: Readonly<{
             readonly max: 255;
             readonly type: "number";
             readonly readable: true;
-        };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Humidity Control Setpoint"];
-            property: "setpointScale";
-            propertyKey: number;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -7115,6 +7115,11 @@ export const HumidityControlSetpointCCValues: Readonly<{
             readonly property: "setpoint";
             readonly propertyKey: number;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Humidity Control Setpoint"];
+            property: "setpoint";
+            propertyKey: number;
+        };
         readonly meta: {
             readonly label: `Setpoint (${string})`;
             readonly ccSpecific: {
@@ -7123,11 +7128,6 @@ export const HumidityControlSetpointCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Humidity Control Setpoint"];
-            property: "setpoint";
-            propertyKey: number;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -7463,14 +7463,14 @@ export const IndicatorCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: number;
         };
+        readonly id: {
+            commandClass: CommandClasses.Indicator;
+            property: number;
+        };
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: CommandClasses.Indicator;
-            property: number;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -7490,6 +7490,11 @@ export const IndicatorCCValues: Readonly<{
             readonly property: number;
             readonly propertyKey: number;
         };
+        readonly id: {
+            commandClass: CommandClasses.Indicator;
+            property: number;
+            propertyKey: number;
+        };
         readonly meta: {
             readonly ccSpecific: {
                 indicatorId: number;
@@ -7498,11 +7503,6 @@ export const IndicatorCCValues: Readonly<{
             readonly type: "any";
             readonly readable: true;
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: CommandClasses.Indicator;
-            property: number;
-            propertyKey: number;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -7522,15 +7522,15 @@ export const IndicatorCCValues: Readonly<{
             readonly property: "supportedPropertyIDs";
             readonly propertyKey: number;
         };
-        readonly meta: {
-            readonly type: "any";
-            readonly readable: true;
-            readonly writeable: true;
-        };
         readonly id: {
             commandClass: CommandClasses.Indicator;
             property: "supportedPropertyIDs";
             propertyKey: number;
+        };
+        readonly meta: {
+            readonly type: "any";
+            readonly readable: true;
+            readonly writeable: true;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -7847,16 +7847,16 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "startStop";
         };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "startStop";
+        };
         readonly meta: {
             readonly label: `${string}: Start/Stop`;
             readonly type: "boolean";
             readonly readable: true;
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "startStop";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -7876,6 +7876,11 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "duration";
         };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "duration";
+        };
         readonly meta: {
             readonly label: `${string}: Run duration`;
             readonly min: 1;
@@ -7884,11 +7889,6 @@ export const IrrigationCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "duration";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -7908,16 +7908,16 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "useMoistureSensor";
         };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "useMoistureSensor";
+        };
         readonly meta: {
             readonly label: `${string}: Use moisture sensor`;
             readonly type: "boolean";
             readonly readable: true;
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "useMoistureSensor";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -7937,16 +7937,16 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "useRainSensor";
         };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "useRainSensor";
+        };
         readonly meta: {
             readonly label: `${string}: Use rain sensor`;
             readonly type: "boolean";
             readonly readable: true;
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "useRainSensor";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -7966,16 +7966,16 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "errorLowFlow";
         };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "errorLowFlow";
+        };
         readonly meta: {
             readonly label: `${string}: Error - Flow below high threshold`;
             readonly writeable: false;
             readonly type: "boolean";
             readonly readable: true;
-        };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "errorLowFlow";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -7995,6 +7995,11 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "lowFlowThreshold";
         };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "lowFlowThreshold";
+        };
         readonly meta: {
             readonly label: `${string}: Low flow threshold`;
             readonly min: 0;
@@ -8002,11 +8007,6 @@ export const IrrigationCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "lowFlowThreshold";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -8026,16 +8026,16 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "errorHighFlow";
         };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "errorHighFlow";
+        };
         readonly meta: {
             readonly label: `${string}: Error - Flow above high threshold`;
             readonly writeable: false;
             readonly type: "boolean";
             readonly readable: true;
-        };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "errorHighFlow";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -8055,6 +8055,11 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "highFlowThreshold";
         };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "highFlowThreshold";
+        };
         readonly meta: {
             readonly label: `${string}: High flow threshold`;
             readonly min: 0;
@@ -8062,11 +8067,6 @@ export const IrrigationCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "highFlowThreshold";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -8086,16 +8086,16 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "errorMaximumFlow";
         };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "errorMaximumFlow";
+        };
         readonly meta: {
             readonly label: `${string}: Error - Maximum flow detected`;
             readonly writeable: false;
             readonly type: "boolean";
             readonly readable: true;
-        };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "errorMaximumFlow";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -8115,6 +8115,11 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "maximumFlow";
         };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "maximumFlow";
+        };
         readonly meta: {
             readonly label: `${string}: Maximum flow`;
             readonly min: 0;
@@ -8122,11 +8127,6 @@ export const IrrigationCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "maximumFlow";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -8146,16 +8146,16 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "errorLowCurrent";
         };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "errorLowCurrent";
+        };
         readonly meta: {
             readonly label: `${string}: Error - Current below low threshold`;
             readonly writeable: false;
             readonly type: "boolean";
             readonly readable: true;
-        };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "errorLowCurrent";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -8175,16 +8175,16 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "errorHighCurrent";
         };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "errorHighCurrent";
+        };
         readonly meta: {
             readonly label: `${string}: Error - Current above high threshold`;
             readonly writeable: false;
             readonly type: "boolean";
             readonly readable: true;
-        };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "errorHighCurrent";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -8204,16 +8204,16 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "errorShortCircuit";
         };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "errorShortCircuit";
+        };
         readonly meta: {
             readonly label: `${string}: Error - Short circuit detected`;
             readonly writeable: false;
             readonly type: "boolean";
             readonly readable: true;
-        };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "errorShortCircuit";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -8233,6 +8233,11 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "nominalCurrentLowThreshold";
         };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "nominalCurrentLowThreshold";
+        };
         readonly meta: {
             readonly label: `${string}: Nominal current - low threshold`;
             readonly min: 0;
@@ -8241,11 +8246,6 @@ export const IrrigationCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "nominalCurrentLowThreshold";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -8265,6 +8265,11 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "nominalCurrentHighThreshold";
         };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "nominalCurrentHighThreshold";
+        };
         readonly meta: {
             readonly label: `${string}: Nominal current - high threshold`;
             readonly min: 0;
@@ -8273,11 +8278,6 @@ export const IrrigationCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "nominalCurrentHighThreshold";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -8297,17 +8297,17 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "nominalCurrent";
         };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "nominalCurrent";
+        };
         readonly meta: {
             readonly label: `${string}: Nominal current`;
             readonly unit: "mA";
             readonly writeable: false;
             readonly type: "boolean";
             readonly readable: true;
-        };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "nominalCurrent";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -8327,16 +8327,16 @@ export const IrrigationCCValues: Readonly<{
             readonly property: ValveId;
             readonly propertyKey: "valveConnected";
         };
+        readonly id: {
+            commandClass: CommandClasses.Irrigation;
+            property: ValveId;
+            propertyKey: "valveConnected";
+        };
         readonly meta: {
             readonly label: `${string}: Connected`;
             readonly writeable: false;
             readonly type: "boolean";
             readonly readable: true;
-        };
-        readonly id: {
-            commandClass: CommandClasses.Irrigation;
-            property: ValveId;
-            propertyKey: "valveConnected";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -9679,16 +9679,16 @@ export const ManufacturerSpecificCCValues: Readonly<{
             readonly property: "deviceId";
             readonly propertyKey: string;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Manufacturer Specific"];
+            property: "deviceId";
+            propertyKey: string;
+        };
         readonly meta: {
             readonly label: string;
             readonly writeable: false;
             readonly type: "string";
             readonly readable: true;
-        };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Manufacturer Specific"];
-            property: "deviceId";
-            propertyKey: string;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -9914,6 +9914,11 @@ export const MeterCCValues: Readonly<{
             readonly property: "value";
             readonly propertyKey: number;
         };
+        readonly id: {
+            commandClass: CommandClasses.Meter;
+            property: "value";
+            propertyKey: number;
+        };
         readonly meta: {
             readonly ccSpecific: {
                 readonly meterType: number;
@@ -9923,11 +9928,6 @@ export const MeterCCValues: Readonly<{
             readonly writeable: false;
             readonly type: "number";
             readonly readable: true;
-        };
-        readonly id: {
-            commandClass: CommandClasses.Meter;
-            property: "value";
-            propertyKey: number;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -9947,6 +9947,11 @@ export const MeterCCValues: Readonly<{
             readonly property: "reset";
             readonly propertyKey: number;
         };
+        readonly id: {
+            commandClass: CommandClasses.Meter;
+            property: "reset";
+            propertyKey: number;
+        };
         readonly meta: {
             readonly label: `Reset (${string})`;
             readonly ccSpecific: {
@@ -9955,11 +9960,6 @@ export const MeterCCValues: Readonly<{
             readonly readable: false;
             readonly type: "boolean";
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: CommandClasses.Meter;
-            property: "reset";
-            propertyKey: number;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -10287,15 +10287,15 @@ export const MultiChannelAssociationCCValues: Readonly<{
             readonly property: "endpoints";
             readonly propertyKey: number;
         };
-        readonly meta: {
-            readonly type: "any";
-            readonly readable: true;
-            readonly writeable: true;
-        };
         readonly id: {
             commandClass: (typeof CommandClasses)["Multi Channel Association"];
             property: "endpoints";
             propertyKey: number;
+        };
+        readonly meta: {
+            readonly type: "any";
+            readonly readable: true;
+            readonly writeable: true;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -10315,15 +10315,15 @@ export const MultiChannelAssociationCCValues: Readonly<{
             readonly property: "nodeIds";
             readonly propertyKey: number;
         };
-        readonly meta: {
-            readonly type: "any";
-            readonly readable: true;
-            readonly writeable: true;
-        };
         readonly id: {
             commandClass: (typeof CommandClasses)["Multi Channel Association"];
             property: "nodeIds";
             propertyKey: number;
+        };
+        readonly meta: {
+            readonly type: "any";
+            readonly readable: true;
+            readonly writeable: true;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -10343,15 +10343,15 @@ export const MultiChannelAssociationCCValues: Readonly<{
             readonly property: "maxNodes";
             readonly propertyKey: number;
         };
-        readonly meta: {
-            readonly type: "any";
-            readonly readable: true;
-            readonly writeable: true;
-        };
         readonly id: {
             commandClass: (typeof CommandClasses)["Multi Channel Association"];
             property: "maxNodes";
             propertyKey: number;
+        };
+        readonly meta: {
+            readonly type: "any";
+            readonly readable: true;
+            readonly writeable: true;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -10630,15 +10630,15 @@ export const MultiChannelCCValues: Readonly<{
             readonly property: "members";
             readonly propertyKey: number;
         };
-        readonly meta: {
-            readonly type: "any";
-            readonly readable: true;
-            readonly writeable: true;
-        };
         readonly id: {
             commandClass: (typeof CommandClasses)["Multi Channel"];
             property: "members";
             propertyKey: number;
+        };
+        readonly meta: {
+            readonly type: "any";
+            readonly readable: true;
+            readonly writeable: true;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -11028,15 +11028,15 @@ export const MultilevelSensorCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: string;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Multilevel Sensor"];
+            property: string;
+        };
         readonly meta: {
             readonly label: string;
             readonly writeable: false;
             readonly type: "number";
             readonly readable: true;
-        };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Multilevel Sensor"];
-            property: string;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -11056,15 +11056,15 @@ export const MultilevelSensorCCValues: Readonly<{
             readonly property: "supportedScales";
             readonly propertyKey: number;
         };
-        readonly meta: {
-            readonly type: "any";
-            readonly readable: true;
-            readonly writeable: true;
-        };
         readonly id: {
             commandClass: (typeof CommandClasses)["Multilevel Sensor"];
             property: "supportedScales";
             propertyKey: number;
+        };
+        readonly meta: {
+            readonly type: "any";
+            readonly readable: true;
+            readonly writeable: true;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -11252,6 +11252,10 @@ export const MultilevelSwitchCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: string;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Multilevel Switch"];
+            property: string;
+        };
         readonly meta: {
             readonly label: `Perform a level change (${string})`;
             readonly valueChangeOptions: readonly ["transitionDuration"];
@@ -11261,10 +11265,6 @@ export const MultilevelSwitchCCValues: Readonly<{
             readonly readable: false;
             readonly type: "boolean";
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Multilevel Switch"];
-            property: string;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -11283,6 +11283,10 @@ export const MultilevelSwitchCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: string;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Multilevel Switch"];
+            property: string;
+        };
         readonly meta: {
             readonly label: `Perform a level change (${string})`;
             readonly valueChangeOptions: readonly ["transitionDuration"];
@@ -11292,10 +11296,6 @@ export const MultilevelSwitchCCValues: Readonly<{
             readonly readable: false;
             readonly type: "boolean";
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Multilevel Switch"];
-            property: string;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -11848,15 +11848,15 @@ export const NotificationCCValues: Readonly<{
             readonly property: string;
             readonly propertyKey: string;
         };
-        readonly meta: {
-            readonly type: "any";
-            readonly readable: true;
-            readonly writeable: true;
-        };
         readonly id: {
             commandClass: CommandClasses.Notification;
             property: string;
             propertyKey: string;
+        };
+        readonly meta: {
+            readonly type: "any";
+            readonly readable: true;
+            readonly writeable: true;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -11876,6 +11876,11 @@ export const NotificationCCValues: Readonly<{
             readonly property: string;
             readonly propertyKey: "unknown";
         };
+        readonly id: {
+            commandClass: CommandClasses.Notification;
+            property: string;
+            propertyKey: "unknown";
+        };
         readonly meta: {
             readonly label: `${string}: Unknown value`;
             readonly ccSpecific: {
@@ -11886,11 +11891,6 @@ export const NotificationCCValues: Readonly<{
             readonly max: 255;
             readonly type: "number";
             readonly readable: true;
-        };
-        readonly id: {
-            commandClass: CommandClasses.Notification;
-            property: string;
-            propertyKey: "unknown";
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -11909,6 +11909,10 @@ export const NotificationCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: string;
         };
+        readonly id: {
+            commandClass: CommandClasses.Notification;
+            property: string;
+        };
         readonly meta: {
             readonly label: `Unknown notification (${string})`;
             readonly ccSpecific: {
@@ -11919,10 +11923,6 @@ export const NotificationCCValues: Readonly<{
             readonly max: 255;
             readonly type: "number";
             readonly readable: true;
-        };
-        readonly id: {
-            commandClass: CommandClasses.Notification;
-            property: string;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -11942,15 +11942,15 @@ export const NotificationCCValues: Readonly<{
             readonly property: "supportedNotificationEvents";
             readonly propertyKey: number;
         };
-        readonly meta: {
-            readonly type: "any";
-            readonly readable: true;
-            readonly writeable: true;
-        };
         readonly id: {
             commandClass: CommandClasses.Notification;
             property: "supportedNotificationEvents";
             propertyKey: number;
+        };
+        readonly meta: {
+            readonly type: "any";
+            readonly readable: true;
+            readonly writeable: true;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -12866,16 +12866,16 @@ export const SceneActuatorConfigurationCCValues: Readonly<{
             readonly property: "dimmingDuration";
             readonly propertyKey: number;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Scene Actuator Configuration"];
+            property: "dimmingDuration";
+            propertyKey: number;
+        };
         readonly meta: {
             readonly label: `Dimming duration (${number})`;
             readonly type: "duration";
             readonly readable: true;
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Scene Actuator Configuration"];
-            property: "dimmingDuration";
-            propertyKey: number;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -12895,6 +12895,11 @@ export const SceneActuatorConfigurationCCValues: Readonly<{
             readonly property: "level";
             readonly propertyKey: number;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Scene Actuator Configuration"];
+            property: "level";
+            propertyKey: number;
+        };
         readonly meta: {
             readonly label: `Level (${number})`;
             readonly valueChangeOptions: readonly ["transitionDuration"];
@@ -12903,11 +12908,6 @@ export const SceneActuatorConfigurationCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Scene Actuator Configuration"];
-            property: "level";
-            propertyKey: number;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -13009,16 +13009,16 @@ export const SceneControllerConfigurationCCValues: Readonly<{
             readonly property: "dimmingDuration";
             readonly propertyKey: number;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Scene Controller Configuration"];
+            property: "dimmingDuration";
+            propertyKey: number;
+        };
         readonly meta: {
             readonly label: `Dimming duration (${number})`;
             readonly type: "duration";
             readonly readable: true;
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Scene Controller Configuration"];
-            property: "dimmingDuration";
-            propertyKey: number;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -13038,6 +13038,11 @@ export const SceneControllerConfigurationCCValues: Readonly<{
             readonly property: "sceneId";
             readonly propertyKey: number;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Scene Controller Configuration"];
+            property: "sceneId";
+            propertyKey: number;
+        };
         readonly meta: {
             readonly label: `Associated Scene ID (${number})`;
             readonly valueChangeOptions: readonly ["transitionDuration"];
@@ -13046,11 +13051,6 @@ export const SceneControllerConfigurationCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Scene Controller Configuration"];
-            property: "sceneId";
-            propertyKey: number;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -14570,15 +14570,15 @@ export const SupervisionCCValues: Readonly<{
             readonly property: "ccSupported";
             readonly propertyKey: CommandClasses;
         };
-        readonly meta: {
-            readonly type: "any";
-            readonly readable: true;
-            readonly writeable: true;
-        };
         readonly id: {
             commandClass: CommandClasses.Supervision;
             property: "ccSupported";
             propertyKey: CommandClasses;
+        };
+        readonly meta: {
+            readonly type: "any";
+            readonly readable: true;
+            readonly writeable: true;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -15511,15 +15511,15 @@ export const ThermostatSetpointCCValues: Readonly<{
             readonly property: "setpointScale";
             readonly propertyKey: ThermostatSetpointType;
         };
-        readonly meta: {
-            readonly type: "any";
-            readonly readable: true;
-            readonly writeable: true;
-        };
         readonly id: {
             commandClass: (typeof CommandClasses)["Thermostat Setpoint"];
             property: "setpointScale";
             propertyKey: ThermostatSetpointType;
+        };
+        readonly meta: {
+            readonly type: "any";
+            readonly readable: true;
+            readonly writeable: true;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -15539,6 +15539,11 @@ export const ThermostatSetpointCCValues: Readonly<{
             readonly property: "setpoint";
             readonly propertyKey: ThermostatSetpointType;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["Thermostat Setpoint"];
+            property: "setpoint";
+            propertyKey: ThermostatSetpointType;
+        };
         readonly meta: {
             readonly label: `Setpoint (${string})`;
             readonly ccSpecific: {
@@ -15547,11 +15552,6 @@ export const ThermostatSetpointCCValues: Readonly<{
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["Thermostat Setpoint"];
-            property: "setpoint";
-            propertyKey: ThermostatSetpointType;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -16352,15 +16352,15 @@ export const UserCodeCCValues: Readonly<{
             readonly property: "userCode";
             readonly propertyKey: number;
         };
-        readonly meta: {
-            readonly type: "any";
-            readonly readable: true;
-            readonly writeable: true;
-        };
         readonly id: {
             commandClass: (typeof CommandClasses)["User Code"];
             property: "userCode";
             propertyKey: number;
+        };
+        readonly meta: {
+            readonly type: "any";
+            readonly readable: true;
+            readonly writeable: true;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;
@@ -16380,16 +16380,16 @@ export const UserCodeCCValues: Readonly<{
             readonly property: "userIdStatus";
             readonly propertyKey: number;
         };
+        readonly id: {
+            commandClass: (typeof CommandClasses)["User Code"];
+            property: "userIdStatus";
+            propertyKey: number;
+        };
         readonly meta: {
             readonly label: `User ID status (${number})`;
             readonly type: "number";
             readonly readable: true;
             readonly writeable: true;
-        };
-        readonly id: {
-            commandClass: (typeof CommandClasses)["User Code"];
-            property: "userIdStatus";
-            propertyKey: number;
         };
     }) & {
         is: (valueId: ValueID_2) => boolean;

--- a/packages/cc/src/index.ts
+++ b/packages/cc/src/index.ts
@@ -18,5 +18,6 @@ export {
 	SPANExtension,
 } from "./lib/Security2/Extension";
 export * from "./lib/Security2/shared";
+export { CCValueOptions, defaultCCValueOptions } from "./lib/Values";
 export * from "./lib/_Types";
 export { utils };

--- a/packages/core/api.md
+++ b/packages/core/api.md
@@ -2267,7 +2267,7 @@ export function topologicalSort<T>(graph: GraphNode<T>[]): T[];
 
 // Warning: (ae-missing-release-tag) "TranslatedValueID" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public
 export interface TranslatedValueID extends ValueID {
     // (undocumented)
     commandClassName: string;
@@ -2763,6 +2763,8 @@ export interface ValueMetadataAny {
     description?: string;
     label?: string;
     readable: boolean;
+    secret?: boolean;
+    stateful?: boolean;
     type: ValueType;
     valueChangeOptions?: readonly (keyof ValueChangeOptions)[];
     writeable: boolean;

--- a/packages/core/src/values/Metadata.ts
+++ b/packages/core/src/values/Metadata.ts
@@ -66,6 +66,10 @@ export interface ValueMetadataAny {
 	ccSpecific?: Record<string, any>;
 	/** Options that can be provided when changing this value on a device via its value ID. */
 	valueChangeOptions?: readonly (keyof ValueChangeOptions)[];
+	/** Whether this value represents a state (`true`) or a notification/event (`false`) */
+	stateful?: boolean;
+	/** Omit this value from value logs */
+	secret?: boolean;
 }
 
 /**

--- a/packages/core/src/values/_Types.ts
+++ b/packages/core/src/values/_Types.ts
@@ -2,7 +2,6 @@ import type { CommandClasses } from "../capabilities/CommandClasses";
 import type { ValueMetadata } from "./Metadata";
 
 /** Uniquely identifies to which CC, endpoint and property a value belongs to */
-
 export interface ValueID {
 	commandClass: CommandClasses;
 	endpoint?: number;
@@ -10,6 +9,7 @@ export interface ValueID {
 	propertyKey?: string | number;
 }
 
+/** Extends the {@link ValueID} interface with human-readable labels */
 export interface TranslatedValueID extends ValueID {
 	commandClassName: string;
 	propertyName?: string;

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -72,7 +72,7 @@ import { MessageOptions } from '@zwave-js/serial';
 import { MessageOrCCLogEntry } from '@zwave-js/core';
 import { MessagePriority } from '@zwave-js/core';
 import { MessageType } from '@zwave-js/serial';
-import type { MetadataUpdatedArgs } from '@zwave-js/core';
+import type { MetadataUpdatedArgs } from '@zwave-js/core/safe';
 import { MockControllerBehavior } from '@zwave-js/testing';
 import { MockNodeBehavior } from '@zwave-js/testing';
 import { MulticastCC } from '@zwave-js/core';
@@ -81,7 +81,6 @@ import { MultilevelSwitchCommand } from '@zwave-js/cc/safe';
 import { NODE_ID_BROADCAST } from '@zwave-js/core/safe';
 import { NODE_ID_MAX } from '@zwave-js/core/safe';
 import { NodeStatus } from '@zwave-js/core/safe';
-import type { NodeStatus as NodeStatus_2 } from '@zwave-js/core';
 import { NodeType } from '@zwave-js/core/safe';
 import { NodeType as NodeType_2 } from '@zwave-js/core';
 import { NodeUpdatePayload } from '@zwave-js/core';
@@ -124,12 +123,13 @@ import { SetValueAPIOptions } from '@zwave-js/cc';
 import { SinglecastCC } from '@zwave-js/core';
 import type { SpecificDeviceClass } from '@zwave-js/config';
 import { Switchpoint } from '@zwave-js/cc';
+import { TranslatedValueID } from '@zwave-js/core/safe';
 import { TranslatedValueID as TranslatedValueID_2 } from '@zwave-js/core';
 import { TransmitOptions } from '@zwave-js/core';
 import { TXReport } from '@zwave-js/core/safe';
 import { TypedEventEmitter } from '@zwave-js/shared';
 import * as util from 'util';
-import type { ValueAddedArgs } from '@zwave-js/core';
+import type { ValueAddedArgs } from '@zwave-js/core/safe';
 import { ValueDB } from '@zwave-js/core';
 import { ValueID } from '@zwave-js/core/safe';
 import { ValueID as ValueID_2 } from '@zwave-js/core';
@@ -139,10 +139,10 @@ import { ValueMetadataAny } from '@zwave-js/core/safe';
 import { ValueMetadataBoolean } from '@zwave-js/core/safe';
 import { ValueMetadataNumeric } from '@zwave-js/core/safe';
 import { ValueMetadataString } from '@zwave-js/core/safe';
-import type { ValueNotificationArgs } from '@zwave-js/core';
-import type { ValueRemovedArgs } from '@zwave-js/core';
+import type { ValueNotificationArgs } from '@zwave-js/core/safe';
+import type { ValueRemovedArgs } from '@zwave-js/core/safe';
 import { ValueType } from '@zwave-js/core/safe';
-import type { ValueUpdatedArgs } from '@zwave-js/core';
+import type { ValueUpdatedArgs } from '@zwave-js/core/safe';
 import { ZWaveApiVersion } from '@zwave-js/core/safe';
 import type { ZWaveApplicationHost } from '@zwave-js/host';
 import { ZWaveDataRate } from '@zwave-js/core';
@@ -874,17 +874,7 @@ export type SmartStartProvisioningEntry = PlannedProvisioningEntry | IncludedPro
 
 export { Switchpoint }
 
-// Warning: (ae-missing-release-tag) "TranslatedValueID" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export interface TranslatedValueID extends ValueID_2 {
-    // (undocumented)
-    commandClassName: string;
-    // (undocumented)
-    propertyKeyName?: string;
-    // (undocumented)
-    propertyName?: string;
-}
+export { TranslatedValueID }
 
 export { TXReport }
 
@@ -1195,7 +1185,7 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner, IZWaveNod
     // (undocumented)
     get firmwareVersion(): string | undefined;
     getAllEndpoints(): Endpoint[];
-    getDefinedValueIDs(): TranslatedValueID[];
+    getDefinedValueIDs(): TranslatedValueID_2[];
     getEndpoint(index: 0): Endpoint;
     // (undocumented)
     getEndpoint(index: number): Endpoint | undefined;
@@ -1340,7 +1330,7 @@ export type ZWaveNodeMetadataUpdatedCallback = (node: ZWaveNode, args: ZWaveNode
 // Warning: (ae-missing-release-tag) "ZWaveNodeStatusChangeCallback" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export type ZWaveNodeStatusChangeCallback = (node: ZWaveNode, oldStatus: NodeStatus_2) => void;
+export type ZWaveNodeStatusChangeCallback = (node: ZWaveNode, oldStatus: NodeStatus) => void;
 
 // Warning: (ae-missing-release-tag) "ZWaveNodeValueAddedArgs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -1454,7 +1444,7 @@ export interface ZWaveNotificationCallbackArgs_PowerlevelCC {
 // @public
 export type ZWaveNotificationCallbackParams_EntryControlCC = [
 node: ZWaveNode,
-ccId: typeof CommandClasses_2["Entry Control"],
+ccId: typeof CommandClasses["Entry Control"],
 args: ZWaveNotificationCallbackArgs_EntryControlCC
 ];
 
@@ -1463,7 +1453,7 @@ args: ZWaveNotificationCallbackArgs_EntryControlCC
 // @public
 export type ZWaveNotificationCallbackParams_MultilevelSwitchCC = [
 node: ZWaveNode,
-ccId: typeof CommandClasses_2["Multilevel Switch"],
+ccId: typeof CommandClasses["Multilevel Switch"],
 args: ZWaveNotificationCallbackArgs_MultilevelSwitchCC
 ];
 
@@ -1472,7 +1462,7 @@ args: ZWaveNotificationCallbackArgs_MultilevelSwitchCC
 // @public
 export type ZWaveNotificationCallbackParams_NotificationCC = [
 node: ZWaveNode,
-ccId: CommandClasses_2.Notification,
+ccId: CommandClasses.Notification,
 args: ZWaveNotificationCallbackArgs_NotificationCC
 ];
 
@@ -1481,7 +1471,7 @@ args: ZWaveNotificationCallbackArgs_NotificationCC
 // @public
 export type ZWaveNotificationCallbackParams_PowerlevelCC = [
 node: ZWaveNode,
-ccId: CommandClasses_2.Powerlevel,
+ccId: CommandClasses.Powerlevel,
 args: ZWaveNotificationCallbackArgs_PowerlevelCC
 ];
 

--- a/packages/zwave-js/src/Values.ts
+++ b/packages/zwave-js/src/Values.ts
@@ -5,6 +5,7 @@ export type { Scale, SensorType } from "@zwave-js/config";
 export { Duration, ValueMetadata } from "@zwave-js/core/safe";
 export type {
 	DurationUnit,
+	TranslatedValueID,
 	ValueID,
 	ValueMetadataAny,
 	ValueMetadataBoolean,
@@ -13,7 +14,6 @@ export type {
 	ValueType,
 } from "@zwave-js/core/safe";
 export type {
-	TranslatedValueID,
 	ZWaveNodeMetadataUpdatedArgs,
 	ZWaveNodeValueAddedArgs,
 	ZWaveNodeValueNotificationArgs,

--- a/packages/zwave-js/src/lib/node/_Types.ts
+++ b/packages/zwave-js/src/lib/node/_Types.ts
@@ -13,12 +13,12 @@ import type {
 	CommandClasses,
 	MetadataUpdatedArgs,
 	NodeStatus,
+	TranslatedValueID,
 	ValueAddedArgs,
-	ValueID,
 	ValueNotificationArgs,
 	ValueRemovedArgs,
 	ValueUpdatedArgs,
-} from "@zwave-js/core";
+} from "@zwave-js/core/safe";
 import type { ZWaveNode } from "./Node";
 import type { RouteStatistics } from "./NodeStatistics";
 
@@ -31,12 +31,6 @@ export {
 	PowerlevelTestStatus,
 } from "@zwave-js/cc/safe";
 export { InterviewStage, NodeStatus } from "@zwave-js/core/safe";
-
-export interface TranslatedValueID extends ValueID {
-	commandClassName: string;
-	propertyName?: string;
-	propertyKeyName?: string;
-}
 
 export type NodeInterviewFailedEventArgs = {
 	errorMessage: string;

--- a/packages/zwave-js/src/lib/node/utils.ts
+++ b/packages/zwave-js/src/lib/node/utils.ts
@@ -261,9 +261,9 @@ export function translateValueID<T extends ValueID>(
  * Removes all Value IDs from an array that belong to a root endpoint and have a corresponding
  * Value ID on a non-root endpoint
  */
-export function filterRootApplicationCCValueIDs(
-	allValueIds: ValueID[],
-): ValueID[] {
+export function filterRootApplicationCCValueIDs<T extends ValueID>(
+	allValueIds: T[],
+): T[] {
 	const shouldHideRootValueID = (
 		valueId: ValueID,
 		allValueIds: ValueID[],


### PR DESCRIPTION
With this PR, the `ValueMetadata` returned from `Node.getValueMetadata()` now includes two flags `stateful` and `secret` to indicate whether the value is stateful/stateless, and whether it should be omitted or obfuscated in (public) logs. This is derived from the ValueID definition and cannot be overwritten.