### PR TITLE
fix: handle non-ready controller when testing if CCs should be discarded

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -3620,7 +3620,7 @@ ${handlers.length} left`,
 		// the command from a supporting node if not received at the highest common
 		// security level between the controlling node and the sending S2 node.
 
-		const node = this.controller.nodes.get(cc.nodeId as number);
+		const node = this._controller?.nodes.get(cc.nodeId as number);
 		if (!node) {
 			// Node does not exist, don't accept the CC
 			this.controllerLog.logNode(


### PR DESCRIPTION
reported on Discord