### PR TITLE
fix(config): add another device ID for Switch IO On/Off Power Switch

### DIFF
--- a/packages/config/config/devices/0x0267/10002034-13x.json
+++ b/packages/config/config/devices/0x0267/10002034-13x.json
@@ -19,6 +19,10 @@
 		{
 			"productType": "0x0001",
 			"productId": "0x0477"
+		},
+		{
+			"productType": "0x0001",
+			"productId": "0x00f5"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
A new identifier for Switch IO On/Off Power Switch