### PR TITLE
feat: improve return type of `firmwareUpdateOTA` and `firmwareUpdateOTW` methods

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -940,15 +940,16 @@ interface GetFirmwareUpdatesOptions {
 #### `firmwareUpdateOTA`
 
 ```ts
-firmwareUpdateOTA(nodeId: number, update: FirmwareUpdateFileInfo): Promise<boolean>
+firmwareUpdateOTA(nodeId: number, update: FirmwareUpdateFileInfo): Promise<FirmwareUpdateResult>
 ```
 
 > [!WARNING] We don't take any responsibility if devices upgraded using Z-Wave JS don't work after an update. Always double-check that the correct update is about to be installed.
 
-Downloads the desired firmware update from the [Z-Wave JS firmware update service](https://github.com/zwave-js/firmware-updates/) and performs an over-the-air (OTA) firmware update for the given node. The return value indicates whether the update was successful.  
-This is very similar to [`ZWaveNode.updateFirmware`](api/node#updatefirmware), except that the updates are officially provided by manufacturers and downloaded in the background.
+Downloads the desired firmware update from the [Z-Wave JS firmware update service](https://github.com/zwave-js/firmware-updates/) and performs an over-the-air (OTA) firmware update for the given node. This is very similar to [`ZWaveNode.updateFirmware`](api/node#updatefirmware), except that the updates are officially provided by manufacturers and downloaded in the background.
 
 To keep track of the update progress, use the [`"firmware update progress"` and `"firmware update finished"` events](api/node#quotfirmware-update-progressquot) of the corresponding node.
+
+The return value indicates whether the update was successful and includes some additional information. This is the same information that is emitted using the `"firmware update finished"` event.
 
 > [!NOTE] Calling this will result in an HTTP request to the URL contained in the `update` parameter.
 
@@ -963,18 +964,27 @@ Returns whether an OTA firmware update is in progress for any node.
 ### Updating the firmware of the controller (OTW)
 
 ```ts
-firmwareUpdateOTW(data: Buffer): Promise<boolean>
+firmwareUpdateOTW(data: Buffer): Promise<ControllerFirmwareUpdateResult>
 ```
 
 > [!WARNING] We don't take any responsibility if devices upgraded using Z-Wave JS don't work after an update. Always double-check that the correct update is about to be installed.
 
-Performs an over-the-wire (OTW) firmware update for the controller using the given firmware image. The return value indicates whether the update was successful.
-
-To do so, the controller gets put in bootloader mode where a new firmware image can be uploaded.
+Performs an over-the-wire (OTW) firmware update for the controller using the given firmware image. To do so, the controller gets put in bootloader mode where a new firmware image can be uploaded.
 
 > [!WARNING] A failure during this process may leave your controller in recovery mode, rendering it unusable until a correct firmware image is uploaded.
 
 To keep track of the update progress, use the [`"firmware update progress"` and `"firmware update finished"` events](api/controller#quotfirmware-update-progressquot) of the controller.
+
+The return value indicates whether the update was successful and includes an error code that can be used to determine the reason for a failure. This is the same information that is emitted using the `"firmware update finished"` event:
+
+<!-- #import ControllerFirmwareUpdateResult from "zwave-js" -->
+
+```ts
+interface ControllerFirmwareUpdateResult {
+	success: boolean;
+	status: ControllerFirmwareUpdateStatus;
+}
+```
 
 ### `isFirmwareUpdateInProgress`
 

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -277,12 +277,12 @@ type FirmwareUpdateCapabilities =
 ### `updateFirmware`
 
 ```ts
-updateFirmware(updates: Firmware[]): Promise<boolean>
+updateFirmware(updates: Firmware[]): Promise<FirmwareUpdateResult>
 ```
 
 > [!WARNING] Use at your own risk! We don't take any responsibility if your devices don't work after an update.
 
-Performs an OTA firmware update process for this node, applying the provided firmware updates in sequence. The returned Promise will resolve after the process has **COMPLETED** and indicates whether the update was successful. Failure to start any one of the provided updates will throw an error.
+Performs an OTA firmware update process for this node, applying the provided firmware updates in sequence. The returned Promise will resolve after the process has **COMPLETED** and indicates whether the update was successful and includes some additional information. Failure to start any one of the provided updates will throw an error.
 
 This method an array of firmware updates, each of which contains the following properties:
 
@@ -295,6 +295,23 @@ This method an array of firmware updates, each of which contains the following p
 interface Firmware {
 	data: Buffer;
 	firmwareTarget?: number;
+}
+```
+
+The information contained in the returned Promise is the same that is emitted in the `firmware update finished` event.
+
+<!-- #import FirmwareUpdateResult from "@zwave-js/cc" -->
+
+```ts
+interface FirmwareUpdateResult {
+	/** The status returned by the device for this firmware update attempt. For multi-target updates, this will be the status for the last update. */
+	status: FirmwareUpdateStatus;
+	/** Whether the update was successful. This is a simpler interpretation of the `status` field. */
+	success: boolean;
+	/** How long (in seconds) to wait before interacting with the device again */
+	waitTime?: number;
+	/** Whether the device will be re-interviewed. If this is `true`, applications should wait for the `"ready"` event to interact with the device again. */
+	reInterview: boolean;
 }
 ```
 

--- a/docs/getting-started/migrating-to-v11.md
+++ b/docs/getting-started/migrating-to-v11.md
@@ -9,3 +9,14 @@ The `Window Covering CC` allows for more granular control of covers to the point
 As a result, the Z-Wave specification forbids interacting with the `Multilevel Switch CC` on devices that support the `Window Covering CC`.
 
 To avoid removing functionality for users, applications that plan on upgrading to `v11` must make sure to have support for the `Window Covering CC`.
+
+## Changed return types of `Controller.firmwareUpdateOTA` and `Controller.firmwareUpdateOTW` methods
+
+These methods previously only returned a `boolean` indicating success or failure. To get more information about the update result, applications had to listen to the `firmware update finished` event in addition to awaiting the returned promise.
+
+To make this easier:
+
+-   `firmwareUpdateOTA` now returns a `Promise<FirmwareUpdateResult>`
+-   `firmwareUpdateOTW` now returns a `Promise<ControllerFirmwareUpdateResult>`
+
+both of which contain the same information as the corresponding `firmware update finished` events.

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -45,6 +45,7 @@ import { FirmwareFileFormat } from '@zwave-js/core';
 import { FirmwareUpdateCapabilities } from '@zwave-js/cc';
 import type { FirmwareUpdateProgress } from '@zwave-js/cc/safe';
 import type { FirmwareUpdateResult } from '@zwave-js/cc/safe';
+import { FirmwareUpdateResult as FirmwareUpdateResult_2 } from '@zwave-js/cc';
 import { FirmwareUpdateStatus } from '@zwave-js/cc/safe';
 import { FLiRS } from '@zwave-js/core/safe';
 import { FLiRS as FLiRS_2 } from '@zwave-js/core';
@@ -1076,8 +1077,8 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
         endOfFile: boolean;
     }>;
     externalNVMWriteByte(offset: number, data: number): Promise<boolean>;
-    firmwareUpdateOTA(nodeId: number, updates: FirmwareUpdateFileInfo[]): Promise<boolean>;
-    firmwareUpdateOTW(data: Buffer): Promise<boolean>;
+    firmwareUpdateOTA(nodeId: number, updates: FirmwareUpdateFileInfo[]): Promise<FirmwareUpdateResult_2>;
+    firmwareUpdateOTW(data: Buffer): Promise<ControllerFirmwareUpdateResult>;
     // (undocumented)
     get firmwareVersion(): string | undefined;
     getAllAssociationGroups(nodeId: number): ReadonlyMap<number, ReadonlyMap<number, AssociationGroup>>;
@@ -1358,7 +1359,7 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner, IZWaveNod
     get supportsWakeUpOnDemand(): boolean | undefined;
     testPowerlevel(testNodeId: number, powerlevel: Powerlevel_2, healthCheckTestFrameCount: number, onProgress?: (acknowledged: number, total: number) => void): Promise<number>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-    updateFirmware(updates: Firmware[]): Promise<boolean>;
+    updateFirmware(updates: Firmware[]): Promise<FirmwareUpdateResult_2>;
     waitForWakeup(): Promise<void>;
     // (undocumented)
     get zwavePlusNodeType(): ZWavePlusNodeType | undefined;


### PR DESCRIPTION
This PR changes the return types of the aforementioned methods so that they return the same information as the corresponding `firmware update finished` events.

fixes: #5344