### PR TITLE
fix: the `currentMode` property for `Door Lock CC` is readonly

### DIFF
--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -5178,11 +5178,11 @@ export const DoorLockCCValues: Readonly<{
             readonly states: {
                 [x: number]: string;
             };
+            readonly writeable: false;
             readonly min: 0;
             readonly max: 255;
             readonly type: "number";
             readonly readable: true;
-            readonly writeable: true;
         };
         readonly options: {
             readonly internal: false;

--- a/packages/cc/src/cc/DoorLockCC.ts
+++ b/packages/cc/src/cc/DoorLockCC.ts
@@ -61,7 +61,7 @@ export const DoorLockCCValues = Object.freeze({
 		} as const),
 
 		...V.staticProperty("currentMode", {
-			...ValueMetadata.UInt8,
+			...ValueMetadata.ReadOnlyUInt8,
 			label: "Current lock mode",
 			states: enumValuesToMetadataStates(DoorLockMode),
 		} as const),


### PR DESCRIPTION
fixes: #5502