### PR TITLE
feat: automatically refresh some CC values regularly/on wakeup

### DIFF
--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -1725,6 +1725,8 @@ export class BatteryCC extends CommandClass {
     interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
+    // (undocumented)
+    shouldRefreshValues(this: SinglecastCC_2<this>, applHost: ZWaveApplicationHost_2): boolean;
 }
 
 // Warning: (ae-missing-release-tag) "BatteryCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1800,7 +1802,7 @@ export const BatteryCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: "lowTemperatureStatus";
         };
-        readonly is: (valueId: ValueID_2) => boolean;
+        readonly is: (valueId: ValueID) => boolean;
         readonly meta: {
             readonly label: "Battery temperature is low";
             readonly writeable: false;
@@ -1826,7 +1828,7 @@ export const BatteryCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: "disconnected";
         };
-        readonly is: (valueId: ValueID_2) => boolean;
+        readonly is: (valueId: ValueID) => boolean;
         readonly meta: {
             readonly label: "Battery is disconnected";
             readonly writeable: false;
@@ -1852,7 +1854,7 @@ export const BatteryCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: "rechargeOrReplace";
         };
-        readonly is: (valueId: ValueID_2) => boolean;
+        readonly is: (valueId: ValueID) => boolean;
         readonly meta: {
             readonly label: "Recharge or replace";
             readonly states: {
@@ -1883,7 +1885,7 @@ export const BatteryCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: "lowFluid";
         };
-        readonly is: (valueId: ValueID_2) => boolean;
+        readonly is: (valueId: ValueID) => boolean;
         readonly meta: {
             readonly label: "Fluid is low";
             readonly writeable: false;
@@ -1909,7 +1911,7 @@ export const BatteryCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: "overheating";
         };
-        readonly is: (valueId: ValueID_2) => boolean;
+        readonly is: (valueId: ValueID) => boolean;
         readonly meta: {
             readonly label: "Overheating";
             readonly writeable: false;
@@ -1935,7 +1937,7 @@ export const BatteryCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: "backup";
         };
-        readonly is: (valueId: ValueID_2) => boolean;
+        readonly is: (valueId: ValueID) => boolean;
         readonly meta: {
             readonly label: "Used as backup";
             readonly writeable: false;
@@ -1961,7 +1963,7 @@ export const BatteryCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: "rechargeable";
         };
-        readonly is: (valueId: ValueID_2) => boolean;
+        readonly is: (valueId: ValueID) => boolean;
         readonly meta: {
             readonly label: "Rechargeable";
             readonly writeable: false;
@@ -1987,7 +1989,7 @@ export const BatteryCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: "chargingStatus";
         };
-        readonly is: (valueId: ValueID_2) => boolean;
+        readonly is: (valueId: ValueID) => boolean;
         readonly meta: {
             readonly label: "Charging status";
             readonly states: {
@@ -2018,7 +2020,7 @@ export const BatteryCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: "temperature";
         };
-        readonly is: (valueId: ValueID_2) => boolean;
+        readonly is: (valueId: ValueID) => boolean;
         readonly meta: {
             readonly label: "Temperature";
             readonly writeable: false;
@@ -2046,7 +2048,7 @@ export const BatteryCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: "maximumCapacity";
         };
-        readonly is: (valueId: ValueID_2) => boolean;
+        readonly is: (valueId: ValueID) => boolean;
         readonly meta: {
             readonly max: 100;
             readonly unit: "%";
@@ -2075,7 +2077,7 @@ export const BatteryCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: "isLow";
         };
-        readonly is: (valueId: ValueID_2) => boolean;
+        readonly is: (valueId: ValueID) => boolean;
         readonly meta: {
             readonly label: "Low battery level";
             readonly writeable: false;
@@ -2101,7 +2103,7 @@ export const BatteryCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: "level";
         };
-        readonly is: (valueId: ValueID_2) => boolean;
+        readonly is: (valueId: ValueID) => boolean;
         readonly meta: {
             readonly max: 100;
             readonly unit: "%";
@@ -3874,6 +3876,7 @@ export class CommandClass implements ICommandClass {
     getPartialCCSessionId(): Record<string, any> | undefined;
     protected getValue<T>(applHost: ZWaveApplicationHost, ccValue: CCValue): T | undefined;
     protected getValueDB(applHost: ZWaveApplicationHost): ValueDB;
+    protected getValueTimestamp(applHost: ZWaveApplicationHost, ccValue: CCValue): number | undefined;
     // (undocumented)
     protected host: ZWaveHost;
     interview(_applHost: ZWaveApplicationHost): Promise<void>;
@@ -3909,6 +3912,7 @@ export class CommandClass implements ICommandClass {
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     protected setMetadata(applHost: ZWaveApplicationHost, ccValue: CCValue, meta?: ValueMetadata): void;
     protected setValue(applHost: ZWaveApplicationHost, ccValue: CCValue, value: unknown): void;
+    shouldRefreshValues(this: SinglecastCC<this>, _applHost: ZWaveApplicationHost): boolean;
     skipEndpointInterview(): boolean;
     // (undocumented)
     protected throwMissingCriticalInterviewResponse(): never;
@@ -9833,6 +9837,8 @@ export class MeterCC extends CommandClass {
     // (undocumented)
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
+    shouldRefreshValues(this: SinglecastCC_2<this>, applHost: ZWaveApplicationHost_2): boolean;
+    // (undocumented)
     translatePropertyKey(applHost: ZWaveApplicationHost_2, property: string | number, propertyKey: string | number): string | undefined;
 }
 
@@ -9943,7 +9949,7 @@ export const MeterCCValues: Readonly<{
             readonly readable: true;
         };
     }) & {
-        is: (valueId: ValueID_2) => boolean;
+        is: (valueId: ValueID) => boolean;
         readonly options: {
             readonly internal: false;
             readonly minVersion: 1;
@@ -9975,7 +9981,7 @@ export const MeterCCValues: Readonly<{
             readonly writeable: true;
         };
     }) & {
-        is: (valueId: ValueID_2) => boolean;
+        is: (valueId: ValueID) => boolean;
         readonly options: {
             readonly internal: false;
             readonly minVersion: 1;
@@ -9995,7 +10001,7 @@ export const MeterCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: "reset";
         };
-        readonly is: (valueId: ValueID_2) => boolean;
+        readonly is: (valueId: ValueID) => boolean;
         readonly meta: {
             readonly label: "Reset accumulated values";
             readonly readable: false;
@@ -10021,7 +10027,7 @@ export const MeterCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: "supportedRateTypes";
         };
-        readonly is: (valueId: ValueID_2) => boolean;
+        readonly is: (valueId: ValueID) => boolean;
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
@@ -10046,7 +10052,7 @@ export const MeterCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: "supportedScales";
         };
-        readonly is: (valueId: ValueID_2) => boolean;
+        readonly is: (valueId: ValueID) => boolean;
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
@@ -10071,7 +10077,7 @@ export const MeterCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: "supportsReset";
         };
-        readonly is: (valueId: ValueID_2) => boolean;
+        readonly is: (valueId: ValueID) => boolean;
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
@@ -10096,7 +10102,7 @@ export const MeterCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: "type";
         };
-        readonly is: (valueId: ValueID_2) => boolean;
+        readonly is: (valueId: ValueID) => boolean;
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
@@ -10937,6 +10943,8 @@ export class MultilevelSensorCC extends CommandClass {
     // (undocumented)
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
+    shouldRefreshValues(this: SinglecastCC_2<this>, applHost: ZWaveApplicationHost_2): boolean;
+    // (undocumented)
     translatePropertyKey(applHost: ZWaveApplicationHost_2, property: string | number, propertyKey: string | number): string | undefined;
 }
 
@@ -11737,6 +11745,8 @@ export class NotificationCC extends CommandClass {
     interview(applHost: ZWaveApplicationHost_2): Promise<void>;
     // (undocumented)
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
+    // (undocumented)
+    shouldRefreshValues(this: SinglecastCC_2<this>, applHost: ZWaveApplicationHost_2): boolean;
 }
 
 // Warning: (ae-missing-release-tag) "NotificationCCEventSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -11877,7 +11887,7 @@ export const NotificationCCValues: Readonly<{
             readonly writeable: true;
         };
     }) & {
-        is: (valueId: ValueID_2) => boolean;
+        is: (valueId: ValueID) => boolean;
         readonly options: {
             readonly internal: false;
             readonly minVersion: 1;
@@ -11911,7 +11921,7 @@ export const NotificationCCValues: Readonly<{
             readonly readable: true;
         };
     }) & {
-        is: (valueId: ValueID_2) => boolean;
+        is: (valueId: ValueID) => boolean;
         readonly options: {
             readonly internal: false;
             readonly minVersion: 1;
@@ -11943,7 +11953,7 @@ export const NotificationCCValues: Readonly<{
             readonly readable: true;
         };
     }) & {
-        is: (valueId: ValueID_2) => boolean;
+        is: (valueId: ValueID) => boolean;
         readonly options: {
             readonly internal: false;
             readonly minVersion: 1;
@@ -11971,7 +11981,7 @@ export const NotificationCCValues: Readonly<{
             readonly writeable: true;
         };
     }) & {
-        is: (valueId: ValueID_2) => boolean;
+        is: (valueId: ValueID) => boolean;
         readonly options: {
             readonly stateful: true;
             readonly secret: false;
@@ -11991,7 +12001,7 @@ export const NotificationCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: "alarmLevel";
         };
-        readonly is: (valueId: ValueID_2) => boolean;
+        readonly is: (valueId: ValueID) => boolean;
         readonly meta: {
             readonly label: "Alarm Level";
             readonly writeable: false;
@@ -12019,7 +12029,7 @@ export const NotificationCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: "alarmType";
         };
-        readonly is: (valueId: ValueID_2) => boolean;
+        readonly is: (valueId: ValueID) => boolean;
         readonly meta: {
             readonly label: "Alarm Type";
             readonly writeable: false;
@@ -12037,6 +12047,31 @@ export const NotificationCCValues: Readonly<{
             readonly autoCreate: true;
         };
     };
+    lastRefresh: {
+        readonly id: {
+            commandClass: CommandClasses.Notification;
+            property: "lastRefresh";
+        };
+        readonly endpoint: (endpoint?: number | undefined) => {
+            readonly commandClass: CommandClasses.Notification;
+            readonly endpoint: number;
+            readonly property: "lastRefresh";
+        };
+        readonly is: (valueId: ValueID) => boolean;
+        readonly meta: {
+            readonly type: "any";
+            readonly readable: true;
+            readonly writeable: true;
+        };
+        readonly options: {
+            readonly stateful: true;
+            readonly secret: false;
+            readonly minVersion: 1;
+            readonly supportsEndpoints: true;
+            readonly autoCreate: true;
+            readonly internal: true;
+        };
+    };
     notificationMode: {
         readonly id: {
             commandClass: CommandClasses.Notification;
@@ -12047,7 +12082,7 @@ export const NotificationCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: "notificationMode";
         };
-        readonly is: (valueId: ValueID_2) => boolean;
+        readonly is: (valueId: ValueID) => boolean;
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
@@ -12072,7 +12107,7 @@ export const NotificationCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: "supportedNotificationTypes";
         };
-        readonly is: (valueId: ValueID_2) => boolean;
+        readonly is: (valueId: ValueID) => boolean;
         readonly meta: {
             readonly type: "any";
             readonly readable: true;
@@ -12097,7 +12132,7 @@ export const NotificationCCValues: Readonly<{
             readonly endpoint: number;
             readonly property: "supportsV1Alarm";
         };
-        readonly is: (valueId: ValueID_2) => boolean;
+        readonly is: (valueId: ValueID) => boolean;
         readonly meta: {
             readonly type: "any";
             readonly readable: true;

--- a/packages/cc/src/lib/CommandClass.ts
+++ b/packages/cc/src/lib/CommandClass.ts
@@ -497,6 +497,19 @@ export class CommandClass implements ICommandClass {
 		// This needs to be overwritten per command class. In the default implementation, don't do anything
 	}
 
+	/**
+	 * Checks if the CC values need to be manually refreshed.
+	 * This should be called regularly and when sleeping nodes wake up
+	 */
+	public shouldRefreshValues(
+		this: SinglecastCC<this>,
+		_applHost: ZWaveApplicationHost,
+	): boolean {
+		// This needs to be overwritten per command class.
+		// In the default implementation, don't require a refresh
+		return false;
+	}
+
 	/** Determines which CC interviews must be performed before this CC can be interviewed */
 	public determineRequiredCCInterviews(): readonly CommandClasses[] {
 		// By default, all CCs require the VersionCC interview
@@ -691,6 +704,19 @@ export class CommandClass implements ICommandClass {
 		const valueDB = this.getValueDB(applHost);
 		const valueId = ccValue.endpoint(this.endpointIndex);
 		return valueDB.getValue(valueId);
+	}
+
+	/**
+	 * Reads when the value stored for the value ID of the given CC value was last updated in the value DB.
+	 * The endpoint index of the current CC instance is automatically taken into account.
+	 */
+	protected getValueTimestamp(
+		applHost: ZWaveApplicationHost,
+		ccValue: CCValue,
+	): number | undefined {
+		const valueDB = this.getValueDB(applHost);
+		const valueId = ccValue.endpoint(this.endpointIndex);
+		return valueDB.getTimestamp(valueId);
 	}
 
 	/** Returns the CC value definition for the current CC which matches the given value ID */

--- a/packages/core/src/util/date.ts
+++ b/packages/core/src/util/date.ts
@@ -108,7 +108,7 @@ export function highResTimestamp(): number {
 }
 
 export const timespan = Object.freeze({
-	seconds: (num: number) => num * 1000,
+	seconds: (num: number) => Math.round(num * 1000),
 	minutes: (num: number) => timespan.seconds(num * 60),
 	hours: (num: number) => timespan.minutes(num * 60),
 	days: (num: number) => timespan.hours(num * 24),

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -1285,7 +1285,6 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner, IZWaveNod
     refreshValues(): Promise<void>;
     // (undocumented)
     requestNodeInfo(): Promise<NodeUpdatePayload>;
-    requiresManualValueRefresh(): boolean;
     // (undocumented)
     get sdkVersion(): string | undefined;
     // (undocumented)

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -2451,16 +2451,24 @@ protocol version:      ${this.protocolVersion}`;
 			for (const cc of endpoint.getSupportedCCInstances() as readonly SinglecastCC<CommandClass>[]) {
 				if (!cc.shouldRefreshValues(this.driver)) continue;
 
+				this.driver.controllerLog.logNode(this.id, {
+					message: `${getCCName(
+						cc.ccId,
+					)} CC values may be stale, refreshing...`,
+					endpoint: endpoint.index,
+					direction: "outbound",
+				});
+
 				try {
 					await cc.refreshValues(this.driver);
 				} catch (e) {
-					this.driver.controllerLog.logNode(
-						this.id,
-						`failed to refresh values for ${getCCName(
+					this.driver.controllerLog.logNode(this.id, {
+						message: `failed to refresh values for ${getCCName(
 							cc.ccId,
-						)}, endpoint ${endpoint.index}: ${getErrorMessage(e)}`,
-						"error",
-					);
+						)} CC: ${getErrorMessage(e)}`,
+						endpoint: endpoint.index,
+						level: "error",
+					});
 				}
 			}
 		}

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -65,7 +65,6 @@ import { NodeNamingAndLocationCCValues } from "@zwave-js/cc/NodeNamingCC";
 import {
 	getNotificationStateValueWithEnum,
 	getNotificationValueMetadata,
-	NotificationCC,
 	NotificationCCReport,
 	NotificationCCValues,
 } from "@zwave-js/cc/NotificationCC";
@@ -123,8 +122,8 @@ import {
 	SecurityClassOwner,
 	SendCommandOptions,
 	sensorCCs,
+	SinglecastCC,
 	SupervisionStatus,
-	timespan,
 	topologicalSort,
 	TranslatedValueID,
 	TXReport,
@@ -339,7 +338,6 @@ export class ZWaveNode
 		for (const timeout of [
 			this.centralSceneKeyHeldDownContext?.timeout,
 			...this.notificationIdleTimeouts.values(),
-			...this.manualRefreshTimers.values(),
 		]) {
 			if (timeout) clearTimeout(timeout);
 		}
@@ -2347,8 +2345,12 @@ protocol version:      ${this.protocolVersion}`;
 		// supporting node issues a Wake Up Notification Command for sleeping nodes.
 
 		// This is not the handler for wakeup notifications, but some legacy devices send this
-		// message whenever there's an update.
-		if (this.requiresManualValueRefresh()) {
+		// message whenever there's an update and want to be polled.
+		if (
+			this.interviewStage === InterviewStage.Complete &&
+			!this.supportsCC(CommandClasses["Z-Wave Plus Info"]) &&
+			!this.valueDB.getValue(AssociationCCValues.hasLifeline.id)
+		) {
 			const delay =
 				this.deviceConfig?.compat?.manualValueRefreshDelayMs || 0;
 			this.driver.controllerLog.logNode(this.nodeId, {
@@ -2357,79 +2359,6 @@ protocol version:      ${this.protocolVersion}`;
 				}...`,
 			});
 			setTimeout(() => this.refreshValues(), delay);
-		}
-	}
-
-	/** Returns whether a manual refresh of non-static values is likely necessary for this node */
-	public requiresManualValueRefresh(): boolean {
-		// If there was no lifeline configured, we assume that the controller
-		// does not receive unsolicited updates from the node
-		return (
-			this.interviewStage === InterviewStage.Complete &&
-			!this.supportsCC(CommandClasses["Z-Wave Plus Info"]) &&
-			!this.valueDB.getValue(AssociationCCValues.hasLifeline.id)
-		);
-	}
-
-	/**
-	 * @internal
-	 * Schedules the regular refreshes of some CC values
-	 */
-	public scheduleManualValueRefreshes(): void {
-		// Only schedule this for listening nodes. Sleeping nodes are queried on wakeup
-		if (!this.canSleep) return;
-		// Only schedule this if we don't expect any unsolicited updates
-		if (!this.requiresManualValueRefresh()) return;
-
-		// TODO: The timespan definitions should be on the CCs themselves (probably as decorators)
-		this.scheduleManualValueRefresh(
-			CommandClasses.Battery,
-			// The specs say once per month, but that's a bit too unfrequent IMO
-			// Also the maximum that setInterval supports is ~24.85 days
-			timespan.days(7),
-		);
-		this.scheduleManualValueRefresh(
-			CommandClasses.Meter,
-			timespan.hours(6),
-		);
-		this.scheduleManualValueRefresh(
-			CommandClasses["Multilevel Sensor"],
-			timespan.hours(6),
-		);
-		if (
-			this.supportsCC(CommandClasses.Notification) &&
-			NotificationCC.getNotificationMode(this.driver, this) === "pull"
-		) {
-			this.scheduleManualValueRefresh(
-				CommandClasses.Notification,
-				timespan.hours(6),
-			);
-		}
-	}
-
-	private manualRefreshTimers = new Map<CommandClasses, NodeJS.Timeout>();
-	/**
-	 * Is used to schedule a manual value refresh for nodes that don't send unsolicited commands
-	 */
-	private scheduleManualValueRefresh(
-		cc: CommandClasses,
-		timeout: number,
-	): void {
-		// // Avoid triggering the refresh multiple times
-		// this.cancelManualValueRefresh(cc);
-		this.manualRefreshTimers.set(
-			cc,
-			setInterval(() => {
-				void this.refreshCCValues(cc);
-			}, timeout).unref(),
-		);
-	}
-
-	private cancelManualValueRefresh(cc: CommandClasses): void {
-		if (this.manualRefreshTimers.has(cc)) {
-			const timeout = this.manualRefreshTimers.get(cc)!;
-			clearTimeout(timeout);
-			this.manualRefreshTimers.delete(cc);
 		}
 	}
 
@@ -2498,6 +2427,30 @@ protocol version:      ${this.protocolVersion}`;
 				) {
 					continue;
 				}
+				try {
+					await cc.refreshValues(this.driver);
+				} catch (e) {
+					this.driver.controllerLog.logNode(
+						this.id,
+						`failed to refresh values for ${getCCName(
+							cc.ccId,
+						)}, endpoint ${endpoint.index}: ${getErrorMessage(e)}`,
+						"error",
+					);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Refreshes the values of all CCs that should be reporting regularly, but haven't been
+	 * @internal
+	 */
+	public async autoRefreshValues(): Promise<void> {
+		for (const endpoint of this.getAllEndpoints()) {
+			for (const cc of endpoint.getSupportedCCInstances() as readonly SinglecastCC<CommandClass>[]) {
+				if (!cc.shouldRefreshValues(this.driver)) continue;
+
 				try {
 					await cc.refreshValues(this.driver);
 				} catch (e) {
@@ -2605,10 +2558,6 @@ protocol version:      ${this.protocolVersion}`;
 	 * Handles a CommandClass that was received from this node
 	 */
 	public async handleCommand(command: CommandClass): Promise<void> {
-		// If the node sent us an unsolicited update, our initial assumption
-		// was wrong. Stop querying it regularly for updates
-		this.cancelManualValueRefresh(command.ccId);
-
 		// If this is a report for the root endpoint and the node supports the CC on another endpoint,
 		// we need to map it to endpoint 1. Either it does not support multi channel associations or
 		// it is misbehaving. In any case, we would hide this report if we didn't map it
@@ -3041,10 +2990,14 @@ protocol version:      ${this.protocolVersion}`;
 		}
 		this.lastWakeUp = now;
 
-		// Some devices expect us to query them on wake up in order to function correctly
+		// Some legacy devices expect us to query them on wake up in order to function correctly
 		if (this._deviceConfig?.compat?.queryOnWakeup) {
-			// Don't wait
 			void this.compatDoWakeupQueries();
+		} else {
+			// For other devices we may have to refresh their values from time to time
+			void this.autoRefreshValues().catch(() => {
+				// ignore
+			});
 		}
 
 		// In case there are no messages in the queue, the node may go back to sleep very soon


### PR DESCRIPTION
With this PR, the following CCs have their values queried regularly if some of them haven't been updated recently:
* Battery CC (7 days)
* Multilevel Sensor CC (6 hours)
* Meter CC (6 hours)
* Notification CC (pull-mode nodes only, 6 hours)

To distribute the potential queries a bit, we first check if a refresh is necessary is checked every hour ± 10 minutes for listening and FLiRS nodes, randomized when the node is ready. For sleeping nodes we check on every wake up. Only if the values haven't been updated, e.g. through an unsolicited report, they will be refreshed.

fixes: #5558
fixes: #2589