### PR TITLE
test: move mock responses for Notification CC into testing lib

### DIFF
--- a/packages/testing/api.md
+++ b/packages/testing/api.md
@@ -17,6 +17,18 @@ import { ZWaveApiVersion } from '@zwave-js/core/safe';
 import type { ZWaveHost } from '@zwave-js/host';
 import { ZWaveLibraryTypes } from '@zwave-js/core/safe';
 
+// Warning: (ae-missing-release-tag) "CCIdToCapabilities" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type CCIdToCapabilities<T extends CommandClasses = CommandClasses> = T extends keyof CCSpecificCapabilities ? CCSpecificCapabilities[T] : never;
+
+// Warning: (ae-missing-release-tag) "CCSpecificCapabilities" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type CCSpecificCapabilities = {
+    [CommandClasses.Notification]: NotificationCCCapabilities;
+};
+
 // Warning: (ae-missing-release-tag) "createMockZWaveAckFrame" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -164,6 +176,8 @@ export class MockNode {
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     expectControllerFrame<T extends MockZWaveFrame = MockZWaveFrame>(timeout: number, predicate: (msg: MockZWaveFrame) => msg is T): Promise<T>;
     // (undocumented)
+    getCCCapabilities<T extends CommandClasses>(ccId: T, endpointIndex?: number): Partial<CCIdToCapabilities<T>> | undefined;
+    // (undocumented)
     readonly host: ZWaveHost;
     // (undocumented)
     readonly id: number;
@@ -236,9 +250,22 @@ export interface MockZWaveRequestFrame {
     type: MockZWaveFrameType.Request;
 }
 
-// Warnings were encountered during analysis:
+// Warning: (ae-missing-release-tag) "NotificationCCCapabilities" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// src/MockNode.ts:54:3 - (ae-forgotten-export) The symbol "PartialCCCapabilities" needs to be exported by the entry point index.d.ts
+// @public (undocumented)
+export interface NotificationCCCapabilities {
+    // (undocumented)
+    notificationTypesAndEvents: Record<number, number[]>;
+    // (undocumented)
+    supportsV1Alarm: false;
+}
+
+// Warning: (ae-missing-release-tag) "PartialCCCapabilities" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type PartialCCCapabilities<T extends CommandClasses = CommandClasses> = T | ({
+    ccId: T;
+} & Partial<CommandClassInfo> & Partial<CCIdToCapabilities<T>>);
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/testing/src/CCSpecificCapabilities.ts
+++ b/packages/testing/src/CCSpecificCapabilities.ts
@@ -1,0 +1,13 @@
+import { CommandClasses } from "@zwave-js/core";
+
+export interface NotificationCCCapabilities {
+	supportsV1Alarm: false;
+	notificationTypesAndEvents: Record<number, number[]>;
+}
+
+export type CCSpecificCapabilities = {
+	[CommandClasses.Notification]: NotificationCCCapabilities;
+};
+
+export type CCIdToCapabilities<T extends CommandClasses = CommandClasses> =
+	T extends keyof CCSpecificCapabilities ? CCSpecificCapabilities[T] : never;

