### PR TITLE
fix: value timestamps are no longer updated for optimistic value updates

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -50,9 +50,9 @@ Metadata in `zwave-js` can be separated into a **static** and a **dynamic** part
 getValueTimestamp(valueId: ValueID): number | undefined
 ```
 
-Returns when the given value was last updated in the local cache. Like `getValue` this takes a single argument of the type [`ValueID`](api/valueid.md#ValueID).
+Returns when the given value was last updated by the node. This includes unsolicited updates, responses to GET-type requests and successful supervised SET-type requests.
 
-The method either returns the stored timestamp if it was found, and `undefined` otherwise.
+Like `getValue` this takes a single argument of the type [`ValueID`](api/valueid.md#ValueID). The method either returns the stored timestamp if it was found, and `undefined` otherwise.
 
 > [!NOTE]
 > This does **not** communicate with the node.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@actions/core": "^1.9.1",
     "@actions/exec": "^1.1.1",
     "@actions/github": "^5.0.3",
-    "@alcalzone/jsonl-db": "^3.0.0",
+    "@alcalzone/jsonl-db": "^3.1.0",
     "@alcalzone/monopack": "^1.2.0",
     "@alcalzone/release-script": "~3.5.9",
     "@commitlint/cli": "^17.1.2",

--- a/packages/core/api.md
+++ b/packages/core/api.md
@@ -2169,6 +2169,7 @@ export interface SetValueOptions {
     noThrow?: boolean;
     source?: ValueUpdatedArgs["source"];
     stateful?: boolean;
+    updateTimestamp?: boolean;
 }
 
 // Warning: (ae-missing-release-tag) "SimpleReflectionDecorator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -76,7 +76,7 @@
     "test:dirty": "node -r ../../maintenance/esbuild-register.js ../maintenance/src/resolveDirtyTests.ts --run"
   },
   "dependencies": {
-    "@alcalzone/jsonl-db": "^3.0.0",
+    "@alcalzone/jsonl-db": "^3.1.0",
     "@zwave-js/shared": "workspace:*",
     "alcalzone-shared": "^4.0.8",
     "ansi-colors": "^4.1.3",

--- a/packages/core/src/values/ValueDB.ts
+++ b/packages/core/src/values/ValueDB.ts
@@ -187,7 +187,7 @@ export class ValueDB extends TypedEventEmitter<ValueDBEventCallbacks> {
 			}
 
 			this._index.add(dbKey);
-			this._db.set(dbKey, value);
+			this._db.set(dbKey, value, options.updateTimestamp !== false);
 			if (valueId.commandClass >= 0 && options.noEvent !== true) {
 				this.emit(event, cbArg);
 			}

--- a/packages/core/src/values/_Types.ts
+++ b/packages/core/src/values/_Types.ts
@@ -45,7 +45,7 @@ export interface MetadataUpdatedArgs extends ValueID {
 export interface SetValueOptions {
 	/** When this is true, no event will be emitted for the value change */
 	noEvent?: boolean;
-	/** When this is true,  */
+	/** When this is true, trying to set invalid value IDs will not throw an error */
 	noThrow?: boolean;
 	/**
 	 * When this is `false`, the value will not be stored and a `value notification` event will be emitted instead (implies `noEvent: false`).
@@ -53,4 +53,6 @@ export interface SetValueOptions {
 	stateful?: boolean;
 	/** Allows defining the source of a value update */
 	source?: ValueUpdatedArgs["source"];
+	/** Whether the timestamp of the value should be updated. Default: `true` */
+	updateTimestamp?: boolean;
 }

--- a/packages/zwave-js/package.json
+++ b/packages/zwave-js/package.json
@@ -110,7 +110,7 @@
     "test:dirty": "node -r ../../maintenance/esbuild-register.js ../maintenance/src/resolveDirtyTests.ts --run"
   },
   "dependencies": {
-    "@alcalzone/jsonl-db": "^3.0.0",
+    "@alcalzone/jsonl-db": "^3.1.0",
     "@alcalzone/pak": "^0.8.1",
     "@esm2cjs/got": "^12.5.3",
     "@esm2cjs/p-queue": "^7.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,14 +52,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@alcalzone/jsonl-db@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@alcalzone/jsonl-db@npm:3.0.0"
+"@alcalzone/jsonl-db@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@alcalzone/jsonl-db@npm:3.1.0"
   dependencies:
     "@alcalzone/proper-lockfile": ^4.1.3-0
     alcalzone-shared: ^4.0.8
     fs-extra: ^10.1.0
-  checksum: e0c50a59faa6d19c6b5055cfafab0d69547a0d7a735bec2b976c15f959887944303d92b36caa69150d592b028dde2a8aac64cd2d70ed9a9a652f9ed27483326a
+  checksum: 7ca8b6ba7ba92abc59e2ef6affecaeeb0797d20756904f08e906882e15173b6a2c975fc170355ac9b2ac57c07fd1e37a09c70c4a1a1c35249ab51b425514a04d
   languageName: node
   linkType: hard
 
@@ -1782,7 +1782,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@zwave-js/core@workspace:packages/core"
   dependencies:
-    "@alcalzone/jsonl-db": ^3.0.0
+    "@alcalzone/jsonl-db": ^3.1.0
     "@microsoft/api-extractor": "*"
     "@types/node": ^14.18.36
     "@types/sinon": ^10.0.13
@@ -1907,7 +1907,7 @@ __metadata:
     "@actions/core": ^1.9.1
     "@actions/exec": ^1.1.1
     "@actions/github": ^5.0.3
-    "@alcalzone/jsonl-db": ^3.0.0
+    "@alcalzone/jsonl-db": ^3.1.0
     "@alcalzone/monopack": ^1.2.0
     "@alcalzone/release-script": ~3.5.9
     "@commitlint/cli": ^17.1.2
@@ -8835,7 +8835,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "zwave-js@workspace:packages/zwave-js"
   dependencies:
-    "@alcalzone/jsonl-db": ^3.0.0
+    "@alcalzone/jsonl-db": ^3.1.0
     "@alcalzone/pak": ^0.8.1
     "@esm2cjs/got": ^12.5.3
     "@esm2cjs/p-queue": ^7.3.0


### PR DESCRIPTION
This PR fixes the edge case of optimistic value updates mentioned in https://github.com/zwave-js/node-zwave-js/pull/5556

We now only update the timestamp of a value when
- the node sends an unsolicited update
- the node responds to GET-type requests
- a supervised SET-type call was successful