### PR TITLE
fix(config): extend version range for Vesternet VES-ZW-HLD-016

### DIFF
--- a/packages/config/config/devices/0x0330/ves-zw-hld-016.json
+++ b/packages/config/config/devices/0x0330/ves-zw-hld-016.json
@@ -11,7 +11,7 @@
 	],
 	"firmwareVersion": {
 		"min": "2.2.5",
-		"max": "2.2.7"
+		"max": "2.4"
 	},
 	"paramInformation": [
 		{


### PR DESCRIPTION
Update firmwareVersion max to account for newer version of the Vesternet High Load Switch module.

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->
