### PR TITLE
fix(cc): inconsistencies between auto-discovered and documented params

### DIFF
--- a/packages/cc/src/cc/ConfigurationCC.ts
+++ b/packages/cc/src/cc/ConfigurationCC.ts
@@ -2179,6 +2179,7 @@ export class ConfigurationCCNameReport extends ConfigurationCC {
 
 		this.extendParamInformation(applHost, this.parameter, undefined, {
 			name: this.name,
+			label: this.name,
 		});
 		return true;
 	}
@@ -2298,6 +2299,7 @@ export class ConfigurationCCInfoReport extends ConfigurationCC {
 
 		this.extendParamInformation(applHost, this.parameter, undefined, {
 			info: this.info,
+			description: this.info,
 		});
 		return true;
 	}
@@ -2497,18 +2499,22 @@ export class ConfigurationCCPropertiesReport extends ConfigurationCC {
 				this.valueFormat === ConfigValueFormat.UnsignedInteger
 					? "number"
 					: "number[]";
-			const paramInfo: Partial<ConfigurationMetadata> = stripUndefined({
+			const paramInfo = stripUndefined({
 				type: valueType,
-				valueFormat: this.valueFormat,
+				format: this.valueFormat,
 				valueSize: this.valueSize,
-				minValue: this.minValue,
-				maxValue: this.maxValue,
-				defaultValue: this.defaultValue,
+				min: this.minValue,
+				max: this.maxValue,
+				default: this.defaultValue,
 				requiresReInclusion: this.altersCapabilities,
+				readable: true,
 				writeable: !this.isReadonly,
+				allowManualEntry: true,
 				isAdvanced: this.isAdvanced,
 				noBulkSupport: this.noBulkSupport,
-			});
+				isFromConfig: false,
+			} as const satisfies ConfigurationMetadata);
+
 			this.extendParamInformation(
 				applHost,
 				this.parameter,

--- a/packages/core/api.md
+++ b/packages/core/api.md
@@ -441,20 +441,26 @@ export interface ConfigurationMetadata extends ValueMetadataAny {
     // (undocumented)
     default?: ConfigValue;
     // (undocumented)
-    format?: ConfigValueFormat;
+    description?: string;
     // (undocumented)
+    format?: ConfigValueFormat;
+    // @deprecated (undocumented)
     info?: string;
     // (undocumented)
     isAdvanced?: boolean;
     // (undocumented)
     isFromConfig?: boolean;
     // (undocumented)
+    label?: string;
+    // (undocumented)
     max?: ConfigValue;
     // (undocumented)
     min?: ConfigValue;
-    // (undocumented)
+    // @deprecated (undocumented)
     name?: string;
-    // (undocumented)
+    // Warning: (tsdoc-missing-deprecation-message) The @deprecated block must include a deprecation message, e.g. describing the recommended alternative
+    //
+    // @deprecated (undocumented)
     noBulkSupport?: boolean;
     // (undocumented)
     requiresReInclusion?: boolean;

--- a/packages/core/src/values/Metadata.ts
+++ b/packages/core/src/values/Metadata.ts
@@ -164,8 +164,13 @@ export interface ConfigurationMetadata extends ValueMetadataAny {
 	unit?: string;
 	valueSize?: number;
 	format?: ConfigValueFormat;
+	label?: string;
+	description?: string;
+	/** @deprecated Use the `label` property instead */
 	name?: string;
+	/** @deprecated Use the `description` property instead */
 	info?: string;
+	/** @deprecated */
 	noBulkSupport?: boolean;
 	isAdvanced?: boolean;
 	requiresReInclusion?: boolean;


### PR DESCRIPTION
This PR cleans up some inconsistencies in the metadata of auto-discovered parameters which did not actually match the type definitions. As a result, the `name` property has been deprecated in favor of the `label` property, and the `info` property in favor of `description`.

fixes: https://github.com/zwave-js/node-zwave-js/issues/5754
fixes: https://github.com/zwave-js/node-zwave-js/issues/5719