### PR TITLE
feat: implement convenience open/close values for Window Covering CC and improve valueIDs

### DIFF
--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -17802,6 +17802,8 @@ export class WindowCoveringCC extends CommandClass {
     ccCommand: WindowCoveringCommand;
     // (undocumented)
     interview(applHost: ZWaveApplicationHost): Promise<void>;
+    // (undocumented)
+    translatePropertyKey(_applHost: ZWaveApplicationHost, _property: string | number, propertyKey: string | number): string | undefined;
 }
 
 // Warning: (ae-missing-release-tag) "WindowCoveringCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -17886,7 +17888,10 @@ export class WindowCoveringCCSupportedGet extends WindowCoveringCC {
 //
 // @public (undocumented)
 export class WindowCoveringCCSupportedReport extends WindowCoveringCC {
-    constructor(host: ZWaveHost, options: CommandClassDeserializationOptions);
+    // Warning: (ae-forgotten-export) The symbol "WindowCoveringCCSupportedReportOptions" needs to be exported by the entry point index.d.ts
+    constructor(host: ZWaveHost, options: CommandClassDeserializationOptions | WindowCoveringCCSupportedReportOptions);
+    // (undocumented)
+    serialize(): Buffer;
     // (undocumented)
     readonly supportedParameters: readonly WindowCoveringParameter[];
 }
