### PR TITLE
feat: simplify working with mixed-security multicast

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -641,12 +641,10 @@ When controlling multiple nodes, a "waterfall" effect can often be observed, bec
 > [!NOTE]
 > Multicast does **NOT** reduce the number of messages sent, but it can eliminate the waterfall effect when targeting many nodes. All multicasts are followed up by singlecast messages to the individual nodes. This makes sure that all nodes got the command, and is necessary to make secure (S2) multicast work at all.
 
-> [!NOTE]
-> There are some caveats when secure nodes are involved:
->
-> -   True broadcast is only possible for insecure nodes. Secure nodes will not react to broadcasts.
-> -   Nodes that are included via `Security S0` can only be controlled using singlecast.
-> -   When controlling nodes with mixed security classes, each group of nodes must be targeted individually. It is not possible to send a single command that both secure and insecure nodes will understand. This happens automatically though.
+There are some caveats when secure nodes are involved:
+
+-   Nodes that are included via `Security S0` can only be controlled using singlecast.
+-   When controlling nodes with mixed security classes, each group of nodes will automatically be targeted individually. It is not possible to send a single command that both secure and insecure nodes will understand.
 
 > [!NOTE]
 > Virtual nodes do not support all methods that physical nodes do. Check [`VirtualNode`](api/virtual-node-endpoint.md) for details on the available methods and properties.
@@ -668,10 +666,10 @@ Creates a virtual node that can be used to send commands to multiple supporting 
 getBroadcastNode(): VirtualNode
 ```
 
-Returns a reference to the (virtual) broadcast node. This can be used to send a command to all nodes in the network with a single message. You can target individual endpoints as usual.
+Returns a reference to the (virtual) broadcast node. This can be used to send a command to all nodes in the network with a single command. You can target individual endpoints as usual.
 
 > [!NOTE]
-> When the network contains devices with mixed security classes, this will do the same as `getMulticastGroup` instead.
+> When the network contains devices with mixed security classes, this will do the same as `getMulticastGroup` instead and send multiple commands.
 
 ### Configuring the Z-Wave radio
 

--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -646,7 +646,7 @@ When controlling multiple nodes, a "waterfall" effect can often be observed, bec
 >
 > -   True broadcast is only possible for insecure nodes. Secure nodes will not react to broadcasts.
 > -   Nodes that are included via `Security S0` can only be controlled using singlecast.
-> -   When controlling nodes with mixed security classes, each group of nodes must be targeted individually. It is not possible to send a single command that both secure and insecure nodes will understand.
+> -   When controlling nodes with mixed security classes, each group of nodes must be targeted individually. It is not possible to send a single command that both secure and insecure nodes will understand. This happens automatically though.
 
 > [!NOTE]
 > Virtual nodes do not support all methods that physical nodes do. Check [`VirtualNode`](api/virtual-node-endpoint.md) for details on the available methods and properties.
@@ -654,29 +654,24 @@ When controlling multiple nodes, a "waterfall" effect can often be observed, bec
 #### Multicast
 
 ```ts
-getMulticastGroups(nodeIDs: number[]): VirtualNode[]
+getMulticastGroup(nodeIDs: number[]): VirtualNode
 ```
 
-Creates one or more virtual nodes that can be used to send commands to multiple supporting nodes with as few multicast messages as possible. Nodes are grouped by security class automatically, and get ignored if they cannot be controlled via multicast. You can target individual endpoints as usual.
+Creates a virtual node that can be used to send commands to multiple supporting nodes with as few multicast messages as possible. Nodes are grouped by security class automatically, and get ignored if they cannot be controlled via multicast. You can target individual endpoints as usual.
 
 > [!NOTE]
-> This will actually send **broadcast** frames, since it has been found that some (all?) devices interpret S2 multicast frames as the S2 singlecast followup, causing them to respond incorrectly.
+> This may actually send **broadcast** frames, since it has been found that some (all?) devices interpret S2 multicast frames as the S2 singlecast followup, causing them to respond incorrectly.
 
 #### Broadcast
 
 ```ts
