### PR TITLE
fix(config): define config parameters for Zipato ZD2301EU-5

### DIFF
--- a/packages/config/config/devices/0x0109/zd2301eu-5.json
+++ b/packages/config/config/devices/0x0109/zd2301eu-5.json
@@ -17,10 +17,8 @@
 	"paramInformation": [
 		{
 			"#": "1",
-			"label": "Temperature Report Unit",
-			"description": "Select the temperature report unit, celsius or fahrenheit",
+			"label": "Temperature Unit",
 			"valueSize": 1,
-			"unit": "°C",
 			"defaultValue": 0,
 			"unsigned": true,
 			"allowManualEntry": false,
@@ -38,18 +36,16 @@
 		{
 			"#": "2",
 			"label": "Temperature Report Threshold",
-			"description": "In 0.1 celsius increments",
 			"valueSize": 1,
-			"unit": "°C",
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
+			"unit": "0.1 (°C/°F)",
+			"minValue": 1,
+			"maxValue": 50,
+			"defaultValue": 10,
 			"unsigned": true
 		},
 		{
 			"#": "3",
 			"label": "Humidity Report Threshold",
-			"description": "Range from 1 to 50 percent",
 			"valueSize": 1,
 			"unit": "%",
 			"minValue": 1,
@@ -60,13 +56,19 @@
 		{
 			"#": "4",
 			"label": "Luminance Report Threshold",
-			"description": "Range from 0 to 50 percent",
+			"description": "Allowable range: 0, 5-50",
 			"valueSize": 1,
 			"unit": "%",
 			"minValue": 0,
 			"maxValue": 50,
 			"defaultValue": 10,
-			"unsigned": true
+			"unsigned": true,
+			"options": [
+				{
+					"label": "Disabled",
+					"value": 0
+				}
+			]
 		}
 	],
 	"metadata": {

--- a/packages/config/config/devices/0x0109/zd2301eu-5.json
+++ b/packages/config/config/devices/0x0109/zd2301eu-5.json
@@ -14,6 +14,61 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"label": "Temperature Report Unit",
+			"description": "Select the temperature report unit, celsius or fahrenheit",
+			"valueSize": 1,
+			"unit": "°C",
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Celsius",
+					"value": 0
+				},
+				{
+					"label": "Fahrenheit",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "2",
+			"label": "Temperature Report Threshold",
+			"description": "In 0.1 celsius increments",
+			"valueSize": 1,
+			"unit": "°C",
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 1,
+			"unsigned": true
+		},
+		{
+			"#": "3",
+			"label": "Humidity Report Threshold",
+			"description": "Range from 1 to 50 percent",
+			"valueSize": 1,
+			"unit": "%",
+			"minValue": 1,
+			"maxValue": 50,
+			"defaultValue": 10,
+			"unsigned": true
+		},
+		{
+			"#": "4",
+			"label": "Luminance Report Threshold",
+			"description": "Range from 0 to 50 percent",
+			"valueSize": 1,
+			"unit": "%",
+			"minValue": 0,
+			"maxValue": 50,
+			"defaultValue": 10,
+			"unsigned": true
+		}
+	],
 	"metadata": {
 		"inclusion": "4. For “Inclusion” in (adding to) a network: Put the Z-Wave™ Interface Controller into “inclusion” mode, and following its instruction to add the ZD2301 to your controller. To get in the “inclusion” mode, the distance between sensor and controller is suggested to be in one meter. Press the program switch of ZD2301 for sending the NIF. After sending NIF, Z-Wave will send the auto inclusion; otherwise, ZD2301 will go to sleep after 20 seconds",
 		"exclusion": "5. For “Exclusion” from (removing from) a network: Put the Z-Wave™ Interface Controller into “exclusion” mode, and following its instruction to delete the ZD2301 from your controller. Press the program switch of ZD2301 for 1 second at least to be excluded.\nNote: All user and network settings will be cleared and the device reset to factory defaults when the device is excluded.",

--- a/packages/config/config/devices/0x0131/vs-zd2301.json
+++ b/packages/config/config/devices/0x0131/vs-zd2301.json
@@ -2,7 +2,7 @@
 	"manufacturer": "Zipato",
 	"manufacturerId": "0x0131",
 	"label": "VS-ZD2301",
-	"description": "Zipato 4 in 1 Door Sensor",
+	"description": "4 in 1 Door Sensor",
 	"devices": [
 		{
 			"productType": "0x201f",
@@ -17,10 +17,8 @@
 	"paramInformation": [
 		{
 			"#": "1",
-			"label": "Temperature Report Unit",
-			"description": "Select the temperature report unit, celsius or fahrenheit",
+			"label": "Temperature Unit",
 			"valueSize": 1,
-			"unit": "°C",
 			"defaultValue": 0,
 			"unsigned": true,
 			"allowManualEntry": false,
@@ -38,18 +36,16 @@
 		{
 			"#": "2",
 			"label": "Temperature Report Threshold",
-			"description": "In 0.1 celsius increments",
 			"valueSize": 1,
-			"unit": "°C",
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 1,
+			"unit": "0.1 (°C/°F)",
+			"minValue": 1,
+			"maxValue": 50,
+			"defaultValue": 10,
 			"unsigned": true
 		},
 		{
 			"#": "3",
 			"label": "Humidity Report Threshold",
-			"description": "Range from 1 to 50 percent",
 			"valueSize": 1,
 			"unit": "%",
 			"minValue": 1,
@@ -60,13 +56,19 @@
 		{
 			"#": "4",
 			"label": "Luminance Report Threshold",
-			"description": "Range from 0 to 50 percent",
+			"description": "Allowable range: 0, 5-50",
 			"valueSize": 1,
 			"unit": "%",
 			"minValue": 0,
 			"maxValue": 50,
 			"defaultValue": 10,
-			"unsigned": true
+			"unsigned": true,
+			"options": [
+				{
+					"label": "Disabled",
+					"value": 0
+				}
+			]
 		}
 	],
 	"metadata": {


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

ZD2301EU-5 works in a Zipato system like VS-ZD2301. The same 4 parameters can be configured. ZD2301EU-5 were missing the configuration parameters
