### PR TITLE
fix: make `Driver` and `ZWave[Application]Host` interfaces compatible for external projects

### DIFF
--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -23,6 +23,7 @@ import { Comparable } from 'alcalzone-shared/comparable';
 import { CompareResult } from 'alcalzone-shared/comparable';
 import { ConfigManager } from '@zwave-js/config';
 import { ControllerLogContext } from '@zwave-js/core';
+import { ControllerLogger } from '@zwave-js/core';
 import { ControllerNodeLogContext } from '@zwave-js/core';
 import { ControllerSelfLogContext } from '@zwave-js/core';
 import { ControllerValueLogContext } from '@zwave-js/core';
@@ -31,7 +32,7 @@ import { DataRate } from '@zwave-js/core/safe';
 import { DataRate as DataRate_2 } from '@zwave-js/core';
 import { DeepPartial } from '@zwave-js/shared';
 import type { DeferredPromise } from 'alcalzone-shared/deferred-promise';
-import type { DeviceConfig } from '@zwave-js/config';
+import { DeviceConfig } from '@zwave-js/config';
 import { Duration } from '@zwave-js/core/safe';
 import { DurationUnit } from '@zwave-js/core/safe';
 import { EntryControlDataTypes } from '@zwave-js/cc/safe';
@@ -81,6 +82,7 @@ import { MulticastDestination } from '@zwave-js/core/safe';
 import { MultilevelSwitchCommand } from '@zwave-js/cc/safe';
 import { NODE_ID_BROADCAST } from '@zwave-js/core/safe';
 import { NODE_ID_MAX } from '@zwave-js/core/safe';
+import type { NodeSchedulePollOptions } from '@zwave-js/host';
 import { NodeStatus } from '@zwave-js/core/safe';
 import { NodeType } from '@zwave-js/core/safe';
 import { NodeType as NodeType_2 } from '@zwave-js/core';
@@ -115,6 +117,8 @@ import { Scale } from '@zwave-js/config';
 import type { SecurityClass } from '@zwave-js/core/safe';
 import { SecurityClass as SecurityClass_2 } from '@zwave-js/core';
 import { SecurityClassOwner } from '@zwave-js/core';
+import { SecurityManager } from '@zwave-js/core';
+import { SecurityManager2 } from '@zwave-js/core';
 import { SendCommandOptions } from '@zwave-js/core';
 import { SendCommandReturnType } from '@zwave-js/core';
 import { SendMessageOptions } from '@zwave-js/core';
@@ -287,6 +291,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> implements Z
     // (undocumented)
     get configVersion(): string;
     get controller(): ZWaveController;
+    get controllerLog(): ControllerLogger;
     // Warning: (ae-forgotten-export) The symbol "SendDataMessage" needs to be exported by the entry point index.d.ts
     createSendDataMessage(command: CommandClass, options?: Omit<SendCommandOptions, keyof SendMessageOptions>): SendDataMessage;
     destroy(): Promise<void>;
@@ -296,6 +301,10 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> implements Z
     enableStatistics(appInfo: Pick<AppInfo, "applicationName" | "applicationVersion">): void;
     static enumerateSerialPorts(): Promise<string[]>;
     getConservativeWaitTimeAfterFirmwareUpdate(advertisedWaitTime: number | undefined): number;
+    // (undocumented)
+    getDeviceConfig(nodeId: number): DeviceConfig | undefined;
+    // (undocumented)
+    getHighestSecurityClass(nodeId: number): SecurityClass_2 | undefined;
     getLogConfig(): LogConfig;
     readonly getNextCallbackId: () => number;
     readonly getNextSupervisionSessionId: () => number;
@@ -316,16 +325,25 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> implements Z
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     getSupportedCCVersionForEndpoint(cc: CommandClasses_2, nodeId: number, endpointIndex?: number): number;
     getUserAgentStringWithComponents(components?: Record<string, string | null | undefined>): string;
