### PR TITLE
chore: clarify the encoding in GetSerialApiInitDataResponse

### DIFF
--- a/packages/zwave-js/src/lib/serialapi/capability/GetSerialApiInitDataMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/capability/GetSerialApiInitDataMessages.ts
@@ -67,23 +67,9 @@ export class GetSerialApiInitDataResponse extends Message {
 			}
 
 			const capabilities = this.payload[1];
-			// TODO: Up to SDK 7.19.1 (inclusive), maybe later, the encoding for these flags is still the old one,
-			// despite the official Host API specs having changed it. When this is fixed, update the version comparison
-			// and uncomment the `if` branch
-
-			// if (
-			// 	this.zwaveApiVersion.kind === "official" &&
-			// 	sdkVersionGte(options.sdkVersion, "7.19.2")
-			// ) {
-			// 	// The new "official" Host API specs sneakily switched the meaning of some flags
-			// 	this.nodeType =
-			// 		capabilities & 0b0001
-			// 			? NodeType.Controller
-			// 			: NodeType["End Node"];
-			// 	this.supportsTimers = !!(capabilities & 0b0010);
-			// 	this.isPrimary = !!(capabilities & 0b0100);
-			// 	this.isSIS = !!(capabilities & 0b1000);
-			// } else {
+			// The new "official" Host API specs incorrectly switched the meaning of some flags
+			// Apparently this was never intended, and the firmware correctly uses the "old" encoding.
+			// https://community.silabs.com/s/question/0D58Y00009qjEghSAE/bug-in-firmware-7191-get-init-data-response-does-not-match-host-api-specification?language=en_US
 			this.nodeType =
 				capabilities & 0b0001
 					? NodeType["End Node"]
@@ -91,7 +77,6 @@ export class GetSerialApiInitDataResponse extends Message {
 			this.supportsTimers = !!(capabilities & 0b0010);
 			this.isPrimary = !(capabilities & 0b0100);
 			this.isSIS = !!(capabilities & 0b1000);
-			// }
 
 			let offset = 2;
 			this.nodeIds = [];


### PR DESCRIPTION
closes: #5429