### PR TITLE
feat(cc): add caching for Schedule Entry Lock CC: schedules, enabled users, scheduling kind for each user

### DIFF
--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -13316,6 +13316,14 @@ export class ScheduleEntryLockCC extends CommandClass {
     static getNumWeekDaySlotsCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): number;
     static getNumYearDaySlotsCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): number;
     // (undocumented)
+    static getScheduleCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, scheduleKind: ScheduleEntryLockScheduleKind.WeekDay, userId: number, slotId: number): ScheduleEntryLockWeekDaySchedule | undefined;
+    // (undocumented)
+    static getScheduleCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, scheduleKind: ScheduleEntryLockScheduleKind.YearDay, userId: number, slotId: number): ScheduleEntryLockYearDaySchedule | undefined;
+    // (undocumented)
+    static getScheduleCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, scheduleKind: ScheduleEntryLockScheduleKind.DailyRepeating, userId: number, slotId: number): ScheduleEntryLockDailyRepeatingSchedule | undefined;
+    static getUserCodeScheduleEnabledCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, userId: number): boolean;
+    static getUserCodeScheduleKindCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, userId: number): ScheduleEntryLockScheduleKind | undefined;
+    // (undocumented)
     interview(applHost: ZWaveApplicationHost): Promise<void>;
 }
 
@@ -13345,6 +13353,8 @@ export class ScheduleEntryLockCCDailyRepeatingScheduleReport extends ScheduleEnt
     durationHour?: number;
     // (undocumented)
     durationMinute?: number;
+    // (undocumented)
+    persistValues(applHost: ZWaveApplicationHost): boolean;
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
@@ -13494,6 +13504,90 @@ export class ScheduleEntryLockCCTimeOffsetSet extends ScheduleEntryLockCC {
 //
 // @public (undocumented)
 export const ScheduleEntryLockCCValues: Readonly<{
+    schedule: ((scheduleKind: ScheduleEntryLockScheduleKind, userId: number, slotId: number) => {
+        readonly meta: {
+            readonly type: "any";
+            readonly readable: true;
+            readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses_2)["Schedule Entry Lock"];
+            property: "schedule";
+            propertyKey: number;
+        };
+        readonly endpoint: (endpoint?: number | undefined) => {
+            readonly commandClass: (typeof CommandClasses_2)["Schedule Entry Lock"];
+            readonly endpoint: number;
+            readonly property: "schedule";
+            readonly propertyKey: number;
+        };
+    }) & {
+        is: (valueId: ValueID) => boolean;
+        readonly options: {
+            readonly stateful: true;
+            readonly secret: false;
+            readonly minVersion: 1;
+            readonly supportsEndpoints: true;
+            readonly autoCreate: true;
+            readonly internal: true;
+        };
+    };
+    scheduleKind: ((userId: number) => {
+        readonly meta: {
+            readonly type: "any";
+            readonly readable: true;
+            readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses_2)["Schedule Entry Lock"];
+            property: "scheduleKind";
+            propertyKey: number;
+        };
+        readonly endpoint: (endpoint?: number | undefined) => {
+            readonly commandClass: (typeof CommandClasses_2)["Schedule Entry Lock"];
+            readonly endpoint: number;
+            readonly property: "scheduleKind";
+            readonly propertyKey: number;
+        };
+    }) & {
+        is: (valueId: ValueID) => boolean;
+        readonly options: {
+            readonly stateful: true;
+            readonly secret: false;
+            readonly minVersion: 1;
+            readonly supportsEndpoints: true;
+            readonly autoCreate: true;
+            readonly internal: true;
+        };
+    };
+    userEnabled: ((userId: number) => {
+        readonly meta: {
+            readonly type: "any";
+            readonly readable: true;
+            readonly writeable: true;
+        };
+        readonly id: {
+            commandClass: (typeof CommandClasses_2)["Schedule Entry Lock"];
+            property: "userEnabled";
+            propertyKey: number;
+        };
+        readonly endpoint: (endpoint?: number | undefined) => {
+            readonly commandClass: (typeof CommandClasses_2)["Schedule Entry Lock"];
+            readonly endpoint: number;
+            readonly property: "userEnabled";
+            readonly propertyKey: number;
+        };
+    }) & {
+        is: (valueId: ValueID) => boolean;
+        readonly options: {
+            readonly stateful: true;
+            readonly secret: false;
+            readonly minVersion: 1;
+            readonly supportsEndpoints: true;
+            readonly autoCreate: true;
+            readonly internal: true;
+        };
+    };
     numDailyRepeatingSlots: {
         readonly id: {
             commandClass: (typeof CommandClasses_2)["Schedule Entry Lock"];
@@ -13594,6 +13688,8 @@ export class ScheduleEntryLockCCWeekDayScheduleReport extends ScheduleEntryLockC
     // Warning: (ae-forgotten-export) The symbol "ScheduleEntryLockCCWeekDayScheduleReportOptions" needs to be exported by the entry point index.d.ts
     constructor(host: ZWaveHost, options: CommandClassDeserializationOptions | ScheduleEntryLockCCWeekDayScheduleReportOptions);
     // (undocumented)
+    persistValues(applHost: ZWaveApplicationHost): boolean;
+    // (undocumented)
     serialize(): Buffer;
     // (undocumented)
     slotId: number;
@@ -13672,6 +13768,8 @@ export class ScheduleEntryLockCCYearDayScheduleGet extends ScheduleEntryLockCC {
 export class ScheduleEntryLockCCYearDayScheduleReport extends ScheduleEntryLockCC {
     // Warning: (ae-forgotten-export) The symbol "ScheduleEntryLockCCYearDayScheduleReportOptions" needs to be exported by the entry point index.d.ts
     constructor(host: ZWaveHost, options: CommandClassDeserializationOptions | ScheduleEntryLockCCYearDayScheduleReportOptions);
+    // (undocumented)
+    persistValues(applHost: ZWaveApplicationHost): boolean;
     // (undocumented)
     serialize(): Buffer;
     // (undocumented)
@@ -13801,6 +13899,18 @@ export interface ScheduleEntryLockDailyRepeatingSchedule {
     startMinute: number;
     // (undocumented)
     weekdays: ScheduleEntryLockWeekday[];
+}
+
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockScheduleKind" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export enum ScheduleEntryLockScheduleKind {
+    // (undocumented)
+    DailyRepeating = 2,
+    // (undocumented)
+    WeekDay = 0,
+    // (undocumented)
+    YearDay = 1
 }
 
 // Warning: (ae-missing-release-tag) "ScheduleEntryLockSetAction" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -13316,11 +13316,11 @@ export class ScheduleEntryLockCC extends CommandClass {
     static getNumWeekDaySlotsCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): number;
     static getNumYearDaySlotsCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint): number;
     // (undocumented)
-    static getScheduleCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, scheduleKind: ScheduleEntryLockScheduleKind.WeekDay, userId: number, slotId: number): ScheduleEntryLockWeekDaySchedule | undefined;
+    static getScheduleCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, scheduleKind: ScheduleEntryLockScheduleKind.WeekDay, userId: number, slotId: number): ScheduleEntryLockWeekDaySchedule | false | undefined;
     // (undocumented)