--- a/packages/testing/src/MockNode.ts
+++ b/packages/testing/src/MockNode.ts
@@ -9,6 +9,7 @@ import {
 import type { ZWaveHost } from "@zwave-js/host";
 import { TimedExpectation } from "@zwave-js/shared";
 import { isDeepStrictEqual } from "util";
+import type { CCIdToCapabilities } from "./CCSpecificCapabilities";
 import type { MockController } from "./MockController";
 import {
 	getDefaultMockEndpointCapabilities,
@@ -401,6 +402,24 @@ export class MockNode {
 	/** Forgets all recorded frames sent to the controller */
 	public clearSentControllerFrames(): void {
 		this.sentControllerFrames = [];
+	}
+
+	public getCCCapabilities<T extends CommandClasses>(
+		ccId: T,
+		endpointIndex?: number,
+	): Partial<CCIdToCapabilities<T>> | undefined {
+		let ccInfo: CommandClassInfo | undefined;
+		if (endpointIndex) {
+			const endpoint = this.endpoints.get(endpointIndex);
+			ccInfo = endpoint?.implementedCCs.get(ccId);
+		} else {
+			ccInfo = this.implementedCCs.get(ccId);
+		}
+		if (ccInfo) {
+			const { isSupported, isControlled, version, secure, ...ret } =
+				ccInfo;
+			return ret;
+		}
 	}
 }
 

--- a/packages/testing/src/MockNodeCapabilities.ts
+++ b/packages/testing/src/MockNodeCapabilities.ts
@@ -4,12 +4,12 @@ import {
 	NodeProtocolInfoAndDeviceClass,
 	NodeType,
 } from "@zwave-js/core";
+import type { CCIdToCapabilities } from "./CCSpecificCapabilities";
 
-export type PartialCCCapabilities =
-	| ({
-			ccId: CommandClasses;
-	  } & Partial<CommandClassInfo>)
-	| CommandClasses;
+export type PartialCCCapabilities<T extends CommandClasses = CommandClasses> =
+	| T
+	| ({ ccId: T } & Partial<CommandClassInfo> &
+			Partial<CCIdToCapabilities<T>>);
 
 export interface MockNodeCapabilities extends NodeProtocolInfoAndDeviceClass {
 	firmwareVersion: string;

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,3 +1,5 @@
+export * from "./CCSpecificCapabilities";
 export * from "./MockController";
 export * from "./MockNode";
+export type { PartialCCCapabilities } from "./MockNodeCapabilities";
 export * from "./MockZWaveFrame";

--- a/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
+++ b/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
@@ -25,6 +25,7 @@ import {
 	MockNodeBehavior,
 	MockZWaveFrameType,
 } from "@zwave-js/testing";
+import { behaviors as NotificationCCBehaviors } from "./mockCCBehaviors/Notification";
 
 const respondToRequestNodeInfo: MockNodeBehavior = {
 	async onControllerFrame(controller, self, frame) {
@@ -269,5 +270,7 @@ export function createDefaultBehaviors(): MockNodeBehavior[] {
 		respondToZWavePlusCCGet,
 		respondToS0ZWavePlusCCGet,
 		respondToS2ZWavePlusCCGet,
+
+		...NotificationCCBehaviors,
 	];
 }

--- a/packages/zwave-js/src/lib/node/mockCCBehaviors/Notification.ts
+++ b/packages/zwave-js/src/lib/node/mockCCBehaviors/Notification.ts
@@ -1,0 +1,91 @@
+import {
+	NotificationCCEventSupportedGet,
+	NotificationCCEventSupportedReport,
+	NotificationCCSupportedGet,
+	NotificationCCSupportedReport,
+} from "@zwave-js/cc/NotificationCC";
+import { CommandClasses } from "@zwave-js/core";
+import type { NotificationCCCapabilities } from "@zwave-js/testing";
+import {
+	createMockZWaveRequestFrame,
+	MockZWaveFrameType,
+	type MockNodeBehavior,
+} from "@zwave-js/testing";
+
+const defaultCapabilities: NotificationCCCapabilities = {
+	supportsV1Alarm: false,
+	notificationTypesAndEvents: {}, // none
+};
+
+const respondToNotificationSupportedGet: MockNodeBehavior = {
+	async onControllerFrame(controller, self, frame) {
+		if (
+			frame.type === MockZWaveFrameType.Request &&
+			frame.payload instanceof NotificationCCSupportedGet
+		) {
+			const capabilities = {
+				...defaultCapabilities,
+				...self.getCCCapabilities(
+					CommandClasses.Notification,
+					frame.payload.endpointIndex,
+				),
+			};
+			const cc = new NotificationCCSupportedReport(self.host, {
+				nodeId: controller.host.ownNodeId,
+				supportsV1Alarm: capabilities.supportsV1Alarm,
+				supportedNotificationTypes: Object.keys(
+					capabilities.notificationTypesAndEvents,
+				).map((t) => parseInt(t)),
+			});
+			await self.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			return true;
+		}
+		return false;
+	},
+};
+
+const respondToNotificationEventSupportedGet: MockNodeBehavior = {
+	async onControllerFrame(controller, self, frame) {
+		if (
+			frame.type === MockZWaveFrameType.Request &&
+			frame.payload instanceof NotificationCCEventSupportedGet
+		) {
+			const capabilities = {
+				...defaultCapabilities,
+				...self.getCCCapabilities(
+					CommandClasses.Notification,
+					frame.payload.endpointIndex,
+				),
+			};
+			if (
+				frame.payload.notificationType in
+				capabilities.notificationTypesAndEvents
+			) {
+				const cc = new NotificationCCEventSupportedReport(self.host, {
+					nodeId: controller.host.ownNodeId,
+					notificationType: frame.payload.notificationType,
+					supportedEvents:
+						capabilities.notificationTypesAndEvents[
+							frame.payload.notificationType
+						],
+				});
+				await self.sendToController(
+					createMockZWaveRequestFrame(cc, {
+						ackRequested: false,
+					}),
+				);
+				return true;
+			}
+		}
+		return false;
+	},
+};
+
+export const behaviors = [
+	respondToNotificationSupportedGet,
+	respondToNotificationEventSupportedGet,
+];

--- a/packages/zwave-js/src/lib/test/cc-specific/notificationEnums.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/notificationEnums.test.ts
@@ -1,17 +1,9 @@
 import {
-	NotificationCCEventSupportedGet,
-	NotificationCCEventSupportedReport,
 	NotificationCCReport,
-	NotificationCCSupportedGet,
-	NotificationCCSupportedReport,
 	NotificationCCValues,
 } from "@zwave-js/cc/NotificationCC";
 import { CommandClasses, ValueMetadataNumeric } from "@zwave-js/core";
-import {
-	createMockZWaveRequestFrame,
-	MockZWaveFrameType,
-	type MockNodeBehavior,
-} from "@zwave-js/testing";
+import { createMockZWaveRequestFrame } from "@zwave-js/testing";
 import { wait } from "alcalzone-shared/async";
 import { integrationTest } from "../integrationTestSuite";
 
@@ -21,64 +13,17 @@ integrationTest(
 		// debug: true,
 
 		nodeCapabilities: {
-			commandClasses: [CommandClasses.Notification],
-		},
-
-		customSetup: async (driver, controller, mockNode) => {
-			// Node supports the Water Valve notifications Valve Operation Status
-			const respondToNotificationSupportedGet: MockNodeBehavior = {
-				async onControllerFrame(controller, self, frame) {
-					if (
-						frame.type === MockZWaveFrameType.Request &&
-						frame.payload instanceof NotificationCCSupportedGet
-					) {
-						const cc = new NotificationCCSupportedReport(
-							self.host,
-							{
-								nodeId: controller.host.ownNodeId,
-								supportsV1Alarm: false,
-								supportedNotificationTypes: [0x0f],
-							},
-						);
-						await self.sendToController(
-							createMockZWaveRequestFrame(cc, {
-								ackRequested: false,
-							}),
-						);
-						return true;
-					}
-					return false;
+			commandClasses: [
+				{
+					ccId: CommandClasses.Notification,
+					version: 8,
+					supportsV1Alarm: false,
+					notificationTypesAndEvents: {
+						// Water Valve - Valve operation status
+						[0x0f]: [0x01],
+					},
 				},
-			};
-			mockNode.defineBehavior(respondToNotificationSupportedGet);
-
-			const respondToNotificationEventSupportedGet: MockNodeBehavior = {
-				async onControllerFrame(controller, self, frame) {
-					if (
-						frame.type === MockZWaveFrameType.Request &&
-						frame.payload instanceof
-							NotificationCCEventSupportedGet &&
-						frame.payload.notificationType === 0x0f
-					) {
-						const cc = new NotificationCCEventSupportedReport(
-							self.host,
-							{
-								nodeId: controller.host.ownNodeId,
-								notificationType: 0x0f,
-								supportedEvents: [0x01],
-							},
-						);
-						await self.sendToController(
-							createMockZWaveRequestFrame(cc, {
-								ackRequested: false,
-							}),
-						);
-						return true;
-					}
-					return false;
-				},
-			};
-			mockNode.defineBehavior(respondToNotificationEventSupportedGet);
+			],
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
@@ -146,64 +91,17 @@ integrationTest(
 		// debug: true,
 
 		nodeCapabilities: {
-			commandClasses: [CommandClasses.Notification],
-		},
-
-		customSetup: async (driver, controller, mockNode) => {
-			// Node supports the Access Control notifications Window open and Window closed
-			const respondToNotificationSupportedGet: MockNodeBehavior = {
-				async onControllerFrame(controller, self, frame) {
-					if (
-						frame.type === MockZWaveFrameType.Request &&
-						frame.payload instanceof NotificationCCSupportedGet
-					) {
-						const cc = new NotificationCCSupportedReport(
-							self.host,
-							{
-								nodeId: controller.host.ownNodeId,
-								supportsV1Alarm: false,
-								supportedNotificationTypes: [0x06],
-							},
-						);
-						await self.sendToController(
-							createMockZWaveRequestFrame(cc, {
-								ackRequested: false,
-							}),
-						);
-						return true;
-					}
-					return false;
+			commandClasses: [
+				{
+					ccId: CommandClasses.Notification,
+					version: 8,
+					supportsV1Alarm: false,
+					notificationTypesAndEvents: {
+						// Access Control - Window open and Window closed
+						[0x06]: [0x16, 0x17],
+					},
 				},
-			};
-			mockNode.defineBehavior(respondToNotificationSupportedGet);
-
-			const respondToNotificationEventSupportedGet: MockNodeBehavior = {
-				async onControllerFrame(controller, self, frame) {
-					if (
-						frame.type === MockZWaveFrameType.Request &&
-						frame.payload instanceof
-							NotificationCCEventSupportedGet &&
-						frame.payload.notificationType === 0x06
-					) {
-						const cc = new NotificationCCEventSupportedReport(
-							self.host,
-							{
-								nodeId: controller.host.ownNodeId,
-								notificationType: 0x06,
-								supportedEvents: [0x16, 0x17],
-							},
-						);
-						await self.sendToController(
-							createMockZWaveRequestFrame(cc, {
-								ackRequested: false,
-							}),
-						);
-						return true;
-					}
-					return false;
-				},
-			};
-			mockNode.defineBehavior(respondToNotificationEventSupportedGet);
+			],
 		},
 
 		testBody: async (t, driver, node, _mockController, _mockNode) => {
@@ -239,61 +137,13 @@ integrationTest("The 'simple' Door state value works correctly", {
 				ccId: CommandClasses.Notification,
 				isSupported: true,
 				version: 8,
+				supportsV1Alarm: false,
+				notificationTypesAndEvents: {
+					// Access Control - Window open and Window closed
+					[0x06]: [0x16, 0x17],
+				},
 			},
 		],
-	},
-
-	customSetup: async (driver, controller, mockNode) => {
-		// Node supports the Access Control notifications Window open and Window closed
-		const respondToNotificationSupportedGet: MockNodeBehavior = {
-			async onControllerFrame(controller, self, frame) {
-				if (
-					frame.type === MockZWaveFrameType.Request &&
-					frame.payload instanceof NotificationCCSupportedGet
-				) {
-					const cc = new NotificationCCSupportedReport(self.host, {
-						nodeId: controller.host.ownNodeId,
-						supportsV1Alarm: false,
-						supportedNotificationTypes: [0x06],
-					});
-					await self.sendToController(
-						createMockZWaveRequestFrame(cc, {
-							ackRequested: false,
-						}),
-					);
-					return true;
-				}
-				return false;
-			},
-		};
-		mockNode.defineBehavior(respondToNotificationSupportedGet);
-
-		const respondToNotificationEventSupportedGet: MockNodeBehavior = {
-			async onControllerFrame(controller, self, frame) {
-				if (
-					frame.type === MockZWaveFrameType.Request &&
-					frame.payload instanceof NotificationCCEventSupportedGet &&
-					frame.payload.notificationType === 0x06
-				) {
-					const cc = new NotificationCCEventSupportedReport(
-						self.host,
-						{
-							nodeId: controller.host.ownNodeId,
-							notificationType: 0x06,
-							supportedEvents: [0x16, 0x17],
-						},
-					);
-					await self.sendToController(
-						createMockZWaveRequestFrame(cc, {
-							ackRequested: false,
-						}),
-					);
-					return true;
-				}
-				return false;
-			},
-		};
-		mockNode.defineBehavior(respondToNotificationEventSupportedGet);
 	},
 
 	testBody: async (t, driver, node, mockController, mockNode) => {

--- a/packages/zwave-js/src/lib/test/cc-specific/notificationMultipleEventsMetadata.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/notificationMultipleEventsMetadata.test.ts
@@ -1,86 +1,25 @@
-import {
-	NotificationCCEventSupportedGet,
-	NotificationCCEventSupportedReport,
-	NotificationCCSupportedGet,
-	NotificationCCSupportedReport,
-	NotificationCCValues,
-} from "@zwave-js/cc/NotificationCC";
+import { NotificationCCValues } from "@zwave-js/cc/NotificationCC";
 import { CommandClasses, ValueMetadataNumeric } from "@zwave-js/core";
-import {
-	createMockZWaveRequestFrame,
-	MockZWaveFrameType,
-	type MockNodeBehavior,
-} from "@zwave-js/testing";
 import { integrationTest } from "../integrationTestSuite";
 
 integrationTest(
 	"Notification types with multiple supported events preserve states for all of them",
 	{
 		// debug: true,
-		// provisioningDirectory: path.join(
-		// 	__dirname,
-		// 	"__fixtures/supervision_binary_switch",
-		// ),
 
 		nodeCapabilities: {
-			commandClasses: [CommandClasses.Notification],
-		},
-
-		customSetup: async (driver, controller, mockNode) => {
-			// Node supports the Smoke Alarm notifications Smoke alarm test, Alarm silenced (and idle)
-			const respondToNotificationSupportedGet: MockNodeBehavior = {
-				async onControllerFrame(controller, self, frame) {
-					if (
-						frame.type === MockZWaveFrameType.Request &&
-						frame.payload instanceof NotificationCCSupportedGet
-					) {
-						const cc = new NotificationCCSupportedReport(
-							self.host,
-							{
-								nodeId: controller.host.ownNodeId,
-								supportsV1Alarm: false,
-								supportedNotificationTypes: [0x01],
-							},
-						);
-						await self.sendToController(
-							createMockZWaveRequestFrame(cc, {
-								ackRequested: false,
-							}),
-						);
-						return true;
-					}
-					return false;
+			commandClasses: [
+				{
+					ccId: CommandClasses.Notification,
+					isSupported: true,
+					version: 8,
+					supportsV1Alarm: false,
+					notificationTypesAndEvents: {
+						// Smoke Alarm - Smoke alarm test, Alarm silenced (and idle)
+						[0x01]: [0x03, 0x06],
+					},
 				},
-			};
-			mockNode.defineBehavior(respondToNotificationSupportedGet);
-
-			const respondToNotificationEventSupportedGet: MockNodeBehavior = {
-				async onControllerFrame(controller, self, frame) {
-					if (
-						frame.type === MockZWaveFrameType.Request &&
-						frame.payload instanceof
-							NotificationCCEventSupportedGet &&
-						frame.payload.notificationType === 0x01
-					) {
-						const cc = new NotificationCCEventSupportedReport(
-							self.host,
-							{
-								nodeId: controller.host.ownNodeId,
-								notificationType: 0x01,
-								supportedEvents: [0x03, 0x06],
-							},
-						);
-						await self.sendToController(
-							createMockZWaveRequestFrame(cc, {
-								ackRequested: false,
-							}),
-						);
-						return true;
-					}
-					return false;
-				},
-			};
-			mockNode.defineBehavior(respondToNotificationEventSupportedGet);
+			],
 		},
 
 		testBody: async (t, driver, node, _mockController, _mockNode) => {


### PR DESCRIPTION
I found those to be repeated a bit too often in test files. Also there's now a framework for defining CC-specific mock capabilities, which can then be used by the mock implementations.