@@ -17895,6 +17900,138 @@ export class WindowCoveringCCSupportedReport extends WindowCoveringCC {
 //
 // @public (undocumented)
 export const WindowCoveringCCValues: Readonly<{
+    tiltClose99: ((parameter: WindowCoveringParameter) => {
+        readonly meta: {
+            readonly label: `Close Left - ${string}` | `Close Down - ${string}`;
+            readonly ccSpecific: {
+                readonly parameter: WindowCoveringParameter;
+            };
+            readonly valueChangeOptions: readonly ["transitionDuration"];
+            readonly readable: false;
+            readonly type: "boolean";
+            readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses_2)["Window Covering"];
+            property: "close99";
+            propertyKey: WindowCoveringParameter;
+        };
+        readonly endpoint: (endpoint?: number | undefined) => {
+            readonly commandClass: (typeof CommandClasses_2)["Window Covering"];
+            readonly endpoint: number;
+            readonly property: "close99";
+            readonly propertyKey: WindowCoveringParameter;
+        };
+    }) & {
+        is: (valueId: ValueID) => boolean;
+        readonly options: {
+            readonly internal: false;
+            readonly minVersion: 1;
+            readonly secret: false;
+            readonly stateful: true;
+            readonly supportsEndpoints: true;
+            readonly autoCreate: true;
+        };
+    };
+    tiltClose0: ((parameter: WindowCoveringParameter) => {
+        readonly meta: {
+            readonly label: `Close Right - ${string}` | `Close Up - ${string}`;
+            readonly ccSpecific: {
+                readonly parameter: WindowCoveringParameter;
+            };
+            readonly valueChangeOptions: readonly ["transitionDuration"];
+            readonly readable: false;
+            readonly type: "boolean";
+            readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses_2)["Window Covering"];
+            property: "close0";
+            propertyKey: WindowCoveringParameter;
+        };
+        readonly endpoint: (endpoint?: number | undefined) => {
+            readonly commandClass: (typeof CommandClasses_2)["Window Covering"];
+            readonly endpoint: number;
+            readonly property: "close0";
+            readonly propertyKey: WindowCoveringParameter;
+        };
+    }) & {
+        is: (valueId: ValueID) => boolean;
+        readonly options: {
+            readonly internal: false;
+            readonly minVersion: 1;
+            readonly secret: false;
+            readonly stateful: true;
+            readonly supportsEndpoints: true;
+            readonly autoCreate: true;
+        };
+    };
+    positionClose: ((parameter: WindowCoveringParameter) => {
+        readonly meta: {
+            readonly label: `Close - ${string}`;
+            readonly ccSpecific: {
+                readonly parameter: WindowCoveringParameter;
+            };
+            readonly valueChangeOptions: readonly ["transitionDuration"];
+            readonly readable: false;
+            readonly type: "boolean";
+            readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses_2)["Window Covering"];
+            property: "close";
+            propertyKey: WindowCoveringParameter;
+        };
+        readonly endpoint: (endpoint?: number | undefined) => {
+            readonly commandClass: (typeof CommandClasses_2)["Window Covering"];
+            readonly endpoint: number;
+            readonly property: "close";
+            readonly propertyKey: WindowCoveringParameter;
+        };
+    }) & {
+        is: (valueId: ValueID) => boolean;
+        readonly options: {
+            readonly internal: false;
+            readonly minVersion: 1;
+            readonly secret: false;
+            readonly stateful: true;
+            readonly supportsEndpoints: true;
+            readonly autoCreate: true;
+        };
+    };
+    open: ((parameter: WindowCoveringParameter) => {
+        readonly meta: {
+            readonly label: `Open - ${string}`;
+            readonly ccSpecific: {
+                readonly parameter: WindowCoveringParameter;
+            };
+            readonly valueChangeOptions: readonly ["transitionDuration"];
+            readonly readable: false;
+            readonly type: "boolean";
+            readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses_2)["Window Covering"];
+            property: "open";
+            propertyKey: WindowCoveringParameter;
+        };
+        readonly endpoint: (endpoint?: number | undefined) => {
+            readonly commandClass: (typeof CommandClasses_2)["Window Covering"];
+            readonly endpoint: number;
+            readonly property: "open";
+            readonly propertyKey: WindowCoveringParameter;
+        };
+    }) & {
+        is: (valueId: ValueID) => boolean;
+        readonly options: {
+            readonly internal: false;
+            readonly minVersion: 1;
+            readonly secret: false;
+            readonly stateful: true;
+            readonly supportsEndpoints: true;
+            readonly autoCreate: true;
+        };
+    };
     duration: ((parameter: WindowCoveringParameter) => {
         readonly meta: {
             readonly label: `Remaining duration - ${string}`;
@@ -17929,12 +18066,12 @@ export const WindowCoveringCCValues: Readonly<{
     };
     targetValue: ((parameter: WindowCoveringParameter) => {
         readonly meta: {
-            readonly label: `Target value - ${string}`;
-            readonly writeable: boolean;
             readonly ccSpecific: {
                 readonly parameter: WindowCoveringParameter;
             };
             readonly valueChangeOptions: readonly ["transitionDuration"];
+            readonly label: `Target value - ${string}`;
+            readonly writeable: boolean;
             readonly max: 99;
             readonly min: 0;
             readonly type: "number";
@@ -17964,10 +18101,10 @@ export const WindowCoveringCCValues: Readonly<{
     };
     currentValue: ((parameter: WindowCoveringParameter) => {
         readonly meta: {
-            readonly label: string;
             readonly ccSpecific: {
-                parameter: WindowCoveringParameter;
+                readonly parameter: WindowCoveringParameter;
             };
+            readonly label: `Current value - ${string}`;
             readonly writeable: false;
             readonly max: 99;
             readonly min: 0;

--- a/packages/core/api.md
+++ b/packages/core/api.md
@@ -802,7 +802,7 @@ export function encodeApplicationNodeInformation(nif: ApplicationNodeInformation
 // Warning: (ae-missing-release-tag) "encodeBitMask" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-export function encodeBitMask(values: readonly number[], maxValue: number, startValue?: number): Buffer;
+export function encodeBitMask(values: readonly number[], maxValue?: number, startValue?: number): Buffer;
 
 // Warning: (ae-missing-release-tag) "encodeBoolean" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/packages/core/src/values/Primitive.ts
+++ b/packages/core/src/values/Primitive.ts
@@ -204,7 +204,7 @@ export function parseBitMask(mask: Buffer, startValue: number = 1): number[] {
 /** Serializes a numeric array with a given maximum into a bit mask */
 export function encodeBitMask(
 	values: readonly number[],
-	maxValue: number,
+	maxValue: number = Math.max(...values),
 	startValue: number = 1,
 ): Buffer {
 	const numBytes = Math.ceil((maxValue - startValue + 1) / 8);

--- a/packages/testing/api.md
+++ b/packages/testing/api.md
@@ -33,6 +33,7 @@ export type CCIdToCapabilities<T extends CommandClasses = CommandClasses> = T ex
 export type CCSpecificCapabilities = {
     [CommandClasses.Notification]: NotificationCCCapabilities;
     [121]: SoundSwitchCCCapabilities;
+    [106]: WindowCoveringCCCapabilities;
 };
 
 // Warning: (ae-missing-release-tag) "createMockZWaveAckFrame" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -286,6 +287,14 @@ export interface SoundSwitchCCCapabilities {
         name: string;
         duration: number;
     }[];
+}
+
+// Warning: (ae-missing-release-tag) "WindowCoveringCCCapabilities" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface WindowCoveringCCCapabilities {
+    // (undocumented)
+    supportedParameters: number[];
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/testing/src/CCSpecificCapabilities.ts
+++ b/packages/testing/src/CCSpecificCapabilities.ts
@@ -14,9 +14,15 @@ export interface SoundSwitchCCCapabilities {
 	}[];
 }
 
+export interface WindowCoveringCCCapabilities {
+	// FIXME: This should be WindowCoveringParameter[], but that would introduce a dependency cycle
+	supportedParameters: number[];
+}
+
 export type CCSpecificCapabilities = {
 	[CommandClasses.Notification]: NotificationCCCapabilities;
 	[121 /* Sound Switch */]: SoundSwitchCCCapabilities;
+	[106 /* Window Covering */]: WindowCoveringCCCapabilities;
 };
 
 export type CCIdToCapabilities<T extends CommandClasses = CommandClasses> =

--- a/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
+++ b/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
@@ -27,6 +27,7 @@ import {
 } from "@zwave-js/testing";
 import { behaviors as NotificationCCBehaviors } from "./mockCCBehaviors/Notification";
 import { behaviors as SoundSwitchCCBehaviors } from "./mockCCBehaviors/SoundSwitch";
+import { behaviors as WindowCoveringCCBehaviors } from "./mockCCBehaviors/WindowCovering";
 
 const respondToRequestNodeInfo: MockNodeBehavior = {
 	async onControllerFrame(controller, self, frame) {
@@ -274,5 +275,6 @@ export function createDefaultBehaviors(): MockNodeBehavior[] {
 
 		...NotificationCCBehaviors,
 		...SoundSwitchCCBehaviors,
+		...WindowCoveringCCBehaviors,
 	];
 }

--- a/packages/zwave-js/src/lib/node/mockCCBehaviors/WindowCovering.ts
+++ b/packages/zwave-js/src/lib/node/mockCCBehaviors/WindowCovering.ts
@@ -1,0 +1,45 @@
+import {
+	WindowCoveringCCSupportedGet,
+	WindowCoveringCCSupportedReport,
+} from "@zwave-js/cc/WindowCoveringCC";
+import { CommandClasses } from "@zwave-js/core/safe";
+import {
+	createMockZWaveRequestFrame,
+	MockZWaveFrameType,
+	WindowCoveringCCCapabilities,
+	type MockNodeBehavior,
+} from "@zwave-js/testing";
+
+const defaultCapabilities: WindowCoveringCCCapabilities = {
+	supportedParameters: [],
+};
+
+const respondToWindowCoveringSupportedGet: MockNodeBehavior = {
+	async onControllerFrame(controller, self, frame) {
+		if (
+			frame.type === MockZWaveFrameType.Request &&
+			frame.payload instanceof WindowCoveringCCSupportedGet
+		) {
+			const capabilities = {
+				...defaultCapabilities,
+				...self.getCCCapabilities(
+					CommandClasses["Window Covering"],
+					frame.payload.endpointIndex,
+				),
+			};
+			const cc = new WindowCoveringCCSupportedReport(self.host, {
+				nodeId: controller.host.ownNodeId,
+				supportedParameters: capabilities.supportedParameters,
+			});
+			await self.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			return true;
+		}
+		return false;
+	},
+};
+
+export const behaviors = [respondToWindowCoveringSupportedGet];


### PR DESCRIPTION
This PR adds several value IDs to open/close the individual parameters, and improves the existing value ID definitions.

With this change, the following public value IDs and metadata are defined for the Window Covering CC:
[valueIDs.json.txt](https://github.com/zwave-js/node-zwave-js/files/11286273/valueIDs.json.txt)
