### PR TITLE
Update siren.json

### DIFF
--- a/packages/config/config/devices/0x017f/siren.json
+++ b/packages/config/config/devices/0x017f/siren.json
@@ -72,7 +72,7 @@
 			"options": [
 				{
 					"label": "Chime Will Not Play",
-					"value": 255
+					"value": -1
 				},
 				{
 					"label": "Does Not Stop",


### PR DESCRIPTION
modify the secondary notification Length to -1 (line 75) as described in the Wink documentation for the siren.  255 is not within the assigned range. http://manuals-backend.z-wave.info/make.php?lang=en&sku=Wink%20Siren&cert=ZC10-17065664

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

PR description here
