### PR TITLE
fix(config): preserve root endpoint with master switch and total consumption for Aeotec DSC11

### DIFF
--- a/packages/config/config/devices/0x0086/dsc11.json
+++ b/packages/config/config/devices/0x0086/dsc11.json
@@ -385,5 +385,4 @@
 		// Add missing root binary switch and electrical consumption
 		"preserveRootApplicationCCValueIDs": true
 	}
-
 }

--- a/packages/config/config/devices/0x0086/dsc11.json
+++ b/packages/config/config/devices/0x0086/dsc11.json
@@ -382,7 +382,7 @@
 		}
 	],
 	"compat": {
-		// Add missing root binary switch and electrical consumption
+		// The root endpoint exposes a master binary switch and total energy consumption
 		"preserveRootApplicationCCValueIDs": true
 	}
 }

--- a/packages/config/config/devices/0x0086/dsc11.json
+++ b/packages/config/config/devices/0x0086/dsc11.json
@@ -380,5 +380,10 @@
 			"#": "255",
 			"$import": "templates/aeotec_template.json#factory_reset"
 		}
-	]
+	],
+	"compat": {
+		// Add missing root binary switch and electrical consumption
+		"preserveRootApplicationCCValueIDs": true
+	}
+
 }


### PR DESCRIPTION
Fixes Aeotec DSC11 to include root binary switch and electrical measurement values.
