### PR TITLE
fix: add legacy/simple door sensor value to restore old behavior

### DIFF
--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -11992,6 +11992,43 @@ export const NotificationCCValues: Readonly<{
             readonly supportsEndpoints: false;
         };
     };
+    doorStateSimple: {
+        readonly id: {
+            commandClass: CommandClasses.Notification;
+            property: "Access Control";
+            propertyKey: "Door state (simple)";
+        };
+        readonly endpoint: (endpoint?: number | undefined) => {
+            readonly commandClass: CommandClasses.Notification;
+            readonly endpoint: number;
+            readonly property: "Access Control";
+            readonly propertyKey: "Door state (simple)";
+        };
+        readonly is: (valueId: ValueID) => boolean;
+        readonly meta: {
+            readonly label: "Door state (simple)";
+            readonly states: {
+                readonly 22: "Window/door is open";
+                readonly 23: "Window/door is closed";
+            };
+            readonly ccSpecific: {
+                readonly notificationType: 6;
+            };
+            readonly writeable: false;
+            readonly min: 0;
+            readonly max: 255;
+            readonly type: "number";
+            readonly readable: true;
+        };
+        readonly options: {
+            readonly internal: false;
+            readonly stateful: true;
+            readonly secret: false;
+            readonly minVersion: 1;
+            readonly supportsEndpoints: true;
+            readonly autoCreate: (applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2) => boolean;
+        };
+    };
     alarmLevel: {
         readonly id: {
             commandClass: CommandClasses.Notification;


### PR DESCRIPTION
https://github.com/zwave-js/node-zwave-js/pull/5394 introduced a change for the `Door state` notification variable that was more breaking than anticipated, due to applications automatically generating binary sensors for two-state notification values.

This PR adds a new value `Door state (simple)` which only has two states and behaves just like the now 4-state `Door state` variable did before:

| Value sent from device   | Door state                      | Door state (simple) |
|--------------------------|---------------------------------|---------------------|
| open                     | open (22)                       | open (22)           |
| open in regular position | open in regular position (5632) | open (22)           |
| open in tilt position    | open in tilt position (5633)    | open (22)           |
| closed                   | closed (23)                     | closed (23)         |