+    getValueDB(nodeId: number): ValueDB;
     hardReset(): Promise<void>;
     // Warning: (ae-forgotten-export) The symbol "Transaction" needs to be exported by the entry point index.d.ts
     hasPendingTransactions(predicate: (t: Transaction) => boolean): boolean;
+    // (undocumented)
+    hasSecurityClass(nodeId: number, securityClass: SecurityClass_2): Maybe<boolean>;
+    get homeId(): number;
     installConfigUpdate(): Promise<boolean>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     isCCSecure(ccId: CommandClasses_2, nodeId: number, endpointIndex?: number): boolean;
+    isControllerNode(nodeId: number): boolean;
     // (undocumented)
     isInBootloader(): boolean;
+    get nodes(): ReadonlyThrowingMap<number, ZWaveNode>;
+    // (undocumented)
+    get options(): Readonly<ZWaveOptions>;
+    get ownNodeId(): number;
     get ready(): boolean;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     registerCommandHandler<T extends ICommandClass>(predicate: (cc: ICommandClass) => boolean, handler: (cc: T) => void): {
@@ -337,6 +355,9 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> implements Z
     // Warning: (ae-forgotten-export) The symbol "RequestHandler" needs to be exported by the entry point index.d.ts
     registerRequestHandler<T extends Message>(fnType: FunctionType, handler: RequestHandler<T>, oneTime?: boolean): void;
     restoreNetworkStructureFromCache(): Promise<void>;
+    schedulePoll(nodeId: number, valueId: ValueID_2, options: NodeSchedulePollOptions): boolean;
+    get securityManager(): SecurityManager | undefined;
+    get securityManager2(): SecurityManager2 | undefined;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "zwave-js" does not have an export "SupervisionResult"
@@ -346,12 +367,14 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> implements Z
     sendMessage<TResponse extends Message = Message>(msg: Message, options?: SendMessageOptions): Promise<TResponse>;
     get sendThreadIdle(): boolean;
     setPreferredScales(scales: ZWaveOptions["preferences"]["scales"]): void;
+    setSecurityClass(nodeId: number, securityClass: SecurityClass_2, granted: boolean): void;
     shutdown(): Promise<boolean>;
     softReset(): Promise<void>;
     start(): Promise<void>;
     get statisticsEnabled(): boolean;
     // (undocumented)
     tryGetEndpoint(cc: CommandClass): Endpoint | undefined;
+    tryGetValueDB(nodeId: number): ValueDB | undefined;
     trySoftReset(): Promise<void>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
@@ -1607,6 +1630,8 @@ export interface ZWaveOptions extends ZWaveHostOptions {
         sendDataCallback: number;
         report: number;
         nonce: number;
+        refreshValue: number;
+        refreshValueAfterTransition: number;
         serialAPIStarted: number;
     };
     userAgent?: Record<string, string>;

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -440,9 +440,9 @@ export class Driver
 		}
 
 		// merge given options with defaults
-		this.options = mergeDeep(options, defaultOptions) as ZWaveOptions;
+		this._options = mergeDeep(options, defaultOptions) as ZWaveOptions;
 		// And make sure they contain valid values
-		checkOptions(this.options);
+		checkOptions(this._options);
 		if (options?.userAgent) {
 			if (!isObject(options.userAgent)) {
 				throw new ZWaveError(
@@ -455,18 +455,18 @@ export class Driver
 		}
 
 		// Initialize logging
-		this._logContainer = new ZWaveLogContainer(this.options.logConfig);
+		this._logContainer = new ZWaveLogContainer(this._options.logConfig);
 		this._driverLog = new DriverLogger(this, this._logContainer);
 		this._controllerLog = new ControllerLogger(this._logContainer);
 
 		// Initialize the cache
-		this.cacheDir = this.options.storage.cacheDir;
+		this.cacheDir = this._options.storage.cacheDir;
 
 		// Initialize config manager
 		this.configManager = new ConfigManager({
 			logContainer: this._logContainer,
 			deviceConfigPriorityDir:
-				this.options.storage.deviceConfigPriorityDir,
+				this._options.storage.deviceConfigPriorityDir,
 		});
 
 		// And initialize but don't start the send thread machine
@@ -584,7 +584,7 @@ export class Driver
 				log: this.driverLog.print.bind(this.driverLog),
 				logQueue: this.driverLog.sendQueue.bind(this.driverLog),
 			},
-			pick(this.options, ["timeouts", "attempts"]),
+			pick(this._options, ["timeouts", "attempts"]),
 		);
 		this.sendThread = interpret(sendThreadMachine);
 		this._sendThreadIdle = false;
