### PR TITLE
fix(config): updated Leviton VRS15 metadata

### DIFF
--- a/packages/config/config/devices/0x001d/vrs15.json
+++ b/packages/config/config/devices/0x001d/vrs15.json
@@ -26,7 +26,8 @@
 		}
 	},
 	"metadata": {
-		"reset": "Gently press the top of the pushpad until the bottom pops out of the frame. Wait 5 seconds, and push the bottom back in and hold down until LED turns amber then flashes red.",
-		"manual": "http://communities.leviton.com/servlet/JiveServlet/previewBody/1581-102-1-2190/Ins%20VRS15-1L.pdf"
+		"inclusion": "While the Programmer/Controller is in the Inclusion mode and the Locator LED is ON on the switch, press the push pad to turn on the switch. The Programmer/Controller will verify inclusion and the Locator LED will turn OFF.\nIf the switch is ﬂashing Amber while in the Inclusion mode, the Programmer/Controller is still trying to communicate with the switch. Wait until the device stops ﬂashing, then press the push pad.\n\nNOTE: If the Locator LED on the switch turns solid Red while including, there has been a communication error.",
+		"exclusion": "While the Programmer/Controller is in the Exclusion mode and the locator LED is ON on the switch, press the push pad to turn on the switch. The Programmer/Controller will verify Exclusion and the locator LED will turn OFF. If the switch is ﬂashing Amber while in the Exclusion mode, the Programmer/Controller is still trying to communicate with the switch. Wait until the device stops ﬂashing, then press the push pad.",
+		"reset": "On the switch, engage the air-gap switch by gently pressing the top of the push pad until the bottom lifts completely out of the frame and a click is heard (refer to figure).\nWait 5 seconds and then press the push pad back into the frame and hold push pad until the locator LED turns Amber and then flashes Red.\nThe switch is now reset.\nOnce the switch is reset, it will be necessary to Re-Include it to a network before it can be used."
 	}
 }


### PR DESCRIPTION
Added inclusion, exclusion, and updated reset per the installation guide. Removed broken link to manual.

Here is an online copy I found that can be referenced: https://vdocuments.net/leviton-vrs15-1lz-installation-manual-and-setup-guide.html

It's not from an official leviton site, so I did not add this as the manual link.