### PR TITLE
feat(config): add Nexa ZPR-111 metered plug-in switch

### DIFF
--- a/packages/config/config/devices/0x0268/zpr111.json
+++ b/packages/config/config/devices/0x0268/zpr111.json
@@ -1,0 +1,22 @@
+{
+	"manufacturer": "Nexa Trading AB",
+	"manufacturerId": "0x0268",
+	"label": "ZPR-111",
+	"description": "Metered Wall Plug Switch",
+	"devices": [
+		{
+			"productType": "0x0002",
+			"productId": "0x1027"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"metadata": {
+		"comments": {
+			"level": "warning",
+			"text": "This device is buggy and sends large negative Meter Reports from time to time."
+		}
+	}
+}


### PR DESCRIPTION
Add configuration metadata for the Nexa ZPR-111 metered plug-in switch.

It has the infamous random bit 31 flip causing bugged metering values, so added a warning for that.

Didn't find any existing metadata in databases mentioned in the guidelines.

> Addendum: I want to share my experience relating to this device. Not only does it seem to exhibit issues related to invalid metering data, but it might also have other hardware issues (or defects) that I have been [documenting](https://gist.github.com/andersevenrud/5d13d30bfcc08a4e121222671f8cb9e9#file-1_zpr-111-md) relating to operation.