### PR TITLE
feat: implement mock-server to expose simulated controller via tcp

### DIFF
--- a/packages/zwave-js/bin/mock-server.js
+++ b/packages/zwave-js/bin/mock-server.js
@@ -1,0 +1,58 @@
+// @ts-check
+const { MockServer } = require("../build/Testing");
+const { readFileSync } = require("fs");
+const path = require("path");
+
+const args = process.argv.slice(2);
+
+if (args.includes("--help") || args.includes("-h")) {
+	// Print a help text explaining the usage of this script and mention the options it supports
+	console.log(`
+Usage: node ${path.basename(__filename)} [options]
+
+Options:
+  -h, --help        Displays this help
+  -i, --interface   The network interface to bind to. Default: all interfaces
+  -p, --port        The port to bind to. Default: 5555
+  -c, --config      Path to a config file (either .js or .json), which defines the mock
+
+`);
+	process.exit(0);
+}
+
+// Parse config
+const configIndex = args.findIndex((arg) => arg === "--config" || arg === "-c");
+const configPath = configIndex === -1 ? undefined : args[configIndex + 1];
+let config;
+if (configPath?.endsWith(".js")) {
+	config = require(path.join(process.cwd(), configPath)).default;
+} else if (configPath?.endsWith(".json")) {
+	// TODO: JSON5 support
+	config = JSON.parse(readFileSync(configPath, "utf8"));
+}
+
+// Parse interface
+const interfaceIndex = args.findIndex(
+	(arg) => arg === "--interface" || arg === "-i",
+);
+const interface = interfaceIndex === -1 ? undefined : args[interfaceIndex + 1];
+
+// Parse port
+const portIndex = args.findIndex((arg) => arg === "--port" || arg === "-p");
+let port = portIndex === -1 ? undefined : parseInt(args[portIndex + 1]);
+if (Number.isNaN(port)) port = undefined;
+
+let server;
+(async () => {
+	server = new MockServer({
+		interface,
+		port,
+		config,
+	});
+	await server.start();
+})();
+
+process.on("SIGINT", async () => {
+	await server.stop();
+	process.exit(0);
+});

--- a/packages/zwave-js/package.json
+++ b/packages/zwave-js/package.json
@@ -46,8 +46,12 @@
     }
   },
   "files": [
+    "bin/",
     "build/**/*.{js,d.ts,map}"
   ],
