### PR TITLE
fix: on secure nodes, use S2 for non-secure commands too

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -2261,6 +2261,14 @@ export class Driver
 		nodeId: number,
 		endpointIndex: number = 0,
 	): boolean {
+		// This is obvious
+		if (
+			ccId === CommandClasses.Security ||
+			ccId === CommandClasses["Security 2"]
+		) {
+			return true;
+		}
+
 		const node = this.controller.nodes.get(nodeId);
 		// Node is unknown, don't use secure communication
 		if (!node) return false;


### PR DESCRIPTION
fixes: https://github.com/zwave-js/node-zwave-js/issues/5491

Turns out this was a bug in HELTUN devices, but can't hurt to just communicate securely where possible.