### PR TITLE
fix: correct low battery alarm mapping for Yale and Kwikset locks

### DIFF
--- a/packages/config/config/devices/0x0090/910.json
+++ b/packages/config/config/devices/0x0090/910.json
@@ -228,6 +228,9 @@
 			},
 			{
 				"$import": "templates/kwikset_template.json#alarm_map_low_battery"
+			},
+			{
+				"$import": "templates/kwikset_template.json#alarm_map_critical_battery"
 			}
 		]
 	},

--- a/packages/config/config/devices/0x0090/912.json
+++ b/packages/config/config/devices/0x0090/912.json
@@ -231,6 +231,9 @@
 			},
 			{
 				"$import": "templates/kwikset_template.json#alarm_map_low_battery"
+			},
+			{
+				"$import": "templates/kwikset_template.json#alarm_map_critical_battery"
 			}
 		]
 	}

--- a/packages/config/config/devices/0x0090/914.json
+++ b/packages/config/config/devices/0x0090/914.json
@@ -222,6 +222,9 @@
 			},
 			{
 				"$import": "templates/kwikset_template.json#alarm_map_low_battery"
+			},
+			{
+				"$import": "templates/kwikset_template.json#alarm_map_critical_battery"
 			}
 		]
 	}

--- a/packages/config/config/devices/0x0090/smartcode_888.json
+++ b/packages/config/config/devices/0x0090/smartcode_888.json
@@ -177,6 +177,9 @@
 			},
 			{
 				"$import": "templates/kwikset_template.json#alarm_map_low_battery"
+			},
+			{
+				"$import": "templates/kwikset_template.json#alarm_map_critical_battery"
 			}
 		]
 	},

--- a/packages/config/config/devices/0x0090/templates/kwikset_template.json
+++ b/packages/config/config/devices/0x0090/templates/kwikset_template.json
@@ -388,11 +388,28 @@
 	},
 	"alarm_map_low_battery": {
 		"from": {
+			// Low battery <= 4.8 V
 			"alarmType": 167
 		},
 		"to": {
 			"notificationType": 8, // Power Management
-			"notificationEvent": 10 // Replace battery soon
+			"notificationEvent": 14, // Charge battery soon
+			"eventParameters": {
+				"batteryLevel": "alarmLevel"
+			}
+		}
+	},
+	"alarm_map_critical_battery": {
+		"from": {
+			// Low battery <= 4.5 V
+			"alarmType": 168
+		},
+		"to": {
+			"notificationType": 8, // Power Management
+			"notificationEvent": 15, // Charge battery now
+			"eventParameters": {
+				"batteryLevel": "alarmLevel"
+			}
 		}
 	}
 }

--- a/packages/config/config/devices/0x0109/yrd210.json
+++ b/packages/config/config/devices/0x0109/yrd210.json
@@ -92,6 +92,9 @@
 				"$import": "~/0x0129/templates/yale_template.json#alarm_map_low_battery"
 			},
 			{
+				"$import": "~/0x0129/templates/yale_template.json#alarm_map_critical_battery"
+			},
+			{
 				"$import": "~/0x0129/templates/yale_template.json#alarm_map_auto_relock"
 			}
 		]

--- a/packages/config/config/devices/0x0129/sd-l1000-ch.json
+++ b/packages/config/config/devices/0x0129/sd-l1000-ch.json
@@ -71,6 +71,9 @@
 				"$import": "templates/yale_template.json#alarm_map_low_battery"
 			},
 			{
+				"$import": "templates/yale_template.json#alarm_map_critical_battery"
+			},
+			{
 				"$import": "templates/yale_template.json#alarm_map_auto_relock"
 			},
 			{

--- a/packages/config/config/devices/0x0129/templates/yale_template.json
+++ b/packages/config/config/devices/0x0129/templates/yale_template.json
@@ -455,11 +455,25 @@
 	},
 	"alarm_map_low_battery": {
 		"from": {
+			// Low battery <= 4.8 V
 			"alarmType": 167
 		},
 		"to": {
 			"notificationType": 8, // Power Management
-			"notificationEvent": 10, // Replace battery soon
+			"notificationEvent": 14, // Charge battery soon
+			"eventParameters": {
+				"batteryLevel": "alarmLevel"
+			}
+		}
+	},
+	"alarm_map_critical_battery": {
+		"from": {
+			// Low battery <= 4.5 V
+			"alarmType": 168
+		},
+		"to": {
+			"notificationType": 8, // Power Management
+			"notificationEvent": 15, // Charge battery now
 			"eventParameters": {
 				"batteryLevel": "alarmLevel"
 			}

--- a/packages/config/config/devices/0x0129/yrd110.json
+++ b/packages/config/config/devices/0x0129/yrd110.json
@@ -77,6 +77,9 @@
 				"$import": "templates/yale_template.json#alarm_map_low_battery"
 			},
 			{
+				"$import": "templates/yale_template.json#alarm_map_critical_battery"
+			},
+			{
 				"$import": "templates/yale_template.json#alarm_map_auto_relock"
 			}
 		]