+  "bin": {
+    "mock-server": "bin/mock-server.js"
+  },
   "author": {
     "name": "AlCalzone",
     "email": "d.griesel@gmx.net"

--- a/packages/zwave-js/src/Testing.ts
+++ b/packages/zwave-js/src/Testing.ts
@@ -1,1 +1,2 @@
 export { createAndStartDriverWithMockPort } from "./lib/driver/DriverMock";
+export { MockServer } from "./mockServer";

--- a/packages/zwave-js/src/mockServer.ts
+++ b/packages/zwave-js/src/mockServer.ts
@@ -1,0 +1,137 @@
+import type { ZWaveSerialPort } from "@zwave-js/serial";
+import {
+	createAndOpenMockedZWaveSerialPort,
+	MockPortBinding,
+} from "@zwave-js/serial/mock";
+import {
+	MockController,
+	MockControllerOptions,
+	MockNode,
+	type MockNodeOptions,
+} from "@zwave-js/testing";
+import { createDeferredPromise } from "alcalzone-shared/deferred-promise";
+import { AddressInfo, createServer, Server } from "net";
+import {
+	createDefaultMockControllerBehaviors,
+	createDefaultMockNodeBehaviors,
+} from "./Utils";
+
+export interface MockServerOptions {
+	interface?: string;
+	port?: number;
+	// eslint-disable-next-line @typescript-eslint/ban-types
+	config?: {};
+}
+
+export class MockServer {
+	public constructor(private options: MockServerOptions = {}) {}
+
+	private serialport: ZWaveSerialPort | undefined;
+	private binding: MockPortBinding | undefined;
+	private server: Server | undefined;
+
+	public async start(): Promise<void> {
+		const { port: serialport, binding } =
+			await createAndOpenMockedZWaveSerialPort("/tty/FAKE");
+
+		this.serialport = serialport;
+		this.binding = binding;
+
+		console.log("Mock serial port opened");
+
+		// Hook up a fake controller and nodes
+		prepareMocks(
+			binding,
+			(this.options.config as any)?.controller,
+			(this.options.config as any)?.nodes,
+		);
+
+		// Start a TCP server, listen for connections, and forward them to the serial port
+		this.server = createServer((socket) => {
+			if (!this.serialport) {
+				console.error("Serial port not initialized");
+				socket.destroy();
+				return;
+			}
+
+			console.log("Client connected");
+
+			socket.pipe(this.serialport);
+			this.serialport.on("data", (chunk) => {
+				if (typeof chunk === "number") {
+					socket.write(Buffer.from([chunk]));
+				} else {
+					socket.write(chunk);
+				}
+			});
+
+			// when the connection is closed, unpipe the streams
+			socket.on("close", () => {
+				console.log("Client disconnected");
+
+				socket.unpipe(this.serialport);
+				this.serialport?.removeAllListeners("data");
+			});
+		});
+
+		// Do not allow more than one client to connect
+		this.server.maxConnections = 1;
+
+		const promise = createDeferredPromise();
+		this.server.on("error", (err) => {
+			if ((err as any).code === "EADDRINUSE") {
+				promise.reject(err);
+			}
+		});
+		this.server.listen(
+			{
+				host: this.options.interface,
+				port: this.options.port ?? 5555,
+			},
+			() => {
+				const address: AddressInfo = this.server!.address() as any;
+				console.log(
+					`Server listening on tcp://${address.address}:${address.port}`,
+				);
+				promise.resolve();
+			},
+		);
+	}
+
+	public async stop(): Promise<void> {
+		console.log("Shutting down mock server...");
+		this.server?.close();
+		await this.serialport?.close();
+		if (this.binding?.isOpen) await this.binding?.close();
+		console.log("Mock server shut down");
+	}
+}
+
+function prepareMocks(
+	mockPort: MockPortBinding,
+	controller: Pick<
+		MockControllerOptions,
+		"ownNodeId" | "homeId" | "capabilities"
+	> = {},
+	nodes: Pick<MockNodeOptions, "id" | "capabilities">[] = [],
+): void {
+	const mockController = new MockController({
+		homeId: 0x7e570001,
+		ownNodeId: 1,
+		...controller,
+		serial: mockPort,
+	});
+	// Apply default behaviors that are required for interacting with the driver correctly
+	mockController.defineBehavior(...createDefaultMockControllerBehaviors());
+
+	for (const node of nodes) {
+		const mockNode = new MockNode({
+			...node,
+			controller: mockController,
+		});
+		mockController.addNode(mockNode);
+
+		// Apply default behaviors that are required for interacting with the driver correctly
+		mockNode.defineBehavior(...createDefaultMockNodeBehaviors());
+	}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8993,5 +8993,7 @@ __metadata:
     typescript: 4.9.5
     winston: ^3.8.2
     xstate: 4.29.0
+  bin:
+    mock-server: bin/mock-server.js
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
We've had this functionality for a while in integration tests, but there are use cases in development where talking to a simulated controller and nodes makes sense. This PR adds a simple mock-server which exposes a fake serial port via TCP that zwave-js can connect to. Behind that port is fake controller with fake nodes whose capabilities can be configured.

Example config for a network with the controller and a node that supports Version CC and Window Covering CC with all parameters:
```js
// filename: mock_config.js

// @ts-check
const { CommandClasses } = require("@zwave-js/core");
const { ccCaps } = require("@zwave-js/testing");

module.exports.default = {
	nodes: [
		{
			id: 2,
			capabilities: {
				commandClasses: [
					CommandClasses.Version,
					ccCaps({
						ccId: CommandClasses["Window Covering"],
						isSupported: true,
						version: 1,
						supportedParameters: new Array(24)
							.fill(0)
							.map((_, i) => i),
					}),
				],
			},
		},
	],
};
```

This can be executed using
```
yarn mock-server -c mock_config.js
```
in the `zwave-js` repo. It should also be possible to run this in any project zwave-js is installed in, but this is untested.

The config file may be `.js` or `.json`, but `.js` is recommended because it allows the use of exports from `zwave-js`.