### PR TITLE
fix: if endpoint does not support Version CC, still query CC versions for the endpoint, not the node

### DIFF
--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -16930,11 +16930,14 @@ export class VersionCCCommandClassGet extends VersionCC {
 //
 // @public (undocumented)
 export class VersionCCCommandClassReport extends VersionCC {
-    constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
+    // Warning: (ae-forgotten-export) The symbol "VersionCCCommandClassReportOptions" needs to be exported by the entry point index.d.ts
+    constructor(host: ZWaveHost_2, options: VersionCCCommandClassReportOptions | CommandClassDeserializationOptions);
     // (undocumented)
-    get ccVersion(): number;
+    ccVersion: number;
     // (undocumented)
-    get requestedCC(): CommandClasses;
+    requestedCC: CommandClasses;
+    // (undocumented)
+    serialize(): Buffer;
     // (undocumented)
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }

--- a/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
+++ b/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
@@ -1,9 +1,17 @@
 import {
 	CommandClass,
+	MultiChannelCCCapabilityGet,
+	MultiChannelCCCapabilityReport,
+	MultiChannelCCEndPointFind,
+	MultiChannelCCEndPointFindReport,
+	MultiChannelCCEndPointGet,
+	MultiChannelCCEndPointReport,
 	Security2CC,
 	Security2CCMessageEncapsulation,
 	SecurityCC,
 	SecurityCCCommandEncapsulation,
+	VersionCCCommandClassGet,
+	VersionCCCommandClassReport,
 	ZWavePlusNodeType,
 	ZWavePlusRoleType,
 } from "@zwave-js/cc";
@@ -38,6 +46,125 @@ const respondToRequestNodeInfo: MockNodeBehavior = {
 			);
 			return true;
 		}
+	},
+};
+
+const respondToVersionCCCommandClassGet: MockNodeBehavior = {
+	async onControllerFrame(controller, self, frame) {
+		if (
+			frame.type === MockZWaveFrameType.Request &&
+			frame.payload instanceof VersionCCCommandClassGet
+		) {
+			const endpoint =
+				frame.payload.endpointIndex === 0
+					? self
+					: self.endpoints.get(frame.payload.endpointIndex);
+			if (!endpoint) return false;
+
+			let version = 0;
+			for (const ep of [self, ...self.endpoints.values()]) {
+				const info = ep.implementedCCs.get(frame.payload.requestedCC);
+				if (info?.version) {
+					version = info.version;
+					break;
+				}
+			}
+
+			const cc = new VersionCCCommandClassReport(self.host, {
+				nodeId: self.id,
+				endpoint: "index" in endpoint ? endpoint.index : undefined,
+				requestedCC: frame.payload.requestedCC,
+				ccVersion: version,
+			});
+			await self.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+
+			return true;
+		}
+	},
+};
+
+const respondToMultiChannelCCEndPointGet: MockNodeBehavior = {
+	async onControllerFrame(controller, self, frame) {
+		if (
+			frame.type === MockZWaveFrameType.Request &&
+			frame.payload instanceof MultiChannelCCEndPointGet
+		) {
+			const cc = new MultiChannelCCEndPointReport(self.host, {
+				nodeId: controller.host.ownNodeId,
+				countIsDynamic: false,
+				identicalCapabilities: false,
+				individualCount: self.endpoints.size,
+			});
+			await self.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			return true;
+		}
+		return false;
+	},
+};
+
+const respondToMultiChannelCCEndPointFind: MockNodeBehavior = {
+	async onControllerFrame(controller, self, frame) {
+		if (
+			frame.type === MockZWaveFrameType.Request &&
+			frame.payload instanceof MultiChannelCCEndPointFind
+		) {
+			const request = frame.payload;
+			const cc = new MultiChannelCCEndPointFindReport(self.host, {
+				nodeId: controller.host.ownNodeId,
+				genericClass: request.genericClass,
+				specificClass: request.specificClass,
+				foundEndpoints: [...self.endpoints.keys()],
+				reportsToFollow: 0,
+			});
+			await self.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			return true;
+		}
+		return false;
+	},
+};
+
+const respondToMultiChannelCCCapabilityGet: MockNodeBehavior = {
+	async onControllerFrame(controller, self, frame) {
+		if (
+			frame.type === MockZWaveFrameType.Request &&
+			frame.payload instanceof MultiChannelCCCapabilityGet
+		) {
+			const endpoint = self.endpoints.get(
+				frame.payload.requestedEndpoint,
+			)!;
+			const cc = new MultiChannelCCCapabilityReport(self.host, {
+				nodeId: controller.host.ownNodeId,
+				endpointIndex: endpoint.index,
+				genericDeviceClass:
+					endpoint?.capabilities.genericDeviceClass ??
+					self.capabilities.genericDeviceClass,
+				specificDeviceClass:
+					endpoint?.capabilities.specificDeviceClass ??
+					self.capabilities.specificDeviceClass,
+				isDynamic: false,
+				wasRemoved: false,
+				supportedCCs: [...endpoint.implementedCCs.keys()],
+			});
+			await self.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			return true;
+		}
+		return false;
 	},
 };
 
