### PR TITLE
feat: add additional signature for manuallyIdleNotificationValue

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -595,10 +595,14 @@ The following CCs will be used (when supported or necessary) in this process:
 ### `manuallyIdleNotificationValue`
 
 ```ts
+manuallyIdleNotificationValue(valueId: ValueID): void;
+```
+
+```ts
 manuallyIdleNotificationValue(notificationType: number, prevValue: number, endpointIndex?: number): void;
 ```
 
-Many devices using `Notification CC` do not idle their notification values, since this requirement was only introduced in v8 of the Command Class. To alleviate the problem, this method can be used to manually idle the value. It takes the following arguments:
+Many devices using `Notification CC` do not idle their notification values, since this requirement was only introduced in v8 of the Command Class. To alleviate the problem, this method can be used to manually idle the value. It takes either the `valueId` of the value to idle or the following arguments:
 
 -   `notificationType`: The standardized notification type the value belongs to. If unknown, this can be read from the `ccSpecific.notificationType` property of the corresponding value metadata.
 -   `prevValue`: The value of the notification variable in its non-idle state. This is used to determine which notification variable should be reset to idle. It **must** match the current value, otherwise the value will not be reset.

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -602,7 +602,7 @@ manuallyIdleNotificationValue(valueId: ValueID): void;
 manuallyIdleNotificationValue(notificationType: number, prevValue: number, endpointIndex?: number): void;
 ```
 
-Many devices using `Notification CC` do not idle their notification values, since this requirement was only introduced in v8 of the Command Class. To alleviate the problem, this method can be used to manually idle the value. It takes either the `valueId` of the value to idle or the following arguments:
+Many devices using `Notification CC` do not idle their notification values, since this requirement was only introduced in v8 of the Command Class. To alleviate the problem, this method can be used to manually idle the value. The method has two signatures; it takes either the `valueId` of the value to idle or the following arguments:
 
 -   `notificationType`: The standardized notification type the value belongs to. If unknown, this can be read from the `ccSpecific.notificationType` property of the corresponding value metadata.
 -   `prevValue`: The value of the notification variable in its non-idle state. This is used to determine which notification variable should be reset to idle. It **must** match the current value, otherwise the value will not be reset.

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -596,9 +596,6 @@ The following CCs will be used (when supported or necessary) in this process:
 
 ```ts
 manuallyIdleNotificationValue(valueId: ValueID): void;
-```
-
-```ts
 manuallyIdleNotificationValue(notificationType: number, prevValue: number, endpointIndex?: number): void;
 ```
 

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -1283,7 +1283,7 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner, IZWaveNod
     set location(value: string | undefined);
     manuallyIdleNotificationValue(valueId: ValueID_2): void;
     // (undocumented)
-    manuallyIdleNotificationValue(notificationType: number, prevValue?: number, endpointIndex?: number): void;
+    manuallyIdleNotificationValue(notificationType: number, prevValue: number, endpointIndex?: number): void;
     // (undocumented)
     get manufacturerId(): number | undefined;
     // (undocumented)

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -1281,7 +1281,9 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner, IZWaveNod
     protected loadDeviceConfig(): Promise<void>;
     get location(): string | undefined;
     set location(value: string | undefined);
-    manuallyIdleNotificationValue(notificationType: number, prevValue: number, endpointIndex?: number): void;
+    manuallyIdleNotificationValue(valueId: ValueID_2): void;
+    // (undocumented)
+    manuallyIdleNotificationValue(notificationType: number, prevValue?: number, endpointIndex?: number): void;
     // (undocumented)
     get manufacturerId(): number | undefined;
     // (undocumented)

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3365,7 +3365,7 @@ protocol version:      ${this.protocolVersion}`;
 
 	public manuallyIdleNotificationValue(
 		notificationType: number,
-		prevValue?: number,
+		prevValue: number,
 		endpointIndex?: number,
 	): void;
 

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3388,19 +3388,6 @@ protocol version:      ${this.protocolVersion}`;
 			endpointIndex = notificationTypeOrValueID.endpoint ?? 0;
 		}
 
-		return this.manuallyIdleNotificationValueInternal(
-			notificationType,
-			prevValue!,
-			endpointIndex,
-		);
-	}
-
-	/** Manually resets a single notification value to idle */
-	private manuallyIdleNotificationValueInternal(
-		notificationType: number,
-		prevValue: number,
-		endpointIndex: number,
-	): void {
 		if (
 			!this.getEndpoint(endpointIndex)?.supportsCC(
 				CommandClasses.Notification,
@@ -3413,6 +3400,19 @@ protocol version:      ${this.protocolVersion}`;
 			this.driver.configManager.lookupNotification(notificationType);
 		if (!notificationConfig) return;
 
+		return this.manuallyIdleNotificationValueInternal(
+			notificationConfig,
+			prevValue!,
+			endpointIndex,
+		);
+	}
+
+	/** Manually resets a single notification value to idle */
+	private manuallyIdleNotificationValueInternal(
+		notificationConfig: Notification,
+		prevValue: number,
+		endpointIndex: number,
+	): void {
 		const valueConfig = notificationConfig.lookupValue(prevValue);
 		// Only known variables may be reset to idle
 		if (!valueConfig || valueConfig.type !== "state") return;

--- a/packages/zwave-js/src/lib/test/cc-specific/notificationIdleManually.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/notificationIdleManually.test.ts
@@ -66,3 +66,66 @@ integrationTest("Notification values can get idled manually", {
 		t.is(node.getValue(doorStateValueId), 0x16 /* Door state */);
 	},
 });
+
+integrationTest(
+	"node.manuallyIdleNotificationValue can accept ValueID as input",
+	{
+		// debug: true,
+		provisioningDirectory: path.join(__dirname, "fixtures/notificationCC"),
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const alarmStatusValueId =
+				NotificationCCValues.notificationVariable(
+					"Smoke Alarm",
+					"Alarm status",
+				).id;
+
+			let cc = new NotificationCCReport(mockNode.host, {
+				nodeId: mockController.host.ownNodeId,
+				notificationType: 0x01, // Smoke Alarm
+				notificationEvent: 0x03, // Smoke alarm test
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			// wait a bit for the value to be updated
+			await wait(100);
+			t.is(
+				node.getValue(alarmStatusValueId),
+				0x03 /* Smoke alarm test */,
+			);
+
+			// Idling with a valueId does work
+			node.manuallyIdleNotificationValue(alarmStatusValueId);
+			t.is(node.getValue(alarmStatusValueId), 0x00 /* Idle */);
+
+			// Now try one that cannot be idled
+
+			const doorStateValueId = NotificationCCValues.notificationVariable(
+				"Access Control",
+				"Door state",
+			).id;
+
+			cc = new NotificationCCReport(mockNode.host, {
+				nodeId: mockController.host.ownNodeId,
+				notificationType: 0x06, // Access Control
+				notificationEvent: 0x16, // Door state
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			// wait a bit for the value to be updated
+			await wait(100);
+
+			t.is(node.getValue(doorStateValueId), 0x16 /* Door state */);
+
+			node.manuallyIdleNotificationValue(doorStateValueId);
+			// Unchanged
+			t.is(node.getValue(doorStateValueId), 0x16 /* Door state */);
+		},
+	},
+);


### PR DESCRIPTION
As discussed in Discord, adds an additional signature for the `node.manuallyIdleNotificationValue` method
