### PR TITLE
feat: add `allowManualEntry` property to numeric metadata to indicate whether `states` are only informational

### DIFF
--- a/packages/core/api.md
+++ b/packages/core/api.md
@@ -2929,6 +2929,7 @@ export interface ValueMetadataDuration extends ValueMetadataAny {
 //
 // @public (undocumented)
 export interface ValueMetadataNumeric extends ValueMetadataAny {
+    allowManualEntry?: boolean;
     default?: number;
     max?: number;
     min?: number;

--- a/packages/core/src/values/Metadata.ts
+++ b/packages/core/src/values/Metadata.ts
@@ -97,6 +97,13 @@ export interface ValueMetadataNumeric extends ValueMetadataAny {
 	default?: number;
 	/** Speaking names for numeric values */
 	states?: Record<number, string>;
+	/**
+	 * Whether a user should be able to manually enter all legal values in the range `min...max` (`true`),
+	 * or if only the ones defined in `states` should be selectable in a dropdown (`false`).
+	 *
+	 * If missing, applications should assume this to be `true` if no `states` are defined and `false` if `states` are defined.
+	 */
+	allowManualEntry?: boolean;
 	/** An optional unit for numeric values */
 	unit?: string;
 }


### PR DESCRIPTION
Some numeric metadata can benefit from having named `states`, but if they are supposed to be writable, we need a way to indicate whether the `states` are simply informational or limit what the user can enter.
We copy this attribute from configuration metadata which shares the same logic.