### PR TITLE
fix(config): correct warm and cold white config parameter for Aeotec ZWA001

### DIFF
--- a/packages/config/config/devices/0x0371/zwa001.json
+++ b/packages/config/config/devices/0x0371/zwa001.json
@@ -24,7 +24,6 @@
 			"description": "To send notifications to (Group 1) when state change.0 = Nothing.1= Basic CC.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"readOnly": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -45,7 +44,6 @@
 			"minValue": 2700,
 			"maxValue": 4999,
 			"defaultValue": 2700,
-			"readOnly": true,
 			"options": [
 				{
 					"label": "Warm White(0x0A8C(2700k) ~ 0x1387 (4999k))",


### PR DESCRIPTION
_The parameters 81 and 82 are intended to be written to change the emitted color temperature per the manual, so they should not be read-only: http://manuals-backend.z-wave.info/make.php?lang=en&sku=ZWA001-C&cert=ZC10-18036060_

Hello, first off I'd like to say thank you all for this _awesome_ project! I finally got around to migrating to Z-Wave JS from OpenZWave in my Home Assistant system and things are working really well.

I noticed that the migration broke some automations related to setting the color temperature of an **Aeotec ZWA001** lightbulb I have: I'm not knowledgeable enough about Z-Wave devices to know if Aeotec's implementation is unusual here, but I realized it was because I could no longer set the two config parameters responsible for changing the color temperature emitted by the lightbulb. I have to imagine this is not the 'proper'  or intended way to set the color temperature of light bulbs in the Z-Wave world, but it's the only way that has worked for me with this particular device model.

I made these changes on my own system and confirmed they are working as expected with my device.