### PR TITLE
fix(cc): always include duration field in serialized buffer for CC versions that support it

### DIFF
--- a/packages/cc/src/cc/BinarySwitchCC.ts
+++ b/packages/cc/src/cc/BinarySwitchCC.ts
@@ -308,8 +308,8 @@ export class BinarySwitchCCSet extends BinarySwitchCC {
 
 	public serialize(): Buffer {
 		const payload: number[] = [this.targetValue ? 0xff : 0x00];
-		if (this.version >= 2 && this.duration) {
-			payload.push(this.duration.serializeSet());
+		if (this.version >= 2) {
+			payload.push((this.duration ?? Duration.default()).serializeSet());
 		}
 		this.payload = Buffer.from(payload);
 		return super.serialize();

--- a/packages/cc/src/cc/ColorSwitchCC.ts
+++ b/packages/cc/src/cc/ColorSwitchCC.ts
@@ -917,7 +917,7 @@ export class ColorSwitchCCSet extends ColorSwitchCC {
 		}
 		if (this.version >= 2) {
 			this.payload[i] = (
-				this.duration ?? Duration.from("default")
+				this.duration ?? Duration.default()
 			).serializeSet();
 		}
 		return super.serialize();
@@ -996,8 +996,8 @@ export class ColorSwitchCCStartLevelChange extends ColorSwitchCC {
 			(this.ignoreStartLevel ? 0b0010_0000 : 0);
 		const payload = [controlByte, this.colorComponent, this.startLevel];
 
-		if (this.version >= 3 && this.duration) {
-			payload.push(this.duration.serializeSet());
+		if (this.version >= 3) {
+			payload.push((this.duration ?? Duration.default()).serializeSet());
 		}
 		this.payload = Buffer.from(payload);
 		return super.serialize();

--- a/packages/cc/src/cc/MultilevelSwitchCC.ts
+++ b/packages/cc/src/cc/MultilevelSwitchCC.ts
@@ -597,8 +597,8 @@ export class MultilevelSwitchCCSet extends MultilevelSwitchCC {
 
 	public serialize(): Buffer {
 		const payload = [this.targetValue];
-		if (this.version >= 2 && this.duration) {
-			payload.push(this.duration.serializeSet());
+		if (this.version >= 2) {
+			payload.push((this.duration ?? Duration.default()).serializeSet());
 		}
 		this.payload = Buffer.from(payload);
 		return super.serialize();
@@ -732,8 +732,8 @@ export class MultilevelSwitchCCStartLevelChange extends MultilevelSwitchCC {
 			(LevelChangeDirection[this.direction] << 6) |
 			(this.ignoreStartLevel ? 0b0010_0000 : 0);
 		const payload = [controlByte, this.startLevel];
-		if (this.version >= 2 && this.duration) {
-			payload.push(this.duration.serializeSet());
+		if (this.version >= 2) {
+			payload.push((this.duration ?? Duration.default()).serializeSet());
 		}
 		this.payload = Buffer.from(payload);
 		return super.serialize();

--- a/packages/zwave-js/src/lib/test/cc/BinarySwitchCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/BinarySwitchCC.test.ts
@@ -35,6 +35,7 @@ test("the Set command (v1) should serialize correctly", (t) => {
 		nodeId: 2,
 		targetValue: false,
 	});
+	cc.version = 1;
 	const expected = buildCCBuffer(
 		Buffer.from([
 			BinarySwitchCommand.Set, // CC Command
@@ -51,6 +52,7 @@ test("the Set command (v2) should serialize correctly", (t) => {
 		targetValue: true,
 		duration,
 	});
+	cc.version = 2;
 	const expected = buildCCBuffer(
 		Buffer.from([
 			BinarySwitchCommand.Set, // CC Command

--- a/packages/zwave-js/src/lib/test/cc/MultilevelSwitchCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/MultilevelSwitchCC.test.ts
@@ -38,6 +38,7 @@ test("the Set command (V1) should serialize correctly", (t) => {
 		nodeId: 2,
 		targetValue: 55,
 	});
+	cc.version = 1;
 	const expected = buildCCBuffer(
 		Buffer.from([
 			MultilevelSwitchCommand.Set, // CC Command
@@ -53,6 +54,7 @@ test("the Set command (V2) should serialize correctly", (t) => {
 		targetValue: 55,
 		duration: new Duration(2, "minutes"),
 	});
+	cc.version = 2;
 	const expected = buildCCBuffer(
 		Buffer.from([
 			MultilevelSwitchCommand.Set, // CC Command
@@ -106,6 +108,7 @@ test("the StartLevelChange command (V1) should serialize correctly (up, ignore s
 		direction: "up",
 		ignoreStartLevel: true,
 	});
+	cc.version = 1;
 	const expected = buildCCBuffer(
 		Buffer.from([
 			MultilevelSwitchCommand.StartLevelChange, // CC Command
@@ -123,6 +126,7 @@ test("the StartLevelChange command (V1) should serialize correctly (down)", (t) 
 		ignoreStartLevel: false,
 		startLevel: 50,
 	});
+	cc.version = 1;
 	const expected = buildCCBuffer(
 		Buffer.from([
 			MultilevelSwitchCommand.StartLevelChange, // CC Command
@@ -153,6 +157,7 @@ test("the StartLevelChange command (V2) should serialize correctly (down, with d
 		startLevel: 50,
 		duration: new Duration(3, "seconds"),
 	});
+	cc.version = 2;
 	const expected = buildCCBuffer(
 		Buffer.from([
 			MultilevelSwitchCommand.StartLevelChange, // CC Command


### PR DESCRIPTION
fixes: #5749