### PR TITLE
feat: idle Battery level status notifications using Battery CC Reports

### DIFF
--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -1779,6 +1779,8 @@ export class BatteryCCReport extends BatteryCC {
     // (undocumented)
     readonly overheating: boolean | undefined;
     // (undocumented)
+    persistValues(applHost: ZWaveApplicationHost_2): boolean;
+    // (undocumented)
     readonly rechargeable: boolean | undefined;
     // (undocumented)
     readonly rechargeOrReplace: BatteryReplacementStatus | undefined;


### PR DESCRIPTION
As a followup to https://github.com/zwave-js/node-zwave-js/pull/5632 and as mentioned in https://github.com/zwave-js/node-zwave-js/issues/1543#issuecomment-1497218026, this PR adds a heuristic to the Battery CC that will reset the corresponding Notification CC values for "low battery" to idle if the battery is near full charge.