### PR TITLE
fix(cc): fall back to query Basic CC even if not advertised

### DIFF
--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -427,6 +427,7 @@ export class Endpoint implements IZWaveEndpoint {
     get installerIcon(): number | undefined;
     invokeCCAPI<CC extends CCNameOrId, TMethod extends keyof TAPI, TAPI extends Record<string, (...args: any[]) => any> = CommandClasses_2 extends CC ? any : Omit<CCNameOrId, CommandClasses_2> extends CC ? any : APIMethodsOf<CC>>(cc: CC, method: TMethod, ...args: Parameters<TAPI[TMethod]>): ReturnType<TAPI[TMethod]>;
     isCCSecure(cc: CommandClasses_2): boolean;
+    maybeAddBasicCCAsFallback(): void;
     readonly nodeId: number;
     removeCC(cc: CommandClasses_2): void;
     protected reset(): void;

--- a/packages/zwave-js/src/lib/node/Endpoint.ts
+++ b/packages/zwave-js/src/lib/node/Endpoint.ts
@@ -218,6 +218,16 @@ export class Endpoint implements IZWaveEndpoint {
 		return !!this._implementedCommandClasses.get(cc)?.isControlled;
 	}
 
+	/** Adds Basic CC to the supported CCs if no other actuator CCs are supported */
+	public maybeAddBasicCCAsFallback(): void {
+		if (
+			!this.supportsCC(CommandClasses.Basic) &&
+			!actuatorCCs.some((cc) => this.supportsCC(cc))
+		) {
+			this.addCC(CommandClasses.Basic, { isSupported: true });
+		}
+	}
+
 	/** Removes the BasicCC from the supported CCs if any other actuator CCs are supported */
 	public hideBasicCCInFavorOfActuatorCCs(): void {
 		// This behavior is defined in SDS14223

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -2023,6 +2023,10 @@ protocol version:      ${this.protocolVersion}`;
 			);
 		}
 
+		// Basic CC MUST only be used/interviewed when no other actuator CC is supported. If Basic CC is not in the NIF
+		// or list of supported CCs, we need to add it here manually, so its version can get queried.
+		this.maybeAddBasicCCAsFallback();
+
 		if (this.supportsCC(CommandClasses.Version)) {
 			this.driver.controllerLog.logNode(
 				this.nodeId,
@@ -2289,6 +2293,10 @@ protocol version:      ${this.protocolVersion}`;
 					});
 				}
 			}
+
+			// Basic CC MUST only be used/interviewed when no other actuator CC is supported. If Basic CC is not in the NIF
+			// or list of supported CCs, we need to add it here manually, so its version can get queried.
+			this.maybeAddBasicCCAsFallback();
 
 			// This intentionally checks for Version CC support on the root device.
 			// Endpoints SHOULD not support this CC, but we still need to query their


### PR DESCRIPTION
When no actuator CC is supported, the controller MUST check if Basic CC is. We now do that, even if Basic CC is not advertised as supported anywhere.