-    static getScheduleCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, scheduleKind: ScheduleEntryLockScheduleKind.YearDay, userId: number, slotId: number): ScheduleEntryLockYearDaySchedule | undefined;
+    static getScheduleCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, scheduleKind: ScheduleEntryLockScheduleKind.YearDay, userId: number, slotId: number): ScheduleEntryLockYearDaySchedule | false | undefined;
     // (undocumented)
-    static getScheduleCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, scheduleKind: ScheduleEntryLockScheduleKind.DailyRepeating, userId: number, slotId: number): ScheduleEntryLockDailyRepeatingSchedule | undefined;
+    static getScheduleCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, scheduleKind: ScheduleEntryLockScheduleKind.DailyRepeating, userId: number, slotId: number): ScheduleEntryLockDailyRepeatingSchedule | false | undefined;
     static getUserCodeScheduleEnabledCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, userId: number): boolean;
     static getUserCodeScheduleKindCached(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint, userId: number): ScheduleEntryLockScheduleKind | undefined;
     // (undocumented)

--- a/packages/cc/src/cc/ScheduleEntryLockCC.ts
+++ b/packages/cc/src/cc/ScheduleEntryLockCC.ts
@@ -120,6 +120,7 @@ function persistSchedule(
 		| ScheduleEntryLockWeekDaySchedule
 		| ScheduleEntryLockYearDaySchedule
 		| ScheduleEntryLockDailyRepeatingSchedule
+		| false
 		| undefined,
 ): void {
 	const scheduleValue = ScheduleEntryLockCCValues.schedule(
@@ -128,7 +129,7 @@ function persistSchedule(
 		slotId,
 	);
 
-	if (schedule) {
+	if (schedule != undefined) {
 		this.setValue(applHost, scheduleValue, schedule);
 	} else {
 		this.removeValue(applHost, scheduleValue);
@@ -352,7 +353,7 @@ export class ScheduleEntryLockCCAPI extends CCAPI {
 				ScheduleEntryLockScheduleKind.WeekDay,
 				slot.userId,
 				slot.slotId,
-				schedule,
+				schedule ?? false,
 			);
 		}
 
@@ -455,7 +456,7 @@ export class ScheduleEntryLockCCAPI extends CCAPI {
 				ScheduleEntryLockScheduleKind.YearDay,
 				slot.userId,
 				slot.slotId,
-				schedule,
+				schedule ?? false,
 			);
 		}
 
@@ -567,7 +568,7 @@ export class ScheduleEntryLockCCAPI extends CCAPI {
 				ScheduleEntryLockScheduleKind.DailyRepeating,
 				slot.userId,
 				slot.slotId,
-				schedule,
+				schedule ?? false,
 			);
 		}
 
@@ -819,7 +820,7 @@ daily repeating: ${slotsResp.numDailyRepeatingSlots}`;
 		scheduleKind: ScheduleEntryLockScheduleKind.WeekDay,
 		userId: number,
 		slotId: number,
-	): ScheduleEntryLockWeekDaySchedule | undefined;
+	): ScheduleEntryLockWeekDaySchedule | false | undefined;
 
 	public static getScheduleCached(
 		applHost: ZWaveApplicationHost,
@@ -827,7 +828,7 @@ daily repeating: ${slotsResp.numDailyRepeatingSlots}`;
 		scheduleKind: ScheduleEntryLockScheduleKind.YearDay,
 		userId: number,
 		slotId: number,
-	): ScheduleEntryLockYearDaySchedule | undefined;
+	): ScheduleEntryLockYearDaySchedule | false | undefined;
 
 	public static getScheduleCached(
 		applHost: ZWaveApplicationHost,
@@ -835,11 +836,13 @@ daily repeating: ${slotsResp.numDailyRepeatingSlots}`;
 		scheduleKind: ScheduleEntryLockScheduleKind.DailyRepeating,
 		userId: number,
 		slotId: number,
-	): ScheduleEntryLockDailyRepeatingSchedule | undefined;
+	): ScheduleEntryLockDailyRepeatingSchedule | false | undefined;
 
 	/**
 	 * Returns the assumed state of a schedule. Since the Schedule Entry Lock CC
 	 * provides no way to query the current state, Z-Wave JS tracks this in its own cache.
+	 *
+	 * A return value of `false` means the slot is empty, a return value of `undefined` means the information is not cached yet.
 	 *
 	 * This only works AFTER the interview process.
 	 */
@@ -853,6 +856,7 @@ daily repeating: ${slotsResp.numDailyRepeatingSlots}`;
 		| ScheduleEntryLockWeekDaySchedule
 		| ScheduleEntryLockYearDaySchedule
 		| ScheduleEntryLockDailyRepeatingSchedule
+		| false
 		| undefined {
 		return applHost
 			.getValueDB(endpoint.nodeId)
@@ -1204,7 +1208,7 @@ export class ScheduleEntryLockCCWeekDayScheduleReport extends ScheduleEntryLockC
 						stopHour: this.stopHour!,
 						stopMinute: this.stopMinute!,
 				  }
-				: undefined,
+				: false,
 		);
 
 		return true;
