### PR TITLE
feat: measure background RSSI frequently when the controller is idle

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -1249,28 +1249,25 @@ interface ControllerStatistics {
 	/** No. of outgoing messages that were dropped because they could not be sent */
 	messagesDroppedTX: number;
 
-	/** Background RSSI of the network. */
+	/**
+	 * Background RSSI of the network. The `average` values are calculated using an exponential moving average.
+	 * The `current` values are the most recent measurements, which can be compared to the average to detect interference/jamming.
+	 * The `timestamp` is the time of the most recent update of these measurements, and can be used to draw graphs.
+	 */
 	backgroundRSSI?: {
-		/**
-		 * Average background RSSI of the network.
-		 * Consecutive measurements are combined using an exponential moving average.
-		 */
-		average: {
-			rssiChannel0: RSSI;
-			rssiChannel1: RSSI;
-			rssiChannel2?: RSSI;
-		};
-		/**
-		 * Current background RSSI of the network.
-		 * Can be compared to the average to detect interference/jamming.
-		 */
-		current: {
-			rssiChannel0: RSSI;
-			rssiChannel1: RSSI;
-			rssiChannel2?: RSSI;
-		};
-		/** Timestamp of the most recent measurement */
 		timestamp: number;
+		channel0: {
+			average: RSSI;
+			current: RSSI;
+		};
+		channel1: {
+			average: RSSI;
+			current: RSSI;
+		};
+		channel2?: {
+			average: RSSI;
+			current: RSSI;
+		};
 	};
 }
 ```

--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -1250,23 +1250,25 @@ interface ControllerStatistics {
 	messagesDroppedTX: number;
 
 	/**
-	 * Background RSSI of the network. The `average` values are calculated using an exponential moving average.
+	 * Background RSSI of the network in dBm. These values are typically between -100 and -30, but can be even smaller (down to -128 dBm) in quiet environments.
+	 *
+	 * The `average` values are calculated using an exponential moving average.
 	 * The `current` values are the most recent measurements, which can be compared to the average to detect interference/jamming.
 	 * The `timestamp` is the time of the most recent update of these measurements, and can be used to draw graphs.
 	 */
 	backgroundRSSI?: {
 		timestamp: number;
 		channel0: {
-			average: RSSI;
-			current: RSSI;
+			average: number;
+			current: number;
 		};
 		channel1: {
-			average: RSSI;
-			current: RSSI;
+			average: number;
+			current: number;
 		};
 		channel2?: {
-			average: RSSI;
-			current: RSSI;
+			average: number;
+			current: number;
 		};
 	};
 }

--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -1248,6 +1248,30 @@ interface ControllerStatistics {
 	timeoutCallback: number;
 	/** No. of outgoing messages that were dropped because they could not be sent */
 	messagesDroppedTX: number;
+
+	/** Background RSSI of the network. */
+	backgroundRSSI?: {
+		/**
+		 * Average background RSSI of the network.
+		 * Consecutive measurements are combined using an exponential moving average.
+		 */
+		average: {
+			rssiChannel0: RSSI;
+			rssiChannel1: RSSI;
+			rssiChannel2?: RSSI;
+		};
+		/**
+		 * Current background RSSI of the network.
+		 * Can be compared to the average to detect interference/jamming.
+		 */
+		current: {
+			rssiChannel0: RSSI;
+			rssiChannel1: RSSI;
+			rssiChannel2?: RSSI;
+		};
+		/** Timestamp of the most recent measurement */
+		timestamp: number;
+	};
 }
 ```
 

