### PR TITLE
feat(config): add ZVIDAR Z-CM-V01

### DIFF
--- a/packages/config/config/devices/0x045a/Z-CM-V01.json
+++ b/packages/config/config/devices/0x045a/Z-CM-V01.json
@@ -1,0 +1,195 @@
+{
+	"manufacturer": "ZVIDAR",
+	"manufacturerId": "0x045a",
+	"label": "Z-CM-V01",
+	"description": "Smart Curtain Motor",
+	"devices": [
+		{
+			"productType": "0x0904",
+			"productId": "0x0507"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"label": "Set To Start Holding Hands",
+			"description": "This parameter can be used to set the motor open hand start function",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Close hand start function",
+					"value": 0
+				},
+				{
+					"label": "Open hand start function",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "2",
+			"label": "Motor Direction",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Forward",
+					"value": 1
+				},
+				{
+					"label": "Opposite",
+					"value": 2
+				},
+				{
+					"label": "Reverse",
+					"value": 3
+				}
+			]
+		},
+		{
+			"#": "3",
+			"label": "Manually Set Open Boundary",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Cancel",
+					"value": 0
+				},
+				{
+					"label": "Start",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "4",
+			"label": "Manually Set Closed Boundary",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Cancel",
+					"value": 0
+				},
+				{
+					"label": "Start",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "5",
+			"label": "Control Motor",
+			"valueSize": 1,
+			"defaultValue": 3,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Open (Up)",
+					"value": 1
+				},
+				{
+					"label": "Close (Down)",
+					"value": 2
+				},
+				{
+					"label": "Stop",
+					"value": 3
+				}
+			]
+		},
+		{
+			"#": "6",
+			"label": "Calibrate Limit Position",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Upper limit",
+					"value": 1
+				},
+				{
+					"label": "Lower limit",
+					"value": 2
+				},
+				{
+					"label": "Third limit",
+					"value": 3
+				}
+			]
+		},
+		{
+			"#": "7",
+			"label": "Delete Limit Position",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "All limits",
+					"value": 0
+				},
+				{
+					"label": "Only upper limit",
+					"value": 1
+				},
+				{
+					"label": "Only lower limit",
+					"value": 2
+				},
+				{
+					"label": "Only third limit",
+					"value": 3
+				}
+			]
+		},
+		{
+			"#": "8",
+			"label": "Low Battery Level Alarm Threshold",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 50,
+			"defaultValue": 10,
+			"unit": "%",
+			"unsigned": true
+		},
+		{
+			"#": "9",
+			"label": "Battery Report Interval",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 2678400,
+			"defaultValue": 3600,
+			"unit": "seconds",
+			"unsigned": true
+		},
+		{
+			"#": "10",
+			"label": "Battery Change Report Threshold",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 50,
+			"defaultValue": 5,
+			"unit": "%",
+			"unsigned": true
+		}
+	]
+}

--- a/packages/config/config/devices/0x045a/Z-CM-V01.json
+++ b/packages/config/config/devices/0x045a/Z-CM-V01.json
@@ -16,6 +16,8 @@
 	"paramInformation": [
 		{
 			"#": "1",
+			// TODO: It is unknown what this parameter does. If anyone knows,
+			// let us know so we can find a better label for it
 			"label": "Set To Start Holding Hands",
 			"description": "This parameter can be used to set the motor open hand start function",
 			"valueSize": 1,
@@ -45,6 +47,8 @@
 					"label": "Forward",
 					"value": 1
 				},
+				// TODO: The difference between these two is unknown.
+				// If anyone knows, please tell us.
 				{
 					"label": "Opposite",
 					"value": 2


### PR DESCRIPTION
* Add config for ZVIDAR Smart Curtain Motor (Z-CM-V01)

* The `productType` and `productId` were pulled from the UI (I'm not sure which of Product vs Product Code goes with which number):
![image](https://user-images.githubusercontent.com/19751919/229376376-3515d720-3f77-402f-8cf9-b9aa2083d282.png)

* Parameters were defined based on this manual:
[zwave motor.pdf](https://github.com/zwave-js/node-zwave-js/files/11133206/zwave.motor.pdf)
