### PR TITLE
fix: use stricter checks when receiving a `DeviceResetLocallyNotification`

### DIFF
--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -4399,6 +4399,7 @@ export class DeviceResetLocallyCC extends CommandClass {
 //
 // @public (undocumented)
 export class DeviceResetLocallyCCNotification extends DeviceResetLocallyCC {
+    constructor(host: ZWaveHost_2, options: CommandClassOptions);
 }
 
 // Warning: (ae-missing-release-tag) "DeviceResetLocallyCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/cc/src/cc/DeviceResetLocallyCC.ts
+++ b/packages/cc/src/cc/DeviceResetLocallyCC.ts
@@ -1,5 +1,10 @@
-import { CommandClasses } from "@zwave-js/core/safe";
-import { CommandClass } from "../lib/CommandClass";
+import { CommandClasses, validatePayload } from "@zwave-js/core/safe";
+import type { ZWaveHost } from "@zwave-js/host/safe";
+import {
+	CommandClass,
+	CommandClassOptions,
+	gotDeserializationOptions,
+} from "../lib/CommandClass";
 import {
 	CCCommand,
 	commandClass,
@@ -19,4 +24,17 @@ export class DeviceResetLocallyCC extends CommandClass {
 }
 
 @CCCommand(DeviceResetLocallyCommand.Notification)
-export class DeviceResetLocallyCCNotification extends DeviceResetLocallyCC {}
+export class DeviceResetLocallyCCNotification extends DeviceResetLocallyCC {
+	public constructor(host: ZWaveHost, options: CommandClassOptions) {
+		super(host, options);
+
+		if (gotDeserializationOptions(options)) {
+			// We need to make sure this doesn't get parsed accidentally, e.g. because of a bit flip
+
+			// This CC has no payload
+			validatePayload(this.payload.length === 0);
+			// It MUST be issued by the root device
+			validatePayload(this.endpointIndex === 0);
+		}
+	}
+}


### PR DESCRIPTION
We now discard this CC when it has any payload at all, because this means it was "created" by a bit flip.

fixes: #5509