### PR TITLE
feat(config): add missing parameter 9 to Logic Group ZDB5100

### DIFF
--- a/packages/config/config/devices/0x0234/templates/logic_group_template.json
+++ b/packages/config/config/devices/0x0234/templates/logic_group_template.json
@@ -526,5 +526,29 @@
 				"value": 2
 			}
 		]
+	},
+	"turn_on_level": {
+		"label": "Light level at turn on",
+		"description":"The function sets the light level at turn on with three value options: 0 (default), 1-99 (next turn on only), and 129-228 (each turn on by subtracting 128 from parameter value).",
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 228,
+		"defaultValue": 0,
+		"unsigned": true,
+		"allowManualEntry": true,
+		"options": [
+			{
+				"label": "No effect",
+				"value": 0
+			},
+			{
+				"label": "Max brightness (once)",
+				"value": 99
+			},
+			{
+				"label": "Max brightness (always)",
+				"value": 228
+			}
+		]
 	}
 }

--- a/packages/config/config/devices/0x0234/templates/logic_group_template.json
+++ b/packages/config/config/devices/0x0234/templates/logic_group_template.json
@@ -535,7 +535,6 @@
 		"maxValue": 228,
 		"defaultValue": 0,
 		"unsigned": true,
-		"allowManualEntry": true,
 		"options": [
 			{
 				"label": "No effect",

--- a/packages/config/config/devices/0x0234/templates/logic_group_template.json
+++ b/packages/config/config/devices/0x0234/templates/logic_group_template.json
@@ -527,9 +527,9 @@
 			}
 		]
 	},
-	"turn_on_level": {
-		"label": "Light level at turn on",
-		"description":"The function sets the light level at turn on with three value options: 0 (default), 1-99 (next turn on only), and 129-228 (each turn on by subtracting 128 from parameter value).",
+	"default_brightness": {
+		"label": "Default Brightness",
+		"description": "Next turn on only: 1-99. Every turn on: 129-228 (target brightness + 128)",
 		"valueSize": 1,
 		"minValue": 0,
 		"maxValue": 228,

--- a/packages/config/config/devices/0x0234/zdb5100.json
+++ b/packages/config/config/devices/0x0234/zdb5100.json
@@ -213,6 +213,12 @@
 			"defaultValue": 1
 		},
 		{
+			"#": "9",
+			"$if": "firmwareVersion >= 1.8",
+			"$import": "templates/logic_group_template.json#turn_on_level",
+			"defaultValue": 0
+		},
+		{
 			"#": "10",
 			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Enhanced LED Control"

--- a/packages/config/config/devices/0x0234/zdb5100.json
+++ b/packages/config/config/devices/0x0234/zdb5100.json
@@ -215,8 +215,7 @@
 		{
 			"#": "9",
 			"$if": "firmwareVersion >= 1.8",
-			"$import": "templates/logic_group_template.json#turn_on_level",
-			"defaultValue": 0
+			"$import": "templates/logic_group_template.json#default_brightness"
 		},
 		{
 			"#": "10",
@@ -225,9 +224,7 @@
 		},
 		{
 			"#": "11",
-			"$import": "templates/logic_group_template.json#button_debounce",
-			"unit": "10 ms",
-			"defaultValue": 5
+			"$import": "templates/logic_group_template.json#button_debounce"
 		},
 		{
 			"#": "12",


### PR DESCRIPTION
In firmware `1.8` of the Logic Group ZDB5100, parameter 9 was added to control the brightness on the next turning on of the switch.

The setting has two ranges besides 0 for "No effect": 1-99 to affect only the next turning on, and 129-228 to affect _every_ turning on. I picked an option type with manual input allowed, but maybe something else is better suited? I tried to communicate the specifics in description