### PR TITLE
feat: record timestamps of value updates

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -44,6 +44,19 @@ Metadata in `zwave-js` can be separated into a **static** and a **dynamic** part
 >
 > If applications plan to use metadata, they **must not** assume that metadata does not exist if there was no `"metadata updated"` event. Instead the `getValueMetadata` method **must** be used to retrieve the metadata initially.
 
+### `getValueTimestamp`
+
+```ts
+getValueTimestamp(valueId: ValueID): number | undefined
+```
+
+Returns when the given value was last updated in the local cache. Like `getValue` this takes a single argument of the type [`ValueID`](api/valueid.md#ValueID).
+
+The method either returns the stored timestamp if it was found, and `undefined` otherwise.
+
+> [!NOTE]
+> This does **not** communicate with the node.
+
 ### `getDefinedValueIDs`
 
 ```ts

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@actions/core": "^1.9.1",
     "@actions/exec": "^1.1.1",
     "@actions/github": "^5.0.3",
-    "@alcalzone/jsonl-db": "^2.5.3",
+    "@alcalzone/jsonl-db": "^3.0.0",
     "@alcalzone/monopack": "^1.2.0",
     "@alcalzone/release-script": "~3.5.9",
     "@commitlint/cli": "^17.1.2",

--- a/packages/core/api.md
+++ b/packages/core/api.md
@@ -2488,6 +2488,7 @@ export class ValueDB extends TypedEventEmitter<ValueDBEventCallbacks> {
         metadata: ValueMetadata;
     })[];
     getMetadata(valueId: ValueID): ValueMetadata | undefined;
+    getTimestamp(valueId: ValueID): number | undefined;
     getValue<T = unknown>(valueId: ValueID): T | undefined;
     getValues(forCC: CommandClasses): (ValueID & {
         value: unknown;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -76,7 +76,7 @@
     "test:dirty": "node -r ../../maintenance/esbuild-register.js ../maintenance/src/resolveDirtyTests.ts --run"
   },
   "dependencies": {
-    "@alcalzone/jsonl-db": "^2.5.3",
+    "@alcalzone/jsonl-db": "^3.0.0",
     "@zwave-js/shared": "workspace:*",
     "alcalzone-shared": "^4.0.8",
     "ansi-colors": "^4.1.3",

--- a/packages/core/src/values/ValueDB.ts
+++ b/packages/core/src/values/ValueDB.ts
@@ -275,6 +275,14 @@ export class ValueDB extends TypedEventEmitter<ValueDBEventCallbacks> {
 		return ret;
 	}
 
+	/**
+	 * Returns when the given value id was last updated
+	 */
+	public getTimestamp(valueId: ValueID): number | undefined {
+		const key = this.valueIdToDBKey(valueId);
+		return this._db.getTimestamp(key);
+	}
+
 	/** Clears all values from the value DB */
 	public clear(options: SetValueOptions = {}): void {
 		for (const key of this._index) {

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -1235,6 +1235,7 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner, IZWaveNod
     getHighestSecurityClass(): SecurityClass_2 | undefined;
     getValue<T = unknown>(valueId: ValueID_2): T | undefined;
     getValueMetadata(valueId: ValueID_2): ValueMetadata_2;
+    getValueTimestamp(valueId: ValueID_2): number | undefined;
     // (undocumented)
     hasSecurityClass(securityClass: SecurityClass_2): Maybe<boolean>;
     get hasSUCReturnRoute(): boolean;

--- a/packages/zwave-js/package.json
+++ b/packages/zwave-js/package.json
@@ -110,7 +110,7 @@
     "test:dirty": "node -r ../../maintenance/esbuild-register.js ../maintenance/src/resolveDirtyTests.ts --run"
   },
   "dependencies": {
-    "@alcalzone/jsonl-db": "^2.5.3",
+    "@alcalzone/jsonl-db": "^3.0.0",
     "@alcalzone/pak": "^0.8.1",
     "@esm2cjs/got": "^12.5.3",
     "@esm2cjs/p-queue": "^7.3.0",

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1202,6 +1202,7 @@ export class Driver
 		);
 		this._valueDB = new JsonlDB(valueDBFile, {
 			...options,
+			enableTimestamps: true,
 			reviver: (key, value) => deserializeCacheValue(value),
 			serializer: (key, value) => serializeCacheValue(value),
 		});

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -872,6 +872,13 @@ export class ZWaveNode
 	}
 
 	/**
+	 * Returns when the given value id was last updated
+	 */
+	public getValueTimestamp(valueId: ValueID): number | undefined {
+		return this._valueDB.getTimestamp(valueId);
+	}
+
+	/**
 	 * Retrieves metadata for a given value id.
 	 * This can be used to enhance the user interface of an application
 	 */

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,14 +52,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@alcalzone/jsonl-db@npm:^2.5.3":
-  version: 2.5.3
-  resolution: "@alcalzone/jsonl-db@npm:2.5.3"
+"@alcalzone/jsonl-db@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@alcalzone/jsonl-db@npm:3.0.0"
   dependencies:
     "@alcalzone/proper-lockfile": ^4.1.3-0
-    alcalzone-shared: ^4.0.3
+    alcalzone-shared: ^4.0.8
     fs-extra: ^10.1.0
-  checksum: 7e9d798f2a720772e7273a506274e513de95d80ac3eee458ce02b170deba1ba68bfe09ba2b969f566abe883e20c9a7ec0483e0d96b08768fc3f2e800290dab4c
+  checksum: e0c50a59faa6d19c6b5055cfafab0d69547a0d7a735bec2b976c15f959887944303d92b36caa69150d592b028dde2a8aac64cd2d70ed9a9a652f9ed27483326a
   languageName: node
   linkType: hard
 
@@ -1782,7 +1782,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@zwave-js/core@workspace:packages/core"
   dependencies:
-    "@alcalzone/jsonl-db": ^2.5.3
+    "@alcalzone/jsonl-db": ^3.0.0
     "@microsoft/api-extractor": "*"
     "@types/node": ^14.18.36
     "@types/sinon": ^10.0.13
@@ -1907,7 +1907,7 @@ __metadata:
     "@actions/core": ^1.9.1
     "@actions/exec": ^1.1.1
     "@actions/github": ^5.0.3
-    "@alcalzone/jsonl-db": ^2.5.3
+    "@alcalzone/jsonl-db": ^3.0.0
     "@alcalzone/monopack": ^1.2.0
     "@alcalzone/release-script": ~3.5.9
     "@commitlint/cli": ^17.1.2
@@ -2179,7 +2179,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"alcalzone-shared@npm:^4.0.3, alcalzone-shared@npm:^4.0.8":
+"alcalzone-shared@npm:^4.0.8":
   version: 4.0.8
   resolution: "alcalzone-shared@npm:4.0.8"
   dependencies:
@@ -8835,7 +8835,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "zwave-js@workspace:packages/zwave-js"
   dependencies:
-    "@alcalzone/jsonl-db": ^2.5.3
+    "@alcalzone/jsonl-db": ^3.0.0
     "@alcalzone/pak": ^0.8.1
     "@esm2cjs/got": ^12.5.3
     "@esm2cjs/p-queue": ^7.3.0


### PR DESCRIPTION
With this PR, we always store the timestamp of a value when it gets written to the Value DB. This timestamp can then be retrieved using a new method on the `Node` class:
```ts
getValueTimestamp(valueId: ValueID): number | undefined
```

There may be some edge cases when we optimistically update a value and then have to revert it due to communication failure, but that's a problem to be solved for later. The main use case for this is sensor reports anyways, which we don't update ourselves.

fixes: #1608