-getBroadcastNodeInsecure(): VirtualNode
+getBroadcastNode(): VirtualNode
 ```
 
-Returns a reference to the (virtual) broadcast node. This can be used to send a command to all supporting insecure nodes in the network with a single message. You can target individual endpoints as usual.
+Returns a reference to the (virtual) broadcast node. This can be used to send a command to all nodes in the network with a single message. You can target individual endpoints as usual.
 
-It is recommended to use the following method instead, which automatically groups nodes by security class and ignores those that cannot be controlled via broadcast.
-
-Note that this will do the same as `getMulticastGroups` if the network has mixed security classes.
-
-```ts
-getBroadcastNodes(): VirtualNode[]
-```
+> [!NOTE]
+> When the network contains devices with mixed security classes, this will do the same as `getMulticastGroup` instead.
 
 ### Configuring the Z-Wave radio
 

--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -14619,6 +14619,8 @@ export class SupervisionCCReport extends SupervisionCC {
     readonly status: SupervisionStatus;
     // (undocumented)
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
+    // (undocumented)
+    toSupervisionResult(): SupervisionResult;
 }
 
 // Warning: (ae-missing-release-tag) "SupervisionCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/cc/src/cc/SupervisionCC.ts
+++ b/packages/cc/src/cc/SupervisionCC.ts
@@ -9,6 +9,7 @@ import {
 	MessagePriority,
 	MessageRecord,
 	SinglecastCC,
+	SupervisionResult,
 	SupervisionStatus,
 	TransmitOptions,
 	validatePayload,
@@ -329,6 +330,19 @@ export class SupervisionCCReport extends SupervisionCC {
 			...super.toLogEntry(applHost),
 			message,
 		};
+	}
+
+	public toSupervisionResult(): SupervisionResult {
+		if (this.status === SupervisionStatus.Working) {
+			return {
+				status: this.status,
+				remainingDuration: this.duration!,
+			};
+		} else {
+			return {
+				status: this.status,
+			};
+		}
 	}
 }
 

--- a/packages/cc/src/lib/MultiCCAPIWrapper.ts
+++ b/packages/cc/src/lib/MultiCCAPIWrapper.ts
@@ -1,0 +1,158 @@
+import {
+	Duration,
+	isSupervisionResult,
+	SupervisionResult,
+	SupervisionStatus,
+	ZWaveError,
+	ZWaveErrorCodes,
+	type CommandClasses,
+	type SendCommandOptions,
+	type ValueID,
+} from "@zwave-js/core/safe";
+import type { CCAPI, SetValueImplementation } from "./API";
+
+/** Creates a wrapper that looks like an instance of a specific CC API, but can handle multiple instances of that API */
+export function createMultiCCAPIWrapper<T extends CCAPI>(apiInstances: T[]): T {
+	if (apiInstances.length === 0) {
+		throw new ZWaveError(
+			"At least one CC API instance must be provided",
+			ZWaveErrorCodes.Argument_Invalid,
+		);
+	} else if (apiInstances.some((a) => a.ccId !== apiInstances[0].ccId)) {
+		throw new ZWaveError(
+			"All CC API instances must be for the same CC",
+			ZWaveErrorCodes.Argument_Invalid,
+		);
+	}
+
+	const withOptions = (options: SendCommandOptions) =>
+		createMultiCCAPIWrapper(
+			// Create a new wrapper where each instance has the options applied
+			apiInstances.map((a) => a.withOptions(options)),
+		);
+	const withTXReport = () =>
+		createMultiCCAPIWrapper<T>(
+			apiInstances.map((a) => a.withTXReport() as any),
+		);
+
+	// Delegate some properties to the first instance
+	const version = apiInstances[0].version;
+	const ccId = apiInstances[0].ccId;
+	const isSupported = () => apiInstances[0].isSupported();
+	const isSetValueOptimistic = (valueId: ValueID) =>
+		apiInstances[0].isSetValueOptimistic(valueId);
+	const supportsCommand = (cmd: CommandClasses) =>
+		apiInstances[0].supportsCommand(cmd);
+
+	// Since all instances are the same, either all of them or none have a set value implementation
+	const setValue: SetValueImplementation | undefined = apiInstances[0]
+		.setValue
+		? async (...args) => {
+				const tasks = apiInstances.map((a) =>
+					a.setValue!.call(a, ...args),
+				);
+				const results = await Promise.all(tasks);
+				return mergeSupervisionResults(results);
+		  }
+		: undefined;
+
+	// This wrapper is by definition for multiple nodes, so we cannot return one
+	const getNode = () => undefined;
+	const getNodeUnsafe = () => undefined;
+
+	return new Proxy({} as T, {
+		get(target, prop) {
+			// Avoid ultra-weird error messages during testing
+			if (
+				process.env.NODE_ENV === "test" &&
+				typeof prop === "string" &&
+				(prop === "$$typeof" ||
+					prop === "constructor" ||
+					prop.includes("@@__IMMUTABLE"))
+			) {
+				return undefined;
+			}
+
+			switch (prop) {
+				case "ccId":
+					return ccId;
+				case "version":
+					return version;
+				case "isSupported":
+					return isSupported;
+				case "getNode":
+					return getNode;
+				case "getNodeUnsafe":
+					return getNodeUnsafe;
+				case "isSetValueOptimistic":
+					return isSetValueOptimistic;
+				case "supportsCommand":
+					return supportsCommand;
+				case "withOptions":
+					return withOptions;
+				case "withTXReport":
+					return withTXReport;
+
+				case "pollValue":
+					// We don't do multicast polls
+					return undefined;
+				case "setValue":
+					return setValue;
+
+				default:
+					// Assume everything else is a CC-specific method.
+					// Call all of them and merge the results
+					return async (...args: any) => {
+						const tasks = apiInstances.map((a) =>
+							// This may throw when a non-existing method is accessed, but that is desired here
+							(a as any)[prop].call(a, ...args),
+						);
+						const results = await Promise.all(tasks);
+						// The call site may use a GET-type method, which does not make sense in a multicast context
+						// The following will return `undefined` in that case
+						return mergeSupervisionResults(results);
+					};
+			}
+		},
+	});
+}
+
+/** Figures out the final supervision result from an array of things that may be supervision results */
+function mergeSupervisionResults(
+	results: unknown[],
+): SupervisionResult | undefined {
+	const supervisionResults = results.filter(isSupervisionResult);
+	if (!supervisionResults.length) return undefined;
+
+	if (supervisionResults.some((r) => r.status === SupervisionStatus.Fail)) {
+		return {
+			status: SupervisionStatus.Fail,
+		};
+	} else if (
+		supervisionResults.some((r) => r.status === SupervisionStatus.NoSupport)
+	) {
+		return {
+			status: SupervisionStatus.NoSupport,
+		};
+	}
+	const working = supervisionResults.filter(
+		(r): r is SupervisionResult & { status: SupervisionStatus.Working } =>
+			r.status === SupervisionStatus.Working,
+	);
+	if (working.length > 0) {
+		const durations = working.map((r) =>
+			r.remainingDuration.serializeSet(),
+		);
+		const maxDuration =
+			(durations.length > 0 &&
+				Duration.parseReport(Math.max(...durations))) ||
+			new Duration(0, "unknown");
+		return {
+			status: SupervisionStatus.Working,
+			remainingDuration: maxDuration,
+		};
+	}
+	return {
+		status: SupervisionStatus.Success,
+	};
+}

--- a/packages/core/api.md
+++ b/packages/core/api.md
@@ -1364,6 +1364,11 @@ export const MAX_TRANSPORT_SERVICE_SESSION_ID = 15;
 // @public (undocumented)
 export type Maybe<T> = T | BrandedUnknown<T>;
 
+// Warning: (ae-missing-release-tag) "mergeSupervisionResults" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function mergeSupervisionResults(results: unknown[]): SupervisionResult | undefined;
+
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (ae-missing-release-tag) "messageFitsIntoOneLine" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/core/src/consts/Transmission.ts
+++ b/packages/core/src/consts/Transmission.ts
@@ -1,7 +1,7 @@
 import { isObject } from "alcalzone-shared/typeguards";
 import type { ICommandClass } from "../abstractions/ICommandClass";
 import type { ProtocolDataRate } from "../capabilities/Protocols";
-import type { Duration } from "../values/Duration";
+import { Duration } from "../values/Duration";
 
 /** The priority of messages, sorted from high (0) to low (>0) */
 export enum MessagePriority {
@@ -302,4 +302,44 @@ export function isUnsupervisedOrSucceeded(
 			status: SupervisionStatus.Success | SupervisionStatus.Working;
 	  }) {
 	return !result || supervisedCommandSucceeded(result);
+}
+
+/** Figures out the final supervision result from an array of things that may be supervision results */
+export function mergeSupervisionResults(
+	results: unknown[],
+): SupervisionResult | undefined {
+	const supervisionResults = results.filter(isSupervisionResult);
+	if (!supervisionResults.length) return undefined;
+
+	if (supervisionResults.some((r) => r.status === SupervisionStatus.Fail)) {
+		return {
+			status: SupervisionStatus.Fail,
+		};
+	} else if (
+		supervisionResults.some((r) => r.status === SupervisionStatus.NoSupport)
+	) {
+		return {
+			status: SupervisionStatus.NoSupport,
+		};
+	}
+	const working = supervisionResults.filter(
+		(r): r is SupervisionResult & { status: SupervisionStatus.Working } =>
+			r.status === SupervisionStatus.Working,
+	);
+	if (working.length > 0) {
+		const durations = working.map((r) =>
+			r.remainingDuration.serializeSet(),
+		);
+		const maxDuration =
+			(durations.length > 0 &&
+				Duration.parseReport(Math.max(...durations))) ||
+			new Duration(0, "unknown");
+		return {
+			status: SupervisionStatus.Working,
+			remainingDuration: maxDuration,
+		};
+	}
+	return {
+		status: SupervisionStatus.Success,
+	};
 }

--- a/packages/core/src/values/Primitive.ts
+++ b/packages/core/src/values/Primitive.ts
@@ -1,4 +1,4 @@
-import { NUM_NODEMASK_BYTES } from "../consts";
+import { MAX_NODES, NUM_NODEMASK_BYTES } from "../consts";
 import { ZWaveError, ZWaveErrorCodes } from "../error/ZWaveError";
 import {
 	getBitMaskWidth,
@@ -223,7 +223,7 @@ export function parseNodeBitMask(mask: Buffer): number[] {
 }
 
 export function encodeNodeBitMask(nodeIDs: readonly number[]): Buffer {
-	return encodeBitMask(nodeIDs, NUM_NODEMASK_BYTES);
+	return encodeBitMask(nodeIDs, MAX_NODES);
 }
 
 /**

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -116,7 +116,6 @@ import type { SecurityClass } from '@zwave-js/core/safe';
 import { SecurityClass as SecurityClass_2 } from '@zwave-js/core';
 import { SecurityClassOwner } from '@zwave-js/core';
 import { SendCommandOptions } from '@zwave-js/core';
-import { SendCommandOptions as SendCommandOptions_2 } from '@zwave-js/core/safe';
 import { SendCommandReturnType } from '@zwave-js/core';
 import { SendMessageOptions } from '@zwave-js/core';
 import { SensorType } from '@zwave-js/config';
@@ -941,8 +940,7 @@ export class VirtualEndpoint implements IVirtualEndpoint {
     constructor(
     node: VirtualNode | undefined,
     driver: Driver,
-    index: number,
-    defaultCommandOptions?: SendCommandOptions_2 | undefined);
+    index: number);
     get commandClasses(): CCAPIs;
     protected readonly driver: Driver;
     getCCVersion(cc: CommandClasses): number;
@@ -963,8 +961,7 @@ export class VirtualEndpoint implements IVirtualEndpoint {
 // @public (undocumented)
 export class VirtualNode extends VirtualEndpoint implements IVirtualNode {
     constructor(id: number | undefined, driver: Driver,
-    physicalNodes: Iterable<ZWaveNode>,
-    defaultCommandOptions?: SendCommandOptions);
+    physicalNodes: Iterable<ZWaveNode>);
     getDefinedValueIDs(): VirtualValueID[];
     getEndpoint(index: 0): VirtualEndpoint;
     // (undocumented)
@@ -973,7 +970,11 @@ export class VirtualNode extends VirtualEndpoint implements IVirtualNode {
     // (undocumented)
     getEndpointOrThrow(index: number): VirtualEndpoint;
     // (undocumented)
+    get hasMixedSecurityClasses(): boolean;
+    // (undocumented)
     readonly id: number | undefined;
+    // (undocumented)
+    readonly nodesBySecurityClass: ReadonlyMap<SecurityClass_2, readonly ZWaveNode[]>;
     // (undocumented)
     readonly physicalNodes: readonly ZWaveNode[];
     setValue(valueId: ValueID_2, value: unknown, options?: SetValueAPIOptions): Promise<boolean>;
@@ -1062,19 +1063,28 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
         rssiChannel1: RSSI_2;
         rssiChannel2?: RSSI_2;
     }>;
-    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "zwave-js" does not have an export "getBroadcastNodes"
-    //
-    // @deprecated
     getBroadcastNode(): VirtualNode;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "zwave-js" does not have an export "getBroadcastNode"
+    //
+    // @deprecated (undocumented)
     getBroadcastNodeInsecure(): VirtualNode;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "zwave-js" does not have an export "getBroadcastNode"
+    //
+    // @deprecated (undocumented)
     getBroadcastNodes(): VirtualNode[];
     getKnownLifelineRoutes(): ReadonlyMap<number, LifelineRoutes>;
-    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "zwave-js" does not have an export "getMulticastGroups"
+    getMulticastGroup(nodeIDs: number[]): VirtualNode;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "zwave-js" does not have an export "getMulticastGroup"
     //
     // @deprecated
-    getMulticastGroup(nodeIDs: number[]): VirtualNode;
     getMulticastGroupInsecure(nodeIDs: number[]): VirtualNode;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "zwave-js" does not have an export "getMulticastGroup"
+    //
+    // @deprecated (undocumented)
     getMulticastGroups(nodeIDs: number[]): VirtualNode[];
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "zwave-js" does not have an export "getMulticastGroup"
+    //
+    // @deprecated
     getMulticastGroupS2(nodeIDs: number[]): VirtualNode;
     getNodeByDSK(dsk: Buffer | string): ZWaveNode | undefined;
     getNodeNeighbors(nodeId: number, onlyRepeaters?: boolean): Promise<readonly number[]>;

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -43,7 +43,6 @@ import {
 	ProtocolType,
 	RFRegion,
 	RSSI,
-	S2SecurityClass,
 	SecurityClass,
 	securityClassIsS2,
 	securityClassOrder,
@@ -658,13 +657,19 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 
 	/**
 	 * Returns a reference to the (virtual) broadcast node, which allows sending commands to all nodes.
-	 * @deprecated Use {@link getBroadcastNodes} instead, which automatically groups nodes by security class and ignores nodes that cannot be controlled via multicast/broadcast.
+	 * This automatically groups nodes by security class, ignores nodes that cannot be controlled via multicast/broadcast, and will fall back to multicast(s) if necessary.
 	 */
 	public getBroadcastNode(): VirtualNode {
-		return this.getBroadcastNodeInsecure();
+		return new VirtualNode(
+			NODE_ID_BROADCAST,
+			this.driver,
+			this.nodes.values(),
+		);
 	}
 
-	/** Returns a reference to the (virtual) broadcast node, which allows sending commands to all insecure nodes. */
+	/**
+	 * @deprecated This API was a mistake. Use {@link getBroadcastNode} instead.
+	 */
 	public getBroadcastNodeInsecure(): VirtualNode {
 		return new VirtualNode(
 			NODE_ID_BROADCAST,
@@ -674,34 +679,15 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 	}
 
 	/**
-	 * Creates the necessary virtual nodes to be able to send commands to all nodes in the network.
-	 * Nodes are grouped by security class automatically, and get ignored if they cannot be controlled via multicast/broadcast.
+	 * @deprecated This API was a mistake. Use {@link getBroadcastNode} instead.
 	 */
 	public getBroadcastNodes(): VirtualNode[] {
-		const nodesBySecurityClass = this.groupNodesBySecurityClass();
-		nodesBySecurityClass.delete(SecurityClass.S0_Legacy);
-		if (
-			nodesBySecurityClass.size === 1 &&
-			nodesBySecurityClass.has(SecurityClass.None)
-		) {
-			// All nodes are insecure, we can use actual broadcasting
-			return [this.getBroadcastNodeInsecure()];
-		}
-
-		// We have to do multiple multicasts to reach all nodes
-		// Create a virtual node for each security class
-		return [...nodesBySecurityClass].map(([secClass, nodeIDs]) => {
-			if (secClass === SecurityClass.None) {
-				return this.getMulticastGroupInsecure(nodeIDs);
-			} else {
-				return this.getMulticastGroupS2(nodeIDs);
-			}
-		});
+		return [this.getBroadcastNode()];
 	}
 
 	/**
-	 * Creates a virtual node that can be used to send multicast commands to several nodes.
-	 * @deprecated Use {@link getMulticastGroups} instead, which automatically groups nodes by security class and ignores nodes that cannot be controlled via multicast.
+	 * Creates a virtual node that can be used to send one or more multicast commands to several nodes.
+	 * This automatically groups nodes by security class and ignores nodes that cannot be controlled via multicast.
 	 */
 	public getMulticastGroup(nodeIDs: number[]): VirtualNode {
 		if (nodeIDs.length === 0) {
@@ -716,26 +702,17 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 	}
 
 	/**
-	 * Creates the necessary virtual nodes to be able to send commands to the given nodes.
-	 * Nodes are grouped by security class automatically, and get ignored if they cannot be controlled via multicast.
+	 * @deprecated This API was a mistake. Use {@link getMulticastGroup} instead.
 	 */
 	public getMulticastGroups(nodeIDs: number[]): VirtualNode[] {
-		const nodesBySecurityClass = this.groupNodesBySecurityClass(nodeIDs);
-		nodesBySecurityClass.delete(SecurityClass.S0_Legacy);
-
-		// Create a virtual node for each security class
-		return [...nodesBySecurityClass].map(([secClass, nodeIDs]) => {
-			if (secClass === SecurityClass.None) {
-				return this.getMulticastGroupInsecure(nodeIDs);
-			} else {
-				return this.getMulticastGroupS2(nodeIDs);
-			}
-		});
+		return [this.getMulticastGroup(nodeIDs)];
 	}
 
 	/**
 	 * Creates a virtual node that can be used to send multicast commands to several insecure nodes.
 	 * All nodes MUST be included insecurely.
+	 *
+	 * @deprecated This API was a mistake. Use {@link getMulticastGroup} instead and don't worry about the security classes.
 	 */
 	public getMulticastGroupInsecure(nodeIDs: number[]): VirtualNode {
 		if (nodeIDs.length === 0) {
@@ -759,6 +736,8 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 	/**
 	 * Creates a virtual node that can be used to send multicast commands to several nodes using Security S2.
 	 * All nodes MUST be included using Security S2 and MUST have the same (highest) security class.
+	 *
+	 * @deprecated This API was a mistake. Use {@link getMulticastGroup} instead and don't worry about the security classes.
 	 */
 	public getMulticastGroupS2(nodeIDs: number[]): VirtualNode {
 		if (nodeIDs.length === 0) {
@@ -790,23 +769,7 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 			if (i > 0 && secClass !== node0Class) throw fail();
 		}
 
-		return new VirtualNode(
-			undefined,
-			this.driver,
-			nodes,
-			// For convenience, we automatically decide whether to use actual multicast
-			// or fall back to singlecast when there's only a single node
-			// in the multicast "group"
-			nodes.length > 1
-				? {
-						s2MulticastGroupId:
-							this.driver.securityManager2.createMulticastGroup(
-								nodeIDs,
-								node0Class as S2SecurityClass,
-							),
-				  }
-				: undefined,
-		);
+		return new VirtualNode(undefined, this.driver, nodes);
 	}
 
 	/** @internal */

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -4430,16 +4430,7 @@ ${handlers.length} left`,
 			);
 		}
 		// In any case, return the status
