### PR TITLE
fix: handle Transport Service CC with unequal fragment sizes, do not encapsulate CRC16 or Transport Service in Security S0/S2

### DIFF
--- a/packages/cc/src/cc/Security2CC.ts
+++ b/packages/cc/src/cc/Security2CC.ts
@@ -65,8 +65,10 @@ import {
 } from "../lib/Security2/Extension";
 import { ECDHProfiles, KEXFailType, KEXSchemes } from "../lib/Security2/shared";
 import { Security2Command } from "../lib/_Types";
+import { CRC16CC } from "./CRC16CC";
 import { MultiChannelCC } from "./MultiChannelCC";
 import { SecurityCC } from "./SecurityCC";
+import { TransportServiceCC } from "./TransportServiceCC";
 
 function securityClassToBitMask(key: SecurityClass): Buffer {
 	return encodeBitMask(
@@ -699,8 +701,14 @@ export class Security2CC extends CommandClass {
 		if (!(cc.encapsulationFlags & EncapsulationFlags.Security)) {
 			return false;
 		}
-		// S0 -> no S2 encapsulation
-		if (cc instanceof SecurityCC) return false;
+		// S0, CRC16, Transport Service -> no S2 encapsulation
+		if (
+			cc instanceof SecurityCC ||
+			cc instanceof CRC16CC ||
+			cc instanceof TransportServiceCC
+		) {
+			return false;
+		}
 		// S2: check command
 		if (cc instanceof Security2CC) {
 			// These S2 commands need additional encapsulation
@@ -734,7 +742,7 @@ export class Security2CC extends CommandClass {
 			return false;
 		}
 
-		// Everything that's not an S0 or S2 CC needs to be encapsulated if the CC is secure
+		// Everything else needs to be encapsulated if the CC is secure
 		return true;
 	}
 

--- a/packages/cc/src/cc/TransportServiceCC.ts
+++ b/packages/cc/src/cc/TransportServiceCC.ts
@@ -314,19 +314,22 @@ export class TransportServiceCCSubsequentSegment extends TransportServiceCC {
 			return true;
 		}
 		const datagramSize = session[0].datagramSize;
-		const chunkSize = session[0].partialDatagram.length;
-		const received = new Array<boolean>(
-			Math.ceil(datagramSize / chunkSize),
-		).fill(false);
+		const receivedBytes = new Array<boolean>(datagramSize).fill(false);
 		for (const segment of [...session, this]) {
 			const offset =
 				segment instanceof TransportServiceCCFirstSegment
 					? 0
 					: segment.datagramOffset;
-			received[offset / chunkSize] = true;
+			for (
+				let i = offset;
+				i <= offset + segment.partialDatagram.length;
+				i++
+			) {
+				receivedBytes[i] = true;
+			}
 		}
 		// Expect more messages as long as we haven't received everything
-		return !received.every(Boolean);
+		return receivedBytes.some((b) => b === false);
 	}
 
 	public getPartialCCSessionId(): Record<string, any> | undefined {


### PR DESCRIPTION
This PR fixes issues with incorrect encapsulation of the "outer" encapsulation CCs CRC16 and Transport Service. It also fixes how incoming Transport Service CC sessions with unequal fragment sizes are handled.