### PR TITLE
feat: add support for preferred configs with overlapping version ranges

### DIFF
--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -2,20 +2,21 @@
 
 The following properties are defined and should always be present in the same order for consistency among the config files:
 
-| Property           | Description                                                                                                                                                                                                |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `manufacturer`     | The name of the manufacturer (or brand under which the device is sold)                                                                                                                                     |
-| `manufacturerId`   | The ID of the manufacturer (as defined in the Z-Wave specs) as a 4-digit hexadecimal string.                                                                                                               |
-| `label`            | A short label for the device                                                                                                                                                                               |
-| `description`      | A longer description of the device, usually the full name                                                                                                                                                  |
-| `devices`          | An array of product type and product ID combinations, [see below](#devices) for details.                                                                                                                   |
-| `firmwareVersion`  | The firmware version range this config file is valid for, [see below](#firmwareVersion) for details.                                                                                                       |
-| `endpoints`        | Endpoint-specific configuration, [see below](#endpoints) for details. If this is present, `associations` must be specified on endpoint `"0"` instead of on the root level.                                 |
-| `associations`     | The association groups the device supports, [see below](#associations) for details. Only needs to be present if the device does not support Z-Wave+ or requires changes to the default association config. |
-| `paramInformation` | An array of the configuration parameters the device supports. [See below](#paramInformation) for details.                                                                                                  |
-| `proprietary`      | A dictionary of settings for the proprietary CC. The settings depend on each proprietary CC implementation.                                                                                                |
-| `compat`           | Compatibility flags used to influence the communication with non-compliant devices. [See below](#compat) for details.                                                                                      |
-| `metadata`         | Metadata that is intended to help the user, like inclusion instructions etc. [See below](#metadata) for details.                                                                                           |
+| Property           | Description                                                                                                                                                                                                                      |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `manufacturer`     | The name of the manufacturer (or brand under which the device is sold)                                                                                                                                                           |
+| `manufacturerId`   | The ID of the manufacturer (as defined in the Z-Wave specs) as a 4-digit hexadecimal string.                                                                                                                                     |
+| `label`            | A short label for the device                                                                                                                                                                                                     |
+| `description`      | A longer description of the device, usually the full name                                                                                                                                                                        |
+| `devices`          | An array of product type and product ID combinations, [see below](#devices) for details.                                                                                                                                         |
+| `firmwareVersion`  | The firmware version range this config file is valid for, [see below](#firmwareVersion) for details.                                                                                                                             |
+| `preferred`        | Mark this config file as preferred over others with the same IDs, but overlapping firmware versions. Can be used to have a default white-labeled configuration with re-branded versions, without having to split files too much. |
+| `endpoints`        | Endpoint-specific configuration, [see below](#endpoints) for details. If this is present, `associations` must be specified on endpoint `"0"` instead of on the root level.                                                       |
+| `associations`     | The association groups the device supports, [see below](#associations) for details. Only needs to be present if the device does not support Z-Wave+ or requires changes to the default association config.                       |
+| `paramInformation` | An array of the configuration parameters the device supports. [See below](#paramInformation) for details.                                                                                                                        |
+| `proprietary`      | A dictionary of settings for the proprietary CC. The settings depend on each proprietary CC implementation.                                                                                                                      |
+| `compat`           | Compatibility flags used to influence the communication with non-compliant devices. [See below](#compat) for details.                                                                                                            |
+| `metadata`         | Metadata that is intended to help the user, like inclusion instructions etc. [See below](#metadata) for details.                                                                                                                 |
 
 ## `devices`
 

--- a/maintenance/schemas/device-config.json
+++ b/maintenance/schemas/device-config.json
@@ -71,6 +71,10 @@
 			"required": ["min", "max"],
 			"additionalProperties": false
 		},
+		"preferred": {
+			"const": true,
+			"description": "Mark this configuration file as preferred over others with overlapping firmware version ranges"
+		},
 		"supportsZWavePlus": {
 			"const": true
 		},

--- a/packages/config/api.md
+++ b/packages/config/api.md
@@ -235,6 +235,7 @@ export class ConditionalDeviceConfig {
     readonly metadata?: ConditionalDeviceMetadata;
     // (undocumented)
     readonly paramInformation?: ConditionalParamInfoMap;
+    readonly preferred: boolean;
     readonly proprietary?: Record<string, unknown>;
 }
 
@@ -463,7 +464,8 @@ export class DeviceConfig {
     isEmbedded: boolean, manufacturer: string, manufacturerId: number, label: string, description: string, devices: readonly {
         productType: number;
         productId: number;
-    }[], firmwareVersion: FirmwareVersionRange, endpoints?: ReadonlyMap<number, EndpointConfig> | undefined, associations?: ReadonlyMap<number, AssociationConfig> | undefined, paramInformation?: ParamInfoMap | undefined,
+    }[], firmwareVersion: FirmwareVersionRange,
+    preferred: boolean, endpoints?: ReadonlyMap<number, EndpointConfig> | undefined, associations?: ReadonlyMap<number, AssociationConfig> | undefined, paramInformation?: ParamInfoMap | undefined,
     proprietary?: Record<string, unknown> | undefined,
     compat?: CompatConfig | undefined,
     metadata?: DeviceMetadata | undefined);
@@ -500,6 +502,7 @@ export class DeviceConfig {
     readonly metadata?: DeviceMetadata | undefined;
     // (undocumented)
     readonly paramInformation?: ParamInfoMap | undefined;
+    readonly preferred: boolean;
     readonly proprietary?: Record<string, unknown> | undefined;
 }
 
@@ -518,6 +521,8 @@ export interface DeviceConfigIndexEntry {
     firmwareVersion: FirmwareVersionRange;
     // (undocumented)
     manufacturerId: string;
+    // (undocumented)
+    preferred?: true;
     // (undocumented)
     productId: string;
     // (undocumented)
@@ -606,6 +611,8 @@ export interface FulltextDeviceConfigIndexEntry {
     manufacturer: string;
     // (undocumented)
     manufacturerId: string;
+    // (undocumented)
+    preferred?: true;
     // (undocumented)
     productId: string;
     // (undocumented)

--- a/packages/config/maintenance/lintConfigFiles.ts
+++ b/packages/config/maintenance/lintConfigFiles.ts
@@ -1086,10 +1086,15 @@ Consider converting this parameter to unsigned using ${white(
 			// Ensure that the firmware version ranges do not overlap,
 			// except if one is preferred and the other isn't
 			if (
-				!versionInRange(me.min, other.min, other.max) &&
-				!versionInRange(me.max, other.min, other.max) &&
-				entry.preferred !== index[firstIndex].preferred
+				versionInRange(me.min, other.min, other.max) ||
+				versionInRange(me.max, other.min, other.max) ||
+				versionInRange(other.min, me.min, me.max) ||
+				versionInRange(other.max, me.min, me.max)
 			) {
+				if (entry.preferred !== index[firstIndex].preferred) {
+					continue;
+				}
+			} else {
 				continue;
 			}
 		}

--- a/packages/config/maintenance/lintConfigFiles.ts
+++ b/packages/config/maintenance/lintConfigFiles.ts
@@ -1083,10 +1083,12 @@ Consider converting this parameter to unsigned using ${white(
 		if (typeof other === "boolean" || typeof me === "boolean") {
 			if (other !== me) continue;
 		} else {
-			// Ensure that the firmware version ranges do not overlap
+			// Ensure that the firmware version ranges do not overlap,
+			// except if one is preferred and the other isn't
 			if (
 				!versionInRange(me.min, other.min, other.max) &&
-				!versionInRange(me.max, other.min, other.max)
+				!versionInRange(me.max, other.min, other.max) &&
+				entry.preferred !== index[firstIndex].preferred
 			) {
 				continue;
 			}
@@ -1095,7 +1097,8 @@ Consider converting this parameter to unsigned using ${white(
 		addError(
 			entry.filename,
 			`Duplicate config file detected for device (manufacturer id = ${entry.manufacturerId}, product type = ${entry.productType}, product id = ${entry.productId}, firmware range ${me.min} to ${me.max})
-The first occurrence of this device is in file config/devices/${index[firstIndex].filename}, firmware range ${other.min} to ${other.max}`,
+The first occurrence of this device is in file config/devices/${index[firstIndex].filename}, firmware range ${other.min} to ${other.max}.
+If this is intended, consider marking one of the config files as preferred or split files by firmware version.`,
 		);
 	}
 

--- a/packages/config/src/ConfigManager.ts
+++ b/packages/config/src/ConfigManager.ts
@@ -617,7 +617,7 @@ export class ConfigManager {
 		if (!this.index) await this.loadDeviceIndex();
 
 		// Look up the device in the index
-		const indexEntry = this.index!.find(
+		const indexEntries = this.index!.filter(
 			getDeviceEntryPredicate(
 				manufacturerId,
 				productType,
@@ -625,6 +625,9 @@ export class ConfigManager {
 				firmwareVersion,
 			),
 		);
+		// If there are multiple with overlapping firmware ranges, return the preferred one first
+		const indexEntry =
+			indexEntries.find((e) => !!e.preferred) ?? indexEntries[0];
 
 		if (indexEntry) {
 			const devicesDir = getDevicesPaths(


### PR DESCRIPTION
This is mainly meant to support re-branded devices with narrow version ranges more easily, without having to split the whitelabel configs into multiple parts.
Required for https://github.com/zwave-js/node-zwave-js/pull/5567/