@@ -698,7 +698,11 @@ export class Driver
 	}
 
 	private _controllerLog: ControllerLogger;
-	/** @internal */
+	/**
+	 * **!!! INTERNAL !!!**
+	 *
+	 * Not intended to be used by applications
+	 */
 	public get controllerLog(): ControllerLogger {
 		return this._controllerLog;
 	}
@@ -733,29 +737,52 @@ export class Driver
 	}
 
 	private _securityManager: SecurityManager | undefined;
-	/** @internal */
+	/**
+	 * **!!! INTERNAL !!!**
+	 *
+	 * Not intended to be used by applications
+	 */
 	public get securityManager(): SecurityManager | undefined {
 		return this._securityManager;
 	}
 
 	private _securityManager2: SecurityManager2 | undefined;
-	/** @internal */
+	/**
+	 * **!!! INTERNAL !!!**
+	 *
+	 * Not intended to be used by applications
+	 */
 	public get securityManager2(): SecurityManager2 | undefined {
 		return this._securityManager2;
 	}
 
-	/** @internal This is needed for the ZWaveHost interface */
+	/**
+	 * **!!! INTERNAL !!!**
+	 *
+	 * Not intended to be used by applications. Use `controller.homeId` instead!
+	 */
 	public get homeId(): number {
+		// This is needed for the ZWaveHost interface
 		return this.controller.homeId!;
 	}
 
-	/** @internal This is needed for the ZWaveHost interface */
+	/**
+	 * **!!! INTERNAL !!!**
+	 *
+	 * Not intended to be used by applications. Use `controller.ownNodeId` instead!
+	 */
 	public get ownNodeId(): number {
+		// This is needed for the ZWaveHost interface
 		return this.controller.ownNodeId!;
 	}
 
-	/** @internal This is needed for the ZWaveHost interface */
+	/**
+	 * **!!! INTERNAL !!!**
+	 *
+	 * Not intended to be used by applications. Use `controller.nodes` instead!
+	 */
 	public get nodes(): ReadonlyThrowingMap<number, ZWaveNode> {
+		// This is needed for the ZWaveHost interface
 		return this.controller.nodes;
 	}
 
@@ -772,50 +799,70 @@ export class Driver
 		}
 	}
 
-	/** @internal This is needed for the ZWaveHost interface */
+	/**
+	 * **!!! INTERNAL !!!**
+	 *
+	 * Not intended to be used by applications
+	 */
 	public getValueDB(nodeId: number): ValueDB {
+		// This is needed for the ZWaveHost interface
 		const node = this.controller.nodes.getOrThrow(nodeId);
 		return node.valueDB;
 	}
 
-	/** @internal This is needed for the ZWaveHost interface */
+	/**
+	 * **!!! INTERNAL !!!**
+	 *
+	 * Not intended to be used by applications
+	 */
 	public tryGetValueDB(nodeId: number): ValueDB | undefined {
+		// This is needed for the ZWaveHost interface
 		const node = this.controller.nodes.get(nodeId);
 		return node?.valueDB;
 	}
 
-	/** @internal This is needed for the ZWaveHost interface */
 	public getDeviceConfig(nodeId: number): DeviceConfig | undefined {
+		// This is needed for the ZWaveHost interface
 		return this.controller.nodes.get(nodeId)?.deviceConfig;
 	}
 
-	/** @internal This is needed for the ZWaveHost interface */
 	public getHighestSecurityClass(nodeId: number): SecurityClass | undefined {
+		// This is needed for the ZWaveHost interface
 		const node = this.controller.nodes.getOrThrow(nodeId);
 		return node.getHighestSecurityClass();
 	}
 
