### PR TITLE
fix(config): disable Supervision CC for Homeseer HS-FLS100

### DIFF
--- a/packages/config/config/devices/0x000c/hs-fls100.json
+++ b/packages/config/config/devices/0x000c/hs-fls100.json
@@ -51,6 +51,17 @@
 			"label": "Send Basic Report on Trigger"
 		}
 	],
+	"compat": {
+		"commandClasses": {
+			"remove": {
+				"0x6c": {
+					// The device reports that it supports Supervision, but it does not support all
+					// commands supervision-encapsulated
+					"endpoints": "*"
+				}
+			}
+		}
+	},
 	"metadata": {
 		"inclusion": "Z-Wave auto inclusion.\nOr manual inclusion : put the Z-Wave controller into inclusion mode, press the Link button 3 times within 1.5 seconds to put the unit into inclusion mode",
 		"exclusion": "Put the Z-Wave Controller into exclusion mode. Press the Link button 3 times within 1.5 seconds to put the unit into exclusion mode",


### PR DESCRIPTION
Update hs-fls100 - Remove supervision. Fix to set parameters

the Homeseer HS-FLS100+ was unable to have parameters set from zwave-js