### PR TITLE
fix(config): correct Minoston MR40Z parameters to match device

### DIFF
--- a/packages/config/config/devices/0x0312/mr40z.json
+++ b/packages/config/config/devices/0x0312/mr40z.json
@@ -41,14 +41,14 @@
 		},
 		{
 			"#": "7",
-                        "$import": "templates/minoston_template.json#led_indicator_brightness_mr40z"
+			"$import": "templates/minoston_template.json#led_indicator_brightness_mr40z"
 		}
 	],
 	"metadata": {
 		"inclusion": "1. Refer to your primary controller instructions to process the inclusion / exclusion setup procedure.\n2. When prompted by your primary controller, click the first button five times in one second",
 		"exclusion": "1. Refer to your primary controller instructions to process the inclusion / exclusion setup procedure.\n2. When prompted by your primary controller, click the second button five times in one second",
 		"reset": "Press the fourth button five times, then press it five times again when the red light is flashing",
-                "wakeup": "Press the third button 5 times quickly. LED will stay solid blue when awake and turns off when device returns to sleep mode",
+		"wakeup": "Press the third button 5 times quickly. LED will stay solid blue when awake and turns off when device returns to sleep mode",
 		"manual": "https://minoston.com/wp-content/uploads/2022/10/MR40Z-manual.pdf"
 	}
 }

--- a/packages/config/config/devices/0x0312/mr40z.json
+++ b/packages/config/config/devices/0x0312/mr40z.json
@@ -17,39 +17,38 @@
 	"paramInformation": [
 		{
 			"#": "1",
-			"$import": "~/templates/master_template.json#led_indicator_four_options",
-			"options": [
-				{
-					"label": "Always off",
-					"value": 0
-				},
-				{
-					"label": "On at 100% brightness",
-					"value": 1
-				},
-				{
-					"label": "Always on - color per parameter 2",
-					"value": 2
-				},
-				{
-					"label": "Always on - color per parameter 3",
-					"value": 3
-				}
-			]
+			"$import": "templates/minoston_template.json#battery_report_threshold"
 		},
 		{
 			"#": "2",
-			"$import": "templates/minoston_template.json#led_indicator_color_upper"
+			"$import": "templates/minoston_template.json#battery_alarm_report"
 		},
 		{
 			"#": "3",
-			"$import": "templates/minoston_template.json#led_indicator_color_lower"
+			"$import": "templates/minoston_template.json#led_indicator_color_first_button"
+		},
+		{
+			"#": "4",
+			"$import": "templates/minoston_template.json#led_indicator_color_second_button"
+		},
+		{
+			"#": "5",
+			"$import": "templates/minoston_template.json#led_indicator_color_third_button"
+		},
+		{
+			"#": "6",
+			"$import": "templates/minoston_template.json#led_indicator_color_fourth_button"
+		},
+		{
+			"#": "7",
+                        "$import": "templates/minoston_template.json#led_indicator_brightness_mr40z"
 		}
 	],
 	"metadata": {
-		"inclusion": "1. Refer to your primary controller instructions to process the inclusion / exclusion setup procedure.\n2. When prompted by your primary controller, click the button three times in one second",
-		"exclusion": "1. Refer to your primary controller instructions to process the inclusion / exclusion setup procedure.\n2. When prompted by your primary controller, click the button three times in one second",
-		"reset": "Triple-tap and hold to reset, LED indicator will blink red 5 times to confirm successful reset\n(Node:Please use this procedure only when the network primary controller is missing or otherwise inoperable.)",
-		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=product_documents/4246/MR40Z-manual-20210630.pdf"
+		"inclusion": "1. Refer to your primary controller instructions to process the inclusion / exclusion setup procedure.\n2. When prompted by your primary controller, click the first button five times in one second",
+		"exclusion": "1. Refer to your primary controller instructions to process the inclusion / exclusion setup procedure.\n2. When prompted by your primary controller, click the second button five times in one second",
+		"reset": "Press the fourth button five times, then press it five times again when the red light is flashing",
+                "wakeup": "Press the third button 5 times quickly. LED will stay solid blue when awake and turns off when device returns to sleep mode",
+		"manual": "https://minoston.com/wp-content/uploads/2022/10/MR40Z-manual.pdf"
 	}
 }