-	/** @internal This is needed for the ZWaveHost interface */
 	public hasSecurityClass(
 		nodeId: number,
 		securityClass: SecurityClass,
 	): Maybe<boolean> {
+		// This is needed for the ZWaveHost interface
 		const node = this.controller.nodes.getOrThrow(nodeId);
 		return node.hasSecurityClass(securityClass);
 	}
 
-	/** @internal This is needed for the ZWaveHost interface */
+	/**
+	 * **!!! INTERNAL !!!**
+	 *
+	 * Not intended to be used by applications
+	 */
 	public setSecurityClass(
 		nodeId: number,
 		securityClass: SecurityClass,
 		granted: boolean,
 	): void {
+		// This is needed for the ZWaveHost interface
 		const node = this.controller.nodes.getOrThrow(nodeId);
 		node.setSecurityClass(securityClass, granted);
 	}
 
-	/** @internal This is needed for the ZWaveHost interface */
+	/**
+	 * **!!! INTERNAL !!!**
+	 *
+	 * Not intended to be used by applications. Use `node.isControllerNode` instead!
+	 */
 	public isControllerNode(nodeId: number): boolean {
+		// This is needed for the ZWaveHost interface
 		return nodeId === this.ownNodeId;
 	}
 
@@ -833,7 +880,7 @@ export class Driver
 	public setPreferredScales(
 		scales: ZWaveOptions["preferences"]["scales"],
 	): void {
-		this.options.preferences.scales = mergeDeep(
+		this._options.preferences.scales = mergeDeep(
 			defaultOptions.preferences.scales,
 			scales,
 		);
@@ -861,7 +908,7 @@ export class Driver
 		// Create a new deep-merged copy of the options so we can check them for validity
 		// without affecting our own options
 		const newOptions = mergeDeep(
-			cloneDeep(this.options),
+			cloneDeep(this._options),
 			safeOptions,
 			true,
 		) as ZWaveOptions;
@@ -875,7 +922,7 @@ export class Driver
 		}
 
 		// All good, update the options
-		this.options = newOptions;
+		this._options = newOptions;
 
 		if (options.logConfig) {
 			this.updateLogConfig(options.logConfig);
@@ -886,8 +933,10 @@ export class Driver
 		}
 	}
 
-	/** @internal */
-	public options: ZWaveOptions;
+	private _options: ZWaveOptions;
+	public get options(): Readonly<ZWaveOptions> {
+		return this._options;
+	}
 
 	private _wasStarted: boolean = false;
 	private _isOpen: boolean = false;
