### PR TITLE
fix: idle "Keypad state" notifications on keypad events

### DIFF
--- a/packages/config/config/notifications.json
+++ b/packages/config/config/notifications.json
@@ -568,7 +568,11 @@
 				},
 				"idleVariables": [
 					// Lock state - Lock jammed
-					"0x0b"
+					"0x0b",
+					// Keypad state - Keypad temporary disabled
+					"0x10",
+					// Keypad state - Keypad busy
+					"0x11"
 				]
 			},
 			"0x06": {
@@ -579,7 +583,11 @@
 				},
 				"idleVariables": [
 					// Lock state - Lock jammed
-					"0x0b"
+					"0x0b",
+					// Keypad state - Keypad temporary disabled
+					"0x10",
+					// Keypad state - Keypad busy
+					"0x11"
 				]
 			},
 			"0x07": {
@@ -628,7 +636,13 @@
 				"params": {
 					"type": "value",
 					"name": "user ID"
-				}
+				},
+				"idleVariables": [
+					// Keypad state - Keypad temporary disabled
+					"0x10",
+					// Keypad state - Keypad busy
+					"0x11"
+				]
 			},
 			"0x21": {
 				"label": "Lock operation with User Code",


### PR DESCRIPTION
as discussed in https://github.com/zwave-js/node-zwave-js/issues/1543#issuecomment-1498247929
When an event is received that indicates the keypad was just used, we should assume the keypad state has returned to idle (not disabled, not busy).