### PR TITLE
feat(config): add new parameters 10-13 to Zooz ZEN04

### DIFF
--- a/packages/config/config/devices/0x027a/zen04.json
+++ b/packages/config/config/devices/0x027a/zen04.json
@@ -56,8 +56,15 @@
 			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off_on"
 		},
 		{
+			"#": "10",
+			"$if": "firmwareVersion >= 1.30",
+			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
+			"label": "Power (W) Reporting",
+			"defaultValue": 0
+		},
+		{
 			"#": "5",
-			"label": "Power Wattage Reporting Threshold",
+			"label": "Power (W) Reporting Threshold",
 			"unit": "W",
 			"valueSize": 1,
 			"minValue": 5,
@@ -67,7 +74,7 @@
 		},
 		{
 			"#": "6",
-			"label": "Power Wattage Reporting Frequency",
+			"label": "Power (W) Reporting Interval",
 			"unit": "minutes",
 			"valueSize": 4,
 			"minValue": 1,
@@ -76,8 +83,15 @@
 			"unsigned": true
 		},
 		{
+			"#": "11",
+			"$if": "firmwareVersion >= 1.30",
+			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
+			"label": "Current (A) Reporting",
+			"defaultValue": 0
+		},
+		{
 			"#": "7",
-			"label": "Electrical Current Reporting Threshold",
+			"label": "Current (A) Reporting Threshold",
 			"unit": "0.1 A",
 			"valueSize": 1,
 			"minValue": 1,
@@ -86,8 +100,19 @@
 			"unsigned": true
 		},
 		{
+			"#": "12",
+			"$if": "firmwareVersion >= 1.30",
+			"label": "Current (A) Reporting Interval",
+			"unit": "minutes",
+			"valueSize": 4,
+			"minValue": 1,
+			"maxValue": 65535,
+			"defaultValue": 60,
+			"unsigned": true
+		},
+		{
 			"#": "8",
-			"label": "Energy Reporting Threshold",
+			"label": "Energy (kWh) Reporting Threshold",
 			"unit": "0.01 kWh",
 			"valueSize": 1,
 			"minValue": 1,
@@ -96,40 +121,21 @@
 			"unsigned": true
 		},
 		{
-			"#": "10",
-			"$if": "firmwareVersion >= 1.3",
-			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
-			"label": "Power/Energy Monitoring",
-			"defaultValue": 0
-		},
-		{
-			"#": "11",
-			"$if": "firmwareVersion >= 1.3",
-			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
-			"label": "Electrical Current Monitoring",
-			"defaultValue": 0
-		},
-		{
-			"#": "12",
-			"$if": "firmwareVersion >= 1.3",
-			"label": "Electrical Current (A) Report Frequency",
-			"unit": "minutes",
-			"valueSize": 4,
-			"minValue": 1,
-			"maxValue": 65535,
-			"defaultValue": 60,
-			"unsigned": true
-		},
-		{
 			"#": "13",
-			"$if": "firmwareVersion >= 1.3",
-			"label": "Voltage Report (V) Frequency",
+			"$if": "firmwareVersion >= 1.30",
+			"label": "Voltage Report (V) Interval",
 			"unit": "minutes",
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 65535,
 			"defaultValue": 60,
-			"unsigned": true
+			"unsigned": true,
+			"options": [
+				{
+					"label": "Disabled",
+					"value": 0
+				}
+			]
 		}
 	]
 }

--- a/packages/config/config/devices/0x027a/zen04.json
+++ b/packages/config/config/devices/0x027a/zen04.json
@@ -94,6 +94,42 @@
 			"maxValue": 100,
 			"defaultValue": 1,
 			"unsigned": true
+		},
+		{
+			"#": "10",
+			"$if": "firmwareVersion >= 1.3",
+			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
+			"label": "Power/Energy Monitoring",
+			"defaultValue": 0,
+		},
+		{
+			"#": "11",
+			"$if": "firmwareVersion >= 1.3",
+			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
+			"label": "Electrical Current Monitoring",
+			"defaultValue": 0,
+		},
+		{
+			"#": "12",
+			"$if": "firmwareVersion >= 1.3",
+			"label": "Electrical Current (A) Report Frequency",
+			"unit": "minutes",
+			"valueSize": 4,
+			"minValue": 1,
+			"maxValue": 65535,
+			"defaultValue": 60,
+			"unsigned": true
+		},
+		{
+			"#": "13",
+			"$if": "firmwareVersion >= 1.3",
+			"label": "Voltage Report (V) Frequency",
+			"unit": "minutes",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 65535,
+			"defaultValue": 60,
+			"unsigned": true
 		}
 	]
 }

--- a/packages/config/config/devices/0x027a/zen04.json
+++ b/packages/config/config/devices/0x027a/zen04.json
@@ -100,14 +100,14 @@
 			"$if": "firmwareVersion >= 1.3",
 			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
 			"label": "Power/Energy Monitoring",
-			"defaultValue": 0,
+			"defaultValue": 0
 		},
 		{
 			"#": "11",
 			"$if": "firmwareVersion >= 1.3",
 			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
 			"label": "Electrical Current Monitoring",
-			"defaultValue": 0,
+			"defaultValue": 0
 		},
 		{
 			"#": "12",


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

Zooz released firmware 1.3 for ZEN04 device. Adding parameters 10 through 13 for enable/disable energy reporting and additional reporting frequency control.

https://www.support.getzooz.com/kb/article/1387-zen04-smart-plug-change-log/

> Firmware: 1.30 (released 4/2023 as OTA)
> 
>     Fixed bug: reduced the delay after the plug reports a Wattage change when on and the device connected to the smart plug is suddenly unplugged. 
>     Added new parameters to disable energy reporting values (parameters 10 and 11)
>     Added new parameters to set energy reporting frequency (parameters 12 and 13)