@@ -906,7 +955,7 @@ export class Driver
 
 		// Enforce that an error handler is attached, except for testing with a mocked serialport
 		if (
-			!this.options.testingHooks &&
+			!this._options.testingHooks &&
 			(this as unknown as EventEmitter).listenerCount("error") === 0
 		) {
 			throw new ZWaveError(
@@ -942,7 +991,7 @@ export class Driver
 				this.serial = new ZWaveSerialPort(
 					this.port,
 					this._logContainer,
-					this.options.testingHooks?.serialPortBinding,
+					this._options.testingHooks?.serialPortBinding,
 				);
 			}
 		} else {
@@ -998,10 +1047,10 @@ export class Driver
 			spOpenPromise.resolve();
 
 			if (
-				typeof this.options.testingHooks?.onSerialPortOpen ===
+				typeof this._options.testingHooks?.onSerialPortOpen ===
 				"function"
 			) {
-				await this.options.testingHooks.onSerialPortOpen(this.serial!);
+				await this._options.testingHooks.onSerialPortOpen(this.serial!);
 			}
 
 			// Perform initialization sequence
@@ -1010,7 +1059,7 @@ export class Driver
 			// to handle sticks that don't support the soft reset command. Therefore we do it
 			// after opening the value DBs
 
-			if (!this.options.testingHooks?.skipBootloaderCheck) {
+			if (!this._options.testingHooks?.skipBootloaderCheck) {
 				// After an incomplete firmware upgrade, we might be stuck in the bootloader
 				// Therefore wait a short amount of time to see if the serialport detects bootloader mode.
 				// If we are, the bootloader will reply with its menu.
@@ -1025,7 +1074,7 @@ export class Driver
 					// Wait a short time again. If we're in bootloader mode again, we're stuck
 					await wait(1000);
 					if (this._bootloader) {
-						if (this.options.allowBootloaderOnly) {
+						if (this._options.allowBootloaderOnly) {
 							this.driverLog.print(
 								"Failed to recover from bootloader. Staying in bootloader mode as requested.",
 								"warn",
@@ -1054,7 +1103,7 @@ export class Driver
 
 			// Try to create the cache directory. This can fail, in which case we should expose a good error message
 			try {
-				await this.options.storage.driver.ensureDir(this.cacheDir);
+				await this._options.storage.driver.ensureDir(this.cacheDir);
 			} catch (e) {
 				let message: string;
 				if (
@@ -1076,7 +1125,7 @@ export class Driver
 			}
 
 			// Load the necessary configuration
-			if (this.options.testingHooks?.loadConfiguration !== false) {
+			if (this._options.testingHooks?.loadConfiguration !== false) {
 				this.driverLog.print("loading configuration...");
 				try {
 					await this.configManager.loadAll();
@@ -1132,7 +1181,7 @@ export class Driver
 		// After a reset, the serial port may need a few seconds until we can open it - try a few times
 		for (
 			let attempt = 1;
-			attempt <= this.options.attempts.openSerialPort;
+			attempt <= this._options.attempts.openSerialPort;
 			attempt++
 		) {
 			try {
@@ -1141,7 +1190,7 @@ export class Driver
 			} catch (e) {
 				lastError = e;
 			}
-			if (attempt < this.options.attempts.openSerialPort) {
+			if (attempt < this._options.attempts.openSerialPort) {
 				await wait(1000);
 			}
 		}
@@ -1162,11 +1211,11 @@ export class Driver
 	private getJsonlDBOptions(): JsonlDBOptions<any> {
 		const options: JsonlDBOptions<any> = {
 			ignoreReadErrors: true,
-			...throttlePresets[this.options.storage.throttle],
+			...throttlePresets[this._options.storage.throttle],
 		};
-		if (this.options.storage.lockDir) {
+		if (this._options.storage.lockDir) {
 			options.lockfile = {
-				directory: this.options.storage.lockDir,
+				directory: this._options.storage.lockDir,
 			};
 		}
 		return options;
@@ -1247,7 +1296,7 @@ export class Driver
 					this.controller.homeId,
 					this._networkCache,
 					this._valueDB,
-					this.options.storage.driver,
+					this._options.storage.driver,
 					this.cacheDir,
 				);
 
@@ -1281,7 +1330,7 @@ export class Driver
 				.on("node removed", this.onNodeRemoved.bind(this));
 		}
 
-		if (!this.options.testingHooks?.skipControllerIdentification) {
+		if (!this._options.testingHooks?.skipControllerIdentification) {
 			// Determine controller IDs to open the Value DBs
 			// We need to do this first because some older controllers, especially the UZB1 and
 			// some 500-series sticks in virtualized environments don't respond after a soft reset
@@ -1293,15 +1342,15 @@ export class Driver
 			await this.controller.identify();
 			await this.initNetworkCache(this.controller.homeId!);
 
-			if (this.options.enableSoftReset && !this.maySoftReset()) {
+			if (this._options.enableSoftReset && !this.maySoftReset()) {
 				this.driverLog.print(
 					`Soft reset is enabled through config, but this stick does not support it.`,
 					"warn",
 				);
-				this.options.enableSoftReset = false;
+				this._options.enableSoftReset = false;
 			}
 
-			if (this.options.enableSoftReset) {
+			if (this._options.enableSoftReset) {
 				try {
 					await this.softResetInternal(false);
 				} catch (e) {
@@ -1326,7 +1375,7 @@ export class Driver
 			// which isn't valid. In this case try again after having soft-reset the stick
 			if (
 				this.controller.ownNodeId === 0 &&
-				this.options.enableSoftReset
+				this._options.enableSoftReset
 			) {
 				this.driverLog.print(
 					`Controller identification returned invalid node ID 0 - trying again...`,
@@ -1365,7 +1414,7 @@ export class Driver
 
 		// Set up the S0 security manager. We can only do that after the controller
 		// interview because we need to know the controller node id.
-		const S0Key = this.options.securityKeys?.S0_Legacy;
+		const S0Key = this._options.securityKeys?.S0_Legacy;
 		if (S0Key) {
 			this.driverLog.print(
 				"Network key for S0 configured, enabling S0 security manager...",
@@ -1373,7 +1422,7 @@ export class Driver
 			this._securityManager = new SecurityManager({
 				networkKey: S0Key,
 				ownNodeId: this._controller.ownNodeId!,
-				nonceTimeout: this.options.timeouts.nonce,
+				nonceTimeout: this._options.timeouts.nonce,
 			});
 		} else {
 			this.driverLog.print(
@@ -1384,9 +1433,9 @@ export class Driver
 
 		// The S2 security manager could be initialized earlier, but we do it here for consistency
 		if (
-			this.options.securityKeys &&
+			this._options.securityKeys &&
 			// Only set it up if we have security keys for at least one S2 security class
-			Object.keys(this.options.securityKeys).some(
+			Object.keys(this._options.securityKeys).some(
 				(key) =>
 					key.startsWith("S2_") &&
 					key in SecurityClass &&
@@ -1404,7 +1453,7 @@ export class Driver
 				"S2_AccessControl",
 				"S0_Legacy",
 			] as const) {
-				const key = this.options.securityKeys[secClass];
+				const key = this._options.securityKeys[secClass];
 				if (key) {
 					this._securityManager2.setKey(SecurityClass[secClass], key);
 				}
@@ -1429,7 +1478,7 @@ export class Driver
 		this._nodesReady.clear();
 		this._nodesReadyEventEmitted = false;
 
-		if (!this.options.testingHooks?.skipNodeInterview) {
+		if (!this._options.testingHooks?.skipNodeInterview) {
 			// Now interview all nodes
 			// First complete the controller interview
 			const controllerNode = this._controller.nodes.get(
@@ -1511,7 +1560,7 @@ export class Driver
 			ZWaveErrorCodes.Controller_InterviewRestarted,
 		);
 
-		const maxInterviewAttempts = this.options.attempts.nodeInterview;
+		const maxInterviewAttempts = this._options.attempts.nodeInterview;
 
 		try {
 			if (!(await node.interviewInternal())) {
@@ -1968,8 +2017,8 @@ export class Driver
 	private onNodeAdded(node: ZWaveNode): void {
 		this.addNodeEventHandlers(node);
 
-		if (this.options.interview?.disableOnNodeAdded) return;
-		if (this.options.testingHooks?.skipNodeInterview) return;
+		if (this._options.interview?.disableOnNodeAdded) return;
+		if (this._options.testingHooks?.skipNodeInterview) return;
 
 		// Interview the node
 		// don't await the interview, because it may take a very long time
@@ -2315,12 +2364,17 @@ export class Driver
 		return false;
 	}
 
-	/** @internal Required for ZWaveApplicationHost */
+	/**
+	 * **!!! INTERNAL !!!**
+	 *
+	 * Not intended to be used by applications
+	 */
 	public schedulePoll(
 		nodeId: number,
 		valueId: ValueID,
 		options: NodeSchedulePollOptions,
 	): boolean {
+		// Needed for ZWaveApplicationHost
 		const node = this.controller.nodes.getOrThrow(nodeId);
 		return node.schedulePoll(valueId, options);
 	}
@@ -2372,7 +2426,7 @@ export class Driver
 	 * Soft-resets the controller if the feature is enabled
 	 */
 	public async trySoftReset(): Promise<void> {
-		if (this.options.enableSoftReset && this.maySoftReset()) {
+		if (this._options.enableSoftReset && this.maySoftReset()) {
 			await this.softReset();
 		} else {
 			const message = `The soft reset feature is not enabled, skipping API call.`;
@@ -2388,7 +2442,7 @@ export class Driver
 	 * **Warning:** This call will throw if soft-reset is not enabled.
 	 */
 	public async softReset(): Promise<void> {
-		if (!this.options.enableSoftReset) {
+		if (!this._options.enableSoftReset) {
 			const message = `The soft reset feature has been disabled with a config option or the ZWAVEJS_DISABLE_SOFT_RESET environment variable.`;
 			this.controllerLog.print(message, "error");
 			throw new ZWaveError(
@@ -2515,7 +2569,7 @@ export class Driver
 			(msg) => {
 				return msg.functionType === FunctionType.SerialAPIStarted;
 			},
-			this.options.timeouts.serialAPIStarted,
+			this._options.timeouts.serialAPIStarted,
 		).catch(() => false as const);
 
 		if (waitResult) {
@@ -4372,12 +4426,12 @@ ${handlers.length} left`,
 				// Prioritize Bridge commands when they are supported
 				msg = new SendDataBridgeRequest(this, {
 					command,
-					maxSendAttempts: this.options.attempts.sendData,
+					maxSendAttempts: this._options.attempts.sendData,
 				});
 			} else {
 				msg = new SendDataRequest(this, {
 					command,
-					maxSendAttempts: this.options.attempts.sendData,
+					maxSendAttempts: this._options.attempts.sendData,
 				});
 			}
 		} else if (command.isMulticast()) {
@@ -4389,12 +4443,12 @@ ${handlers.length} left`,
 				// Prioritize Bridge commands when they are supported
 				msg = new SendDataMulticastBridgeRequest(this, {
 					command,
-					maxSendAttempts: this.options.attempts.sendData,
+					maxSendAttempts: this._options.attempts.sendData,
 				});
 			} else {
 				msg = new SendDataMulticastRequest(this, {
 					command,
-					maxSendAttempts: this.options.attempts.sendData,
+					maxSendAttempts: this._options.attempts.sendData,
 				});
 			}
 		} else {
@@ -4953,7 +5007,7 @@ ${handlers.length} left`,
 		// otherwise use the driver option
 		return (
 			node?.deviceConfig?.compat?.reportTimeout ??
-			this.options.timeouts.report
+			this._options.timeouts.report
 		);
 	}
 
@@ -5035,7 +5089,7 @@ ${handlers.length} left`,
 			if (this.configManager.useExternalConfig && extConfigDir) {
 				// 1. external config dir, leave node_modules alone
 				await installConfigUpdateInDocker(newVersion, {
-					cacheDir: this.options.storage.cacheDir,
+					cacheDir: this._options.storage.cacheDir,
 					configDir: extConfigDir,
 				});
 			} else if (isDocker()) {

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -29,13 +29,19 @@ export interface ZWaveOptions extends ZWaveHostOptions {
 		nonce: number; // [3000...20000], default: 5000 ms
 
 		/**
-		 * @internal
+		 * **!!! INTERNAL !!!**
+		 *
+		 * Not intended to be used by applications
+		 *
 		 * How long to wait for a poll after setting a value without transition duration
 		 */
 		refreshValue: number;
 
 		/**
-		 * @internal
+		 * **!!! INTERNAL !!!**
+		 *
+		 * Not intended to be used by applications
+		 *
 		 * How long to wait for a poll after setting a value with transition duration. This doubles as the "fast" delay.
 		 */
 		refreshValueAfterTransition: number;


### PR DESCRIPTION
This PR exposes some previously `@internal` properties on the driver. Most of those are NOT meant to be public nor are they meant to be used by applications. However they need to be visible so TypeScript does not complain when a driver instance is passed to a method that accepts a host interface.

fixes: #5602