--- a/packages/core/api.md
+++ b/packages/core/api.md
@@ -74,6 +74,11 @@ export interface AssertZWaveErrorOptions {
 // @public (undocumented)
 export function authHomeIdFromDSK(dsk: Buffer): Buffer;
 
+// Warning: (ae-missing-release-tag) "averageRSSI" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function averageRSSI(acc: RSSI, rssi: RSSI, weight: number): RSSI;
+
 // Warning: (ae-missing-release-tag) "BroadcastCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)

--- a/packages/core/api.md
+++ b/packages/core/api.md
@@ -77,7 +77,7 @@ export function authHomeIdFromDSK(dsk: Buffer): Buffer;
 // Warning: (ae-missing-release-tag) "averageRSSI" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-export function averageRSSI(acc: RSSI, rssi: RSSI, weight: number): RSSI;
+export function averageRSSI(acc: number | undefined, rssi: RSSI, weight: number): number;
 
 // Warning: (ae-missing-release-tag) "BroadcastCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/packages/core/src/consts/Transmission.ts
+++ b/packages/core/src/consts/Transmission.ts
@@ -76,11 +76,16 @@ export function isRssiError(rssi: RSSI): rssi is RssiError {
 }
 
 /** Averages RSSI measurements using an exponential moving average with the given weight for the accumulator */
-export function averageRSSI(acc: RSSI, rssi: RSSI, weight: number): RSSI {
+export function averageRSSI(
+	acc: number | undefined,
+	rssi: RSSI,
+	weight: number,
+): number {
 	if (isRssiError(rssi)) {
 		switch (rssi) {
 			case RssiError.NotAvailable:
-				return acc;
+				// If we don't have a value yet, return 0
+				return acc ?? 0;
 			case RssiError.ReceiverSaturated:
 				// Assume rssi is 0 dBm
 				rssi = 0;
@@ -92,6 +97,7 @@ export function averageRSSI(acc: RSSI, rssi: RSSI, weight: number): RSSI {
 		}
 	}
 
+	if (acc == undefined) return rssi;
 	return Math.round(acc * weight + rssi * (1 - weight));
 }
 

--- a/packages/core/src/consts/Transmission.ts
+++ b/packages/core/src/consts/Transmission.ts
@@ -75,6 +75,26 @@ export function isRssiError(rssi: RSSI): rssi is RssiError {
 	return rssi >= RssiError.NoSignalDetected;
 }
 
+/** Averages RSSI measurements using an exponential moving average with the given weight for the accumulator */
+export function averageRSSI(acc: RSSI, rssi: RSSI, weight: number): RSSI {
+	if (isRssiError(rssi)) {
+		switch (rssi) {
+			case RssiError.NotAvailable:
+				return acc;
+			case RssiError.ReceiverSaturated:
+				// Assume rssi is 0 dBm
+				rssi = 0;
+				break;
+			case RssiError.NoSignalDetected:
+				// Assume rssi is -128 dBm
+				rssi = -128;
+				break;
+		}
+	}
+
+	return Math.round(acc * weight + rssi * (1 - weight));
+}
+
 /**
  * Converts an RSSI value to a human readable format, i.e. the measurement including the unit or the corresponding error message.
  */

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -210,16 +210,16 @@ export interface ControllerStatistics {
     backgroundRSSI?: {
         timestamp: number;
         channel0: {
-            average: RSSI_2;
-            current: RSSI_2;
+            average: number;
+            current: number;
         };
         channel1: {
-            average: RSSI_2;
-            current: RSSI_2;
+            average: number;
+            current: number;
         };
         channel2?: {
-            average: RSSI_2;
-            current: RSSI_2;
+            average: number;
+            current: number;
         };
     };
     CAN: number;

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -208,17 +208,19 @@ export { ControllerSelfLogContext }
 // @public
 export interface ControllerStatistics {
     backgroundRSSI?: {
-        average: {
-            rssiChannel0: RSSI_2;
-            rssiChannel1: RSSI_2;
-            rssiChannel2?: RSSI_2;
-        };
-        current: {
-            rssiChannel0: RSSI_2;
-            rssiChannel1: RSSI_2;
-            rssiChannel2?: RSSI_2;
-        };
         timestamp: number;
+        channel0: {
+            average: RSSI_2;
+            current: RSSI_2;
+        };
+        channel1: {
+            average: RSSI_2;
+            current: RSSI_2;
+        };
+        channel2?: {
+            average: RSSI_2;
+            current: RSSI_2;
+        };
     };
     CAN: number;
     messagesDroppedRX: number;

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -207,6 +207,19 @@ export { ControllerSelfLogContext }
 //
 // @public
 export interface ControllerStatistics {
+    backgroundRSSI?: {
+        average: {
+            rssiChannel0: RSSI_2;
+            rssiChannel1: RSSI_2;
+            rssiChannel2?: RSSI_2;
+        };
+        current: {
+            rssiChannel0: RSSI_2;
+            rssiChannel1: RSSI_2;
+            rssiChannel2?: RSSI_2;
+        };
+        timestamp: number;
+    };
     CAN: number;
     messagesDroppedRX: number;
     messagesDroppedTX: number;
@@ -328,6 +341,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> implements Z
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     sendMessage<TResponse extends Message = Message>(msg: Message, options?: SendMessageOptions): Promise<TResponse>;
+    get sendThreadIdle(): boolean;
     setPreferredScales(scales: ZWaveOptions["preferences"]["scales"]): void;
     softReset(): Promise<void>;
     start(): Promise<void>;

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -5535,32 +5535,39 @@ ${associatedNodes.join(", ")}`,
 
 		this.updateStatistics((current) => {
 			const updated = { ...current };
-			updated.backgroundRSSI = {
-				average: {},
-			} as any;
+			updated.backgroundRSSI = {} as any;
 
 			// Average all channels, defaulting to the current measurement
-			updated.backgroundRSSI!.average.rssiChannel0 = averageRSSI(
-				current.backgroundRSSI?.average.rssiChannel0 ??
+			updated.backgroundRSSI!.channel0 = {
+				current: rssi.rssiChannel0,
+				average: averageRSSI(
+					current.backgroundRSSI?.channel0.average ??
+						rssi.rssiChannel0,
 					rssi.rssiChannel0,
-				rssi.rssiChannel0,
-				0.9,
-			);
-			updated.backgroundRSSI!.average.rssiChannel1 = averageRSSI(
-				current.backgroundRSSI?.average.rssiChannel1 ??
-					rssi.rssiChannel1,
-				rssi.rssiChannel1,
-				0.9,
-			);
-			if (rssi.rssiChannel2 != undefined) {
-				updated.backgroundRSSI!.average.rssiChannel2 = averageRSSI(
-					current.backgroundRSSI?.average.rssiChannel2 ??
-						rssi.rssiChannel2,
-					rssi.rssiChannel2,
 					0.9,
-				);
+				),
+			};
+			updated.backgroundRSSI!.channel1 = {
+				current: rssi.rssiChannel1,
+				average: averageRSSI(
+					current.backgroundRSSI?.channel1.average ??
+						rssi.rssiChannel1,
+					rssi.rssiChannel1,
+					0.9,
+				),
+			};
+
+			if (rssi.rssiChannel2 != undefined) {
+				updated.backgroundRSSI!.channel2 = {
+					current: rssi.rssiChannel2,
+					average: averageRSSI(
+						current.backgroundRSSI?.channel2?.average ??
+							rssi.rssiChannel2,
+						rssi.rssiChannel2,
+						0.9,
+					),
+				};
 			}
-			updated.backgroundRSSI!.current = rssi;
 			updated.backgroundRSSI!.timestamp = Date.now();
 
 			return updated;

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -5541,8 +5541,7 @@ ${associatedNodes.join(", ")}`,
 			updated.backgroundRSSI!.channel0 = {
 				current: rssi.rssiChannel0,
 				average: averageRSSI(
-					current.backgroundRSSI?.channel0.average ??
-						rssi.rssiChannel0,
+					current.backgroundRSSI?.channel0.average,
 					rssi.rssiChannel0,
 					0.9,
 				),
@@ -5550,8 +5549,7 @@ ${associatedNodes.join(", ")}`,
 			updated.backgroundRSSI!.channel1 = {
 				current: rssi.rssiChannel1,
 				average: averageRSSI(
-					current.backgroundRSSI?.channel1.average ??
-						rssi.rssiChannel1,
+					current.backgroundRSSI?.channel1.average,
 					rssi.rssiChannel1,
 					0.9,
 				),
@@ -5561,8 +5559,7 @@ ${associatedNodes.join(", ")}`,
 				updated.backgroundRSSI!.channel2 = {
 					current: rssi.rssiChannel2,
 					average: averageRSSI(
-						current.backgroundRSSI?.channel2?.average ??
-							rssi.rssiChannel2,
+						current.backgroundRSSI?.channel2?.average,
 						rssi.rssiChannel2,
 						0.9,
 					),

--- a/packages/zwave-js/src/lib/controller/ControllerStatistics.ts
+++ b/packages/zwave-js/src/lib/controller/ControllerStatistics.ts
@@ -1,4 +1,3 @@
-import type { RSSI } from "@zwave-js/core";
 import { StatisticsHost } from "../driver/Statistics";
 
 export class ControllerStatisticsHost extends StatisticsHost<ControllerStatistics> {
@@ -39,23 +38,25 @@ export interface ControllerStatistics {
 	messagesDroppedTX: number;
 
 	/**
-	 * Background RSSI of the network. The `average` values are calculated using an exponential moving average.
+	 * Background RSSI of the network in dBm. These values are typically between -100 and -30, but can be even smaller (down to -128 dBm) in quiet environments.
+	 *
+	 * The `average` values are calculated using an exponential moving average.
 	 * The `current` values are the most recent measurements, which can be compared to the average to detect interference/jamming.
 	 * The `timestamp` is the time of the most recent update of these measurements, and can be used to draw graphs.
 	 */
 	backgroundRSSI?: {
 		timestamp: number;
 		channel0: {
-			average: RSSI;
-			current: RSSI;
+			average: number;
+			current: number;
 		};
 		channel1: {
-			average: RSSI;
-			current: RSSI;
+			average: number;
+			current: number;
 		};
 		channel2?: {
-			average: RSSI;
-			current: RSSI;
+			average: number;
+			current: number;
 		};
 	};
 }

--- a/packages/zwave-js/src/lib/controller/ControllerStatistics.ts
+++ b/packages/zwave-js/src/lib/controller/ControllerStatistics.ts
@@ -1,3 +1,4 @@
+import type { RSSI } from "@zwave-js/core";
 import { StatisticsHost } from "../driver/Statistics";
 
 export class ControllerStatisticsHost extends StatisticsHost<ControllerStatistics> {
@@ -36,4 +37,28 @@ export interface ControllerStatistics {
 	timeoutCallback: number;
 	/** No. of outgoing messages that were dropped because they could not be sent */
 	messagesDroppedTX: number;
+
+	/** Background RSSI of the network. */
+	backgroundRSSI?: {
+		/**
+		 * Average background RSSI of the network.
+		 * Consecutive measurements are combined using an exponential moving average.
+		 */
+		average: {
+			rssiChannel0: RSSI;
+			rssiChannel1: RSSI;
+			rssiChannel2?: RSSI;
+		};
+		/**
+		 * Current background RSSI of the network.
+		 * Can be compared to the average to detect interference/jamming.
+		 */
+		current: {
+			rssiChannel0: RSSI;
+			rssiChannel1: RSSI;
+			rssiChannel2?: RSSI;
+		};
+		/** Timestamp of the most recent measurement */
+		timestamp: number;
+	};
 }

--- a/packages/zwave-js/src/lib/controller/ControllerStatistics.ts
+++ b/packages/zwave-js/src/lib/controller/ControllerStatistics.ts
@@ -38,27 +38,24 @@ export interface ControllerStatistics {
 	/** No. of outgoing messages that were dropped because they could not be sent */
 	messagesDroppedTX: number;
 
-	/** Background RSSI of the network. */
+	/**
+	 * Background RSSI of the network. The `average` values are calculated using an exponential moving average.
+	 * The `current` values are the most recent measurements, which can be compared to the average to detect interference/jamming.
+	 * The `timestamp` is the time of the most recent update of these measurements, and can be used to draw graphs.
+	 */
 	backgroundRSSI?: {
-		/**
-		 * Average background RSSI of the network.
-		 * Consecutive measurements are combined using an exponential moving average.
-		 */
-		average: {
-			rssiChannel0: RSSI;
-			rssiChannel1: RSSI;
-			rssiChannel2?: RSSI;
-		};
-		/**
-		 * Current background RSSI of the network.
-		 * Can be compared to the average to detect interference/jamming.
-		 */
-		current: {
-			rssiChannel0: RSSI;
-			rssiChannel1: RSSI;
-			rssiChannel2?: RSSI;
-		};
-		/** Timestamp of the most recent measurement */
 		timestamp: number;
+		channel0: {
+			average: RSSI;
+			current: RSSI;
+		};
+		channel1: {
+			average: RSSI;
+			current: RSSI;
+		};
+		channel2?: {
+			average: RSSI;
+			current: RSSI;
+		};
 	};
 }

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -5125,7 +5125,7 @@ ${handlers.length} left`,
 						// ignore errors
 					});
 				}, timeout);
-			} else if (!idle) {
+			} else {
 				clearTimeout(this.pollBackgroundRSSITimer);
 				this.pollBackgroundRSSITimer = undefined;
 			}

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -585,6 +585,15 @@ export class Driver
 			pick(this.options, ["timeouts", "attempts"]),
 		);
 		this.sendThread = interpret(sendThreadMachine);
+		this._sendThreadIdle = false;
+
+		this.sendThread.onTransition((state) => {
+			if (state.changed) {
+				this.sendThreadIdle = state.matches("idle");
+			}
+		});
+
+		// For debugging
 		// this.sendThread.onTransition((state) => {
 		// 	if (state.changed)
 		// 		this.driverLog.print(
@@ -612,6 +621,18 @@ export class Driver
 	private serial: ZWaveSerialPortBase | undefined;
 	/** An instance of the Send Thread state machine */
 	private sendThread: SendThreadInterpreter;
+
+	private _sendThreadIdle: boolean;
+	/** Whether the Send Thread is currently idle */
+	public get sendThreadIdle(): boolean {
+		return this._sendThreadIdle;
+	}
+	private set sendThreadIdle(value: boolean) {
+		if (this._sendThreadIdle !== value) {
+			this._sendThreadIdle = value;
+			this.handleSendThreadIdleChange(value);
+		}
+	}
 
 	/** A map of handlers for all sorts of requests */
 	private requestHandlers = new Map<FunctionType, RequestHandlerEntry[]>();
@@ -5080,5 +5101,34 @@ ${handlers.length} left`,
 				resolve(chunk as T);
 			});
 		});
+	}
+
+	private pollBackgroundRSSITimer: NodeJS.Timeout | undefined;
+	private lastBackgroundRSSITimestamp = 0;
+
+	private handleSendThreadIdleChange(idle: boolean): void {
+		if (!this.ready) return;
+		if (
+			this.controller.isFunctionSupported(FunctionType.GetBackgroundRSSI)
+		) {
+			// When the send thread stays idle for 5 seconds, poll the background RSSI, but at most every 30s
+			if (idle) {
+				const timeout = Math.max(
+					// Wait at least 5s
+					5000,
+					// and up to 30s if we recently queried the RSSI
+					30_000 - (Date.now() - this.lastBackgroundRSSITimestamp),
+				);
+				this.pollBackgroundRSSITimer = setTimeout(() => {
+					this.lastBackgroundRSSITimestamp = Date.now();
+					void this.controller.getBackgroundRSSI().catch(() => {
+						// ignore errors
+					});
+				}, timeout);
+			} else if (!idle) {
+				clearTimeout(this.pollBackgroundRSSITimer);
+				this.pollBackgroundRSSITimer = undefined;
+			}
+		}
 	}
 }


### PR DESCRIPTION
This PR adds background RSSI to the controller statistics. They are regularly determined (roughly every 30s) automatically when the controller is idle for more than 5s.
This new information can be used to show a graph of the average and current background RSSI on all 2/3 channels (depending on the region).

```ts
	/**
	 * Background RSSI of the network in dBm. These values are typically between -100 and -30, but can be even smaller (down to -128 dBm) in quiet environments.
	 *
	 * The `average` values are calculated using an exponential moving average.
	 * The `current` values are the most recent measurements, which can be compared to the average to detect interference/jamming.
	 * The `timestamp` is the time of the most recent update of these measurements, and can be used to draw graphs.
	 */
	backgroundRSSI?: {
		timestamp: number;
		channel0: {
			average: number;
			current: number;
		};
		channel1: {
			average: number;
			current: number;
		};
		channel2?: {
			average: number;
			current: number;
		};
	};
```

In a future update we may use this information to inform users about noisy environments.