### PR TITLE
feat(cc): add `states` property to `boolean` value metadata

### DIFF
--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -1609,6 +1609,9 @@ export const BasicCCValues: Readonly<{
         readonly is: (valueId: ValueID_2) => boolean;
         readonly meta: {
             readonly label: "Restore previous value";
+            readonly states: {
+                true: string;
+            };
             readonly readable: false;
             readonly type: "boolean";
             readonly writeable: true;
@@ -7721,6 +7724,9 @@ export const IndicatorCCValues: Readonly<{
         readonly is: (valueId: ValueID_2) => boolean;
         readonly meta: {
             readonly label: "Identify";
+            readonly states: {
+                readonly true: "Identify";
+            };
             readonly readable: false;
             readonly type: "boolean";
             readonly writeable: true;
@@ -8008,6 +8014,10 @@ export const IrrigationCCValues: Readonly<{
     valveRunStartStop: ((valveId: ValveId) => {
         readonly meta: {
             readonly label: `${string}: Start/Stop`;
+            readonly states: {
+                readonly true: "Start";
+                readonly false: "Stop";
+            };
             readonly type: "boolean";
             readonly readable: true;
             readonly writeable: true;
@@ -8527,6 +8537,9 @@ export const IrrigationCCValues: Readonly<{
         readonly is: (valueId: ValueID_2) => boolean;
         readonly meta: {
             readonly label: "Shutoff system";
+            readonly states: {
+                readonly true: "Shutoff";
+            };
             readonly readable: false;
             readonly type: "boolean";
             readonly writeable: true;
@@ -10110,6 +10123,9 @@ export const MeterCCValues: Readonly<{
     resetSingle: ((meterType: number) => {
         readonly meta: {
             readonly label: `Reset (${string})`;
+            readonly states: {
+                readonly true: "Reset";
+            };
             readonly ccSpecific: {
                 readonly meterType: number;
             };
@@ -10152,6 +10168,9 @@ export const MeterCCValues: Readonly<{
         readonly is: (valueId: ValueID) => boolean;
         readonly meta: {
             readonly label: "Reset accumulated values";
+            readonly states: {
+                readonly true: "Reset";
+            };
             readonly readable: false;
             readonly type: "boolean";
             readonly writeable: true;
@@ -11419,6 +11438,10 @@ export const MultilevelSwitchCCValues: Readonly<{
         readonly meta: {
             readonly label: `Perform a level change (${string})`;
             readonly valueChangeOptions: readonly ["transitionDuration"];
+            readonly states: {
+                readonly true: "Start";
+                readonly false: "Stop";
+            };
             readonly ccSpecific: {
                 readonly switchType: SwitchType;
             };
@@ -11450,6 +11473,10 @@ export const MultilevelSwitchCCValues: Readonly<{
         readonly meta: {
             readonly label: `Perform a level change (${string})`;
             readonly valueChangeOptions: readonly ["transitionDuration"];
+            readonly states: {
+                readonly true: "Start";
+                readonly false: "Stop";
+            };
             readonly ccSpecific: {
                 readonly switchType: SwitchType;
             };
@@ -11568,6 +11595,9 @@ export const MultilevelSwitchCCValues: Readonly<{
         readonly is: (valueId: ValueID_2) => boolean;
         readonly meta: {
             readonly label: "Restore previous value";
+            readonly states: {
+                readonly true: "Restore";
+            };
             readonly readable: false;
             readonly type: "boolean";
             readonly writeable: true;
@@ -18050,6 +18080,9 @@ export const WindowCoveringCCValues: Readonly<{
     tiltClose99: ((parameter: WindowCoveringParameter) => {
         readonly meta: {
             readonly label: `Close Left - ${string}` | `Close Down - ${string}`;
+            readonly states: {
+                readonly true: "Close";
+            };
             readonly ccSpecific: {
                 readonly parameter: WindowCoveringParameter;
             };
@@ -18083,6 +18116,9 @@ export const WindowCoveringCCValues: Readonly<{
     tiltClose0: ((parameter: WindowCoveringParameter) => {
         readonly meta: {
             readonly label: `Close Right - ${string}` | `Close Up - ${string}`;
+            readonly states: {
+                readonly true: "Close";
+            };
             readonly ccSpecific: {
                 readonly parameter: WindowCoveringParameter;
             };
@@ -18116,6 +18152,9 @@ export const WindowCoveringCCValues: Readonly<{
     positionClose: ((parameter: WindowCoveringParameter) => {
         readonly meta: {
             readonly label: `Close - ${string}`;
+            readonly states: {
+                readonly true: "Close";
+            };
             readonly ccSpecific: {
                 readonly parameter: WindowCoveringParameter;
             };
@@ -18149,6 +18188,9 @@ export const WindowCoveringCCValues: Readonly<{
     open: ((parameter: WindowCoveringParameter) => {
         readonly meta: {
             readonly label: `Open - ${string}`;
+            readonly states: {
+                readonly true: "Open";
+            };
             readonly ccSpecific: {
                 readonly parameter: WindowCoveringParameter;
             };

--- a/packages/cc/src/cc/BasicCC.ts
+++ b/packages/cc/src/cc/BasicCC.ts
@@ -64,6 +64,9 @@ export const BasicCCValues = Object.freeze({
 		...V.staticProperty("restorePrevious", {
 			...ValueMetadata.WriteOnlyBoolean,
 			label: "Restore previous value" as const,
+			states: {
+				true: "Restore",
+			},
 		}),
 
 		// TODO: This should really not be a static CC value, but depend on compat flags:

--- a/packages/cc/src/cc/IndicatorCC.ts
+++ b/packages/cc/src/cc/IndicatorCC.ts
@@ -67,6 +67,9 @@ export const IndicatorCCValues = Object.freeze({
 			{
 				...ValueMetadata.WriteOnlyBoolean,
 				label: "Identify",
+				states: {
+					true: "Identify",
+				},
 			} as const,
 			{ minVersion: 3 } as const,
 		),

--- a/packages/cc/src/cc/IrrigationCC.ts
+++ b/packages/cc/src/cc/IrrigationCC.ts
@@ -182,6 +182,9 @@ export const IrrigationCCValues = Object.freeze({
 		...V.staticPropertyWithName("shutoffSystem", "shutoff", {
 			...ValueMetadata.WriteOnlyBoolean,
 			label: `Shutoff system`,
+			states: {
+				true: "Shutoff",
+			},
 		} as const),
 	}),
 
@@ -461,6 +464,10 @@ export const IrrigationCCValues = Object.freeze({
 				({
 					...ValueMetadata.Boolean,
 					label: `${valveIdToMetadataPrefix(valveId)}: Start/Stop`,
+					states: {
+						true: "Start",
+						false: "Stop",
+					},
 				} as const),
 		),
 	}),

--- a/packages/cc/src/cc/MeterCC.ts
+++ b/packages/cc/src/cc/MeterCC.ts
@@ -70,6 +70,9 @@ export const MeterCCValues = Object.freeze({
 		...V.staticPropertyWithName("resetAll", "reset", {
 			...ValueMetadata.WriteOnlyBoolean,
 			label: `Reset accumulated values`,
+			states: {
+				true: "Reset",
+			},
 		} as const),
 	}),
 
@@ -86,6 +89,9 @@ export const MeterCCValues = Object.freeze({
 					// This is only a placeholder label. A config manager is needed to
 					// determine the actual label.
 					label: `Reset (${num2hex(meterType)})`,
+					states: {
+						true: "Reset",
+					},
 					ccSpecific: { meterType },
 				} as const),
 		),

--- a/packages/cc/src/cc/MultilevelSwitchCC.ts
+++ b/packages/cc/src/cc/MultilevelSwitchCC.ts
@@ -86,8 +86,11 @@ export const MultilevelSwitchCCValues = Object.freeze({
 
 		...V.staticProperty("restorePrevious", {
 			...ValueMetadata.WriteOnlyBoolean,
-			label: "Restore previous value" as const,
-		}),
+			label: "Restore previous value",
+			states: {
+				true: "Restore",
+			},
+		} as const),
 
 		...V.staticPropertyWithName(
 			"compatEvent",
@@ -139,6 +142,10 @@ export const MultilevelSwitchCCValues = Object.freeze({
 					...ValueMetadata.WriteOnlyBoolean,
 					label: `Perform a level change (${up})`,
 					valueChangeOptions: ["transitionDuration"],
+					states: {
+						true: "Start",
+						false: "Stop",
+					},
 					ccSpecific: { switchType },
 				} as const;
 			},
@@ -169,6 +176,10 @@ export const MultilevelSwitchCCValues = Object.freeze({
 					...ValueMetadata.WriteOnlyBoolean,
 					label: `Perform a level change (${down})`,
 					valueChangeOptions: ["transitionDuration"],
+					states: {
+						true: "Start",
+						false: "Stop",
+					},
 					ccSpecific: { switchType },
 				} as const;
 			},

--- a/packages/cc/src/cc/WindowCoveringCC.ts
+++ b/packages/cc/src/cc/WindowCoveringCC.ts
@@ -204,6 +204,9 @@ export const WindowCoveringCCValues = Object.freeze({
 						WindowCoveringParameter,
 						parameter,
 					)}`,
+					states: {
+						true: "Open",
+					},
 					ccSpecific: {
 						parameter,
 					},
@@ -227,6 +230,9 @@ export const WindowCoveringCCValues = Object.freeze({
 						WindowCoveringParameter,
 						parameter,
 					)}`,
+					states: {
+						true: "Close",
+					},
 					ccSpecific: {
 						parameter,
 					},
@@ -259,6 +265,9 @@ export const WindowCoveringCCValues = Object.freeze({
 						WindowCoveringParameter,
 						parameter,
 					)}`,
+					states: {
+						true: "Close",
+					},
 					ccSpecific: {
 						parameter,
 					},
@@ -291,6 +300,9 @@ export const WindowCoveringCCValues = Object.freeze({
 						WindowCoveringParameter,
 						parameter,
 					)}`,
+					states: {
+						true: "Close",
+					},
 					ccSpecific: {
 						parameter,
 					},

--- a/packages/core/api.md
+++ b/packages/core/api.md
@@ -2891,6 +2891,10 @@ export interface ValueMetadataAny {
 // @public (undocumented)
 export interface ValueMetadataBoolean extends ValueMetadataAny {
     default?: number;
+    states?: {
+        true?: string;
+        false?: string;
+    };
     // (undocumented)
     type: "boolean";
 }

--- a/packages/core/src/values/Metadata.ts
+++ b/packages/core/src/values/Metadata.ts
@@ -107,6 +107,11 @@ export interface ValueMetadataBoolean extends ValueMetadataAny {
 	type: "boolean";
 	/** The default value */
 	default?: number;
+	/** Possible values and their meaning */
+	states?: {
+		true?: string;
+		false?: string;
+	};
 }
 
 const defineBoolean = define<ValueMetadataBoolean>();


### PR DESCRIPTION
Until now, some writeonly `boolean` values would only accept `true` (e.g. reset meters), whereas others (start/stop level change) would accept `true` and `false`. To make this more apparent, this PR adds a `states` property to `boolean` metadata.

```ts
	/** Possible values and their meaning */
	states?: {
		true?: string;
		false?: string;
	};
```

This field is optional.
If it is missing, both `true` and `false` are possible values, but without special meaning
If it exists, it defines which values are accepted, and assigns them a label/meaning. For example
```ts
states: {
  true: "Reset"
}
```
means the value will **only** accept `true` as a value. The corresponding button should have the label "Reset".

```ts
states: {
  true: "Start",
  false: "Stop"
}
```
means both `true` and `false` are accepted, where setting `true` will start a process and `false` will stop it again. The corresponding buttons should have the labels "Start" and "Stop", respectively.

fixes: #5750