@@ -1531,7 +1535,7 @@ export class ScheduleEntryLockCCYearDayScheduleReport extends ScheduleEntryLockC
 						stopHour: this.stopHour!,
 						stopMinute: this.stopMinute!,
 				  }
-				: undefined,
+				: false,
 		);
 
 		return true;
@@ -1918,7 +1922,7 @@ export class ScheduleEntryLockCCDailyRepeatingScheduleReport extends ScheduleEnt
 						durationHour: this.durationHour!,
 						durationMinute: this.durationMinute!,
 				  }
-				: undefined,
+				: false,
 		);
 
 		return true;

--- a/packages/cc/src/lib/_Types.ts
+++ b/packages/cc/src/lib/_Types.ts
@@ -1267,6 +1267,12 @@ export interface ScheduleEntryLockWeekDaySchedule {
 	stopMinute: number;
 }
 
+export enum ScheduleEntryLockScheduleKind {
+	WeekDay,
+	YearDay,
+	DailyRepeating,
+}
+
 export enum Security2Command {
 	NonceGet = 0x01,
 	NonceReport = 0x02,


### PR DESCRIPTION
fixes: #5733

With this PR, Z-Wave JS keeps track of Schedule Entry Lock CC schedules in its own cache. To read cached information, a couple of new `static` methods have been added to the `ScheduleEntryLockCC` class:
```ts
getUserCodeScheduleEnabledCached(
	applHost: ZWaveApplicationHost,
	endpoint: IZWaveEndpoint,
	userId: number,
): boolean
```
returns whether scheduling is (known to be) enabled for a given user ID

```ts
getUserCodeScheduleKindCached(
	applHost: ZWaveApplicationHost,
	endpoint: IZWaveEndpoint,
	userId: number,
): ScheduleEntryLockScheduleKind | undefined
```
returns the active scheduling kind for a given user ID (weekday, yearday or dailyrepeating).

The following 3 overloads
```ts
getScheduleCached(
	applHost: ZWaveApplicationHost,
	endpoint: IZWaveEndpoint,
	scheduleKind: ScheduleEntryLockScheduleKind.WeekDay,
	userId: number,
	slotId: number,
): ScheduleEntryLockWeekDaySchedule | false | undefined;

getScheduleCached(
	applHost: ZWaveApplicationHost,
	endpoint: IZWaveEndpoint,
	scheduleKind: ScheduleEntryLockScheduleKind.YearDay,
	userId: number,
	slotId: number,
): ScheduleEntryLockYearDaySchedule | false | undefined

getScheduleCached(
	applHost: ZWaveApplicationHost,
	endpoint: IZWaveEndpoint,
	scheduleKind: ScheduleEntryLockScheduleKind.DailyRepeating,
	userId: number,
	slotId: number,
): ScheduleEntryLockDailyRepeatingSchedule | false | undefined
```
return the cached information about a given schedule slot.
**Note** that both `false` and `undefined` are possible return values! `false` means the slot is empty, `undefined` means the information is not cached yet.