--- a/packages/config/config/devices/0x0129/yrd120.json
+++ b/packages/config/config/devices/0x0129/yrd120.json
@@ -77,6 +77,9 @@
 				"$import": "templates/yale_template.json#alarm_map_low_battery"
 			},
 			{
+				"$import": "templates/yale_template.json#alarm_map_critical_battery"
+			},
+			{
 				"$import": "templates/yale_template.json#alarm_map_auto_relock"
 			}
 		]

--- a/packages/config/config/devices/0x0129/yrd210.json
+++ b/packages/config/config/devices/0x0129/yrd210.json
@@ -93,6 +93,9 @@
 				"$import": "templates/yale_template.json#alarm_map_low_battery"
 			},
 			{
+				"$import": "templates/yale_template.json#alarm_map_critical_battery"
+			},
+			{
 				"$import": "templates/yale_template.json#alarm_map_auto_relock"
 			}
 		]

--- a/packages/config/config/devices/0x0129/yrd220.json
+++ b/packages/config/config/devices/0x0129/yrd220.json
@@ -113,6 +113,9 @@
 				"$import": "templates/yale_template.json#alarm_map_low_battery"
 			},
 			{
+				"$import": "templates/yale_template.json#alarm_map_critical_battery"
+			},
+			{
 				"$import": "templates/yale_template.json#alarm_map_auto_relock"
 			}
 		]

--- a/packages/config/config/devices/0x0129/yrd256-zw3.json
+++ b/packages/config/config/devices/0x0129/yrd256-zw3.json
@@ -99,6 +99,9 @@
 				"$import": "templates/yale_template.json#alarm_map_low_battery"
 			},
 			{
+				"$import": "templates/yale_template.json#alarm_map_critical_battery"
+			},
+			{
 				"$import": "templates/yale_template.json#alarm_map_auto_relock"
 			}
 		]

--- a/packages/config/config/devices/0x0129/yrd256.json
+++ b/packages/config/config/devices/0x0129/yrd256.json
@@ -99,6 +99,9 @@
 				"$import": "templates/yale_template.json#alarm_map_low_battery"
 			},
 			{
+				"$import": "templates/yale_template.json#alarm_map_critical_battery"
+			},
+			{
 				"$import": "templates/yale_template.json#alarm_map_auto_relock"
 			}
 		]

--- a/packages/config/config/devices/0x0129/yrl210.json
+++ b/packages/config/config/devices/0x0129/yrl210.json
@@ -80,6 +80,9 @@
 				"$import": "templates/yale_template.json#alarm_map_low_battery"
 			},
 			{
+				"$import": "templates/yale_template.json#alarm_map_critical_battery"
+			},
+			{
 				"$import": "templates/yale_template.json#alarm_map_auto_relock"
 			}
 		]

--- a/packages/config/config/devices/0x0129/yrl220.json
+++ b/packages/config/config/devices/0x0129/yrl220.json
@@ -109,6 +109,9 @@
 				"$import": "templates/yale_template.json#alarm_map_low_battery"
 			},
 			{
+				"$import": "templates/yale_template.json#alarm_map_critical_battery"
+			},
+			{
 				"$import": "templates/yale_template.json#alarm_map_auto_relock"
 			}
 		]

--- a/packages/config/config/devices/0x0129/yrl256.json
+++ b/packages/config/config/devices/0x0129/yrl256.json
@@ -89,6 +89,9 @@
 				"$import": "templates/yale_template.json#alarm_map_low_battery"
 			},
 			{
+				"$import": "templates/yale_template.json#alarm_map_critical_battery"
+			},
+			{
 				"$import": "templates/yale_template.json#alarm_map_auto_relock"
 			}
 		]


### PR DESCRIPTION
As a followup to https://github.com/zwave-js/node-zwave-js/pull/5630 and as described in https://github.com/zwave-js/node-zwave-js/issues/1543#issuecomment-1497218026,
the alarm-to-battery mapping in these locks wasn't correct.

While the notification variables are called "Replace battery soon/now", they belong to the "Battery maintenance status", which is not meant for indicating a low battery but rather a rechargeable battery that is near its end of life.

This PR corrects this error, which further allows using Battery reports to idle these values. (followup PR)