### PR TITLE
feat(config): add kVar and kVarh to Aeotec Home Energy Meter Gen 5

### DIFF
--- a/packages/config/config/devices/0x0086/templates/aeotec_template.json
+++ b/packages/config/config/devices/0x0086/templates/aeotec_template.json
@@ -1124,6 +1124,46 @@
 		"label": "Automatic Report: Group 1 - kWh (Channel 2)",
 		"valueSize": 4
 	},
+	"auto_report_group1_kVarh_wholehem": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 1 - kVarh (Whole HEM)",
+		"valueSize": 4
+	},
+	"auto_report_group1_kVar_wholehem": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 1 - kVar (Whole HEM)",
+		"valueSize": 4
+	},
+	"auto_report_group1_kVarh_clamp1": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 1 - kVarh (Clamp 1)",
+		"valueSize": 4
+	},
+	"auto_report_group1_kVarh_clamp2": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 1 - kVarh (Clamp 2)",
+		"valueSize": 4
+	},
+	"auto_report_group1_kVarh_clamp3": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 1 - kVarh (Clamp 3)",
+		"valueSize": 4
+	},
+	"auto_report_group1_kVar_clamp1": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 1 - kVar (Clamp 1)",
+		"valueSize": 4
+	},
+	"auto_report_group1_kVar_clamp2": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 1 - kVar (Clamp 2)",
+		"valueSize": 4
+	},
+	"auto_report_group1_kVar_clamp3": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 1 - kVar (Clamp 3)",
+		"valueSize": 4
+	},
 	"auto_report_group2_battery": {
 		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 2 - Battery",
@@ -1294,6 +1334,46 @@
 		"label": "Automatic Report: Group 2 - kWh (Channel 2)",
 		"valueSize": 4
 	},
+	"auto_report_group2_kVarh_wholehem": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 2 - kVarh (Whole HEM)",
+		"valueSize": 4
+	},
+	"auto_report_group2_kVar_wholehem": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 2 - kVar (Whole HEM)",
+		"valueSize": 4
+	},
+	"auto_report_group2_kVarh_clamp1": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 2 - kVarh (Clamp 1)",
+		"valueSize": 4
+	},
+	"auto_report_group2_kVarh_clamp2": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 2 - kVarh (Clamp 2)",
+		"valueSize": 4
+	},
+	"auto_report_group2_kVarh_clamp3": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 2 - kVarh (Clamp 3)",
+		"valueSize": 4
+	},
+	"auto_report_group2_kVar_clamp1": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 2 - kVar (Clamp 1)",
+		"valueSize": 4
+	},
+	"auto_report_group2_kVar_clamp2": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 2 - kVar (Clamp 2)",
+		"valueSize": 4
+	},
+	"auto_report_group2_kVar_clamp3": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 2 - kVar (Clamp 3)",
+		"valueSize": 4
+	},
 	"auto_report_group3_battery": {
 		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - Battery",
@@ -1462,6 +1542,46 @@
 	"auto_report_group3_kwh_channel2": {
 		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Automatic Report: Group 3 - kWh (Channel 2)",
+		"valueSize": 4
+	},
+	"auto_report_group3_kVarh_wholehem": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 3 - kVarh (Whole HEM)",
+		"valueSize": 4
+	},
+	"auto_report_group3_kVar_wholehem": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 3 - kVar (Whole HEM)",
+		"valueSize": 4
+	},
+	"auto_report_group3_kVarh_clamp1": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 3 - kVarh (Clamp 1)",
+		"valueSize": 4
+	},
+	"auto_report_group3_kVarh_clamp2": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 3 - kVarh (Clamp 2)",
+		"valueSize": 4
+	},
+	"auto_report_group3_kVarh_clamp3": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 3 - kVarh (Clamp 3)",
+		"valueSize": 4
+	},
+	"auto_report_group3_kVar_clamp1": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 3 - kVar (Clamp 1)",
+		"valueSize": 4
+	},
+	"auto_report_group3_kVar_clamp2": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 3 - kVar (Clamp 2)",
+		"valueSize": 4
+	},
+	"auto_report_group3_kVar_clamp3": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Automatic Report: Group 3 - kVar (Clamp 3)",
 		"valueSize": 4
 	},
 	"device_tag": {

--- a/packages/config/config/devices/0x0086/zw095.json
+++ b/packages/config/config/devices/0x0086/zw095.json
@@ -123,6 +123,14 @@
 			"$import": "templates/aeotec_template.json#auto_report_group1_amp_wholehem"
 		},
 		{
+			"#": "101[0x10]",
+			"$import": "templates/aeotec_template.json#auto_report_group1_kVarh_wholehem"
+		},
+		{
+			"#": "101[0x20]",
+			"$import": "templates/aeotec_template.json#auto_report_group1_kVar_wholehem"
+		},
+		{
 			"#": "101[0x0100]",
 			"$import": "templates/aeotec_template.json#auto_report_group1_watt_clamp1"
 		},
