### PR TITLE
fix(config): add 0x1351 product ID for MCOHome A8-9

### DIFF
--- a/packages/config/config/devices/0x015f/a8-9.json
+++ b/packages/config/config/devices/0x015f/a8-9.json
@@ -6,8 +6,7 @@
 	"devices": [
 		{
 			"productType": "0xa803",
-			"productId": "0x135a",
-			"zwaveAllianceId": [3456, 3995]
+			"productId": "0x1351"
 		},
 		{
 			"productType": "0xa803",
@@ -15,7 +14,8 @@
 		},
 		{
 			"productType": "0xa803",
-			"productId": "0x1351"
+			"productId": "0x135a",
+			"zwaveAllianceId": [3456, 3995]
 		}
 	],
 	"firmwareVersion": {

--- a/packages/config/config/devices/0x015f/a8-9.json
+++ b/packages/config/config/devices/0x015f/a8-9.json
@@ -12,6 +12,10 @@
 		{
 			"productType": "0xa803",
 			"productId": "0x1352"
+		},
+		{
+			"productType": "0xa803",
+			"productId": "0x1351"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

I purchased this air quality sensor and it has with a different product ID than any of the ones in the existing configuration file. I added the product Id to the list, that should solve the issue and let me set the configuration.

![image](https://user-images.githubusercontent.com/2053039/227233098-19cb6e3d-b3ff-4afa-82ee-e53e077d660d.png)