--- a/packages/config/config/devices/0x0312/templates/minoston_template.json
+++ b/packages/config/config/devices/0x0312/templates/minoston_template.json
@@ -1,4 +1,42 @@
 {
+	"base_led_color": {
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 6,
+		"defaultValue": 1,
+		"unsigned": true,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "White",
+				"value": 0
+			},
+			{
+				"label": "Blue",
+				"value": 1
+			},
+			{
+				"label": "Green",
+				"value": 2
+			},
+			{
+				"label": "Red",
+				"value": 3
+			},
+			{
+				"label": "Magenta",
+				"value": 4
+			},
+			{
+				"label": "Yellow",
+				"value": 5
+			},
+			{
+				"label": "Cyan",
+				"value": 6
+			}
+		]
+	},
 	"base_led_color_mr40z": {
 		"valueSize": 1,
 		"minValue": 0,
@@ -222,6 +260,14 @@
 				"value": 3
 			}
 		]
+	},
+	"led_indicator_color_upper": {
+		"$import": "#base_led_color",
+		"label": "Led Indicator: Upper Paddle Color"
+	},
+	"led_indicator_color_lower": {
+		"$import": "#base_led_color",
+		"label": "Led Indicator: Lower Paddle Color"
 	},
 	"led_indicator_color_first_button": {
 		"$import": "#base_led_color_mr40z",

--- a/packages/config/config/devices/0x0312/templates/minoston_template.json
+++ b/packages/config/config/devices/0x0312/templates/minoston_template.json
@@ -1,9 +1,9 @@
 {
-	"base_led_color": {
+	"base_led_color_mr40z": {
 		"valueSize": 1,
 		"minValue": 0,
 		"maxValue": 6,
-		"defaultValue": 1,
+		"defaultValue": 0,
 		"unsigned": true,
 		"allowManualEntry": false,
 		"options": [
@@ -12,27 +12,27 @@
 				"value": 0
 			},
 			{
-				"label": "Blue",
+				"label": "Purple",
 				"value": 1
 			},
 			{
-				"label": "Green",
+				"label": "Orange",
 				"value": 2
 			},
 			{
-				"label": "Red",
+				"label": "Cyan",
 				"value": 3
 			},
 			{
-				"label": "Magenta",
+				"label": "Red",
 				"value": 4
 			},
 			{
-				"label": "Yellow",
+				"label": "Green",
 				"value": 5
 			},
 			{
-				"label": "Cyan",
+				"label": "Blue",
 				"value": 6
 			}
 		]
@@ -223,13 +223,25 @@
 			}
 		]
 	},
-	"led_indicator_color_upper": {
-		"$import": "#base_led_color",
-		"label": "Led Indicator: Upper Paddle Color"
+	"led_indicator_color_first_button": {
+		"$import": "#base_led_color_mr40z",
+		"default": 0,
+		"label": "Led Indicator: First Button"
 	},
-	"led_indicator_color_lower": {
-		"$import": "#base_led_color",
-		"label": "Led Indicator: Lower Paddle Color"
+	"led_indicator_color_second_button": {
+		"$import": "#base_led_color_mr40z",
+		"default": 1,
+		"label": "Led Indicator: Second Button"
+	},
+	"led_indicator_color_third_button": {
+		"$import": "#base_led_color_mr40z",
+		"default": 2,
+		"label": "Led Indicator: Third Button"
+	},
+	"led_indicator_color_fourth_button": {
+		"$import": "#base_led_color_mr40z",
+		"default": 3,
+		"label": "Led Indicator: Fourth Button"
 	},
 	"led_indicator_brightness": {
 		"label": "Led Indicator: Brightness",
@@ -251,6 +263,61 @@
 			{
 				"label": "Low",
 				"value": 2
+			}
+		]
+	},
+	"led_indicator_brightness_mr40z": {
+		"label": "Led Indicator: Brightness",
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 10,
+		"defaultValue": 5,
+		"unsigned": true,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "LED OFf",
+				"value": 0
+			},
+			{
+				"label": "10% Brightness",
+				"value": 1
+			},
+			{
+				"label": "20% Brightness",
+				"value": 2
+			},
+			{
+				"label": "30% Brightness",
+				"value": 3
+			},
+			{
+				"label": "40% Brightness",
+				"value": 4
+			},
+			{
+				"label": "50% Brightness",
+				"value": 5
+			},
+			{
+				"label": "60% Brightness",
+				"value": 6
+			},
+			{
+				"label": "70% Brightness",
+				"value": 7
+			},
+			{
+				"label": "80% Brightness",
+				"value": 8
+			},
+			{
+				"label": "90% Brightness",
+				"value": 9
+			},
+			{
+				"label": "100% Brightness",
+				"value": 10
 			}
 		]
 	},
@@ -368,5 +435,23 @@
 		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Local Control",
 		"defaultValue": 1
