### PR TITLE
fix: do not wait for NonceReports during FW updates

### DIFF
--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -13781,6 +13781,7 @@ export class Security2CC extends CommandClass {
         securityClass?: SecurityClass;
         multicastOutOfSync?: boolean;
         multicastGroupId?: number;
+        verifyDelivery?: boolean;
     }): Security2CCMessageEncapsulation;
     // (undocumented)
     interview(applHost: ZWaveApplicationHost_2): Promise<void>;
@@ -13898,6 +13899,8 @@ export class Security2CCMessageEncapsulation extends Security2CC {
     serialize(): Buffer;
     // (undocumented)
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
+    // (undocumented)
+    readonly verifyDelivery: boolean;
 }
 
 // Warning: (ae-missing-release-tag) "Security2CCNetworkKeyGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/cc/src/cc/FirmwareUpdateMetaDataCC.ts
+++ b/packages/cc/src/cc/FirmwareUpdateMetaDataCC.ts
@@ -143,8 +143,13 @@ export class FirmwareUpdateMetaDataCCAPI extends PhysicalCCAPI {
 		});
 		// Since the response may take longer than with other commands,
 		// we do not use the built-in waiting functionality, which would block
-		// all other communication
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		// all other communication.
+
+		await this.applHost.sendCommand(cc, {
+			...this.commandOptions,
+			// Do not wait for Nonce Reports
+			s2VerifyDelivery: false,
+		});
 		const { status } =
 			await this.applHost.waitForCommand<FirmwareUpdateMetaDataCCRequestReport>(
 				(cc) =>
@@ -176,7 +181,11 @@ export class FirmwareUpdateMetaDataCCAPI extends PhysicalCCAPI {
 			isLast: isLastFragment,
 			firmwareData: data,
 		});
-		await this.applHost.sendCommand(cc, this.commandOptions);
+		await this.applHost.sendCommand(cc, {
+			...this.commandOptions,
+			// Do not wait for Nonce Reports
+			s2VerifyDelivery: false,
+		});
 	}
 
 	/** Activates a previously transferred firmware image */

--- a/packages/cc/src/cc/Security2CC.ts
+++ b/packages/cc/src/cc/Security2CC.ts
@@ -722,6 +722,7 @@ export class Security2CC extends CommandClass {
 			securityClass?: SecurityClass;
 			multicastOutOfSync?: boolean;
 			multicastGroupId?: number;
+			verifyDelivery?: boolean;
 		},
 	): Security2CCMessageEncapsulation {
 		// Determine which extensions must be used on the command
@@ -744,6 +745,7 @@ export class Security2CC extends CommandClass {
 			encapsulated: cc,
 			securityClass: options?.securityClass,
 			extensions,
+			verifyDelivery: options?.verifyDelivery,
 		});
 
 		// Copy the encapsulation flags from the encapsulated command
@@ -760,6 +762,7 @@ interface Security2CCMessageEncapsulationOptions extends CCCommandOptions {
 	securityClass?: SecurityClass;
 	extensions?: Security2Extension[];
 	encapsulated?: CommandClass;
+	verifyDelivery?: boolean;
 }
 
 // An S2 encapsulated command may result in a NonceReport to be sent by the node if it couldn't decrypt the message
@@ -1046,6 +1049,8 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 				options.encapsulated.encapsulatingCC = this as any;
 			}
 
+			this.verifyDelivery = options.verifyDelivery !== false;
+
 			this.extensions = options.extensions ?? [];
 			if (
 				typeof this.nodeId !== "number" &&
@@ -1067,6 +1072,8 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 	private authData?: Buffer;
 	private authTag?: Buffer;
 	private ciphertext?: Buffer;
+
+	public readonly verifyDelivery: boolean = true;
 
 	private _sequenceNumber: number | undefined;
 	/**

--- a/packages/core/api.md
+++ b/packages/core/api.md
@@ -2123,6 +2123,7 @@ export type SendCommandReturnType<TResponse extends ICommandClass | undefined> =
 //
 // @public (undocumented)
 export type SendCommandSecurityS2Options = {
+    s2VerifyDelivery?: boolean;
     s2MulticastOutOfSync?: boolean;
     s2MulticastGroupId?: number;
 };

--- a/packages/core/src/consts/Transmission.ts
+++ b/packages/core/src/consts/Transmission.ts
@@ -216,9 +216,11 @@ export type SupervisionOptions =
 	  };
 
 export type SendCommandSecurityS2Options = {
-	/** Whether the MOS extension should be included in S2 message encapsulation */
+	/** Whether delivery of non-supervised SET-type commands is verified by waiting for potential Nonce Reports. Default: true */
+	s2VerifyDelivery?: boolean;
+	/** Whether the MOS extension should be included in S2 message encapsulation. */
 	s2MulticastOutOfSync?: boolean;
-	/** The optional multicast group ID to use for S2 message encapsulation */
+	/** The optional multicast group ID to use for S2 message encapsulation. */
 	s2MulticastGroupId?: number;
 };
 

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -2637,7 +2637,11 @@ supported CCs: ${nodeInfo.supportedCCs
 		this.cancelBootstrapS2Promise = createDeferredPromise();
 
 		try {
-			const api = node.commandClasses["Security 2"];
+			const api = node.commandClasses["Security 2"].withOptions({
+				// Do not wait for Nonce Reports after SET-type commands.
+				// Timing is critical here
+				s2VerifyDelivery: false,
+			});
 			const abort = async (failType?: KEXFailType): Promise<void> => {
 				if (failType != undefined) {
 					try {

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -3967,6 +3967,7 @@ ${handlers.length} left`,
 				cmd = Security2CC.encapsulate(this, cmd, {
 					multicastOutOfSync: !!options.s2MulticastOutOfSync,
 					multicastGroupId: options.s2MulticastGroupId,
+					verifyDelivery: options.s2VerifyDelivery,
 				});
 			}
 

--- a/packages/zwave-js/src/lib/driver/MessageGenerators.ts
+++ b/packages/zwave-js/src/lib/driver/MessageGenerators.ts
@@ -3,7 +3,6 @@ import {
 	isCommandClassContainer,
 	MGRPExtension,
 	MPANExtension,
-	Security2CC,
 	Security2CCMessageEncapsulation,
 	Security2CCNonceGet,
 	Security2CCNonceReport,
@@ -567,13 +566,11 @@ export const secureMessageGeneratorS2: MessageGeneratorImplementation =
 		// If we want to make sure that a node understood a SET-type S2-encapsulated message, we either need to use
 		// Supervision and wait for the Supervision Report (handled by the simpleMessageGenerator), or we need to add a
 		// short delay between commands and wait if a NonceReport is received.
-
-		// However, we MUST NOT do this if the encapsulated command is also a Security S2 command, because this means
-		// we're in the middle of S2 bootstrapping, where timing is critical.
+		// However, in situations where timing is critical (e.g. S2 bootstrapping), verifyDelivery is set to false, and we don't do this.
 		let nonceReport: Security2CCNonceReport | undefined;
 		if (
 			isTransmitReport(response) &&
-			!(msg.command.encapsulated instanceof Security2CC) &&
+			msg.command.verifyDelivery &&
 			!msg.command.expectsCCResponse() &&
 			!msg.command.getEncapsulatedCC(
 				CommandClasses.Supervision,


### PR DESCRIPTION
fixes: #5594 

Since merging the S2 multicast PR, we started waiting for Nonce Reports after sending a set-type unsupervised S2-encapsulated command. This effectively introduced a race condition with how we handle the initialization of firmware updates.