### PR TITLE
fix: revert change to notification auto-idle

### DIFF
--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3513,9 +3513,7 @@ protocol version:      ${this.protocolVersion}`;
 				// We don't know what this notification refers to, so we don't force a reset
 				allowIdleReset = false;
 			} else if (valueConfig.type === "state") {
-				// CL:0071.01.52.07.2: A controlling node SHOULD NOT use timeouts to consider a state variable
-				// to be idle [...] for v8 or newer supporting nodes.
-				allowIdleReset = command.version >= 8 && valueConfig.idle;
+				allowIdleReset = valueConfig.idle;
 			} else {
 				// This is an event
 				this.emit("notification", this, CommandClasses.Notification, {


### PR DESCRIPTION
PR #5634 introduced changes to auto-idling which were the opposite of the intended change. On top of that, the intended change would clash with the fact that we need to allow auto-idling notification values for misbehaving v8 devices.

So this PR reverts those changes. Auto-idling is enabled for all devices with the corresponding compat flag set.