### PR TITLE
fix: don't change security classes outside interview/bootstrapping

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -3678,18 +3678,6 @@ ${handlers.length} left`,
 		if (isCommandClassContainer(msg)) {
 			// For further actions, we are only interested in the innermost CC
 			this.unwrapCommands(msg);
-
-			const node = this.getNodeUnsafe(msg);
-			// If we receive an encrypted message but assume the node is insecure, change our assumption
-			if (
-				node?.isSecure === false &&
-				(msg.command.ccId === CommandClasses.Security ||
-					msg.command.isEncapsulatedWith(CommandClasses.Security))
-			) {
-				node.securityClasses.set(SecurityClass.S0_Legacy, true);
-				// Force a new interview
-				void node.refreshInfo();
-			}
 		}
 
 		// Otherwise go through the static handlers


### PR DESCRIPTION
If our assumptions are really wrong, re-interviewing with the `resetSecurityClasses` option should do the trick.

fixes: #4184
fixes: https://github.com/zwave-js/node-zwave-js/issues/4185