### PR TITLE
feat(cc): influence the `setValue` implementation of CC APIs using hooks

### DIFF
--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -2510,6 +2510,8 @@ export class CCAPI {
     protected [POLL_VALUE]: PollValueImplementation | undefined;
     // (undocumented)
     protected [SET_VALUE]: SetValueImplementation | undefined;
+    // (undocumented)
+    protected [SET_VALUE_HOOKS]: SetValueImplementationHooksFactory | undefined;
     constructor(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint | IVirtualEndpoint);
     // (undocumented)
     protected readonly applHost: ZWaveApplicationHost;
@@ -2544,8 +2546,9 @@ export class CCAPI {
     };
     isSupported(): boolean;
     get pollValue(): PollValueImplementation | undefined;
-    protected schedulePoll(property: ValueIDProperties, expectedValue: unknown, { duration, transition }?: SchedulePollOptions): boolean;
+    protected schedulePoll({ property, propertyKey }: ValueIDProperties, expectedValue: unknown, { duration, transition }?: SchedulePollOptions): boolean;
     get setValue(): SetValueImplementation | undefined;
+    get setValueHooks(): SetValueImplementationHooksFactory | undefined;
     supportsCommand(command: number): Maybe_2<boolean>;
     protected tryGetValueDB(): ValueDB | undefined;
     get version(): number;
@@ -14540,6 +14543,11 @@ export enum SecurityCommand {
 // @public
 export const SET_VALUE: unique symbol;
 
+// Warning: (ae-missing-release-tag) "SET_VALUE_HOOKS" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const SET_VALUE_HOOKS: unique symbol;
+
 // Warning: (ae-missing-release-tag) "SetbackSpecialState" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -14572,6 +14580,24 @@ export type SetValueAPIOptions = Partial<ValueChangeOptions>;
 //
 // @public (undocumented)
 export type SetValueImplementation = (property: ValueIDProperties, value: unknown, options?: SetValueAPIOptions) => Promise<SupervisionResult_2 | undefined>;
+
+// Warning: (ae-missing-release-tag) "SetValueImplementationHooks" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type SetValueImplementationHooks = AllOrNone_2<{
+    supervisionDelayedUpdates: boolean;
+    supervisionOnSuccess: () => void | Promise<void>;
+    supervisionOnFailure: () => void | Promise<void>;
+}> & {
+    optimisticallyUpdateRelatedValues?: () => void;
+    forceVerifyChanges?: () => boolean;
+    verifyChanges?: () => void | Promise<void>;
+};
+
+// Warning: (ae-missing-release-tag) "SetValueImplementationHooksFactory" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type SetValueImplementationHooksFactory = (property: ValueIDProperties, value: unknown, options?: SetValueAPIOptions) => SetValueImplementationHooks | undefined;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
 // Warning: (ae-missing-release-tag) "shouldUseSupervision" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/cc/src/cc/BasicCC.ts
+++ b/packages/cc/src/cc/BasicCC.ts
@@ -179,7 +179,7 @@ export class BasicCCAPI extends CCAPI {
 					) {
 						// We query currentValue instead of targetValue to make sure that unsolicited updates cancel the scheduled poll
 						(this as this).schedulePoll(
-							{ property: "currentValue" },
+							currentValueValueId,
 							value === 255 ? undefined : value,
 						);
 					}

--- a/packages/cc/src/cc/BinarySwitchCC.ts
+++ b/packages/cc/src/cc/BinarySwitchCC.ts
@@ -153,13 +153,11 @@ export class BinarySwitchCCAPI extends CCAPI {
 		options,
 	) => {
 		if (property === "targetValue") {
+			const currentValueValueId =
+				BinarySwitchCCValues.currentValue.endpoint(this.endpoint.index);
+
 			return {
 				optimisticallyUpdateRelatedValues: () => {
-					const currentValueValueId =
-						BinarySwitchCCValues.currentValue.endpoint(
-							this.endpoint.index,
-						);
-
 					// After setting targetValue, optimistically update currentValue
 					if (this.isSinglecast()) {
 						this.tryGetValueDB()?.setValue(
@@ -186,7 +184,7 @@ export class BinarySwitchCCAPI extends CCAPI {
 				verifyChanges: () => {
 					if (this.isSinglecast()) {
 						// We query currentValue instead of targetValue to make sure that unsolicited updates cancel the scheduled poll
-						this.schedulePoll({ property: "currentValue" }, value, {
+						this.schedulePoll(currentValueValueId, value, {
 							duration: Duration.from(
 								options?.transitionDuration,
 							),

--- a/packages/cc/src/cc/BinarySwitchCC.ts
+++ b/packages/cc/src/cc/BinarySwitchCC.ts
@@ -199,8 +199,6 @@ export class BinarySwitchCCAPI extends CCAPI {
 				},
 			};
 		}
-
-		throwUnsupportedProperty(this.ccId, property);
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({

--- a/packages/cc/src/cc/MultilevelSwitchCC.ts
+++ b/packages/cc/src/cc/MultilevelSwitchCC.ts
@@ -443,7 +443,7 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 					) {
 						// We query currentValue instead of targetValue to make sure that unsolicited updates cancel the scheduled poll
 						(this as this).schedulePoll(
-							{ property: "currentValue" },
+							currentValueValueId,
 							value === 255 ? undefined : value,
 							{ duration },
 						);

--- a/packages/cc/src/cc/MultilevelSwitchCC.ts
+++ b/packages/cc/src/cc/MultilevelSwitchCC.ts
@@ -425,12 +425,7 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 							for (const node of affectedNodes) {
 								this.applHost
 									.tryGetValueDB(node.id)
-									?.setValue(
-										MultilevelSwitchCCValues.currentValue.endpoint(
-											this.endpoint.index,
-										),
-										value,
-									);
+									?.setValue(currentValueValueId, value);
 							}
 						}
 					}

--- a/packages/cc/src/cc/WindowCoveringCC.ts
+++ b/packages/cc/src/cc/WindowCoveringCC.ts
@@ -2,15 +2,12 @@ import {
 	CommandClasses,
 	Duration,
 	encodeBitMask,
-	isSupervisionResult,
 	Maybe,
 	MessageOrCCLogEntry,
 	MessagePriority,
 	MessageRecord,
 	parseBitMask,
-	supervisedCommandSucceeded,
 	SupervisionResult,
-	SupervisionStatus,
 	validatePayload,
 	ValueMetadata,
 	ZWaveError,
@@ -24,7 +21,9 @@ import {
 	PollValueImplementation,
 	POLL_VALUE,
 	SetValueImplementation,
+	SetValueImplementationHooksFactory,
 	SET_VALUE,
+	SET_VALUE_HOOKS,
 	throwMissingPropertyKey,
 	throwUnsupportedProperty,
 	throwUnsupportedPropertyKey,
@@ -280,61 +279,7 @@ export class WindowCoveringCCAPI extends CCAPI {
 			const parameter = propertyKey;
 			const duration = Duration.from(options?.transitionDuration);
 
-			const currentValueValueId = WindowCoveringCCValues.currentValue(
-				parameter,
-			).endpoint(this.endpoint.index);
-
-			// Window Covering commands may take some time to be executed.
-			// Therefore we try to supervise the command execution and delay the
-			// optimistic update until the final result is received.
-			const result = await this.withOptions({
-				requestStatusUpdates: true,
-				onUpdate: (update) => {
-					if (update.status === SupervisionStatus.Success) {
-						this.tryGetValueDB()?.setValue(
-							currentValueValueId,
-							value,
-						);
-					} else if (update.status === SupervisionStatus.Fail) {
-						// The transition failed, so now we don't know the status
-						// Refresh the current value
-
-						// eslint-disable-next-line @typescript-eslint/no-empty-function
-						void this.get(parameter).catch(() => {});
-					}
-				},
-			}).set([{ parameter, value }], duration);
-
-			// If the command did not fail, assume that it succeeded and update the currentValue accordingly
-			// so UIs have immediate feedback
-			const shouldUpdateOptimistically =
-				// For unsupervised commands, make the choice to update optimistically dependent on the driver options
-				(!this.applHost.options.disableOptimisticValueUpdate &&
-					result == undefined) ||
-				(isSupervisionResult(result) &&
-					result.status === SupervisionStatus.Success);
-
-			if (this.isSinglecast()) {
-				// Only update currentValue for valid target values
-				if (shouldUpdateOptimistically && value >= 0 && value <= 99) {
-					this.tryGetValueDB()?.setValue(currentValueValueId, value);
-				}
-
-				// Verify the current value after a delay, unless...
-				// ...the command was supervised and successful
-				// ...and we know the actual value
-				if (!supervisedCommandSucceeded(result)) {
-					this.schedulePoll(
-						{
-							property: currentValueValueId.property,
-							propertyKey: currentValueValueId.propertyKey,
-						},
-						value,
-						{ duration },
-					);
-				}
-			}
-			return result;
+			return this.set([{ parameter, value }], duration);
 		} else if (
 			WindowCoveringCCValues.levelChangeUp.is(valueId) ||
 			WindowCoveringCCValues.levelChangeDown.is(valueId)
@@ -362,6 +307,90 @@ export class WindowCoveringCCAPI extends CCAPI {
 			}
 		} else {
 			throwUnsupportedProperty(this.ccId, property);
+		}
+	};
+
+	protected [SET_VALUE_HOOKS]: SetValueImplementationHooksFactory = (
+		{ property, propertyKey },
+		value,
+		options,
+	) => {
+		const valueId = {
+			commandClass: this.ccId,
+			property,
+			propertyKey,
+		};
+
+		if (WindowCoveringCCValues.targetValue.is(valueId)) {
+			if (typeof propertyKey !== "number") return;
+			const parameter = propertyKey;
+
+			const duration = Duration.from(options?.transitionDuration);
+
+			const currentValueValueId = WindowCoveringCCValues.currentValue(
+				parameter,
+			).endpoint(this.endpoint.index);
+
+			return {
+				// Window Covering commands may take some time to be executed.
+				// Therefore we try to supervise the command execution and delay the
+				// optimistic update until the final result is received.
+
+				supervisionDelayedUpdates: true,
+				supervisionOnSuccess: () => {
+					this.tryGetValueDB()?.setValue(currentValueValueId, value);
+				},
+				supervisionOnFailure: async () => {
+					// The transition failed, so now we don't know the status - refresh the current value
+					try {
+						await this.get(parameter);
+					} catch {
+						// ignore
+					}
+				},
+
+				optimisticallyUpdateRelatedValues: () => {
+					// Only update currentValue for valid target values
+					if (
+						typeof value === "number" &&
+						value >= 0 &&
+						value <= 99
+					) {
+						if (this.isSinglecast()) {
+							this.tryGetValueDB()?.setValue(
+								currentValueValueId,
+								value,
+							);
+						} else if (this.isMulticast()) {
+							// Figure out which nodes were affected by this command
+							const affectedNodes =
+								this.endpoint.node.physicalNodes.filter(
+									(node) =>
+										node
+											.getEndpoint(this.endpoint.index)
+											?.supportsCC(this.ccId),
+								);
+							// and optimistically update the currentValue
+							for (const node of affectedNodes) {
+								this.applHost
+									.tryGetValueDB(node.id)
+									?.setValue(currentValueValueId, value);
+							}
+						}
+					}
+				},
+
+				verifyChanges: () => {
+					if (this.isSinglecast()) {
+						// We query currentValue instead of targetValue to make sure that unsolicited updates cancel the scheduled poll
+						this.schedulePoll(currentValueValueId, value, {
+							duration,
+						});
+					} else {
+						// For multicasts, do not schedule a refresh - this could cause a LOT of traffic
+					}
+				},
+			};
 		}
 	};
 

--- a/packages/cc/src/cc/WindowCoveringCC.ts
+++ b/packages/cc/src/cc/WindowCoveringCC.ts
@@ -335,7 +335,6 @@ export class WindowCoveringCCAPI extends CCAPI {
 				// Window Covering commands may take some time to be executed.
 				// Therefore we try to supervise the command execution and delay the
 				// optimistic update until the final result is received.
-
 				supervisionDelayedUpdates: true,
 				supervisionOnSuccess: () => {
 					this.tryGetValueDB()?.setValue(currentValueValueId, value);

--- a/packages/cc/src/lib/API.ts
+++ b/packages/cc/src/lib/API.ts
@@ -64,7 +64,7 @@ export type SetValueImplementationHooksFactory = (
 	property: ValueIDProperties,
 	value: unknown,
 	options?: SetValueAPIOptions,
-) => SetValueImplementationHooks;
+) => SetValueImplementationHooks | undefined;
 
 /**
  * A generic options bag for the `setValue` API.

--- a/packages/cc/src/lib/API.ts
+++ b/packages/cc/src/lib/API.ts
@@ -246,7 +246,7 @@ export class CCAPI {
 	 * @returns `true` if the poll was scheduled, `false` otherwise
 	 */
 	protected schedulePoll(
-		property: ValueIDProperties,
+		{ property, propertyKey }: ValueIDProperties,
 		expectedValue: unknown,
 		{ duration, transition = "slow" }: SchedulePollOptions = {},
 	): boolean {
@@ -268,7 +268,8 @@ export class CCAPI {
 				{
 					commandClass: this.ccId,
 					endpoint: this.endpoint.index,
-					...property,
+					property,
+					propertyKey,
 				},
 				{ timeoutMs, expectedValue },
 			);
@@ -287,7 +288,8 @@ export class CCAPI {
 					{
 						commandClass: this.ccId,
 						endpoint: this.endpoint.index,
-						...property,
+						property,
+						propertyKey,
 					},
 					{ timeoutMs, expectedValue },
 				);

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -30,6 +30,7 @@ import {
 	TimeCCTimeOffsetGet,
 	TimeCommand,
 	TimeParametersCommand,
+	ValueIDProperties,
 	ZWavePlusNodeType,
 	ZWavePlusRoleType,
 } from "@zwave-js/cc";
@@ -947,7 +948,7 @@ export class ZWaveNode
 			// Access the CC API by name
 			const endpointInstance = this.getEndpoint(valueId.endpoint || 0);
 			if (!endpointInstance) return false;
-			const api = (endpointInstance.commandClasses as any)[
+			let api = (endpointInstance.commandClasses as any)[
 				valueId.commandClass
 			] as CCAPI;
 			// Check if the setValue method is implemented
@@ -965,15 +966,34 @@ export class ZWaveNode
 				});
 			}
 
+			const valueIdProps: ValueIDProperties = {
+				property: valueId.property,
+				propertyKey: valueId.propertyKey,
+			};
+
+			const hooks = api.setValueHooks?.(valueIdProps, value, options);
+
+			if (hooks?.supervisionDelayedUpdates) {
+				api = api.withOptions({
+					requestStatusUpdates: true,
+					onUpdate: async (update) => {
+						try {
+							if (update.status === SupervisionStatus.Success) {
+								await hooks.supervisionOnSuccess();
+							} else if (
+								update.status === SupervisionStatus.Fail
+							) {
+								await hooks.supervisionOnFailure();
+							}
+						} catch {
+							// TODO: Log error?
+						}
+					},
+				});
+			}
+
 			// And call it
-			const result = await api.setValue(
-				{
-					property: valueId.property,
-					propertyKey: valueId.propertyKey,
-				},
-				value,
-				options,
-			);
+			const result = await api.setValue!(valueIdProps, value, options);
 
 			if (loglevel === "silly") {
 				let message = `[setValue] result of SET_VALUE API call for ${api.constructor.name}:`;
@@ -998,7 +1018,7 @@ export class ZWaveNode
 				});
 			}
 
-			// Remember the new value if...
+			// Remember the new value for the value we just set, if...
 			// ... the call did not throw (assume that the call was successful)
 			// ... the call was supervised and successful
 			if (
@@ -1037,6 +1057,37 @@ export class ZWaveNode
 					message: `[setValue] not updating value`,
 					level: "silly",
 				});
+			}
+
+			// Depending on the settings of the SET_VALUE implementation, we may have to
+			// optimistically update a different value and/or verify the changes
+			if (hooks) {
+				// If the command did not fail, assume that it succeeded and update the currentValue accordingly
+				// so UIs have immediate feedback
+				const shouldUpdateOptimistically =
+					api.isSetValueOptimistic(valueId) &&
+					// For unsupervised commands, make the choice to update optimistically dependent on the driver options
+					((!this.driver.options.disableOptimisticValueUpdate &&
+						result == undefined) ||
+						(isSupervisionResult(result) &&
+							result.status === SupervisionStatus.Success));
+
+				// Let the API implementation handle additional optimistic updates
+				if (shouldUpdateOptimistically) {
+					hooks.optimisticallyUpdateRelatedValues?.();
+				}
+
+				// Verify the current value after a delay, unless...
+				// ...the command was supervised and successful
+				// ...and the CC API decides not to verify anyways
+				if (
+					!supervisedCommandSucceeded(result) ||
+					hooks.forceVerifyChanges?.()
+				) {
+					// Let the CC API implementation handle the verification.
+					// It may still decide not to do it.
+					await hooks.verifyChanges?.();
+				}
 			}
 
 			return isUnsupervisedOrSucceeded(result);


### PR DESCRIPTION
Until now, handling Supervision results, optimistic updates and validating changes was very weaved into the `SET_VALUE` methods of individual CC APIs. While some of those are implementation specific, the general flow is always the same.

This PR splits up these things from the actual commands and makes it easier to define the desired behavior.

fixes: #5768