### PR TITLE
fix: always return `false` for `canSleep` on the controller node

### DIFF
--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -598,6 +598,8 @@ export class ZWaveNode
 	}
 
 	public get canSleep(): boolean | undefined {
+		// The controller node can never sleep (apparently it can report otherwise though)
+		if (this.isControllerNode) return false;
 		if (this.isListening == undefined) return undefined;
 		if (this.isFrequentListening == undefined) return undefined;
 		return !this.isListening && !this.isFrequentListening;


### PR DESCRIPTION
... even when the controller reports otherwise (why ever it would do that...)

fixes: #5174