### PR TITLE
fix: refresh CC response timeout for possibly matching partial responses

### DIFF
--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -4130,7 +4130,8 @@ export class ConfigurationCCNameGet extends ConfigurationCC {
 //
 // @public (undocumented)
 export class ConfigurationCCNameReport extends ConfigurationCC {
-    constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
+    // Warning: (ae-forgotten-export) The symbol "ConfigurationCCNameReportOptions" needs to be exported by the entry point index.d.ts
+    constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions | ConfigurationCCNameReportOptions);
     // (undocumented)
     expectMoreMessages(): boolean;
     // (undocumented)
@@ -4138,13 +4139,15 @@ export class ConfigurationCCNameReport extends ConfigurationCC {
     // (undocumented)
     mergePartialCCs(applHost: ZWaveApplicationHost_2, partials: ConfigurationCCNameReport[]): void;
     // (undocumented)
-    get name(): string;
+    name: string;
     // (undocumented)
-    get parameter(): number;
+    readonly parameter: number;
     // (undocumented)
     persistValues(applHost: ZWaveApplicationHost_2): boolean;
     // (undocumented)
-    get reportsToFollow(): number;
+    readonly reportsToFollow: number;
+    // (undocumented)
+    serialize(): Buffer;
     // (undocumented)
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
@@ -6766,6 +6769,11 @@ export function getImplementedVersion<T extends CommandClass>(cc: T | CommandCla
 //
 // @public
 export function getImplementedVersionStatic<T extends CCConstructor<CommandClass>>(classConstructor: T): number;
+
+// Warning: (ae-missing-release-tag) "getInnermostCommandClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function getInnermostCommandClass(cc: CommandClass): CommandClass;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
 // Warning: (ae-missing-release-tag) "getManufacturerId" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/cc/src/lib/EncapsulatingCommandClass.ts
+++ b/packages/cc/src/lib/EncapsulatingCommandClass.ts
@@ -49,6 +49,14 @@ export function isEncapsulatingCommandClass(
 	return false;
 }
 
+export function getInnermostCommandClass(cc: CommandClass): CommandClass {
+	if (isEncapsulatingCommandClass(cc)) {
+		return getInnermostCommandClass(cc.encapsulated);
+	} else {
+		return cc;
+	}
+}
+
 /** Defines the static side of an encapsulating command class */
 export interface MultiEncapsulatingCommandClassStatic {
 	new (

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -369,8 +369,9 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> implements Z
     waitForCommand<T extends ICommandClass>(predicate: (cc: ICommandClass) => boolean, timeout: number): Promise<T>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+    // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "zwave-js" does not have an export "waitForCommand"
-    waitForMessage<T extends Message>(predicate: (msg: Message) => boolean, timeout: number): Promise<T>;
+    waitForMessage<T extends Message>(predicate: (msg: Message) => boolean, timeout: number, refreshPredicate?: (msg: Message) => boolean): Promise<T>;
 }
 
 // Warning: (ae-missing-release-tag) "DriverLogContext" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/zwave-js/src/lib/test/cc-specific/soundSwitchInterviewValueChangeOptions.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/soundSwitchInterviewValueChangeOptions.test.ts
@@ -6,7 +6,7 @@ import { integrationTest } from "../integrationTestSuite";
 integrationTest(
 	"The toneId value should have value change options after SoundSwitchCC interview",
 	{
-		debug: true,
+		// debug: true,
 
 		nodeCapabilities: {
 			commandClasses: [

--- a/packages/zwave-js/src/lib/test/driver/multiStageResponseNoTimeout.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/multiStageResponseNoTimeout.test.ts
@@ -1,0 +1,216 @@
+import { BasicCCReport } from "@zwave-js/cc/BasicCC";
+import {
+	ConfigurationCCNameGet,
+	ConfigurationCCNameReport,
+} from "@zwave-js/cc/ConfigurationCC";
+import {
+	MAX_SEGMENT_SIZE,
+	TransportServiceCCFirstSegment,
+	TransportServiceCCSubsequentSegment,
+} from "@zwave-js/cc/TransportServiceCC";
+import { CommandClasses } from "@zwave-js/core";
+import {
+	createMockZWaveRequestFrame,
+	MockZWaveFrameType,
+	type MockNodeBehavior,
+} from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import { integrationTest } from "../integrationTestSuite";
+
+integrationTest(
+	"GET requests don't time out early if the response is split using the 'more to follow' flag",
+	{
+		// debug: true,
+
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				{
+					ccId: CommandClasses.Configuration,
+					isSupported: true,
+					version: 1,
+				},
+			],
+		},
+
+		async customSetup(driver, mockController, mockNode) {
+			const respondToConfigurationNameGet: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof ConfigurationCCNameGet
+					) {
+						await wait(700);
+						let cc = new ConfigurationCCNameReport(self.host, {
+							nodeId: controller.host.ownNodeId,
+							parameter: frame.payload.parameter,
+							name: "Test para",
+							reportsToFollow: 1,
+						});
+						await self.sendToController(
+							createMockZWaveRequestFrame(cc, {
+								ackRequested: false,
+							}),
+						);
+
+						await wait(700);
+
+						cc = new ConfigurationCCNameReport(self.host, {
+							nodeId: controller.host.ownNodeId,
+							parameter: frame.payload.parameter,
+							name: "meter",
+							reportsToFollow: 0,
+						});
+						await self.sendToController(
+							createMockZWaveRequestFrame(cc, {
+								ackRequested: false,
+							}),
+						);
+						return true;
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(respondToConfigurationNameGet);
+		},
+
+		async testBody(t, driver, node, mockController, mockNode) {
+			const name = await node.commandClasses.Configuration.getName(1);
+			t.is(name, "Test parameter");
+		},
+	},
+);
+
+const longName =
+	"Veeeeeeeeeeeeeeeeeeeeeeeeery loooooooooooooooooong parameter name";
+
+integrationTest(
+	"GET requests don't time out early if the response is split using Transport Service CC",
+	{
+		// debug: true,
+
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				{
+					ccId: CommandClasses.Configuration,
+					isSupported: true,
+					version: 1,
+				},
+			],
+		},
+
+		async customSetup(driver, mockController, mockNode) {
+			const respondToConfigurationNameGet: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof ConfigurationCCNameGet
+					) {
+						const configCC = new ConfigurationCCNameReport(
+							self.host,
+							{
+								nodeId: controller.host.ownNodeId,
+								parameter: frame.payload.parameter,
+								name: "Veeeeeeeeeeeeeeeeeeeeeeeeery loooooooooooooooooong parameter name",
+								reportsToFollow: 0,
+							},
+						);
+						const serialized = configCC.serialize();
+						const segment1 = serialized.slice(0, MAX_SEGMENT_SIZE);
+						const segment2 = serialized.slice(MAX_SEGMENT_SIZE);
+
+						const sessionId = 7;
+
+						const tsFS = new TransportServiceCCFirstSegment(
+							self.host,
+							{
+								nodeId: controller.host.ownNodeId,
+								sessionId,
+								datagramSize: serialized.length,
+								partialDatagram: segment1,
+							},
+						);
+						const tsSS = new TransportServiceCCSubsequentSegment(
+							self.host,
+							{
+								nodeId: controller.host.ownNodeId,
+								sessionId,
+								datagramSize: serialized.length,
+								datagramOffset: segment1.length,
+								partialDatagram: segment2,
+							},
+						);
+
+						await wait(700);
+						await self.sendToController(
+							createMockZWaveRequestFrame(tsFS, {
+								ackRequested: false,
+							}),
+						);
+
+						await wait(700);
+						await self.sendToController(
+							createMockZWaveRequestFrame(tsSS, {
+								ackRequested: false,
+							}),
+						);
+						return true;
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(respondToConfigurationNameGet);
+		},
+
+		async testBody(t, driver, node, mockController, mockNode) {
+			const name = await node.commandClasses.Configuration.getName(1);
+			t.is(name, longName);
+		},
+	},
+);
+
+integrationTest("GET requests DO time out if there's no matching response", {
+	// debug: true,
+
+	nodeCapabilities: {
+		commandClasses: [
+			CommandClasses.Version,
+			{
+				ccId: CommandClasses.Configuration,
+				isSupported: true,
+				version: 1,
+			},
+		],
+	},
+
+	async customSetup(driver, mockController, mockNode) {
+		const respondToConfigurationNameGet: MockNodeBehavior = {
+			async onControllerFrame(controller, self, frame) {
+				if (
+					frame.type === MockZWaveFrameType.Request &&
+					frame.payload instanceof ConfigurationCCNameGet
+				) {
+					// This is not the response you're looking for
+					const cc = new BasicCCReport(self.host, {
+						nodeId: controller.host.ownNodeId,
+						currentValue: 1,
+					});
+					await self.sendToController(
+						createMockZWaveRequestFrame(cc, {
+							ackRequested: false,
+						}),
+					);
+					return true;
+				}
+				return false;
+			},
+		};
+		mockNode.defineBehavior(respondToConfigurationNameGet);
+	},
+
+	async testBody(t, driver, node, mockController, mockNode) {
+		const name = await node.commandClasses.Configuration.getName(1);
+		t.is(name, undefined);
+	},
+});

--- a/packages/zwave-js/src/lib/test/integrationTestSuite.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuite.ts
@@ -19,6 +19,9 @@ import {
 import type { ZWaveOptions } from "../driver/ZWaveOptions";
 import type { ZWaveNode } from "../node/Node";
 
+// Integration tests need to run in serial, or they might block the serial port on CI
+const testSerial = test.serial.bind(test);
+
 function prepareDriver(
 	cacheDir: string = path.join(__dirname, "cache"),
 	logToFile: boolean = false,
@@ -198,11 +201,11 @@ function suite(
 	}
 
 	(modifier === "only"
-		? test.only
+		? testSerial.only
 		: modifier === "skip"
-		? test.skip
-		: test
-	).bind(test)(name, async (t) => {
+		? testSerial.skip
+		: testSerial
+	).bind(testSerial)(name, async (t) => {
 		t.timeout(30000);
 		t.teardown(async () => {
 			// Give everything a chance to settle before destroying the driver.


### PR DESCRIPTION
Until now, waiting for a response to a GET-type CC expected the final response to come within the timeout. However if Transport Service CC is involved (or even for long commands using the `reportsToFollow` flag), this timeout can often be too short.

We now test possible "partial" CCs if they are a potential match for an awaited CC. If they are, the corresponding timer will be reset.

fixes: #5682
fixes: #5481