+	},
+	"battery_report_threshold": {
+		"label": "Battery Report Threshold %",
+		"valueSize": 1,
+		"unit": "%",
+		"minValue": 1,
+		"maxValue": 20,
+		"defaultValue": 10,
+		"unsigned": true
+	},
+	"battery_alarm_report": {
+		"label": "Low Battery Alarm Report",
+		"valueSize": 1,
+		"unit": "%",
+		"minValue": 5,
+		"maxValue": 20,
+		"defaultValue": 5,
+		"unsigned": true
 	}
 }

--- a/packages/config/config/devices/0x0312/templates/minoston_template.json
+++ b/packages/config/config/devices/0x0312/templates/minoston_template.json
@@ -235,7 +235,7 @@
 		]
 	},
 	"led_indicator_color": {
-		"label": "Led Indicator: Color",
+		"label": "LED Indicator: Color",
 		"valueSize": 1,
 		"minValue": 0,
 		"maxValue": 3,
@@ -263,34 +263,34 @@
 	},
 	"led_indicator_color_upper": {
 		"$import": "#base_led_color",
-		"label": "Led Indicator: Upper Paddle Color"
+		"label": "LED Indicator: Upper Paddle Color"
 	},
 	"led_indicator_color_lower": {
 		"$import": "#base_led_color",
-		"label": "Led Indicator: Lower Paddle Color"
+		"label": "LED Indicator: Lower Paddle Color"
 	},
 	"led_indicator_color_first_button": {
 		"$import": "#base_led_color_mr40z",
 		"default": 0,
-		"label": "Led Indicator: First Button"
+		"label": "LED Indicator: First Button"
 	},
 	"led_indicator_color_second_button": {
 		"$import": "#base_led_color_mr40z",
 		"default": 1,
-		"label": "Led Indicator: Second Button"
+		"label": "LED Indicator: Second Button"
 	},
 	"led_indicator_color_third_button": {
 		"$import": "#base_led_color_mr40z",
 		"default": 2,
-		"label": "Led Indicator: Third Button"
+		"label": "LED Indicator: Third Button"
 	},
 	"led_indicator_color_fourth_button": {
 		"$import": "#base_led_color_mr40z",
 		"default": 3,
-		"label": "Led Indicator: Fourth Button"
+		"label": "LED Indicator: Fourth Button"
 	},
 	"led_indicator_brightness": {
-		"label": "Led Indicator: Brightness",
+		"label": "LED Indicator: Brightness",
 		"valueSize": 1,
 		"minValue": 0,
 		"maxValue": 2,
@@ -313,7 +313,7 @@
 		]
 	},
 	"led_indicator_brightness_mr40z": {
-		"label": "Led Indicator: Brightness",
+		"label": "LED Indicator: Brightness",
 		"valueSize": 1,
 		"minValue": 0,
 		"maxValue": 10,
@@ -322,47 +322,47 @@
 		"allowManualEntry": false,
 		"options": [
 			{
-				"label": "LED OFf",
+				"label": "Off",
 				"value": 0
 			},
 			{
-				"label": "10% Brightness",
+				"label": "10%",
 				"value": 1
 			},
 			{
-				"label": "20% Brightness",
+				"label": "20%",
 				"value": 2
 			},
 			{
-				"label": "30% Brightness",
+				"label": "30%",
 				"value": 3
 			},
 			{
-				"label": "40% Brightness",
+				"label": "40%",
 				"value": 4
 			},
 			{
-				"label": "50% Brightness",
+				"label": "50%",
 				"value": 5
 			},
 			{
-				"label": "60% Brightness",
+				"label": "60%",
 				"value": 6
 			},
 			{
-				"label": "70% Brightness",
+				"label": "70%",
 				"value": 7
 			},
 			{
-				"label": "80% Brightness",
+				"label": "80%",
 				"value": 8
 			},
 			{
-				"label": "90% Brightness",
+				"label": "90%",
 				"value": 9
 			},
 			{
-				"label": "100% Brightness",
+				"label": "100%",
 				"value": 10
 			}
 		]
@@ -483,7 +483,7 @@
 		"defaultValue": 1
 	},
 	"battery_report_threshold": {
-		"label": "Battery Report Threshold %",
+		"label": "Battery Report Threshold",
 		"valueSize": 1,
 		"unit": "%",
 		"minValue": 1,
@@ -492,7 +492,7 @@
 		"unsigned": true
 	},
 	"battery_alarm_report": {
-		"label": "Low Battery Alarm Report",
+		"label": "Low Battery Alarm Threshold",
 		"valueSize": 1,
 		"unit": "%",
 		"minValue": 5,


### PR DESCRIPTION
It appears that Minoston changed the parameters quite a bit between the manual that was published at the ZWave Alliance and what was actually released. This PR corrects these parameters to what is in the published manual and what works in practice on the actual device.

fixes #5504