@@ -175,6 +183,32 @@
 			"$import": "templates/aeotec_template.json#auto_report_group1_amp_clamp3"
 		},
 		{
+			"#": "101[0x01000000]",
+			"$import": "templates/aeotec_template.json#auto_report_group1_kVarh_clamp1"
+		},
+		{
+			"#": "101[0x02000000]",
+			"$import": "templates/aeotec_template.json#auto_report_group1_kVarh_clamp2"
+		},
+		{
+			"#": "101[0x04000000]",
+			"$if": "productType === 0x0002 && productId === 0x005f",
+			"$import": "templates/aeotec_template.json#auto_report_group1_kVarh_clamp3"
+		},
+		{
+			"#": "101[0x08000000]",
+			"$import": "templates/aeotec_template.json#auto_report_group1_kVar_clamp1"
+		},
+		{
+			"#": "101[0x10000000]",
+			"$import": "templates/aeotec_template.json#auto_report_group1_kVar_clamp2"
+		},
+		{
+			"#": "101[0x20000000]",
+			"$if": "productType === 0x0002 && productId === 0x005f",
+			"$import": "templates/aeotec_template.json#auto_report_group1_kVar_clamp3"
+		},
+		{
 			"#": "102[0x01]",
 			"$import": "templates/aeotec_template.json#auto_report_group2_kwh_wholehem"
 		},
@@ -189,6 +223,14 @@
 		{
 			"#": "102[0x08]",
 			"$import": "templates/aeotec_template.json#auto_report_group2_amp_wholehem"
+		},
+		{
+			"#": "102[0x10]",
+			"$import": "templates/aeotec_template.json#auto_report_group2_kVarh_wholehem"
+		},
+		{
+			"#": "102[0x20]",
+			"$import": "templates/aeotec_template.json#auto_report_group2_kVar_wholehem"
 		},
 		{
 			"#": "102[0x0100]",
@@ -243,6 +285,32 @@
 			"$import": "templates/aeotec_template.json#auto_report_group2_amp_clamp3"
 		},
 		{
+			"#": "102[0x01000000]",
+			"$import": "templates/aeotec_template.json#auto_report_group2_kVarh_clamp1"
+		},
+		{
+			"#": "102[0x02000000]",
+			"$import": "templates/aeotec_template.json#auto_report_group2_kVarh_clamp2"
+		},
+		{
+			"#": "102[0x04000000]",
+			"$if": "productType === 0x0002 && productId === 0x005f",
+			"$import": "templates/aeotec_template.json#auto_report_group2_kVarh_clamp3"
+		},
+		{
+			"#": "102[0x08000000]",
+			"$import": "templates/aeotec_template.json#auto_report_group2_kVar_clamp1"
+		},
+		{
+			"#": "102[0x10000000]",
+			"$import": "templates/aeotec_template.json#auto_report_group2_kVar_clamp2"
+		},
+		{
+			"#": "102[0x20000000]",
+			"$if": "productType === 0x0002 && productId === 0x005f",
+			"$import": "templates/aeotec_template.json#auto_report_group2_kVar_clamp3"
+		},
+		{
 			"#": "103[0x01]",
 			"$import": "templates/aeotec_template.json#auto_report_group3_kwh_wholehem"
 		},
@@ -257,6 +325,14 @@
 		{
 			"#": "103[0x08]",
 			"$import": "templates/aeotec_template.json#auto_report_group3_amp_wholehem"
+		},
+		{
+			"#": "103[0x10]",
+			"$import": "templates/aeotec_template.json#auto_report_group3_kVarh_wholehem"
+		},
+		{
+			"#": "103[0x20]",
+			"$import": "templates/aeotec_template.json#auto_report_group3_kVar_wholehem"
 		},
 		{
 			"#": "103[0x0100]",
@@ -309,6 +385,32 @@
 			"#": "103[0x200000]",
 			"$if": "productType === 0x0002 && productId === 0x005f",
 			"$import": "templates/aeotec_template.json#auto_report_group3_amp_clamp3"
+		},
+		{
+			"#": "103[0x01000000]",
+			"$import": "templates/aeotec_template.json#auto_report_group3_kVarh_clamp1"
+		},
+		{
+			"#": "103[0x02000000]",
+			"$import": "templates/aeotec_template.json#auto_report_group3_kVarh_clamp2"
+		},
+		{
+			"#": "103[0x04000000]",
+			"$if": "productType === 0x0002 && productId === 0x005f",
+			"$import": "templates/aeotec_template.json#auto_report_group3_kVarh_clamp3"
+		},
+		{
+			"#": "103[0x08000000]",
+			"$import": "templates/aeotec_template.json#auto_report_group3_kVar_clamp1"
+		},
+		{
+			"#": "103[0x10000000]",
+			"$import": "templates/aeotec_template.json#auto_report_group3_kVar_clamp2"
+		},
+		{
+			"#": "103[0x20000000]",
+			"$if": "productType === 0x0002 && productId === 0x005f",
+			"$import": "templates/aeotec_template.json#auto_report_group3_kVar_clamp3"
 		},
 		{
 			"#": "111",


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

Home Energy Meter is missing configuration options for kVar and kVarh. These changes add the new options.