-		if (resp.status === SupervisionStatus.Working) {
-			return {
-				status: resp.status,
-				remainingDuration: resp.duration!,
-			};
-		} else {
-			return {
-				status: resp.status,
-			};
-		}
+		return resp.toSupervisionResult();
 	}
 
 	/**

--- a/packages/zwave-js/src/lib/node/MultiCCAPIWrapper.ts
+++ b/packages/zwave-js/src/lib/node/MultiCCAPIWrapper.ts
@@ -1,3 +1,4 @@
+import type { CCAPI, SetValueImplementation } from "@zwave-js/cc";
 import {
 	Duration,
 	isSupervisionResult,
@@ -9,7 +10,6 @@ import {
 	type SendCommandOptions,
 	type ValueID,
 } from "@zwave-js/core/safe";
-import type { CCAPI, SetValueImplementation } from "./API";
 
 /** Creates a wrapper that looks like an instance of a specific CC API, but can handle multiple instances of that API */
 export function createMultiCCAPIWrapper<T extends CCAPI>(apiInstances: T[]): T {

--- a/packages/zwave-js/src/lib/node/VirtualNode.ts
+++ b/packages/zwave-js/src/lib/node/VirtualNode.ts
@@ -4,6 +4,7 @@ import {
 	isZWaveError,
 	IVirtualNode,
 	normalizeValueID,
+	SecurityClass,
 	SendCommandOptions,
 	TranslatedValueID,
 	ValueID,
@@ -128,15 +129,14 @@ export class VirtualNode extends VirtualEndpoint implements IVirtualNode {
 	 * control the physical node(s) this virtual node represents.
 	 */
 	public getDefinedValueIDs(): VirtualValueID[] {
-		// If all nodes are secure, we can't use broadcast/multicast commands
-		if (this.physicalNodes.every((n) => n.isSecure === true)) return [];
-
 		// In order to compare value ids, we need them to be strings
 		const ret = new Map<string, VirtualValueID>();
 
 		for (const pNode of this.physicalNodes) {
-			// Secure nodes cannot be used for broadcast
-			if (pNode.isSecure === true) continue;
+			// Nodes using Security S0 cannot be used for broadcast
+			if (pNode.getHighestSecurityClass() === SecurityClass.S0_Legacy) {
+				continue;
+			}
 
 			// Take only the actuator values
 			const valueIDs: TranslatedValueID[] = pNode

--- a/packages/zwave-js/src/lib/node/VirtualNode.ts
+++ b/packages/zwave-js/src/lib/node/VirtualNode.ts
@@ -5,7 +5,6 @@ import {
 	IVirtualNode,
 	normalizeValueID,
 	SecurityClass,
-	SendCommandOptions,
 	TranslatedValueID,
 	ValueID,
 	valueIdToString,
@@ -26,26 +25,61 @@ export interface VirtualValueID extends TranslatedValueID {
 	ccVersion: number;
 }
 
+function groupNodesBySecurityClass(
+	nodes: Iterable<ZWaveNode>,
+): Map<SecurityClass, ZWaveNode[]> {
+	const ret = new Map<SecurityClass, ZWaveNode[]>();
+
+	for (const node of nodes) {
+		const secClass = node.getHighestSecurityClass();
+		if (secClass === SecurityClass.Temporary || secClass == undefined) {
+			continue;
+		}
+
+		if (!ret.has(secClass)) {
+			ret.set(secClass, []);
+		}
+		ret.get(secClass)!.push(node);
+	}
+
+	return ret;
+}
+
 export class VirtualNode extends VirtualEndpoint implements IVirtualNode {
 	public constructor(
 		public readonly id: number | undefined,
 		driver: Driver,
 		/** The references to the physical node this virtual node abstracts */
 		physicalNodes: Iterable<ZWaveNode>,
-		/** Default command options to use for the CC API */
-		defaultCommandOptions?: SendCommandOptions,
 	) {
 		// Define this node's intrinsic endpoint as the root device (0)
-		super(undefined, driver, 0, defaultCommandOptions);
+		super(undefined, driver, 0);
 		// Set the reference to this and the physical nodes
 		super.setNode(this);
 		this.physicalNodes = [...physicalNodes].filter(
-			// And avoid including the controller node in the support checks
-			(n) => n.id !== driver.controller.ownNodeId,
+			(n) =>
+				// And avoid including the controller node in the support checks
+				n.id !== driver.controller.ownNodeId &&
+				// And omit nodes using Security S0 which does not support broadcast / multicast
+				n.getHighestSecurityClass() !== SecurityClass.S0_Legacy,
 		);
+		this.nodesBySecurityClass = groupNodesBySecurityClass(
+			this.physicalNodes,
+		);
+
+		// If broadcasting is attempted with mixed security classes, automatically fall back to multicast
+		if (this.hasMixedSecurityClasses) this.id = undefined;
 	}
 
 	public readonly physicalNodes: readonly ZWaveNode[];
+	public readonly nodesBySecurityClass: ReadonlyMap<
+		SecurityClass,
+		readonly ZWaveNode[]
+	>;
+
+	public get hasMixedSecurityClasses(): boolean {
+		return this.nodesBySecurityClass.size > 1;
+	}
 
 	/**
 	 * Updates a value for a given property of a given CommandClass.
@@ -133,10 +167,10 @@ export class VirtualNode extends VirtualEndpoint implements IVirtualNode {
 		const ret = new Map<string, VirtualValueID>();
 
 		for (const pNode of this.physicalNodes) {
-			// Nodes using Security S0 cannot be used for broadcast
-			if (pNode.getHighestSecurityClass() === SecurityClass.S0_Legacy) {
-				continue;
-			}
+			// // Nodes using Security S0 cannot be used for broadcast
+			// if (pNode.getHighestSecurityClass() === SecurityClass.S0_Legacy) {
+			// 	continue;
+			// }
 
 			// Take only the actuator values
 			const valueIDs: TranslatedValueID[] = pNode


### PR DESCRIPTION
It has been found that working with the new methods introduced in https://github.com/zwave-js/node-zwave-js/pull/5475 is really awkward. So this PR deprecates them and reverts the public multicast/broadcast API back to the old one that just returns a single `VirtualNode` for both.

Instead, grouping nodes by security classes and targeting multiple groups at once now happens internally. 