### PR TITLE
fix: support sending non-implemented CCs

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -2245,7 +2245,7 @@ export class Driver
 		}
 		throw new ZWaveError(
 			"Cannot retrieve the version of a CC that is not implemented",
-			ZWaveErrorCodes.CC_NotSupported,
+			ZWaveErrorCodes.CC_NotImplemented,
 		);
 	}
 

--- a/packages/zwave-js/src/lib/test/cc/CommandClass.nonImplemented.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/CommandClass.nonImplemented.test.ts
@@ -1,0 +1,22 @@
+import { CommandClass } from "@zwave-js/cc";
+import { CommandClasses } from "@zwave-js/core";
+import { integrationTest } from "../integrationTestSuite";
+
+integrationTest(
+	"the CC constructor does not throw when creating a raw instance of a non-implemented CC",
+	{
+		// debug: true,
+
+		async testBody(t, driver, node, mockController, mockNode) {
+			// This CC will never be supported (certification requirement)
+			const cc = new CommandClass(driver, {
+				nodeId: 2,
+				ccId: CommandClasses["Anti-Theft"],
+				ccCommand: 0x02,
+			});
+			await driver.sendCommand(cc);
+
+			t.pass();
+		},
+	},
+);


### PR DESCRIPTION
fixes: #5586

We now set the version of a CC instance to 0 if determining its version fails because it is not implemented.