@@ -134,6 +261,11 @@ const respondToS2ZWavePlusCCGet: MockNodeBehavior = {
 export function createDefaultBehaviors(): MockNodeBehavior[] {
 	return [
 		respondToRequestNodeInfo,
+		respondToVersionCCCommandClassGet,
+		respondToMultiChannelCCEndPointGet,
+		respondToMultiChannelCCEndPointFind,
+		respondToMultiChannelCCCapabilityGet,
+
 		respondToZWavePlusCCGet,
 		respondToS0ZWavePlusCCGet,
 		respondToS2ZWavePlusCCGet,

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1805,7 +1805,7 @@ protocol version:      ${this.protocolVersion}`;
 				if (force) {
 					instance = CommandClass.createInstanceUnchecked(
 						this.driver,
-						this,
+						endpoint,
 						cc,
 					)!;
 				} else {

--- a/packages/zwave-js/src/lib/test/driver/queryVersionOfEndpointOnlyCCs.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/queryVersionOfEndpointOnlyCCs.test.ts
@@ -1,0 +1,71 @@
+import { CommandClasses } from "@zwave-js/core";
+import { integrationTest } from "../integrationTestSuite";
+
+integrationTest(
+	"The version of endpoint-only CCs gets queried during the interview",
+	{
+		debug: true,
+
+		nodeCapabilities: {
+			isListening: true,
+			isFrequentListening: false,
+
+			commandClasses: [
+				{
+					ccId: CommandClasses.Version,
+					version: 1,
+					isSupported: true,
+				},
+				{
+					ccId: CommandClasses["Multi Channel"],
+					version: 2,
+					isSupported: true,
+				},
+			],
+			endpoints: [
+				// Two identical endpoints
+				{
+					// Binary Power Switch
+					genericDeviceClass: 0x10,
+					specificDeviceClass: 0x01,
+					// Does not support the Version CC, but supports Binary Switch CC V2
+					commandClasses: [
+						{
+							ccId: CommandClasses["Binary Switch"],
+							version: 2,
+							isSupported: true,
+						},
+					],
+				},
+				{
+					// Binary Power Switch
+					genericDeviceClass: 0x10,
+					specificDeviceClass: 0x01,
+					// Does not support the Version CC, but supports Binary Switch CC V2
+					commandClasses: [
+						{
+							ccId: CommandClasses["Binary Switch"],
+							version: 2,
+							isSupported: true,
+						},
+					],
+				},
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			t.is(
+				node
+					.getEndpoint(1)
+					?.getCCVersion(CommandClasses["Binary Switch"]),
+				2,
+			);
+			t.is(
+				node
+					.getEndpoint(2)
+					?.getCCVersion(CommandClasses["Binary Switch"]),
+				2,
+			);
+		},
+	},
+);


### PR DESCRIPTION
fixes: https://github.com/zwave-js/node-zwave-js/issues/5546