### PR TITLE
chore: upgrade api-extractor

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@commitlint/cli": "^17.6.1",
     "@commitlint/config-conventional": "^17.6.1",
     "@esm2cjs/p-queue": "^7.3.0",
-    "@microsoft/api-extractor": "^7.34.7",
+    "@microsoft/api-extractor": "^7.35.0",
     "@monorepo-utils/workspaces-to-typescript-project-references": "^2.9.0",
     "@tsconfig/node14": "^1.0.3",
     "@types/fs-extra": "^9.0.13",

--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -83,12 +83,12 @@ import type { ZWaveHost } from '@zwave-js/host';
 import type { ZWaveHost as ZWaveHost_2 } from '@zwave-js/host/safe';
 import { ZWaveLibraryTypes } from '@zwave-js/core/safe';
 
-// Warning: (ae-missing-release-tag) "addAssociations" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "addAssociations" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 function addAssociations(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2, group: number, destinations: AssociationAddress[]): Promise<void>;
 
-// Warning: (ae-missing-release-tag) "AlarmSensorCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AlarmSensorCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class AlarmSensorCC extends CommandClass {
@@ -102,7 +102,7 @@ export class AlarmSensorCC extends CommandClass {
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "AlarmSensorCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AlarmSensorCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class AlarmSensorCCGet extends AlarmSensorCC {
@@ -116,7 +116,7 @@ export class AlarmSensorCCGet extends AlarmSensorCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "AlarmSensorCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AlarmSensorCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class AlarmSensorCCReport extends AlarmSensorCC {
@@ -135,13 +135,13 @@ export class AlarmSensorCCReport extends AlarmSensorCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "AlarmSensorCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AlarmSensorCCSupportedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class AlarmSensorCCSupportedGet extends AlarmSensorCC {
 }
 
-// Warning: (ae-missing-release-tag) "AlarmSensorCCSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AlarmSensorCCSupportedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class AlarmSensorCCSupportedReport extends AlarmSensorCC {
@@ -154,7 +154,7 @@ export class AlarmSensorCCSupportedReport extends AlarmSensorCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "AlarmSensorCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AlarmSensorCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const AlarmSensorCCValues: Readonly<{
@@ -287,7 +287,7 @@ export const AlarmSensorCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "AlarmSensorCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AlarmSensorCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum AlarmSensorCommand {
@@ -301,7 +301,7 @@ export enum AlarmSensorCommand {
     SupportedReport = 4
 }
 
-// Warning: (ae-missing-release-tag) "AlarmSensorType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AlarmSensorType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum AlarmSensorType {
@@ -321,7 +321,7 @@ export enum AlarmSensorType {
     Smoke = 1
 }
 
-// Warning: (ae-missing-release-tag) "AlarmSensorValueMetadata" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AlarmSensorValueMetadata" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type AlarmSensorValueMetadata = ValueMetadata_2 & {
@@ -331,33 +331,33 @@ export type AlarmSensorValueMetadata = ValueMetadata_2 & {
 };
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "API" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "API" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const API: <TTarget extends CCAPI>(cc: CommandClasses_2) => TypedClassDecorator_2<TTarget>;
 
-// Warning: (ae-missing-release-tag) "APIConstructor" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "APIConstructor" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type APIConstructor<T extends CCAPI = CCAPI> = new (applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint | IVirtualEndpoint) => T;
 
-// Warning: (ae-missing-release-tag) "APIMethodsOf" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "APIMethodsOf" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type APIMethodsOf<CC extends CCNameOrId> = Omit<OnlyMethods<CCToAPI<CC>>, "ccId" | "getNode" | "getNodeUnsafe" | "isSetValueOptimistic" | "isSupported" | "pollValue" | "setValue" | "version" | "supportsCommand" | "withOptions" | "withTXReport">;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "assertValidCCs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "assertValidCCs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function assertValidCCs(container: ICommandClassContainer): void;
 
-// Warning: (ae-missing-release-tag) "assignLifelineIssueingCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "assignLifelineIssueingCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 function assignLifelineIssueingCommand(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2, ccId: CommandClasses, ccCommand: number): Promise<void>;
 
-// Warning: (ae-missing-release-tag) "AssociationAddress" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AssociationAddress" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface AssociationAddress {
@@ -367,7 +367,7 @@ export interface AssociationAddress {
     nodeId: number;
 }
 
-// Warning: (ae-missing-release-tag) "AssociationCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AssociationCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class AssociationCC extends CommandClass {
@@ -384,7 +384,7 @@ export class AssociationCC extends CommandClass {
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "AssociationCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AssociationCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class AssociationCCGet extends AssociationCC {
@@ -398,7 +398,7 @@ export class AssociationCCGet extends AssociationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "AssociationCCRemove" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AssociationCCRemove" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class AssociationCCRemove extends AssociationCC {
@@ -414,7 +414,7 @@ export class AssociationCCRemove extends AssociationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "AssociationCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AssociationCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class AssociationCCReport extends AssociationCC {
@@ -437,7 +437,7 @@ export class AssociationCCReport extends AssociationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "AssociationCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AssociationCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class AssociationCCSet extends AssociationCC {
@@ -453,13 +453,13 @@ export class AssociationCCSet extends AssociationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "AssociationCCSupportedGroupingsGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AssociationCCSupportedGroupingsGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class AssociationCCSupportedGroupingsGet extends AssociationCC {
 }
 
-// Warning: (ae-missing-release-tag) "AssociationCCSupportedGroupingsReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AssociationCCSupportedGroupingsReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class AssociationCCSupportedGroupingsReport extends AssociationCC {
@@ -470,7 +470,7 @@ export class AssociationCCSupportedGroupingsReport extends AssociationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "AssociationCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AssociationCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const AssociationCCValues: Readonly<{
@@ -582,7 +582,7 @@ export const AssociationCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "AssociationCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AssociationCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum AssociationCommand {
@@ -600,7 +600,7 @@ export enum AssociationCommand {
     SupportedGroupingsReport = 6
 }
 
-// Warning: (ae-missing-release-tag) "AssociationGroup" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AssociationGroup" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface AssociationGroup {
@@ -612,7 +612,7 @@ export interface AssociationGroup {
     profile?: AssociationGroupInfoProfile;
 }
 
-// Warning: (ae-missing-release-tag) "AssociationGroupInfoCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AssociationGroupInfoCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class AssociationGroupInfoCC extends CommandClass {
@@ -631,7 +631,7 @@ export class AssociationGroupInfoCC extends CommandClass {
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "AssociationGroupInfoCCCommandListGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AssociationGroupInfoCCCommandListGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class AssociationGroupInfoCCCommandListGet extends AssociationGroupInfoCC {
@@ -647,7 +647,7 @@ export class AssociationGroupInfoCCCommandListGet extends AssociationGroupInfoCC
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "AssociationGroupInfoCCCommandListReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AssociationGroupInfoCCCommandListReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class AssociationGroupInfoCCCommandListReport extends AssociationGroupInfoCC {
@@ -660,7 +660,7 @@ export class AssociationGroupInfoCCCommandListReport extends AssociationGroupInf
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "AssociationGroupInfoCCInfoGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AssociationGroupInfoCCInfoGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class AssociationGroupInfoCCInfoGet extends AssociationGroupInfoCC {
@@ -678,7 +678,7 @@ export class AssociationGroupInfoCCInfoGet extends AssociationGroupInfoCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "AssociationGroupInfoCCInfoReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AssociationGroupInfoCCInfoReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class AssociationGroupInfoCCInfoReport extends AssociationGroupInfoCC {
@@ -697,7 +697,7 @@ export class AssociationGroupInfoCCInfoReport extends AssociationGroupInfoCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "AssociationGroupInfoCCNameGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AssociationGroupInfoCCNameGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class AssociationGroupInfoCCNameGet extends AssociationGroupInfoCC {
@@ -711,7 +711,7 @@ export class AssociationGroupInfoCCNameGet extends AssociationGroupInfoCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "AssociationGroupInfoCCNameReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AssociationGroupInfoCCNameReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class AssociationGroupInfoCCNameReport extends AssociationGroupInfoCC {
@@ -726,7 +726,7 @@ export class AssociationGroupInfoCCNameReport extends AssociationGroupInfoCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "AssociationGroupInfoCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AssociationGroupInfoCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const AssociationGroupInfoCCValues: Readonly<{
@@ -841,7 +841,7 @@ export const AssociationGroupInfoCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "AssociationGroupInfoCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AssociationGroupInfoCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum AssociationGroupInfoCommand {
@@ -859,7 +859,7 @@ export enum AssociationGroupInfoCommand {
     NameReport = 2
 }
 
-// Warning: (ae-missing-release-tag) "AssociationGroupInfoProfile" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AssociationGroupInfoProfile" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum AssociationGroupInfoProfile {
@@ -1211,7 +1211,7 @@ export enum AssociationGroupInfoProfile {
     "Sensor: Weight" = 12558
 }
 
-// Warning: (ae-missing-release-tag) "BarrierOperatorCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BarrierOperatorCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BarrierOperatorCC extends CommandClass {
@@ -1223,7 +1223,7 @@ export class BarrierOperatorCC extends CommandClass {
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "BarrierOperatorCCEventSignalingGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BarrierOperatorCCEventSignalingGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BarrierOperatorCCEventSignalingGet extends BarrierOperatorCC {
@@ -1237,7 +1237,7 @@ export class BarrierOperatorCCEventSignalingGet extends BarrierOperatorCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "BarrierOperatorCCEventSignalingReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BarrierOperatorCCEventSignalingReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BarrierOperatorCCEventSignalingReport extends BarrierOperatorCC {
@@ -1252,7 +1252,7 @@ export class BarrierOperatorCCEventSignalingReport extends BarrierOperatorCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "BarrierOperatorCCEventSignalingSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BarrierOperatorCCEventSignalingSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BarrierOperatorCCEventSignalingSet extends BarrierOperatorCC {
@@ -1268,13 +1268,13 @@ export class BarrierOperatorCCEventSignalingSet extends BarrierOperatorCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "BarrierOperatorCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BarrierOperatorCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BarrierOperatorCCGet extends BarrierOperatorCC {
 }
 
-// Warning: (ae-missing-release-tag) "BarrierOperatorCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BarrierOperatorCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BarrierOperatorCCReport extends BarrierOperatorCC {
@@ -1287,7 +1287,7 @@ export class BarrierOperatorCCReport extends BarrierOperatorCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "BarrierOperatorCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BarrierOperatorCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BarrierOperatorCCSet extends BarrierOperatorCC {
@@ -1301,13 +1301,13 @@ export class BarrierOperatorCCSet extends BarrierOperatorCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "BarrierOperatorCCSignalingCapabilitiesGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BarrierOperatorCCSignalingCapabilitiesGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BarrierOperatorCCSignalingCapabilitiesGet extends BarrierOperatorCC {
 }
 
-// Warning: (ae-missing-release-tag) "BarrierOperatorCCSignalingCapabilitiesReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BarrierOperatorCCSignalingCapabilitiesReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BarrierOperatorCCSignalingCapabilitiesReport extends BarrierOperatorCC {
@@ -1318,7 +1318,7 @@ export class BarrierOperatorCCSignalingCapabilitiesReport extends BarrierOperato
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "BarrierOperatorCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BarrierOperatorCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const BarrierOperatorCCValues: Readonly<{
@@ -1474,7 +1474,7 @@ export const BarrierOperatorCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "BarrierOperatorCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BarrierOperatorCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum BarrierOperatorCommand {
@@ -1496,7 +1496,7 @@ export enum BarrierOperatorCommand {
     SignalingCapabilitiesReport = 5
 }
 
-// Warning: (ae-missing-release-tag) "BarrierState" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BarrierState" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum BarrierState {
@@ -1512,7 +1512,7 @@ export enum BarrierState {
     Stopped = 253
 }
 
-// Warning: (ae-missing-release-tag) "BasicCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BasicCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BasicCC extends CommandClass {
@@ -1524,13 +1524,13 @@ export class BasicCC extends CommandClass {
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "BasicCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BasicCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BasicCCGet extends BasicCC {
 }
 
-// Warning: (ae-missing-release-tag) "BasicCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BasicCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BasicCCReport extends BasicCC {
@@ -1550,7 +1550,7 @@ export class BasicCCReport extends BasicCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "BasicCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BasicCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BasicCCSet extends BasicCC {
@@ -1564,7 +1564,7 @@ export class BasicCCSet extends BasicCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "BasicCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BasicCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const BasicCCValues: Readonly<{
@@ -1711,7 +1711,7 @@ export const BasicCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "BasicCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BasicCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum BasicCommand {
@@ -1723,7 +1723,7 @@ export enum BasicCommand {
     Set = 1
 }
 
-// Warning: (ae-missing-release-tag) "BatteryCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BatteryCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BatteryCC extends CommandClass {
@@ -1737,19 +1737,19 @@ export class BatteryCC extends CommandClass {
     shouldRefreshValues(this: SinglecastCC_2<this>, applHost: ZWaveApplicationHost_2): boolean;
 }
 
-// Warning: (ae-missing-release-tag) "BatteryCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BatteryCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BatteryCCGet extends BatteryCC {
 }
 
-// Warning: (ae-missing-release-tag) "BatteryCCHealthGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BatteryCCHealthGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BatteryCCHealthGet extends BatteryCC {
 }
 
-// Warning: (ae-missing-release-tag) "BatteryCCHealthReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BatteryCCHealthReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BatteryCCHealthReport extends BatteryCC {
@@ -1764,7 +1764,7 @@ export class BatteryCCHealthReport extends BatteryCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "BatteryCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BatteryCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BatteryCCReport extends BatteryCC {
@@ -1798,7 +1798,7 @@ export class BatteryCCReport extends BatteryCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "BatteryCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BatteryCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const BatteryCCValues: Readonly<{
@@ -2134,7 +2134,7 @@ export const BatteryCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "BatteryChargingStatus" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BatteryChargingStatus" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum BatteryChargingStatus {
@@ -2146,7 +2146,7 @@ export enum BatteryChargingStatus {
     Maintaining = 2
 }
 
-// Warning: (ae-missing-release-tag) "BatteryCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BatteryCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum BatteryCommand {
@@ -2160,7 +2160,7 @@ export enum BatteryCommand {
     Report = 3
 }
 
-// Warning: (ae-missing-release-tag) "BatteryReplacementStatus" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BatteryReplacementStatus" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum BatteryReplacementStatus {
@@ -2172,7 +2172,7 @@ export enum BatteryReplacementStatus {
     Soon = 1
 }
 
-// Warning: (ae-missing-release-tag) "BinarySensorCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BinarySensorCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BinarySensorCC extends CommandClass {
@@ -2186,7 +2186,7 @@ export class BinarySensorCC extends CommandClass {
     setMappedBasicValue(applHost: ZWaveApplicationHost_2, value: number): boolean;
 }
 
-// Warning: (ae-missing-release-tag) "BinarySensorCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BinarySensorCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BinarySensorCCGet extends BinarySensorCC {
@@ -2200,7 +2200,7 @@ export class BinarySensorCCGet extends BinarySensorCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "BinarySensorCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BinarySensorCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BinarySensorCCReport extends BinarySensorCC {
@@ -2215,13 +2215,13 @@ export class BinarySensorCCReport extends BinarySensorCC {
     get value(): boolean;
 }
 
-// Warning: (ae-missing-release-tag) "BinarySensorCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BinarySensorCCSupportedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BinarySensorCCSupportedGet extends BinarySensorCC {
 }
 
-// Warning: (ae-missing-release-tag) "BinarySensorCCSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BinarySensorCCSupportedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BinarySensorCCSupportedReport extends BinarySensorCC {
@@ -2232,7 +2232,7 @@ export class BinarySensorCCSupportedReport extends BinarySensorCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "BinarySensorCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BinarySensorCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const BinarySensorCCValues: Readonly<{
@@ -2293,7 +2293,7 @@ export const BinarySensorCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "BinarySensorCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BinarySensorCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum BinarySensorCommand {
@@ -2307,7 +2307,7 @@ export enum BinarySensorCommand {
     SupportedReport = 4
 }
 
-// Warning: (ae-missing-release-tag) "BinarySensorType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BinarySensorType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum BinarySensorType {
@@ -2341,7 +2341,7 @@ export enum BinarySensorType {
     Water = 6
 }
 
-// Warning: (ae-missing-release-tag) "BinarySensorValueMetadata" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BinarySensorValueMetadata" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type BinarySensorValueMetadata = ValueMetadata_2 & {
@@ -2350,7 +2350,7 @@ export type BinarySensorValueMetadata = ValueMetadata_2 & {
     };
 };
 
-// Warning: (ae-missing-release-tag) "BinarySwitchCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BinarySwitchCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BinarySwitchCC extends CommandClass {
@@ -2364,13 +2364,13 @@ export class BinarySwitchCC extends CommandClass {
     setMappedBasicValue(applHost: ZWaveApplicationHost_2, value: number): boolean;
 }
 
-// Warning: (ae-missing-release-tag) "BinarySwitchCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BinarySwitchCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BinarySwitchCCGet extends BinarySwitchCC {
 }
 
-// Warning: (ae-missing-release-tag) "BinarySwitchCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BinarySwitchCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BinarySwitchCCReport extends BinarySwitchCC {
@@ -2388,7 +2388,7 @@ export class BinarySwitchCCReport extends BinarySwitchCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "BinarySwitchCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BinarySwitchCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class BinarySwitchCCSet extends BinarySwitchCC {
@@ -2404,7 +2404,7 @@ export class BinarySwitchCCSet extends BinarySwitchCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "BinarySwitchCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BinarySwitchCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const BinarySwitchCCValues: Readonly<{
@@ -2489,7 +2489,7 @@ export const BinarySwitchCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "BinarySwitchCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BinarySwitchCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum BinarySwitchCommand {
@@ -2502,7 +2502,7 @@ export enum BinarySwitchCommand {
 }
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "CCAPI" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CCAPI" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export class CCAPI {
@@ -2556,7 +2556,7 @@ export class CCAPI {
     withTXReport<T extends this>(): WithTXReport<T>;
 }
 
-// Warning: (ae-missing-release-tag) "CCAPIs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CCAPIs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface CCAPIs {
@@ -2809,12 +2809,12 @@ export interface CCAPIs {
 }
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "CCCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CCCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const CCCommand: <TTarget extends CommandClass>(ccCommand: number) => TypedClassDecorator_2<TTarget>;
 
-// Warning: (ae-missing-release-tag) "CCCommandOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CCCommandOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface CCCommandOptions {
@@ -2824,37 +2824,37 @@ export interface CCCommandOptions {
     nodeId: number | MulticastDestination;
 }
 
-// Warning: (ae-missing-release-tag) "CCConstructor" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CCConstructor" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type CCConstructor<T extends CommandClass> = typeof CommandClass & {
     new (host: ZWaveHost, options: any): T;
 };
 
-// Warning: (ae-missing-release-tag) "CCNameOrId" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CCNameOrId" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type CCNameOrId = CommandClasses_2 | Extract<keyof CCAPIs, string>;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "CCResponsePredicate" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CCResponsePredicate" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export type CCResponsePredicate<TSent extends CommandClass, TReceived extends CommandClass = CommandClass> = (sentCommand: TSent, receivedCommand: TReceived) => CCResponseRole;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "CCResponseRole" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CCResponseRole" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type CCResponseRole = boolean | "checkEncapsulated";
 
-// Warning: (ae-missing-release-tag) "CCToAPI" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CCToAPI" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type CCToAPI<CC extends CCNameOrId> = CC extends CommandClasses_2 ? CCToName<CC> extends keyof CCAPIs ? CCAPIs[CCToName<CC>] : never : CC extends keyof CCAPIs ? CCAPIs[CC] : never;
 
 // Warning: (ae-forgotten-export) The symbol "CCNameMap" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "CCToName" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CCToName" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type CCToName<CC extends CommandClasses_2> = {
@@ -2863,8 +2863,8 @@ export type CCToName<CC extends CommandClasses_2> = {
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
 // Warning: (ae-forgotten-export) The symbol "StaticCCValue" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "ccValue" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "ccValue" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ccValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ccValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function ccValue<TTarget extends CommandClass>(value: StaticCCValue): TypedPropertyDecorator<TTarget>;
@@ -2874,7 +2874,7 @@ export function ccValue<TTarget extends CommandClass>(value: StaticCCValue): Typ
 // @public (undocumented)
 export function ccValue<TTarget extends CommandClass, TArgs extends any[]>(value: DynamicCCValue<TArgs>, getArgs: (self: TTarget) => Readonly<TArgs>): TypedPropertyDecorator<TTarget>;
 
-// Warning: (ae-missing-release-tag) "CCValueOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CCValueOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface CCValueOptions {
@@ -2887,12 +2887,12 @@ export interface CCValueOptions {
 }
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "ccValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ccValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const ccValues: <TTarget extends CommandClass>(valueDefinition: Record<string, StaticCCValue | DynamicCCValue<any[]>>) => TypedClassDecorator_2<TTarget>;
 
-// Warning: (ae-missing-release-tag) "CentralSceneCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CentralSceneCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class CentralSceneCC extends CommandClass {
@@ -2906,13 +2906,13 @@ export class CentralSceneCC extends CommandClass {
     skipEndpointInterview(): boolean;
 }
 
-// Warning: (ae-missing-release-tag) "CentralSceneCCConfigurationGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CentralSceneCCConfigurationGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class CentralSceneCCConfigurationGet extends CentralSceneCC {
 }
 
-// Warning: (ae-missing-release-tag) "CentralSceneCCConfigurationReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CentralSceneCCConfigurationReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class CentralSceneCCConfigurationReport extends CentralSceneCC {
@@ -2923,7 +2923,7 @@ export class CentralSceneCCConfigurationReport extends CentralSceneCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "CentralSceneCCConfigurationSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CentralSceneCCConfigurationSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class CentralSceneCCConfigurationSet extends CentralSceneCC {
@@ -2937,7 +2937,7 @@ export class CentralSceneCCConfigurationSet extends CentralSceneCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "CentralSceneCCNotification" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CentralSceneCCNotification" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class CentralSceneCCNotification extends CentralSceneCC {
@@ -2956,13 +2956,13 @@ export class CentralSceneCCNotification extends CentralSceneCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "CentralSceneCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CentralSceneCCSupportedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class CentralSceneCCSupportedGet extends CentralSceneCC {
 }
 
-// Warning: (ae-missing-release-tag) "CentralSceneCCSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CentralSceneCCSupportedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class CentralSceneCCSupportedReport extends CentralSceneCC {
@@ -2979,7 +2979,7 @@ export class CentralSceneCCSupportedReport extends CentralSceneCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "CentralSceneCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CentralSceneCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const CentralSceneCCValues: Readonly<{
@@ -3118,7 +3118,7 @@ export const CentralSceneCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "CentralSceneCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CentralSceneCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum CentralSceneCommand {
@@ -3136,7 +3136,7 @@ export enum CentralSceneCommand {
     SupportedReport = 2
 }
 
-// Warning: (ae-missing-release-tag) "CentralSceneKeys" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CentralSceneKeys" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum CentralSceneKeys {
@@ -3156,7 +3156,7 @@ export enum CentralSceneKeys {
     KeyReleased = 1
 }
 
-// Warning: (ae-missing-release-tag) "ClimateControlScheduleCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ClimateControlScheduleCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ClimateControlScheduleCC extends CommandClass {
@@ -3164,13 +3164,13 @@ export class ClimateControlScheduleCC extends CommandClass {
     ccCommand: ClimateControlScheduleCommand;
 }
 
-// Warning: (ae-missing-release-tag) "ClimateControlScheduleCCChangedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ClimateControlScheduleCCChangedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ClimateControlScheduleCCChangedGet extends ClimateControlScheduleCC {
 }
 
-// Warning: (ae-missing-release-tag) "ClimateControlScheduleCCChangedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ClimateControlScheduleCCChangedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ClimateControlScheduleCCChangedReport extends ClimateControlScheduleCC {
@@ -3181,7 +3181,7 @@ export class ClimateControlScheduleCCChangedReport extends ClimateControlSchedul
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ClimateControlScheduleCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ClimateControlScheduleCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ClimateControlScheduleCCGet extends ClimateControlScheduleCC {
@@ -3195,13 +3195,13 @@ export class ClimateControlScheduleCCGet extends ClimateControlScheduleCC {
     weekday: Weekday;
 }
 
-// Warning: (ae-missing-release-tag) "ClimateControlScheduleCCOverrideGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ClimateControlScheduleCCOverrideGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ClimateControlScheduleCCOverrideGet extends ClimateControlScheduleCC {
 }
 
-// Warning: (ae-missing-release-tag) "ClimateControlScheduleCCOverrideReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ClimateControlScheduleCCOverrideReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ClimateControlScheduleCCOverrideReport extends ClimateControlScheduleCC {
@@ -3214,7 +3214,7 @@ export class ClimateControlScheduleCCOverrideReport extends ClimateControlSchedu
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ClimateControlScheduleCCOverrideSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ClimateControlScheduleCCOverrideSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ClimateControlScheduleCCOverrideSet extends ClimateControlScheduleCC {
@@ -3230,7 +3230,7 @@ export class ClimateControlScheduleCCOverrideSet extends ClimateControlScheduleC
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ClimateControlScheduleCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ClimateControlScheduleCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ClimateControlScheduleCCReport extends ClimateControlScheduleCC {
@@ -3243,7 +3243,7 @@ export class ClimateControlScheduleCCReport extends ClimateControlScheduleCC {
     readonly weekday: Weekday;
 }
 
-// Warning: (ae-missing-release-tag) "ClimateControlScheduleCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ClimateControlScheduleCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ClimateControlScheduleCCSet extends ClimateControlScheduleCC {
@@ -3259,7 +3259,7 @@ export class ClimateControlScheduleCCSet extends ClimateControlScheduleCC {
     weekday: Weekday;
 }
 
-// Warning: (ae-missing-release-tag) "ClimateControlScheduleCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ClimateControlScheduleCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const ClimateControlScheduleCCValues: Readonly<{
@@ -3350,7 +3350,7 @@ export const ClimateControlScheduleCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "ClimateControlScheduleCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ClimateControlScheduleCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ClimateControlScheduleCommand {
@@ -3372,7 +3372,7 @@ export enum ClimateControlScheduleCommand {
     Set = 1
 }
 
-// Warning: (ae-missing-release-tag) "ClockCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ClockCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ClockCC extends CommandClass {
@@ -3384,13 +3384,13 @@ export class ClockCC extends CommandClass {
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "ClockCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ClockCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ClockCCGet extends ClockCC {
 }
 
-// Warning: (ae-missing-release-tag) "ClockCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ClockCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ClockCCReport extends ClockCC {
@@ -3405,7 +3405,7 @@ export class ClockCCReport extends ClockCC {
     readonly weekday: Weekday;
 }
 
-// Warning: (ae-missing-release-tag) "ClockCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ClockCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ClockCCSet extends ClockCC {
@@ -3423,7 +3423,7 @@ export class ClockCCSet extends ClockCC {
     weekday: Weekday;
 }
 
-// Warning: (ae-missing-release-tag) "ClockCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ClockCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ClockCommand {
@@ -3435,7 +3435,7 @@ export enum ClockCommand {
     Set = 4
 }
 
-// Warning: (ae-missing-release-tag) "ColorComponent" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ColorComponent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ColorComponent {
@@ -3459,7 +3459,7 @@ export enum ColorComponent {
     Red = 2
 }
 
-// Warning: (ae-missing-release-tag) "ColorComponentMap" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ColorComponentMap" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const ColorComponentMap: {
@@ -3474,12 +3474,12 @@ export const ColorComponentMap: {
     index: ColorComponent;
 };
 
-// Warning: (ae-missing-release-tag) "ColorKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ColorKey" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ColorKey = keyof typeof ColorComponentMap;
 
-// Warning: (ae-missing-release-tag) "ColorSwitchCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ColorSwitchCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ColorSwitchCC extends CommandClass {
@@ -3493,7 +3493,7 @@ export class ColorSwitchCC extends CommandClass {
     translatePropertyKey(applHost: ZWaveApplicationHost_2, property: string | number, propertyKey: string | number): string | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "ColorSwitchCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ColorSwitchCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ColorSwitchCCGet extends ColorSwitchCC {
@@ -3508,7 +3508,7 @@ export class ColorSwitchCCGet extends ColorSwitchCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "ColorSwitchCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ColorSwitchCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ColorSwitchCCReport extends ColorSwitchCC {
@@ -3527,7 +3527,7 @@ export class ColorSwitchCCReport extends ColorSwitchCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "ColorSwitchCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ColorSwitchCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ColorSwitchCCSet extends ColorSwitchCC {
@@ -3543,7 +3543,7 @@ export class ColorSwitchCCSet extends ColorSwitchCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "ColorSwitchCCStartLevelChange" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ColorSwitchCCStartLevelChange" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ColorSwitchCCStartLevelChange extends ColorSwitchCC {
@@ -3565,7 +3565,7 @@ export class ColorSwitchCCStartLevelChange extends ColorSwitchCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "ColorSwitchCCStopLevelChange" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ColorSwitchCCStopLevelChange" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ColorSwitchCCStopLevelChange extends ColorSwitchCC {
@@ -3579,13 +3579,13 @@ export class ColorSwitchCCStopLevelChange extends ColorSwitchCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "ColorSwitchCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ColorSwitchCCSupportedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ColorSwitchCCSupportedGet extends ColorSwitchCC {
 }
 
-// Warning: (ae-missing-release-tag) "ColorSwitchCCSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ColorSwitchCCSupportedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ColorSwitchCCSupportedReport extends ColorSwitchCC {
@@ -3596,7 +3596,7 @@ export class ColorSwitchCCSupportedReport extends ColorSwitchCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "ColorSwitchCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ColorSwitchCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const ColorSwitchCCValues: Readonly<{
@@ -3825,7 +3825,7 @@ export const ColorSwitchCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "ColorSwitchCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ColorSwitchCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ColorSwitchCommand {
@@ -3845,12 +3845,12 @@ export enum ColorSwitchCommand {
     SupportedReport = 2
 }
 
-// Warning: (ae-missing-release-tag) "ColorTable" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ColorTable" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export type ColorTable = Partial<Record<ColorKey, number>> | Partial<Record<ColorComponent, number>>;
 
-// Warning: (ae-missing-release-tag) "CommandClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CommandClass" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class CommandClass implements ICommandClass {
@@ -3950,12 +3950,12 @@ export class CommandClass implements ICommandClass {
 }
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "commandClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "commandClass" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const commandClass: <TTarget extends CommandClass>(ccId: CommandClasses_2) => TypedClassDecorator_2<TTarget>;
 
-// Warning: (ae-missing-release-tag) "CommandClassDeserializationOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CommandClassDeserializationOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type CommandClassDeserializationOptions = {
@@ -3971,12 +3971,12 @@ export type CommandClassDeserializationOptions = {
 });
 
 // Warning: (ae-forgotten-export) The symbol "CommandClassCreationOptions" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "CommandClassOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CommandClassOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type CommandClassOptions = CommandClassCreationOptions | CommandClassDeserializationOptions;
 
-// Warning: (ae-missing-release-tag) "ConfigurationCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigurationCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ConfigurationCC extends CommandClass {
@@ -4003,7 +4003,7 @@ export class ConfigurationCC extends CommandClass {
     translatePropertyKey(applHost: ZWaveApplicationHost_2, property: string | number, propertyKey?: string | number): string | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "ConfigurationCCBulkGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigurationCCBulkGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ConfigurationCCBulkGet extends ConfigurationCC {
@@ -4017,7 +4017,7 @@ export class ConfigurationCCBulkGet extends ConfigurationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ConfigurationCCBulkReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigurationCCBulkReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ConfigurationCCBulkReport extends ConfigurationCC {
@@ -4042,7 +4042,7 @@ export class ConfigurationCCBulkReport extends ConfigurationCC {
     get valueSize(): number;
 }
 
-// Warning: (ae-missing-release-tag) "ConfigurationCCBulkSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigurationCCBulkSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ConfigurationCCBulkSet extends ConfigurationCC {
@@ -4066,13 +4066,13 @@ export class ConfigurationCCBulkSet extends ConfigurationCC {
     get valueSize(): number;
 }
 
-// Warning: (ae-missing-release-tag) "ConfigurationCCDefaultReset" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigurationCCDefaultReset" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ConfigurationCCDefaultReset extends ConfigurationCC {
 }
 
-// Warning: (ae-missing-release-tag) "ConfigurationCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigurationCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ConfigurationCCGet extends ConfigurationCC {
@@ -4088,7 +4088,7 @@ export class ConfigurationCCGet extends ConfigurationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ConfigurationCCInfoGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigurationCCInfoGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ConfigurationCCInfoGet extends ConfigurationCC {
@@ -4101,7 +4101,7 @@ export class ConfigurationCCInfoGet extends ConfigurationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ConfigurationCCInfoReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigurationCCInfoReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ConfigurationCCInfoReport extends ConfigurationCC {
@@ -4127,7 +4127,7 @@ export class ConfigurationCCInfoReport extends ConfigurationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ConfigurationCCNameGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigurationCCNameGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ConfigurationCCNameGet extends ConfigurationCC {
@@ -4140,7 +4140,7 @@ export class ConfigurationCCNameGet extends ConfigurationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ConfigurationCCNameReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigurationCCNameReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ConfigurationCCNameReport extends ConfigurationCC {
@@ -4166,7 +4166,7 @@ export class ConfigurationCCNameReport extends ConfigurationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ConfigurationCCPropertiesGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigurationCCPropertiesGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ConfigurationCCPropertiesGet extends ConfigurationCC {
@@ -4179,7 +4179,7 @@ export class ConfigurationCCPropertiesGet extends ConfigurationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ConfigurationCCPropertiesReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigurationCCPropertiesReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ConfigurationCCPropertiesReport extends ConfigurationCC {
@@ -4215,7 +4215,7 @@ export class ConfigurationCCPropertiesReport extends ConfigurationCC {
     valueSize: number;
 }
 
-// Warning: (ae-missing-release-tag) "ConfigurationCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigurationCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ConfigurationCCReport extends ConfigurationCC {
@@ -4235,7 +4235,7 @@ export class ConfigurationCCReport extends ConfigurationCC {
     valueSize: number;
 }
 
-// Warning: (ae-missing-release-tag) "ConfigurationCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigurationCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ConfigurationCCSet extends ConfigurationCC {
@@ -4257,7 +4257,7 @@ export class ConfigurationCCSet extends ConfigurationCC {
     valueSize: number | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "ConfigurationCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigurationCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const ConfigurationCCValues: Readonly<{
@@ -4316,7 +4316,7 @@ export const ConfigurationCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "ConfigurationCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigurationCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ConfigurationCommand {
@@ -4348,14 +4348,14 @@ export enum ConfigurationCommand {
     Set = 4
 }
 
-// Warning: (ae-missing-release-tag) "configureLifelineAssociations" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "configureLifelineAssociations" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 function configureLifelineAssociations(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): Promise<void>;
 
 export { ConfigValue }
 
-// Warning: (ae-missing-release-tag) "CRC16CC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CRC16CC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class CRC16CC extends CommandClass {
@@ -4365,7 +4365,7 @@ export class CRC16CC extends CommandClass {
     static requiresEncapsulation(cc: CommandClass): boolean;
 }
 
-// Warning: (ae-missing-release-tag) "CRC16CCCommandEncapsulation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CRC16CCCommandEncapsulation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class CRC16CCCommandEncapsulation extends CRC16CC {
@@ -4381,7 +4381,7 @@ export class CRC16CCCommandEncapsulation extends CRC16CC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "CRC16Command" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CRC16Command" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum CRC16Command {
@@ -4389,12 +4389,12 @@ export enum CRC16Command {
     CommandEncapsulation = 1
 }
 
-// Warning: (ae-missing-release-tag) "dataRate2ZWaveDataRate" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "dataRate2ZWaveDataRate" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function dataRate2ZWaveDataRate(dataRate: DataRate_2): ZWaveDataRate_2;
 
-// Warning: (ae-missing-release-tag) "defaultCCValueOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "defaultCCValueOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const defaultCCValueOptions: {
@@ -4406,7 +4406,7 @@ export const defaultCCValueOptions: {
     readonly autoCreate: true;
 };
 
-// Warning: (ae-missing-release-tag) "DeviceIdType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DeviceIdType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum DeviceIdType {
@@ -4418,7 +4418,7 @@ export enum DeviceIdType {
     SerialNumber = 1
 }
 
-// Warning: (ae-missing-release-tag) "DeviceResetLocallyCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DeviceResetLocallyCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class DeviceResetLocallyCC extends CommandClass {
@@ -4428,14 +4428,14 @@ export class DeviceResetLocallyCC extends CommandClass {
     nodeId: number;
 }
 
-// Warning: (ae-missing-release-tag) "DeviceResetLocallyCCNotification" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DeviceResetLocallyCCNotification" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class DeviceResetLocallyCCNotification extends DeviceResetLocallyCC {
     constructor(host: ZWaveHost_2, options: CommandClassOptions);
 }
 
-// Warning: (ae-missing-release-tag) "DeviceResetLocallyCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DeviceResetLocallyCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum DeviceResetLocallyCommand {
@@ -4443,12 +4443,12 @@ export enum DeviceResetLocallyCommand {
     Notification = 1
 }
 
-// Warning: (ae-missing-release-tag) "DoorHandleStatus" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorHandleStatus" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type DoorHandleStatus = [boolean, boolean, boolean, boolean];
 
-// Warning: (ae-missing-release-tag) "DoorLockCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorLockCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class DoorLockCC extends CommandClass {
@@ -4460,13 +4460,13 @@ export class DoorLockCC extends CommandClass {
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "DoorLockCCCapabilitiesGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorLockCCCapabilitiesGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class DoorLockCCCapabilitiesGet extends DoorLockCC {
 }
 
-// Warning: (ae-missing-release-tag) "DoorLockCCCapabilitiesReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorLockCCCapabilitiesReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class DoorLockCCCapabilitiesReport extends DoorLockCC {
@@ -4497,13 +4497,13 @@ export class DoorLockCCCapabilitiesReport extends DoorLockCC {
     readonly twistAssistSupported: boolean;
 }
 
-// Warning: (ae-missing-release-tag) "DoorLockCCConfigurationGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorLockCCConfigurationGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class DoorLockCCConfigurationGet extends DoorLockCC {
 }
 
-// Warning: (ae-missing-release-tag) "DoorLockCCConfigurationReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorLockCCConfigurationReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class DoorLockCCConfigurationReport extends DoorLockCC {
@@ -4528,7 +4528,7 @@ export class DoorLockCCConfigurationReport extends DoorLockCC {
     readonly twistAssist?: boolean;
 }
 
-// Warning: (ae-missing-release-tag) "DoorLockCCConfigurationSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorLockCCConfigurationSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class DoorLockCCConfigurationSet extends DoorLockCC {
@@ -4556,13 +4556,13 @@ export class DoorLockCCConfigurationSet extends DoorLockCC {
     twistAssist?: boolean;
 }
 
-// Warning: (ae-missing-release-tag) "DoorLockCCOperationGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorLockCCOperationGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class DoorLockCCOperationGet extends DoorLockCC {
 }
 
-// Warning: (ae-missing-release-tag) "DoorLockCCOperationReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorLockCCOperationReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class DoorLockCCOperationReport extends DoorLockCC {
@@ -4591,7 +4591,7 @@ export class DoorLockCCOperationReport extends DoorLockCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "DoorLockCCOperationSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorLockCCOperationSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class DoorLockCCOperationSet extends DoorLockCC {
@@ -4605,7 +4605,7 @@ export class DoorLockCCOperationSet extends DoorLockCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "DoorLockCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorLockCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const DoorLockCCValues: Readonly<{
@@ -5301,7 +5301,7 @@ export const DoorLockCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "DoorLockCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorLockCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum DoorLockCommand {
@@ -5323,7 +5323,7 @@ export enum DoorLockCommand {
     OperationSet = 1
 }
 
-// Warning: (ae-missing-release-tag) "DoorLockLoggingCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorLockLoggingCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class DoorLockLoggingCC extends CommandClass {
@@ -5335,7 +5335,7 @@ export class DoorLockLoggingCC extends CommandClass {
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "DoorLockLoggingCCRecordGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorLockLoggingCCRecordGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class DoorLockLoggingCCRecordGet extends DoorLockLoggingCC {
@@ -5349,7 +5349,7 @@ export class DoorLockLoggingCCRecordGet extends DoorLockLoggingCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "DoorLockLoggingCCRecordReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorLockLoggingCCRecordReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class DoorLockLoggingCCRecordReport extends DoorLockLoggingCC {
@@ -5362,13 +5362,13 @@ export class DoorLockLoggingCCRecordReport extends DoorLockLoggingCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "DoorLockLoggingCCRecordsSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorLockLoggingCCRecordsSupportedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class DoorLockLoggingCCRecordsSupportedGet extends DoorLockLoggingCC {
 }
 
-// Warning: (ae-missing-release-tag) "DoorLockLoggingCCRecordsSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorLockLoggingCCRecordsSupportedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class DoorLockLoggingCCRecordsSupportedReport extends DoorLockLoggingCC {
@@ -5379,7 +5379,7 @@ export class DoorLockLoggingCCRecordsSupportedReport extends DoorLockLoggingCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "DoorLockLoggingCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorLockLoggingCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const DoorLockLoggingCCValues: Readonly<{
@@ -5410,7 +5410,7 @@ export const DoorLockLoggingCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "DoorLockLoggingCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorLockLoggingCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum DoorLockLoggingCommand {
@@ -5424,7 +5424,7 @@ export enum DoorLockLoggingCommand {
     RecordsSupportedReport = 2
 }
 
-// Warning: (ae-missing-release-tag) "DoorLockLoggingEventType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorLockLoggingEventType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum DoorLockLoggingEventType {
@@ -5494,7 +5494,7 @@ export enum DoorLockLoggingEventType {
     UserCodeDeleted = 24
 }
 
-// Warning: (ae-missing-release-tag) "DoorLockLoggingRecord" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorLockLoggingRecord" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface DoorLockLoggingRecord {
@@ -5510,7 +5510,7 @@ export interface DoorLockLoggingRecord {
     userId?: number;
 }
 
-// Warning: (ae-missing-release-tag) "DoorLockLoggingRecordStatus" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorLockLoggingRecordStatus" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum DoorLockLoggingRecordStatus {
@@ -5520,7 +5520,7 @@ export enum DoorLockLoggingRecordStatus {
     HoldsLegalData = 1
 }
 
-// Warning: (ae-missing-release-tag) "DoorLockMode" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorLockMode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum DoorLockMode {
@@ -5542,7 +5542,7 @@ export enum DoorLockMode {
     UnsecuredWithTimeout = 1
 }
 
-// Warning: (ae-missing-release-tag) "DoorLockOperationType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DoorLockOperationType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum DoorLockOperationType {
@@ -5553,13 +5553,13 @@ export enum DoorLockOperationType {
 }
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "DynamicCCResponse" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DynamicCCResponse" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export type DynamicCCResponse<TSent extends CommandClass, TReceived extends CommandClass = CommandClass> = (sentCC: TSent) => CCConstructor<TReceived> | CCConstructor<TReceived>[] | undefined;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "ECDHProfiles" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ECDHProfiles" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ECDHProfiles {
@@ -5567,14 +5567,14 @@ export enum ECDHProfiles {
     Curve25519 = 0
 }
 
-// Warning: (ae-missing-release-tag) "EncapsulatedCommandClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EncapsulatedCommandClass" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type EncapsulatedCommandClass = CommandClass & {
     encapsulatingCC: EncapsulatingCommandClass;
 };
 
-// Warning: (ae-missing-release-tag) "EncapsulatingCommandClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EncapsulatingCommandClass" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type EncapsulatingCommandClass = CommandClass & {
@@ -5582,7 +5582,7 @@ export type EncapsulatingCommandClass = CommandClass & {
     encapsulated: EncapsulatedCommandClass;
 };
 
-// Warning: (ae-missing-release-tag) "EncapsulatingCommandClassStatic" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EncapsulatingCommandClassStatic" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface EncapsulatingCommandClassStatic {
@@ -5592,7 +5592,7 @@ export interface EncapsulatingCommandClassStatic {
     encapsulate(applHost: ZWaveApplicationHost, cc: CommandClass): EncapsulatingCommandClass;
 }
 
-// Warning: (ae-missing-release-tag) "EndpointAddress" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EndpointAddress" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface EndpointAddress {
@@ -5602,7 +5602,7 @@ export interface EndpointAddress {
     nodeId: number;
 }
 
-// Warning: (ae-missing-release-tag) "EnergyProductionCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EnergyProductionCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class EnergyProductionCC extends CommandClass {
@@ -5614,7 +5614,7 @@ export class EnergyProductionCC extends CommandClass {
     refreshValues(applHost: ZWaveApplicationHost): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "EnergyProductionCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EnergyProductionCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class EnergyProductionCCGet extends EnergyProductionCC {
@@ -5626,7 +5626,7 @@ export class EnergyProductionCCGet extends EnergyProductionCC {
     serialize(): Buffer;
 }
 
-// Warning: (ae-missing-release-tag) "EnergyProductionCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EnergyProductionCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class EnergyProductionCCReport extends EnergyProductionCC {
@@ -5644,7 +5644,7 @@ export class EnergyProductionCCReport extends EnergyProductionCC {
     readonly value: number;
 }
 
-// Warning: (ae-missing-release-tag) "EnergyProductionCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EnergyProductionCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const EnergyProductionCCValues: Readonly<{
@@ -5679,7 +5679,7 @@ export const EnergyProductionCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "EnergyProductionCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EnergyProductionCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum EnergyProductionCommand {
@@ -5689,7 +5689,7 @@ export enum EnergyProductionCommand {
     Report = 3
 }
 
-// Warning: (ae-missing-release-tag) "EnergyProductionParameter" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EnergyProductionParameter" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum EnergyProductionParameter {
@@ -5703,7 +5703,7 @@ export enum EnergyProductionParameter {
     Power = 0
 }
 
-// Warning: (ae-missing-release-tag) "EnergyProductionScale" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EnergyProductionScale" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface EnergyProductionScale {
@@ -5713,7 +5713,7 @@ export interface EnergyProductionScale {
     unit: string;
 }
 
-// Warning: (ae-missing-release-tag) "EntryControlCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EntryControlCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class EntryControlCC extends CommandClass {
@@ -5727,13 +5727,13 @@ export class EntryControlCC extends CommandClass {
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "EntryControlCCConfigurationGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EntryControlCCConfigurationGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class EntryControlCCConfigurationGet extends EntryControlCC {
 }
 
-// Warning: (ae-missing-release-tag) "EntryControlCCConfigurationReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EntryControlCCConfigurationReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class EntryControlCCConfigurationReport extends EntryControlCC {
@@ -5746,7 +5746,7 @@ export class EntryControlCCConfigurationReport extends EntryControlCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "EntryControlCCConfigurationSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EntryControlCCConfigurationSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class EntryControlCCConfigurationSet extends EntryControlCC {
@@ -5762,13 +5762,13 @@ export class EntryControlCCConfigurationSet extends EntryControlCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "EntryControlCCEventSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EntryControlCCEventSupportedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class EntryControlCCEventSupportedGet extends EntryControlCC {
 }
 
-// Warning: (ae-missing-release-tag) "EntryControlCCEventSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EntryControlCCEventSupportedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class EntryControlCCEventSupportedReport extends EntryControlCC {
@@ -5791,13 +5791,13 @@ export class EntryControlCCEventSupportedReport extends EntryControlCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "EntryControlCCKeySupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EntryControlCCKeySupportedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class EntryControlCCKeySupportedGet extends EntryControlCC {
 }
 
-// Warning: (ae-missing-release-tag) "EntryControlCCKeySupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EntryControlCCKeySupportedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class EntryControlCCKeySupportedReport extends EntryControlCC {
@@ -5808,7 +5808,7 @@ export class EntryControlCCKeySupportedReport extends EntryControlCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "EntryControlCCNotification" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EntryControlCCNotification" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class EntryControlCCNotification extends EntryControlCC {
@@ -5825,7 +5825,7 @@ export class EntryControlCCNotification extends EntryControlCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "EntryControlCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EntryControlCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const EntryControlCCValues: Readonly<{
@@ -5965,7 +5965,7 @@ export const EntryControlCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "EntryControlCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EntryControlCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum EntryControlCommand {
@@ -5987,7 +5987,7 @@ export enum EntryControlCommand {
     Notification = 1
 }
 
-// Warning: (ae-missing-release-tag) "EntryControlDataTypes" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EntryControlDataTypes" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum EntryControlDataTypes {
@@ -6001,12 +6001,12 @@ export enum EntryControlDataTypes {
     Raw = 1
 }
 
-// Warning: (ae-missing-release-tag) "entryControlEventTypeLabels" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "entryControlEventTypeLabels" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const entryControlEventTypeLabels: Record<EntryControlEventTypes, string>;
 
-// Warning: (ae-missing-release-tag) "EntryControlEventTypes" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EntryControlEventTypes" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum EntryControlEventTypes {
@@ -6065,18 +6065,18 @@ export enum EntryControlEventTypes {
 }
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "expectedCCResponse" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "expectedCCResponse" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function expectedCCResponse<TSent extends CommandClass, TReceived extends CommandClass>(cc: CCConstructor<TReceived> | DynamicCCResponse<TSent, TReceived>, predicate?: CCResponsePredicate<TSent, TReceived>): TypedClassDecorator_2<CommandClass>;
 
 // Warning: (ae-forgotten-export) The symbol "S2ExtensionType" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "extensionType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "extensionType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function extensionType(type: S2ExtensionType): TypedClassDecorator<Security2Extension>;
 
-// Warning: (ae-missing-release-tag) "FibaroCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FibaroCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class FibaroCC extends ManufacturerProprietaryCC {
@@ -6094,18 +6094,18 @@ export class FibaroCC extends ManufacturerProprietaryCC {
 }
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "fibaroCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "fibaroCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const fibaroCC: <TTarget extends FibaroCC>(fibaroCCId: number) => TypedClassDecorator_2<TTarget>;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "fibaroCCCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "fibaroCCCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const fibaroCCCommand: <TTarget extends FibaroCC>(fibaroCCCommand: number) => TypedClassDecorator_2<TTarget>;
 
-// Warning: (ae-missing-release-tag) "FibaroVenetianBlindCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FibaroVenetianBlindCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class FibaroVenetianBlindCC extends FibaroCC {
@@ -6124,14 +6124,14 @@ export class FibaroVenetianBlindCC extends FibaroCC {
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "FibaroVenetianBlindCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FibaroVenetianBlindCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class FibaroVenetianBlindCCGet extends FibaroVenetianBlindCC {
     constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions | CCCommandOptions);
 }
 
-// Warning: (ae-missing-release-tag) "FibaroVenetianBlindCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FibaroVenetianBlindCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class FibaroVenetianBlindCCReport extends FibaroVenetianBlindCC {
@@ -6146,7 +6146,7 @@ export class FibaroVenetianBlindCCReport extends FibaroVenetianBlindCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "FibaroVenetianBlindCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FibaroVenetianBlindCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class FibaroVenetianBlindCCSet extends FibaroVenetianBlindCC {
@@ -6162,7 +6162,7 @@ export class FibaroVenetianBlindCCSet extends FibaroVenetianBlindCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "FirmwareDownloadStatus" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareDownloadStatus" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum FirmwareDownloadStatus {
@@ -6180,7 +6180,7 @@ export enum FirmwareDownloadStatus {
     OK = 255
 }
 
-// Warning: (ae-missing-release-tag) "FirmwareUpdateActivationStatus" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateActivationStatus" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum FirmwareUpdateActivationStatus {
@@ -6192,7 +6192,7 @@ export enum FirmwareUpdateActivationStatus {
     OK = 255
 }
 
-// Warning: (ae-missing-release-tag) "FirmwareUpdateCapabilities" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateCapabilities" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type FirmwareUpdateCapabilities = {
@@ -6204,8 +6204,8 @@ export type FirmwareUpdateCapabilities = {
     readonly supportsActivation: Maybe<boolean>;
 };
 
-// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaData" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaData" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaData" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaData" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface FirmwareUpdateMetaData {
@@ -6251,7 +6251,7 @@ export interface FirmwareUpdateMetaData {
     supportsActivation: Maybe<boolean>;
 }
 
-// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class FirmwareUpdateMetaDataCC extends CommandClass {
@@ -6263,7 +6263,7 @@ export class FirmwareUpdateMetaDataCC extends CommandClass {
     skipEndpointInterview(): boolean;
 }
 
-// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCActivationReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCActivationReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class FirmwareUpdateMetaDataCCActivationReport extends FirmwareUpdateMetaDataCC {
@@ -6284,7 +6284,7 @@ export class FirmwareUpdateMetaDataCCActivationReport extends FirmwareUpdateMeta
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCActivationSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCActivationSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class FirmwareUpdateMetaDataCCActivationSet extends FirmwareUpdateMetaDataCC {
@@ -6306,7 +6306,7 @@ export class FirmwareUpdateMetaDataCCActivationSet extends FirmwareUpdateMetaDat
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class FirmwareUpdateMetaDataCCGet extends FirmwareUpdateMetaDataCC {
@@ -6319,13 +6319,13 @@ export class FirmwareUpdateMetaDataCCGet extends FirmwareUpdateMetaDataCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCMetaDataGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCMetaDataGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class FirmwareUpdateMetaDataCCMetaDataGet extends FirmwareUpdateMetaDataCC {
 }
 
-// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCMetaDataReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCMetaDataReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class FirmwareUpdateMetaDataCCMetaDataReport extends FirmwareUpdateMetaDataCC implements FirmwareUpdateMetaData {
@@ -6352,7 +6352,7 @@ export class FirmwareUpdateMetaDataCCMetaDataReport extends FirmwareUpdateMetaDa
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCPrepareGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCPrepareGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class FirmwareUpdateMetaDataCCPrepareGet extends FirmwareUpdateMetaDataCC {
@@ -6374,7 +6374,7 @@ export class FirmwareUpdateMetaDataCCPrepareGet extends FirmwareUpdateMetaDataCC
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCPrepareReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCPrepareReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class FirmwareUpdateMetaDataCCPrepareReport extends FirmwareUpdateMetaDataCC {
@@ -6387,7 +6387,7 @@ export class FirmwareUpdateMetaDataCCPrepareReport extends FirmwareUpdateMetaDat
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class FirmwareUpdateMetaDataCCReport extends FirmwareUpdateMetaDataCC {
@@ -6405,7 +6405,7 @@ export class FirmwareUpdateMetaDataCCReport extends FirmwareUpdateMetaDataCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCRequestGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCRequestGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class FirmwareUpdateMetaDataCCRequestGet extends FirmwareUpdateMetaDataCC {
@@ -6431,7 +6431,7 @@ export class FirmwareUpdateMetaDataCCRequestGet extends FirmwareUpdateMetaDataCC
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCRequestReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCRequestReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class FirmwareUpdateMetaDataCCRequestReport extends FirmwareUpdateMetaDataCC {
@@ -6442,7 +6442,7 @@ export class FirmwareUpdateMetaDataCCRequestReport extends FirmwareUpdateMetaDat
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCStatusReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCStatusReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class FirmwareUpdateMetaDataCCStatusReport extends FirmwareUpdateMetaDataCC {
@@ -6454,7 +6454,7 @@ export class FirmwareUpdateMetaDataCCStatusReport extends FirmwareUpdateMetaData
     readonly waitTime?: number;
 }
 
-// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const FirmwareUpdateMetaDataCCValues: Readonly<{
@@ -6560,7 +6560,7 @@ export const FirmwareUpdateMetaDataCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateMetaDataCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum FirmwareUpdateMetaDataCommand {
@@ -6588,7 +6588,7 @@ export enum FirmwareUpdateMetaDataCommand {
     StatusReport = 7
 }
 
-// Warning: (ae-missing-release-tag) "FirmwareUpdateProgress" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateProgress" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface FirmwareUpdateProgress {
@@ -6599,7 +6599,7 @@ export interface FirmwareUpdateProgress {
     totalFragments: number;
 }
 
-// Warning: (ae-missing-release-tag) "FirmwareUpdateRequestStatus" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateRequestStatus" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum FirmwareUpdateRequestStatus {
@@ -6621,7 +6621,7 @@ export enum FirmwareUpdateRequestStatus {
     OK = 255
 }
 
-// Warning: (ae-missing-release-tag) "FirmwareUpdateResult" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateResult" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface FirmwareUpdateResult {
@@ -6631,7 +6631,7 @@ export interface FirmwareUpdateResult {
     waitTime?: number;
 }
 
-// Warning: (ae-missing-release-tag) "FirmwareUpdateStatus" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateStatus" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum FirmwareUpdateStatus {
@@ -6662,180 +6662,180 @@ export enum FirmwareUpdateStatus {
     OK_WaitingForActivation = 253
 }
 
-// Warning: (ae-missing-release-tag) "FLiRS2WakeUpTime" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FLiRS2WakeUpTime" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function FLiRS2WakeUpTime(value: FLiRS_2): WakeUpTime;
 
-// Warning: (ae-missing-release-tag) "getAllAssociationGroups" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getAllAssociationGroups" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 function getAllAssociationGroups(applHost: ZWaveApplicationHost_2, node: IZWaveNode): ReadonlyMap<number, ReadonlyMap<number, AssociationGroup>>;
 
-// Warning: (ae-missing-release-tag) "getAllAssociations" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getAllAssociations" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 function getAllAssociations(applHost: ZWaveApplicationHost_2, node: IZWaveNode): ReadonlyObjectKeyMap<AssociationAddress, ReadonlyMap<number, readonly AssociationAddress[]>>;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "getAPI" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getAPI" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getAPI(cc: CommandClasses_2): APIConstructor | undefined;
 
-// Warning: (ae-missing-release-tag) "getAssociationGroups" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getAssociationGroups" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 function getAssociationGroups(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): ReadonlyMap<number, AssociationGroup>;
 
-// Warning: (ae-missing-release-tag) "getAssociations" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getAssociations" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 function getAssociations(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): ReadonlyMap<number, readonly AssociationAddress[]>;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "getCCCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getCCCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const getCCCommand: (target: CommandClass) => number | undefined;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "getCCCommandConstructor" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getCCCommandConstructor" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const getCCCommandConstructor: (ccId: CommandClasses_2, ccCommand: number) => CCConstructor<CommandClass> | undefined;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "getCCConstructor" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getCCConstructor" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const getCCConstructor: (ccId: CommandClasses_2) => CCConstructor<CommandClass> | undefined;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "getCCResponsePredicate" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getCCResponsePredicate" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getCCResponsePredicate<T extends CommandClass>(ccClass: T): CCResponsePredicate<T> | undefined;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
 // Warning: (ae-forgotten-export) The symbol "StaticCCValueFactory" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "getCCValueProperties" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getCCValueProperties" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getCCValueProperties<TTarget extends CommandClass>(target: TTarget): ReadonlyMap<string | number, StaticCCValue | StaticCCValueFactory<TTarget>>;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "getCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getCCValues<T extends CommandClass>(cc: T | CommandClasses_2): Record<string, StaticCCValue | DynamicCCValue | undefined> | undefined;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "getCommandClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getCommandClass" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getCommandClass(cc: CommandClass | CCAPI): CommandClasses_2;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "getCommandClassStatic" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getCommandClassStatic" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getCommandClassStatic<T extends CCConstructor<CommandClass>>(classConstructor: T): CommandClasses_2;
 
-// Warning: (ae-missing-release-tag) "getEnergyProductionScale" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getEnergyProductionScale" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function getEnergyProductionScale(parameter: EnergyProductionParameter, key: number): EnergyProductionScale;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "getExpectedCCResponse" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getExpectedCCResponse" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getExpectedCCResponse<T extends CommandClass>(ccClass: T): typeof CommandClass | DynamicCCResponse<T> | undefined;
 
-// Warning: (ae-missing-release-tag) "getExtensionType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getExtensionType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getExtensionType<T extends Security2Extension>(ext: T): S2ExtensionType;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "getFibaroCCCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getFibaroCCCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const getFibaroCCCommand: (target: FibaroCC) => number | undefined;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
 // Warning: (ae-forgotten-export) The symbol "ManufacturerProprietaryCCConstructor" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "getFibaroCCCommandConstructor" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getFibaroCCCommandConstructor" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const getFibaroCCCommandConstructor: (fibaroCCId: number, fibaroCCCommand: number) => ManufacturerProprietaryCCConstructor<typeof FibaroCC> | undefined;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "getFibaroCCConstructor" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getFibaroCCConstructor" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const getFibaroCCConstructor: (fibaroCCId: number) => ManufacturerProprietaryCCConstructor<typeof FibaroCC> | undefined;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "getFibaroCCId" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getFibaroCCId" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const getFibaroCCId: (target: FibaroCC) => number | undefined;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "getImplementedVersion" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getImplementedVersion" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getImplementedVersion<T extends CommandClass>(cc: T | CommandClasses_2): number;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "getImplementedVersionStatic" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getImplementedVersionStatic" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getImplementedVersionStatic<T extends CCConstructor<CommandClass>>(classConstructor: T): number;
 
-// Warning: (ae-missing-release-tag) "getInnermostCommandClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getInnermostCommandClass" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function getInnermostCommandClass(cc: CommandClass): CommandClass;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "getManufacturerId" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getManufacturerId" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const getManufacturerId: (target: ManufacturerProprietaryCC) => number | undefined;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "getManufacturerIdStatic" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getManufacturerIdStatic" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getManufacturerIdStatic<T extends ManufacturerProprietaryCCConstructor>(classConstructor: T): number;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "getManufacturerProprietaryAPI" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getManufacturerProprietaryAPI" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const getManufacturerProprietaryAPI: (manufacturerId: number) => APIConstructor<ManufacturerProprietaryCCAPI> | undefined;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "getManufacturerProprietaryCCConstructor" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getManufacturerProprietaryCCConstructor" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const getManufacturerProprietaryCCConstructor: (manufacturerId: number) => ManufacturerProprietaryCCConstructor<typeof ManufacturerProprietaryCC> | undefined;
 
 // Warning: (ae-forgotten-export) The symbol "Security2ExtensionConstructor" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "getS2ExtensionConstructor" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getS2ExtensionConstructor" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getS2ExtensionConstructor(type: S2ExtensionType): Security2ExtensionConstructor<Security2Extension> | undefined;
 
-// Warning: (ae-missing-release-tag) "gotDeserializationOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "gotDeserializationOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function gotDeserializationOptions(options: CommandClassOptions): options is CommandClassDeserializationOptions;
 
-// Warning: (ae-missing-release-tag) "HailCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HailCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class HailCC extends CommandClass {
@@ -6843,7 +6843,7 @@ export class HailCC extends CommandClass {
     ccCommand: HailCommand.Hail;
 }
 
-// Warning: (ae-missing-release-tag) "HailCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HailCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum HailCommand {
@@ -6851,7 +6851,7 @@ export enum HailCommand {
     Hail = 1
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlMode" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlMode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum HumidityControlMode {
@@ -6865,7 +6865,7 @@ export enum HumidityControlMode {
     "Off" = 0
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlModeCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlModeCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class HumidityControlModeCC extends CommandClass {
@@ -6877,13 +6877,13 @@ export class HumidityControlModeCC extends CommandClass {
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlModeCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlModeCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class HumidityControlModeCCGet extends HumidityControlModeCC {
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlModeCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlModeCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class HumidityControlModeCCReport extends HumidityControlModeCC {
@@ -6894,7 +6894,7 @@ export class HumidityControlModeCCReport extends HumidityControlModeCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlModeCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlModeCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class HumidityControlModeCCSet extends HumidityControlModeCC {
@@ -6908,13 +6908,13 @@ export class HumidityControlModeCCSet extends HumidityControlModeCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlModeCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlModeCCSupportedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class HumidityControlModeCCSupportedGet extends HumidityControlModeCC {
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlModeCCSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlModeCCSupportedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class HumidityControlModeCCSupportedReport extends HumidityControlModeCC {
@@ -6927,7 +6927,7 @@ export class HumidityControlModeCCSupportedReport extends HumidityControlModeCC 
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlModeCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlModeCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const HumidityControlModeCCValues: Readonly<{
@@ -6989,7 +6989,7 @@ export const HumidityControlModeCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "HumidityControlModeCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlModeCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum HumidityControlModeCommand {
@@ -7005,7 +7005,7 @@ export enum HumidityControlModeCommand {
     SupportedReport = 5
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlOperatingState" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlOperatingState" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum HumidityControlOperatingState {
@@ -7017,7 +7017,7 @@ export enum HumidityControlOperatingState {
     "Idle" = 0
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlOperatingStateCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlOperatingStateCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class HumidityControlOperatingStateCC extends CommandClass {
@@ -7029,13 +7029,13 @@ export class HumidityControlOperatingStateCC extends CommandClass {
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlOperatingStateCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlOperatingStateCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class HumidityControlOperatingStateCCGet extends HumidityControlOperatingStateCC {
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlOperatingStateCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlOperatingStateCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class HumidityControlOperatingStateCCReport extends HumidityControlOperatingStateCC {
@@ -7046,7 +7046,7 @@ export class HumidityControlOperatingStateCCReport extends HumidityControlOperat
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlOperatingStateCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlOperatingStateCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const HumidityControlOperatingStateCCValues: Readonly<{
@@ -7083,7 +7083,7 @@ export const HumidityControlOperatingStateCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "HumidityControlOperatingStateCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlOperatingStateCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum HumidityControlOperatingStateCommand {
@@ -7093,7 +7093,7 @@ export enum HumidityControlOperatingStateCommand {
     Report = 2
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlSetpointCapabilities" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlSetpointCapabilities" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface HumidityControlSetpointCapabilities {
@@ -7107,7 +7107,7 @@ export interface HumidityControlSetpointCapabilities {
     minValueScale: number;
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlSetpointCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlSetpointCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class HumidityControlSetpointCC extends CommandClass {
@@ -7121,7 +7121,7 @@ export class HumidityControlSetpointCC extends CommandClass {
     translatePropertyKey(applHost: ZWaveApplicationHost_2, property: string | number, propertyKey: string | number): string | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlSetpointCCCapabilitiesGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlSetpointCCCapabilitiesGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class HumidityControlSetpointCCCapabilitiesGet extends HumidityControlSetpointCC {
@@ -7135,7 +7135,7 @@ export class HumidityControlSetpointCCCapabilitiesGet extends HumidityControlSet
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlSetpointCCCapabilitiesReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlSetpointCCCapabilitiesReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class HumidityControlSetpointCCCapabilitiesReport extends HumidityControlSetpointCC {
@@ -7156,7 +7156,7 @@ export class HumidityControlSetpointCCCapabilitiesReport extends HumidityControl
     get type(): HumidityControlSetpointType;
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlSetpointCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlSetpointCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class HumidityControlSetpointCCGet extends HumidityControlSetpointCC {
@@ -7170,7 +7170,7 @@ export class HumidityControlSetpointCCGet extends HumidityControlSetpointCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlSetpointCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlSetpointCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class HumidityControlSetpointCCReport extends HumidityControlSetpointCC {
@@ -7187,7 +7187,7 @@ export class HumidityControlSetpointCCReport extends HumidityControlSetpointCC {
     get value(): number;
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlSetpointCCScaleSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlSetpointCCScaleSupportedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class HumidityControlSetpointCCScaleSupportedGet extends HumidityControlSetpointCC {
@@ -7201,7 +7201,7 @@ export class HumidityControlSetpointCCScaleSupportedGet extends HumidityControlS
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlSetpointCCScaleSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlSetpointCCScaleSupportedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class HumidityControlSetpointCCScaleSupportedReport extends HumidityControlSetpointCC {
@@ -7212,7 +7212,7 @@ export class HumidityControlSetpointCCScaleSupportedReport extends HumidityContr
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlSetpointCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlSetpointCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class HumidityControlSetpointCCSet extends HumidityControlSetpointCC {
@@ -7230,13 +7230,13 @@ export class HumidityControlSetpointCCSet extends HumidityControlSetpointCC {
     value: number;
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlSetpointCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlSetpointCCSupportedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class HumidityControlSetpointCCSupportedGet extends HumidityControlSetpointCC {
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlSetpointCCSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlSetpointCCSupportedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class HumidityControlSetpointCCSupportedReport extends HumidityControlSetpointCC {
@@ -7247,7 +7247,7 @@ export class HumidityControlSetpointCCSupportedReport extends HumidityControlSet
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlSetpointCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlSetpointCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const HumidityControlSetpointCCValues: Readonly<{
@@ -7341,7 +7341,7 @@ export const HumidityControlSetpointCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "HumidityControlSetpointCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlSetpointCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum HumidityControlSetpointCommand {
@@ -7365,7 +7365,7 @@ export enum HumidityControlSetpointCommand {
     SupportedReport = 5
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlSetpointMetadata" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlSetpointMetadata" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type HumidityControlSetpointMetadata = ValueMetadata_2 & {
@@ -7374,7 +7374,7 @@ export type HumidityControlSetpointMetadata = ValueMetadata_2 & {
     };
 };
 
-// Warning: (ae-missing-release-tag) "HumidityControlSetpointType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlSetpointType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum HumidityControlSetpointType {
@@ -7388,7 +7388,7 @@ export enum HumidityControlSetpointType {
     "Humidifier" = 1
 }
 
-// Warning: (ae-missing-release-tag) "HumidityControlSetpointValue" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HumidityControlSetpointValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface HumidityControlSetpointValue {
@@ -7398,7 +7398,7 @@ export interface HumidityControlSetpointValue {
     value: number;
 }
 
-// Warning: (ae-missing-release-tag) "ICommandClassContainer" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ICommandClassContainer" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ICommandClassContainer {
@@ -7407,12 +7407,12 @@ export interface ICommandClassContainer {
 }
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "implementedVersion" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "implementedVersion" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const implementedVersion: <TTarget extends CommandClass>(version: number) => TypedClassDecorator_2<TTarget>;
 
-// Warning: (ae-missing-release-tag) "InclusionControllerCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "InclusionControllerCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class InclusionControllerCC extends CommandClass {
@@ -7420,7 +7420,7 @@ export class InclusionControllerCC extends CommandClass {
     ccCommand: InclusionControllerCommand;
 }
 
-// Warning: (ae-missing-release-tag) "InclusionControllerCCComplete" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "InclusionControllerCCComplete" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class InclusionControllerCCComplete extends InclusionControllerCC {
@@ -7436,7 +7436,7 @@ export class InclusionControllerCCComplete extends InclusionControllerCC {
     toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "InclusionControllerCCInitiate" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "InclusionControllerCCInitiate" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class InclusionControllerCCInitiate extends InclusionControllerCC {
@@ -7452,7 +7452,7 @@ export class InclusionControllerCCInitiate extends InclusionControllerCC {
     toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "InclusionControllerCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "InclusionControllerCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum InclusionControllerCommand {
@@ -7462,7 +7462,7 @@ export enum InclusionControllerCommand {
     Initiate = 1
 }
 
-// Warning: (ae-missing-release-tag) "InclusionControllerStatus" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "InclusionControllerStatus" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum InclusionControllerStatus {
@@ -7476,7 +7476,7 @@ export enum InclusionControllerStatus {
     UserRejected = 2
 }
 
-// Warning: (ae-missing-release-tag) "InclusionControllerStep" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "InclusionControllerStep" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum InclusionControllerStep {
@@ -7489,7 +7489,7 @@ export enum InclusionControllerStep {
 }
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "inclusionTimeouts" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "inclusionTimeouts" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const inclusionTimeouts: Readonly<{
@@ -7502,7 +7502,7 @@ export const inclusionTimeouts: Readonly<{
     readonly TAI2: 240000;
 }>;
 
-// Warning: (ae-missing-release-tag) "IndicatorCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IndicatorCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IndicatorCC extends CommandClass {
@@ -7522,7 +7522,7 @@ export class IndicatorCC extends CommandClass {
     translatePropertyKey(applHost: ZWaveApplicationHost_2, property: string | number, propertyKey: string | number): string | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "IndicatorCCDescriptionGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IndicatorCCDescriptionGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IndicatorCCDescriptionGet extends IndicatorCC {
@@ -7536,7 +7536,7 @@ export class IndicatorCCDescriptionGet extends IndicatorCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "IndicatorCCDescriptionReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IndicatorCCDescriptionReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IndicatorCCDescriptionReport extends IndicatorCC {
@@ -7551,7 +7551,7 @@ export class IndicatorCCDescriptionReport extends IndicatorCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "IndicatorCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IndicatorCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IndicatorCCGet extends IndicatorCC {
@@ -7565,7 +7565,7 @@ export class IndicatorCCGet extends IndicatorCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "IndicatorCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IndicatorCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IndicatorCCReport extends IndicatorCC {
@@ -7582,7 +7582,7 @@ export class IndicatorCCReport extends IndicatorCC {
     readonly values: IndicatorObject[] | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "IndicatorCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IndicatorCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IndicatorCCSet extends IndicatorCC {
@@ -7598,7 +7598,7 @@ export class IndicatorCCSet extends IndicatorCC {
     values: IndicatorObject[] | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "IndicatorCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IndicatorCCSupportedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IndicatorCCSupportedGet extends IndicatorCC {
@@ -7612,7 +7612,7 @@ export class IndicatorCCSupportedGet extends IndicatorCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "IndicatorCCSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IndicatorCCSupportedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IndicatorCCSupportedReport extends IndicatorCC {
@@ -7629,7 +7629,7 @@ export class IndicatorCCSupportedReport extends IndicatorCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "IndicatorCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IndicatorCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const IndicatorCCValues: Readonly<{
@@ -7832,7 +7832,7 @@ export const IndicatorCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "IndicatorCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IndicatorCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum IndicatorCommand {
@@ -7852,7 +7852,7 @@ export enum IndicatorCommand {
     SupportedReport = 5
 }
 
-// Warning: (ae-missing-release-tag) "IndicatorMetadata" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IndicatorMetadata" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type IndicatorMetadata = ValueMetadata_2 & {
@@ -7862,7 +7862,7 @@ export type IndicatorMetadata = ValueMetadata_2 & {
     };
 };
 
-// Warning: (ae-missing-release-tag) "IndicatorTimeout" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IndicatorTimeout" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface IndicatorTimeout {
@@ -7871,7 +7871,7 @@ export interface IndicatorTimeout {
     seconds?: number;
 }
 
-// Warning: (ae-missing-release-tag) "InvalidCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "InvalidCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class InvalidCC extends CommandClass {
@@ -7884,7 +7884,7 @@ export class InvalidCC extends CommandClass {
     toLogEntry(): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "InvalidCCCreationOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "InvalidCCCreationOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface InvalidCCCreationOptions extends CommandClassCreationOptions {
@@ -7894,7 +7894,7 @@ export interface InvalidCCCreationOptions extends CommandClassCreationOptions {
     reason?: string | ZWaveErrorCodes;
 }
 
-// Warning: (ae-missing-release-tag) "IrrigationCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IrrigationCC extends CommandClass {
@@ -7911,13 +7911,13 @@ export class IrrigationCC extends CommandClass {
     translateProperty(applHost: ZWaveApplicationHost_2, property: string | number, propertyKey?: string | number): string;
 }
 
-// Warning: (ae-missing-release-tag) "IrrigationCCSystemConfigGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationCCSystemConfigGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IrrigationCCSystemConfigGet extends IrrigationCC {
 }
 
-// Warning: (ae-missing-release-tag) "IrrigationCCSystemConfigReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationCCSystemConfigReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IrrigationCCSystemConfigReport extends IrrigationCC {
@@ -7936,7 +7936,7 @@ export class IrrigationCCSystemConfigReport extends IrrigationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "IrrigationCCSystemConfigSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationCCSystemConfigSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IrrigationCCSystemConfigSet extends IrrigationCC {
@@ -7957,7 +7957,7 @@ export class IrrigationCCSystemConfigSet extends IrrigationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "IrrigationCCSystemConfigSetOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationCCSystemConfigSetOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type IrrigationCCSystemConfigSetOptions = {
@@ -7968,13 +7968,13 @@ export type IrrigationCCSystemConfigSetOptions = {
     moistureSensorPolarity?: IrrigationSensorPolarity;
 };
 
-// Warning: (ae-missing-release-tag) "IrrigationCCSystemInfoGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationCCSystemInfoGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IrrigationCCSystemInfoGet extends IrrigationCC {
 }
 
-// Warning: (ae-missing-release-tag) "IrrigationCCSystemInfoReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationCCSystemInfoReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IrrigationCCSystemInfoReport extends IrrigationCC {
@@ -7991,7 +7991,7 @@ export class IrrigationCCSystemInfoReport extends IrrigationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "IrrigationCCSystemShutoff" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationCCSystemShutoff" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IrrigationCCSystemShutoff extends IrrigationCC {
@@ -8005,13 +8005,13 @@ export class IrrigationCCSystemShutoff extends IrrigationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "IrrigationCCSystemStatusGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationCCSystemStatusGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IrrigationCCSystemStatusGet extends IrrigationCC {
 }
 
-// Warning: (ae-missing-release-tag) "IrrigationCCSystemStatusReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationCCSystemStatusReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IrrigationCCSystemStatusReport extends IrrigationCC {
@@ -8050,7 +8050,7 @@ export class IrrigationCCSystemStatusReport extends IrrigationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "IrrigationCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const IrrigationCCValues: Readonly<{
@@ -9242,7 +9242,7 @@ export const IrrigationCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "IrrigationCCValveConfigGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationCCValveConfigGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IrrigationCCValveConfigGet extends IrrigationCC {
@@ -9256,7 +9256,7 @@ export class IrrigationCCValveConfigGet extends IrrigationCC {
     valveId: ValveId;
 }
 
-// Warning: (ae-missing-release-tag) "IrrigationCCValveConfigReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationCCValveConfigReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IrrigationCCValveConfigReport extends IrrigationCC {
@@ -9283,7 +9283,7 @@ export class IrrigationCCValveConfigReport extends IrrigationCC {
     valveId: ValveId;
 }
 
-// Warning: (ae-missing-release-tag) "IrrigationCCValveConfigSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationCCValveConfigSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IrrigationCCValveConfigSet extends IrrigationCC {
@@ -9310,7 +9310,7 @@ export class IrrigationCCValveConfigSet extends IrrigationCC {
     valveId: ValveId;
 }
 
-// Warning: (ae-missing-release-tag) "IrrigationCCValveConfigSetOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationCCValveConfigSetOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type IrrigationCCValveConfigSetOptions = {
@@ -9324,7 +9324,7 @@ export type IrrigationCCValveConfigSetOptions = {
     useMoistureSensor: boolean;
 };
 
-// Warning: (ae-missing-release-tag) "IrrigationCCValveInfoGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationCCValveInfoGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IrrigationCCValveInfoGet extends IrrigationCC {
@@ -9338,7 +9338,7 @@ export class IrrigationCCValveInfoGet extends IrrigationCC {
     valveId: ValveId;
 }
 
-// Warning: (ae-missing-release-tag) "IrrigationCCValveInfoReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationCCValveInfoReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IrrigationCCValveInfoReport extends IrrigationCC {
@@ -9367,7 +9367,7 @@ export class IrrigationCCValveInfoReport extends IrrigationCC {
     readonly valveId: ValveId;
 }
 
-// Warning: (ae-missing-release-tag) "IrrigationCCValveRun" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationCCValveRun" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IrrigationCCValveRun extends IrrigationCC {
@@ -9383,7 +9383,7 @@ export class IrrigationCCValveRun extends IrrigationCC {
     valveId: ValveId;
 }
 
-// Warning: (ae-missing-release-tag) "IrrigationCCValveTableGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationCCValveTableGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IrrigationCCValveTableGet extends IrrigationCC {
@@ -9397,7 +9397,7 @@ export class IrrigationCCValveTableGet extends IrrigationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "IrrigationCCValveTableReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationCCValveTableReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IrrigationCCValveTableReport extends IrrigationCC {
@@ -9410,7 +9410,7 @@ export class IrrigationCCValveTableReport extends IrrigationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "IrrigationCCValveTableRun" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationCCValveTableRun" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IrrigationCCValveTableRun extends IrrigationCC {
@@ -9424,7 +9424,7 @@ export class IrrigationCCValveTableRun extends IrrigationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "IrrigationCCValveTableSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationCCValveTableSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IrrigationCCValveTableSet extends IrrigationCC {
@@ -9440,7 +9440,7 @@ export class IrrigationCCValveTableSet extends IrrigationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "IrrigationCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum IrrigationCommand {
@@ -9482,7 +9482,7 @@ export enum IrrigationCommand {
     ValveTableSet = 14
 }
 
-// Warning: (ae-missing-release-tag) "IrrigationSensorPolarity" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IrrigationSensorPolarity" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum IrrigationSensorPolarity {
@@ -9492,36 +9492,36 @@ export enum IrrigationSensorPolarity {
     Low = 0
 }
 
-// Warning: (ae-missing-release-tag) "isAssociationAllowed" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isAssociationAllowed" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 function isAssociationAllowed(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2, group: number, destination: AssociationAddress): boolean;
 
-// Warning: (ae-missing-release-tag) "isCommandClassContainer" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isCommandClassContainer" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function isCommandClassContainer<T>(msg: T | undefined): msg is T & ICommandClassContainer;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// Warning: (ae-missing-release-tag) "isEncapsulatingCommandClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isEncapsulatingCommandClass" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function isEncapsulatingCommandClass(cc: any): cc is CommandClass & EncapsulatingCommandClass;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// Warning: (ae-missing-release-tag) "isMultiEncapsulatingCommandClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isMultiEncapsulatingCommandClass" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function isMultiEncapsulatingCommandClass(cc: any): cc is CommandClass & MultiEncapsulatingCommandClass;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "isTransportServiceEncapsulation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isTransportServiceEncapsulation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function isTransportServiceEncapsulation(command: CommandClass): command is TransportServiceCCFirstSegment | TransportServiceCCSubsequentSegment;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "KEXFailType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "KEXFailType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum KEXFailType {
@@ -9546,7 +9546,7 @@ export enum KEXFailType {
 }
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "KEXSchemes" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "KEXSchemes" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum KEXSchemes {
@@ -9554,7 +9554,7 @@ export enum KEXSchemes {
     KEXScheme1 = 1
 }
 
-// Warning: (ae-missing-release-tag) "KeypadMode" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "KeypadMode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum KeypadMode {
@@ -9568,7 +9568,7 @@ export enum KeypadMode {
     Vacation = 1
 }
 
-// Warning: (ae-missing-release-tag) "LanguageCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "LanguageCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class LanguageCC extends CommandClass {
@@ -9580,13 +9580,13 @@ export class LanguageCC extends CommandClass {
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "LanguageCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "LanguageCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class LanguageCCGet extends LanguageCC {
 }
 
-// Warning: (ae-missing-release-tag) "LanguageCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "LanguageCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class LanguageCCReport extends LanguageCC {
@@ -9599,7 +9599,7 @@ export class LanguageCCReport extends LanguageCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "LanguageCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "LanguageCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class LanguageCCSet extends LanguageCC {
@@ -9617,7 +9617,7 @@ export class LanguageCCSet extends LanguageCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "LanguageCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "LanguageCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const LanguageCCValues: Readonly<{
@@ -9675,7 +9675,7 @@ export const LanguageCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "LanguageCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "LanguageCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum LanguageCommand {
@@ -9687,7 +9687,7 @@ export enum LanguageCommand {
     Set = 1
 }
 
-// Warning: (ae-missing-release-tag) "LevelChangeDirection" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "LevelChangeDirection" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum LevelChangeDirection {
@@ -9697,7 +9697,7 @@ export enum LevelChangeDirection {
     "up" = 0
 }
 
-// Warning: (ae-missing-release-tag) "LocalProtectionState" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "LocalProtectionState" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum LocalProtectionState {
@@ -9709,7 +9709,7 @@ export enum LocalProtectionState {
     Unprotected = 0
 }
 
-// Warning: (ae-missing-release-tag) "LockCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "LockCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class LockCC extends CommandClass {
@@ -9721,13 +9721,13 @@ export class LockCC extends CommandClass {
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "LockCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "LockCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class LockCCGet extends LockCC {
 }
 
-// Warning: (ae-missing-release-tag) "LockCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "LockCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class LockCCReport extends LockCC {
@@ -9738,7 +9738,7 @@ export class LockCCReport extends LockCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "LockCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "LockCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class LockCCSet extends LockCC {
@@ -9752,7 +9752,7 @@ export class LockCCSet extends LockCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "LockCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "LockCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const LockCCValues: Readonly<{
@@ -9785,7 +9785,7 @@ export const LockCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "LockCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "LockCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum LockCommand {
@@ -9798,18 +9798,18 @@ export enum LockCommand {
 }
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "manufacturerId" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "manufacturerId" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const manufacturerId: <TTarget extends ManufacturerProprietaryCC>(manufacturerId: number) => TypedClassDecorator_2<TTarget>;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "manufacturerProprietaryAPI" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "manufacturerProprietaryAPI" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const manufacturerProprietaryAPI: <TTarget extends CCAPI>(manufacturerId: number) => TypedClassDecorator_2<TTarget>;
 
-// Warning: (ae-missing-release-tag) "ManufacturerProprietaryCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ManufacturerProprietaryCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ManufacturerProprietaryCC extends CommandClass {
@@ -9829,7 +9829,7 @@ export class ManufacturerProprietaryCC extends CommandClass {
     serialize(): Buffer;
 }
 
-// Warning: (ae-missing-release-tag) "ManufacturerSpecificCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ManufacturerSpecificCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ManufacturerSpecificCC extends CommandClass {
@@ -9841,7 +9841,7 @@ export class ManufacturerSpecificCC extends CommandClass {
     interview(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "ManufacturerSpecificCCDeviceSpecificGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ManufacturerSpecificCCDeviceSpecificGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ManufacturerSpecificCCDeviceSpecificGet extends ManufacturerSpecificCC {
@@ -9855,7 +9855,7 @@ export class ManufacturerSpecificCCDeviceSpecificGet extends ManufacturerSpecifi
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ManufacturerSpecificCCDeviceSpecificReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ManufacturerSpecificCCDeviceSpecificReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ManufacturerSpecificCCDeviceSpecificReport extends ManufacturerSpecificCC {
@@ -9868,13 +9868,13 @@ export class ManufacturerSpecificCCDeviceSpecificReport extends ManufacturerSpec
     readonly type: DeviceIdType;
 }
 
-// Warning: (ae-missing-release-tag) "ManufacturerSpecificCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ManufacturerSpecificCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ManufacturerSpecificCCGet extends ManufacturerSpecificCC {
 }
 
-// Warning: (ae-missing-release-tag) "ManufacturerSpecificCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ManufacturerSpecificCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ManufacturerSpecificCCReport extends ManufacturerSpecificCC {
@@ -9889,7 +9889,7 @@ export class ManufacturerSpecificCCReport extends ManufacturerSpecificCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ManufacturerSpecificCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ManufacturerSpecificCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const ManufacturerSpecificCCValues: Readonly<{
@@ -10008,7 +10008,7 @@ export const ManufacturerSpecificCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "ManufacturerSpecificCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ManufacturerSpecificCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ManufacturerSpecificCommand {
@@ -10023,14 +10023,14 @@ export enum ManufacturerSpecificCommand {
 }
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "messageIsPing" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "messageIsPing" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function messageIsPing<T extends Message>(msg: T): msg is T & {
     command: NoOperationCC;
 };
 
-// Warning: (ae-missing-release-tag) "MeterCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MeterCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MeterCC extends CommandClass {
@@ -10046,7 +10046,7 @@ export class MeterCC extends CommandClass {
     translatePropertyKey(applHost: ZWaveApplicationHost_2, property: string | number, propertyKey: string | number): string | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "MeterCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MeterCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MeterCCGet extends MeterCC {
@@ -10062,7 +10062,7 @@ export class MeterCCGet extends MeterCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MeterCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MeterCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MeterCCReport extends MeterCC {
@@ -10085,7 +10085,7 @@ export class MeterCCReport extends MeterCC {
     get value(): number;
 }
 
-// Warning: (ae-missing-release-tag) "MeterCCReset" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MeterCCReset" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MeterCCReset extends MeterCC {
@@ -10101,13 +10101,13 @@ export class MeterCCReset extends MeterCC {
     type: number | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "MeterCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MeterCCSupportedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MeterCCSupportedGet extends MeterCC {
 }
 
-// Warning: (ae-missing-release-tag) "MeterCCSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MeterCCSupportedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MeterCCSupportedReport extends MeterCC {
@@ -10126,7 +10126,7 @@ export class MeterCCSupportedReport extends MeterCC {
     readonly type: number;
 }
 
-// Warning: (ae-missing-release-tag) "MeterCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MeterCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const MeterCCValues: Readonly<{
@@ -10329,7 +10329,7 @@ export const MeterCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "MeterCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MeterCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum MeterCommand {
@@ -10345,7 +10345,7 @@ export enum MeterCommand {
     SupportedReport = 4
 }
 
-// Warning: (ae-missing-release-tag) "MeterMetadata" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MeterMetadata" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type MeterMetadata = ValueMetadata_2 & {
@@ -10356,7 +10356,7 @@ export type MeterMetadata = ValueMetadata_2 & {
     };
 };
 
-// Warning: (ae-missing-release-tag) "MGRPExtension" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MGRPExtension" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MGRPExtension extends Security2Extension {
@@ -10371,14 +10371,14 @@ export class MGRPExtension extends Security2Extension {
     toLogEntry(): string;
 }
 
-// Warning: (ae-missing-release-tag) "MOSExtension" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MOSExtension" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MOSExtension extends Security2Extension {
     constructor(options?: Security2ExtensionDeserializationOptions);
 }
 
-// Warning: (ae-missing-release-tag) "MPANExtension" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MPANExtension" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MPANExtension extends Security2Extension {
@@ -10396,7 +10396,7 @@ export class MPANExtension extends Security2Extension {
     toLogEntry(): string;
 }
 
-// Warning: (ae-missing-release-tag) "MultiChannelAssociationCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelAssociationCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultiChannelAssociationCC extends CommandClass {
@@ -10413,7 +10413,7 @@ export class MultiChannelAssociationCC extends CommandClass {
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "MultiChannelAssociationCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelAssociationCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultiChannelAssociationCCGet extends MultiChannelAssociationCC {
@@ -10427,7 +10427,7 @@ export class MultiChannelAssociationCCGet extends MultiChannelAssociationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultiChannelAssociationCCRemove" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelAssociationCCRemove" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultiChannelAssociationCCRemove extends MultiChannelAssociationCC {
@@ -10445,7 +10445,7 @@ export class MultiChannelAssociationCCRemove extends MultiChannelAssociationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultiChannelAssociationCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelAssociationCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultiChannelAssociationCCReport extends MultiChannelAssociationCC {
@@ -10470,7 +10470,7 @@ export class MultiChannelAssociationCCReport extends MultiChannelAssociationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultiChannelAssociationCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelAssociationCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultiChannelAssociationCCSet extends MultiChannelAssociationCC {
@@ -10488,13 +10488,13 @@ export class MultiChannelAssociationCCSet extends MultiChannelAssociationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultiChannelAssociationCCSupportedGroupingsGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelAssociationCCSupportedGroupingsGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultiChannelAssociationCCSupportedGroupingsGet extends MultiChannelAssociationCC {
 }
 
-// Warning: (ae-missing-release-tag) "MultiChannelAssociationCCSupportedGroupingsReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelAssociationCCSupportedGroupingsReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultiChannelAssociationCCSupportedGroupingsReport extends MultiChannelAssociationCC {
@@ -10505,7 +10505,7 @@ export class MultiChannelAssociationCCSupportedGroupingsReport extends MultiChan
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultiChannelAssociationCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelAssociationCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const MultiChannelAssociationCCValues: Readonly<{
@@ -10620,7 +10620,7 @@ export const MultiChannelAssociationCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "MultiChannelAssociationCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelAssociationCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum MultiChannelAssociationCommand {
@@ -10638,7 +10638,7 @@ export enum MultiChannelAssociationCommand {
     SupportedGroupingsReport = 6
 }
 
-// Warning: (ae-missing-release-tag) "MultiChannelCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultiChannelCC extends CommandClass {
@@ -10652,7 +10652,7 @@ export class MultiChannelCC extends CommandClass {
     skipEndpointInterview(): boolean;
 }
 
-// Warning: (ae-missing-release-tag) "MultiChannelCCAggregatedMembersGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelCCAggregatedMembersGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultiChannelCCAggregatedMembersGet extends MultiChannelCC {
@@ -10666,7 +10666,7 @@ export class MultiChannelCCAggregatedMembersGet extends MultiChannelCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultiChannelCCAggregatedMembersReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelCCAggregatedMembersReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultiChannelCCAggregatedMembersReport extends MultiChannelCC {
@@ -10679,7 +10679,7 @@ export class MultiChannelCCAggregatedMembersReport extends MultiChannelCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultiChannelCCCapabilityGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelCCCapabilityGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultiChannelCCCapabilityGet extends MultiChannelCC {
@@ -10693,7 +10693,7 @@ export class MultiChannelCCCapabilityGet extends MultiChannelCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultiChannelCCCapabilityReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelCCCapabilityReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultiChannelCCCapabilityReport extends MultiChannelCC implements ApplicationNodeInformation {
@@ -10719,7 +10719,7 @@ export class MultiChannelCCCapabilityReport extends MultiChannelCC implements Ap
     readonly wasRemoved: boolean;
 }
 
-// Warning: (ae-missing-release-tag) "MultiChannelCCCommandEncapsulation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelCCCommandEncapsulation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultiChannelCCCommandEncapsulation extends MultiChannelCC {
@@ -10737,7 +10737,7 @@ export class MultiChannelCCCommandEncapsulation extends MultiChannelCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultiChannelCCEndPointFind" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelCCEndPointFind" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultiChannelCCEndPointFind extends MultiChannelCC {
@@ -10753,7 +10753,7 @@ export class MultiChannelCCEndPointFind extends MultiChannelCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultiChannelCCEndPointFindReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelCCEndPointFindReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultiChannelCCEndPointFindReport extends MultiChannelCC {
@@ -10779,13 +10779,13 @@ export class MultiChannelCCEndPointFindReport extends MultiChannelCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultiChannelCCEndPointGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelCCEndPointGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultiChannelCCEndPointGet extends MultiChannelCC {
 }
 
-// Warning: (ae-missing-release-tag) "MultiChannelCCEndPointReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelCCEndPointReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultiChannelCCEndPointReport extends MultiChannelCC {
@@ -10805,7 +10805,7 @@ export class MultiChannelCCEndPointReport extends MultiChannelCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultiChannelCCV1CommandEncapsulation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelCCV1CommandEncapsulation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultiChannelCCV1CommandEncapsulation extends MultiChannelCC {
@@ -10821,7 +10821,7 @@ export class MultiChannelCCV1CommandEncapsulation extends MultiChannelCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultiChannelCCV1Get" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelCCV1Get" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultiChannelCCV1Get extends MultiChannelCC {
@@ -10835,7 +10835,7 @@ export class MultiChannelCCV1Get extends MultiChannelCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultiChannelCCV1Report" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelCCV1Report" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultiChannelCCV1Report extends MultiChannelCC {
@@ -10848,7 +10848,7 @@ export class MultiChannelCCV1Report extends MultiChannelCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultiChannelCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const MultiChannelCCValues: Readonly<{
@@ -11057,7 +11057,7 @@ export const MultiChannelCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "MultiChannelCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiChannelCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum MultiChannelCommand {
@@ -11087,7 +11087,7 @@ export enum MultiChannelCommand {
     ReportV1 = 5
 }
 
-// Warning: (ae-missing-release-tag) "MultiCommandCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiCommandCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultiCommandCC extends CommandClass {
@@ -11098,7 +11098,7 @@ export class MultiCommandCC extends CommandClass {
     static requiresEncapsulation(cc: CommandClass): boolean;
 }
 
-// Warning: (ae-missing-release-tag) "MultiCommandCCCommandEncapsulation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiCommandCCCommandEncapsulation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultiCommandCCCommandEncapsulation extends MultiCommandCC {
@@ -11112,7 +11112,7 @@ export class MultiCommandCCCommandEncapsulation extends MultiCommandCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultiCommandCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiCommandCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum MultiCommandCommand {
@@ -11120,7 +11120,7 @@ export enum MultiCommandCommand {
     CommandEncapsulation = 1
 }
 
-// Warning: (ae-missing-release-tag) "MultiEncapsulatingCommandClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiEncapsulatingCommandClass" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface MultiEncapsulatingCommandClass {
@@ -11130,7 +11130,7 @@ export interface MultiEncapsulatingCommandClass {
     encapsulated: EncapsulatedCommandClass[];
 }
 
-// Warning: (ae-missing-release-tag) "MultiEncapsulatingCommandClassStatic" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiEncapsulatingCommandClassStatic" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface MultiEncapsulatingCommandClassStatic {
@@ -11142,7 +11142,7 @@ export interface MultiEncapsulatingCommandClassStatic {
     requiresEncapsulation(cc: CommandClass): boolean;
 }
 
-// Warning: (ae-missing-release-tag) "MultilevelSensorCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultilevelSensorCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultilevelSensorCC extends CommandClass {
@@ -11158,7 +11158,7 @@ export class MultilevelSensorCC extends CommandClass {
     translatePropertyKey(applHost: ZWaveApplicationHost_2, property: string | number, propertyKey: string | number): string | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "MultilevelSensorCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultilevelSensorCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultilevelSensorCCGet extends MultilevelSensorCC {
@@ -11174,7 +11174,7 @@ export class MultilevelSensorCCGet extends MultilevelSensorCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultilevelSensorCCGetSupportedScale" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultilevelSensorCCGetSupportedScale" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultilevelSensorCCGetSupportedScale extends MultilevelSensorCC {
@@ -11188,13 +11188,13 @@ export class MultilevelSensorCCGetSupportedScale extends MultilevelSensorCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultilevelSensorCCGetSupportedSensor" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultilevelSensorCCGetSupportedSensor" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultilevelSensorCCGetSupportedSensor extends MultilevelSensorCC {
 }
 
-// Warning: (ae-missing-release-tag) "MultilevelSensorCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultilevelSensorCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultilevelSensorCCReport extends MultilevelSensorCC {
@@ -11213,7 +11213,7 @@ export class MultilevelSensorCCReport extends MultilevelSensorCC {
     value: number;
 }
 
-// Warning: (ae-missing-release-tag) "MultilevelSensorCCReportOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultilevelSensorCCReportOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface MultilevelSensorCCReportOptions extends CCCommandOptions {
@@ -11225,7 +11225,7 @@ export interface MultilevelSensorCCReportOptions extends CCCommandOptions {
     value: number;
 }
 
-// Warning: (ae-missing-release-tag) "MultilevelSensorCCSupportedScaleReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultilevelSensorCCSupportedScaleReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultilevelSensorCCSupportedScaleReport extends MultilevelSensorCC {
@@ -11238,7 +11238,7 @@ export class MultilevelSensorCCSupportedScaleReport extends MultilevelSensorCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultilevelSensorCCSupportedSensorReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultilevelSensorCCSupportedSensorReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultilevelSensorCCSupportedSensorReport extends MultilevelSensorCC {
@@ -11249,7 +11249,7 @@ export class MultilevelSensorCCSupportedSensorReport extends MultilevelSensorCC 
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultilevelSensorCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultilevelSensorCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const MultilevelSensorCCValues: Readonly<{
@@ -11335,7 +11335,7 @@ export const MultilevelSensorCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "MultilevelSensorCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultilevelSensorCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum MultilevelSensorCommand {
@@ -11353,7 +11353,7 @@ export enum MultilevelSensorCommand {
     SupportedSensorReport = 2
 }
 
-// Warning: (ae-missing-release-tag) "MultilevelSensorValue" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultilevelSensorValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface MultilevelSensorValue {
@@ -11363,7 +11363,7 @@ export interface MultilevelSensorValue {
     value: number;
 }
 
-// Warning: (ae-missing-release-tag) "MultilevelSensorValueMetadata" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultilevelSensorValueMetadata" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type MultilevelSensorValueMetadata = ValueMetadata_2 & {
@@ -11373,7 +11373,7 @@ export type MultilevelSensorValueMetadata = ValueMetadata_2 & {
     };
 };
 
-// Warning: (ae-missing-release-tag) "MultilevelSwitchCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultilevelSwitchCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultilevelSwitchCC extends CommandClass {
@@ -11389,13 +11389,13 @@ export class MultilevelSwitchCC extends CommandClass {
     setMappedBasicValue(applHost: ZWaveApplicationHost_2, value: number): boolean;
 }
 
-// Warning: (ae-missing-release-tag) "MultilevelSwitchCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultilevelSwitchCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultilevelSwitchCCGet extends MultilevelSwitchCC {
 }
 
-// Warning: (ae-missing-release-tag) "MultilevelSwitchCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultilevelSwitchCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultilevelSwitchCCReport extends MultilevelSwitchCC {
@@ -11412,7 +11412,7 @@ export class MultilevelSwitchCCReport extends MultilevelSwitchCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultilevelSwitchCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultilevelSwitchCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultilevelSwitchCCSet extends MultilevelSwitchCC {
@@ -11428,7 +11428,7 @@ export class MultilevelSwitchCCSet extends MultilevelSwitchCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultilevelSwitchCCStartLevelChange" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultilevelSwitchCCStartLevelChange" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultilevelSwitchCCStartLevelChange extends MultilevelSwitchCC {
@@ -11448,19 +11448,19 @@ export class MultilevelSwitchCCStartLevelChange extends MultilevelSwitchCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultilevelSwitchCCStopLevelChange" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultilevelSwitchCCStopLevelChange" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultilevelSwitchCCStopLevelChange extends MultilevelSwitchCC {
 }
 
-// Warning: (ae-missing-release-tag) "MultilevelSwitchCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultilevelSwitchCCSupportedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultilevelSwitchCCSupportedGet extends MultilevelSwitchCC {
 }
 
-// Warning: (ae-missing-release-tag) "MultilevelSwitchCCSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultilevelSwitchCCSupportedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MultilevelSwitchCCSupportedReport extends MultilevelSwitchCC {
@@ -11473,7 +11473,7 @@ export class MultilevelSwitchCCSupportedReport extends MultilevelSwitchCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "MultilevelSwitchCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultilevelSwitchCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const MultilevelSwitchCCValues: Readonly<{
@@ -11739,7 +11739,7 @@ export const MultilevelSwitchCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "MultilevelSwitchCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultilevelSwitchCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum MultilevelSwitchCommand {
@@ -11759,7 +11759,7 @@ export enum MultilevelSwitchCommand {
     SupportedReport = 7
 }
 
-// Warning: (ae-missing-release-tag) "MultilevelSwitchLevelChangeMetadata" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultilevelSwitchLevelChangeMetadata" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type MultilevelSwitchLevelChangeMetadata = ValueMetadata_2 & {
@@ -11768,7 +11768,7 @@ export type MultilevelSwitchLevelChangeMetadata = ValueMetadata_2 & {
     };
 };
 
-// Warning: (ae-missing-release-tag) "NetworkTransferStatus" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NetworkTransferStatus" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum NetworkTransferStatus {
@@ -11788,7 +11788,7 @@ export enum NetworkTransferStatus {
     UpdateWait = 4
 }
 
-// Warning: (ae-missing-release-tag) "NodeNamingAndLocationCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NodeNamingAndLocationCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class NodeNamingAndLocationCC extends CommandClass {
@@ -11802,13 +11802,13 @@ export class NodeNamingAndLocationCC extends CommandClass {
     skipEndpointInterview(): boolean;
 }
 
-// Warning: (ae-missing-release-tag) "NodeNamingAndLocationCCLocationGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NodeNamingAndLocationCCLocationGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class NodeNamingAndLocationCCLocationGet extends NodeNamingAndLocationCC {
 }
 
-// Warning: (ae-missing-release-tag) "NodeNamingAndLocationCCLocationReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NodeNamingAndLocationCCLocationReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class NodeNamingAndLocationCCLocationReport extends NodeNamingAndLocationCC {
@@ -11819,7 +11819,7 @@ export class NodeNamingAndLocationCCLocationReport extends NodeNamingAndLocation
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "NodeNamingAndLocationCCLocationSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NodeNamingAndLocationCCLocationSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class NodeNamingAndLocationCCLocationSet extends NodeNamingAndLocationCC {
@@ -11833,13 +11833,13 @@ export class NodeNamingAndLocationCCLocationSet extends NodeNamingAndLocationCC 
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "NodeNamingAndLocationCCNameGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NodeNamingAndLocationCCNameGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class NodeNamingAndLocationCCNameGet extends NodeNamingAndLocationCC {
 }
 
-// Warning: (ae-missing-release-tag) "NodeNamingAndLocationCCNameReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NodeNamingAndLocationCCNameReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class NodeNamingAndLocationCCNameReport extends NodeNamingAndLocationCC {
@@ -11850,7 +11850,7 @@ export class NodeNamingAndLocationCCNameReport extends NodeNamingAndLocationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "NodeNamingAndLocationCCNameSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NodeNamingAndLocationCCNameSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class NodeNamingAndLocationCCNameSet extends NodeNamingAndLocationCC {
@@ -11864,7 +11864,7 @@ export class NodeNamingAndLocationCCNameSet extends NodeNamingAndLocationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "NodeNamingAndLocationCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NodeNamingAndLocationCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const NodeNamingAndLocationCCValues: Readonly<{
@@ -11922,7 +11922,7 @@ export const NodeNamingAndLocationCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "NodeNamingAndLocationCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NodeNamingAndLocationCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum NodeNamingAndLocationCommand {
@@ -11940,7 +11940,7 @@ export enum NodeNamingAndLocationCommand {
     NameSet = 1
 }
 
-// Warning: (ae-missing-release-tag) "NoOperationCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NoOperationCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class NoOperationCC extends CommandClass {
@@ -11948,12 +11948,12 @@ export class NoOperationCC extends CommandClass {
     ccCommand: undefined;
 }
 
-// Warning: (ae-missing-release-tag) "normalizeCCNameOrId" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "normalizeCCNameOrId" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function normalizeCCNameOrId(ccNameOrId: number | string): CommandClasses_2 | undefined;
 
-// Warning: (ae-missing-release-tag) "NotificationCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NotificationCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class NotificationCC extends CommandClass {
@@ -11970,7 +11970,7 @@ export class NotificationCC extends CommandClass {
     shouldRefreshValues(this: SinglecastCC_2<this>, applHost: ZWaveApplicationHost_2): boolean;
 }
 
-// Warning: (ae-missing-release-tag) "NotificationCCEventSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NotificationCCEventSupportedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class NotificationCCEventSupportedGet extends NotificationCC {
@@ -11984,7 +11984,7 @@ export class NotificationCCEventSupportedGet extends NotificationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "NotificationCCEventSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NotificationCCEventSupportedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class NotificationCCEventSupportedReport extends NotificationCC {
@@ -12002,7 +12002,7 @@ export class NotificationCCEventSupportedReport extends NotificationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "NotificationCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NotificationCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class NotificationCCGet extends NotificationCC {
@@ -12018,7 +12018,7 @@ export class NotificationCCGet extends NotificationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "NotificationCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NotificationCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class NotificationCCReport extends NotificationCC {
@@ -12048,7 +12048,7 @@ export class NotificationCCReport extends NotificationCC {
     readonly zensorNetSourceNodeId: number | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "NotificationCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NotificationCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class NotificationCCSet extends NotificationCC {
@@ -12064,13 +12064,13 @@ export class NotificationCCSet extends NotificationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "NotificationCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NotificationCCSupportedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class NotificationCCSupportedGet extends NotificationCC {
 }
 
-// Warning: (ae-missing-release-tag) "NotificationCCSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NotificationCCSupportedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class NotificationCCSupportedReport extends NotificationCC {
@@ -12086,7 +12086,7 @@ export class NotificationCCSupportedReport extends NotificationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "NotificationCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NotificationCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const NotificationCCValues: Readonly<{
@@ -12407,7 +12407,7 @@ export const NotificationCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "NotificationCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NotificationCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum NotificationCommand {
@@ -12427,7 +12427,7 @@ export enum NotificationCommand {
     SupportedReport = 8
 }
 
-// Warning: (ae-missing-release-tag) "NotificationMetadata" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NotificationMetadata" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type NotificationMetadata = ValueMetadata_2 & {
@@ -12436,17 +12436,17 @@ export type NotificationMetadata = ValueMetadata_2 & {
     };
 };
 
-// Warning: (ae-missing-release-tag) "OwnMethodsOf" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "OwnMethodsOf" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type OwnMethodsOf<API extends CCAPI> = Omit<OnlyMethods<API>, keyof OnlyMethods<CCAPI>>;
 
-// Warning: (ae-missing-release-tag) "parseWakeUpTime" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "parseWakeUpTime" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function parseWakeUpTime(value: number): WakeUpTime;
 
-// Warning: (ae-missing-release-tag) "PhysicalCCAPI" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "PhysicalCCAPI" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export class PhysicalCCAPI extends CCAPI {
@@ -12455,17 +12455,17 @@ export class PhysicalCCAPI extends CCAPI {
     protected readonly endpoint: IZWaveEndpoint;
 }
 
-// Warning: (ae-missing-release-tag) "POLL_VALUE" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "POLL_VALUE" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const POLL_VALUE: unique symbol;
 
-// Warning: (ae-missing-release-tag) "PollValueImplementation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "PollValueImplementation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type PollValueImplementation<T = unknown> = (property: ValueIDProperties) => Promise<T | undefined>;
 
-// Warning: (ae-missing-release-tag) "Powerlevel" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Powerlevel" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum Powerlevel {
@@ -12491,7 +12491,7 @@ export enum Powerlevel {
     "Normal Power" = 0
 }
 
-// Warning: (ae-missing-release-tag) "PowerlevelCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "PowerlevelCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class PowerlevelCC extends CommandClass {
@@ -12499,13 +12499,13 @@ export class PowerlevelCC extends CommandClass {
     ccCommand: PowerlevelCommand;
 }
 
-// Warning: (ae-missing-release-tag) "PowerlevelCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "PowerlevelCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class PowerlevelCCGet extends PowerlevelCC {
 }
 
-// Warning: (ae-missing-release-tag) "PowerlevelCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "PowerlevelCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class PowerlevelCCReport extends PowerlevelCC {
@@ -12518,7 +12518,7 @@ export class PowerlevelCCReport extends PowerlevelCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "PowerlevelCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "PowerlevelCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class PowerlevelCCSet extends PowerlevelCC {
@@ -12534,13 +12534,13 @@ export class PowerlevelCCSet extends PowerlevelCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "PowerlevelCCTestNodeGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "PowerlevelCCTestNodeGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class PowerlevelCCTestNodeGet extends PowerlevelCC {
 }
 
-// Warning: (ae-missing-release-tag) "PowerlevelCCTestNodeReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "PowerlevelCCTestNodeReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class PowerlevelCCTestNodeReport extends PowerlevelCC {
@@ -12555,7 +12555,7 @@ export class PowerlevelCCTestNodeReport extends PowerlevelCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "PowerlevelCCTestNodeSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "PowerlevelCCTestNodeSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class PowerlevelCCTestNodeSet extends PowerlevelCC {
@@ -12573,7 +12573,7 @@ export class PowerlevelCCTestNodeSet extends PowerlevelCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "PowerlevelCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "PowerlevelCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum PowerlevelCommand {
@@ -12591,7 +12591,7 @@ export enum PowerlevelCommand {
     TestNodeSet = 4
 }
 
-// Warning: (ae-missing-release-tag) "PowerlevelTestStatus" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "PowerlevelTestStatus" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum PowerlevelTestStatus {
@@ -12603,7 +12603,7 @@ export enum PowerlevelTestStatus {
     Success = 1
 }
 
-// Warning: (ae-missing-release-tag) "ProtectionCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProtectionCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ProtectionCC extends CommandClass {
@@ -12615,13 +12615,13 @@ export class ProtectionCC extends CommandClass {
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "ProtectionCCExclusiveControlGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProtectionCCExclusiveControlGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ProtectionCCExclusiveControlGet extends ProtectionCC {
 }
 
-// Warning: (ae-missing-release-tag) "ProtectionCCExclusiveControlReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProtectionCCExclusiveControlReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ProtectionCCExclusiveControlReport extends ProtectionCC {
@@ -12632,7 +12632,7 @@ export class ProtectionCCExclusiveControlReport extends ProtectionCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ProtectionCCExclusiveControlSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProtectionCCExclusiveControlSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ProtectionCCExclusiveControlSet extends ProtectionCC {
@@ -12646,13 +12646,13 @@ export class ProtectionCCExclusiveControlSet extends ProtectionCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ProtectionCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProtectionCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ProtectionCCGet extends ProtectionCC {
 }
 
-// Warning: (ae-missing-release-tag) "ProtectionCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProtectionCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ProtectionCCReport extends ProtectionCC {
@@ -12665,7 +12665,7 @@ export class ProtectionCCReport extends ProtectionCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ProtectionCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProtectionCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ProtectionCCSet extends ProtectionCC {
@@ -12681,13 +12681,13 @@ export class ProtectionCCSet extends ProtectionCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ProtectionCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProtectionCCSupportedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ProtectionCCSupportedGet extends ProtectionCC {
 }
 
-// Warning: (ae-missing-release-tag) "ProtectionCCSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProtectionCCSupportedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ProtectionCCSupportedReport extends ProtectionCC {
@@ -12706,13 +12706,13 @@ export class ProtectionCCSupportedReport extends ProtectionCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ProtectionCCTimeoutGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProtectionCCTimeoutGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ProtectionCCTimeoutGet extends ProtectionCC {
 }
 
-// Warning: (ae-missing-release-tag) "ProtectionCCTimeoutReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProtectionCCTimeoutReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ProtectionCCTimeoutReport extends ProtectionCC {
@@ -12723,7 +12723,7 @@ export class ProtectionCCTimeoutReport extends ProtectionCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ProtectionCCTimeoutSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProtectionCCTimeoutSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ProtectionCCTimeoutSet extends ProtectionCC {
@@ -12737,7 +12737,7 @@ export class ProtectionCCTimeoutSet extends ProtectionCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ProtectionCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProtectionCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const ProtectionCCValues: Readonly<{
@@ -12957,7 +12957,7 @@ export const ProtectionCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "ProtectionCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProtectionCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ProtectionCommand {
@@ -12985,7 +12985,7 @@ export enum ProtectionCommand {
     TimeoutSet = 9
 }
 
-// Warning: (ae-missing-release-tag) "RateType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "RateType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum RateType {
@@ -12997,12 +12997,12 @@ export enum RateType {
     Unspecified = 0
 }
 
-// Warning: (ae-missing-release-tag) "removeAssociations" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "removeAssociations" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 function removeAssociations(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2, group: number, destinations: AssociationAddress[]): Promise<void>;
 
-// Warning: (ae-missing-release-tag) "RFProtectionState" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "RFProtectionState" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum RFProtectionState {
@@ -13014,7 +13014,7 @@ export enum RFProtectionState {
     Unprotected = 0
 }
 
-// Warning: (ae-missing-release-tag) "SceneActivationCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SceneActivationCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SceneActivationCC extends CommandClass {
@@ -13022,7 +13022,7 @@ export class SceneActivationCC extends CommandClass {
     ccCommand: SceneActivationCommand;
 }
 
-// Warning: (ae-missing-release-tag) "SceneActivationCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SceneActivationCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SceneActivationCCSet extends SceneActivationCC {
@@ -13038,7 +13038,7 @@ export class SceneActivationCCSet extends SceneActivationCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "SceneActivationCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SceneActivationCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const SceneActivationCCValues: Readonly<{
@@ -13099,7 +13099,7 @@ export const SceneActivationCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "SceneActivationCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SceneActivationCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum SceneActivationCommand {
@@ -13107,7 +13107,7 @@ export enum SceneActivationCommand {
     Set = 1
 }
 
-// Warning: (ae-missing-release-tag) "SceneActuatorConfigurationCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SceneActuatorConfigurationCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SceneActuatorConfigurationCC extends CommandClass {
@@ -13117,7 +13117,7 @@ export class SceneActuatorConfigurationCC extends CommandClass {
     interview(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "SceneActuatorConfigurationCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SceneActuatorConfigurationCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SceneActuatorConfigurationCCGet extends SceneActuatorConfigurationCC {
@@ -13131,7 +13131,7 @@ export class SceneActuatorConfigurationCCGet extends SceneActuatorConfigurationC
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "SceneActuatorConfigurationCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SceneActuatorConfigurationCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SceneActuatorConfigurationCCReport extends SceneActuatorConfigurationCC {
@@ -13148,7 +13148,7 @@ export class SceneActuatorConfigurationCCReport extends SceneActuatorConfigurati
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "SceneActuatorConfigurationCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SceneActuatorConfigurationCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SceneActuatorConfigurationCCSet extends SceneActuatorConfigurationCC {
@@ -13166,7 +13166,7 @@ export class SceneActuatorConfigurationCCSet extends SceneActuatorConfigurationC
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "SceneActuatorConfigurationCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SceneActuatorConfigurationCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const SceneActuatorConfigurationCCValues: Readonly<{
@@ -13233,7 +13233,7 @@ export const SceneActuatorConfigurationCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "SceneActuatorConfigurationCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SceneActuatorConfigurationCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum SceneActuatorConfigurationCommand {
@@ -13245,7 +13245,7 @@ export enum SceneActuatorConfigurationCommand {
     Set = 1
 }
 
-// Warning: (ae-missing-release-tag) "SceneControllerConfigurationCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SceneControllerConfigurationCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SceneControllerConfigurationCC extends CommandClass {
@@ -13260,7 +13260,7 @@ export class SceneControllerConfigurationCC extends CommandClass {
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "SceneControllerConfigurationCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SceneControllerConfigurationCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SceneControllerConfigurationCCGet extends SceneControllerConfigurationCC {
@@ -13274,7 +13274,7 @@ export class SceneControllerConfigurationCCGet extends SceneControllerConfigurat
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "SceneControllerConfigurationCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SceneControllerConfigurationCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SceneControllerConfigurationCCReport extends SceneControllerConfigurationCC {
@@ -13291,7 +13291,7 @@ export class SceneControllerConfigurationCCReport extends SceneControllerConfigu
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "SceneControllerConfigurationCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SceneControllerConfigurationCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SceneControllerConfigurationCCSet extends SceneControllerConfigurationCC {
@@ -13309,7 +13309,7 @@ export class SceneControllerConfigurationCCSet extends SceneControllerConfigurat
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "SceneControllerConfigurationCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SceneControllerConfigurationCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const SceneControllerConfigurationCCValues: Readonly<{
@@ -13376,7 +13376,7 @@ export const SceneControllerConfigurationCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "SceneControllerConfigurationCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SceneControllerConfigurationCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum SceneControllerConfigurationCommand {
@@ -13388,7 +13388,7 @@ export enum SceneControllerConfigurationCommand {
     Set = 1
 }
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ScheduleEntryLockCC extends CommandClass {
@@ -13411,7 +13411,7 @@ export class ScheduleEntryLockCC extends CommandClass {
     interview(applHost: ZWaveApplicationHost): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCDailyRepeatingScheduleGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCDailyRepeatingScheduleGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ScheduleEntryLockCCDailyRepeatingScheduleGet extends ScheduleEntryLockCC {
@@ -13427,7 +13427,7 @@ export class ScheduleEntryLockCCDailyRepeatingScheduleGet extends ScheduleEntryL
     userId: number;
 }
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCDailyRepeatingScheduleReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCDailyRepeatingScheduleReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ScheduleEntryLockCCDailyRepeatingScheduleReport extends ScheduleEntryLockCC {
@@ -13455,7 +13455,7 @@ export class ScheduleEntryLockCCDailyRepeatingScheduleReport extends ScheduleEnt
     weekdays?: ScheduleEntryLockWeekday[];
 }
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCDailyRepeatingScheduleSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCDailyRepeatingScheduleSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ScheduleEntryLockCCDailyRepeatingScheduleSet extends ScheduleEntryLockCC {
@@ -13483,7 +13483,7 @@ export class ScheduleEntryLockCCDailyRepeatingScheduleSet extends ScheduleEntryL
 }
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCDailyRepeatingScheduleSetOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCDailyRepeatingScheduleSetOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ScheduleEntryLockCCDailyRepeatingScheduleSetOptions = CCCommandOptions & ScheduleEntryLockSlotId & ({
@@ -13492,7 +13492,7 @@ export type ScheduleEntryLockCCDailyRepeatingScheduleSetOptions = CCCommandOptio
     action: ScheduleEntryLockSetAction.Set;
 } & ScheduleEntryLockDailyRepeatingSchedule));
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCEnableAllSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCEnableAllSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ScheduleEntryLockCCEnableAllSet extends ScheduleEntryLockCC {
@@ -13506,7 +13506,7 @@ export class ScheduleEntryLockCCEnableAllSet extends ScheduleEntryLockCC {
     toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCEnableSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCEnableSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ScheduleEntryLockCCEnableSet extends ScheduleEntryLockCC {
@@ -13522,13 +13522,13 @@ export class ScheduleEntryLockCCEnableSet extends ScheduleEntryLockCC {
     userId: number;
 }
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCSupportedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ScheduleEntryLockCCSupportedGet extends ScheduleEntryLockCC {
 }
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCSupportedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ScheduleEntryLockCCSupportedReport extends ScheduleEntryLockCC {
@@ -13546,13 +13546,13 @@ export class ScheduleEntryLockCCSupportedReport extends ScheduleEntryLockCC {
     toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCTimeOffsetGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCTimeOffsetGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ScheduleEntryLockCCTimeOffsetGet extends ScheduleEntryLockCC {
 }
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCTimeOffsetReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCTimeOffsetReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ScheduleEntryLockCCTimeOffsetReport extends ScheduleEntryLockCC {
@@ -13568,7 +13568,7 @@ export class ScheduleEntryLockCCTimeOffsetReport extends ScheduleEntryLockCC {
     toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCTimeOffsetSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCTimeOffsetSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ScheduleEntryLockCCTimeOffsetSet extends ScheduleEntryLockCC {
@@ -13584,7 +13584,7 @@ export class ScheduleEntryLockCCTimeOffsetSet extends ScheduleEntryLockCC {
     toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const ScheduleEntryLockCCValues: Readonly<{
@@ -13749,7 +13749,7 @@ export const ScheduleEntryLockCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCWeekDayScheduleGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCWeekDayScheduleGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ScheduleEntryLockCCWeekDayScheduleGet extends ScheduleEntryLockCC {
@@ -13765,7 +13765,7 @@ export class ScheduleEntryLockCCWeekDayScheduleGet extends ScheduleEntryLockCC {
     userId: number;
 }
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCWeekDayScheduleReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCWeekDayScheduleReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ScheduleEntryLockCCWeekDayScheduleReport extends ScheduleEntryLockCC {
@@ -13793,7 +13793,7 @@ export class ScheduleEntryLockCCWeekDayScheduleReport extends ScheduleEntryLockC
     weekday?: ScheduleEntryLockWeekday;
 }
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCWeekDayScheduleSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCWeekDayScheduleSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ScheduleEntryLockCCWeekDayScheduleSet extends ScheduleEntryLockCC {
@@ -13821,7 +13821,7 @@ export class ScheduleEntryLockCCWeekDayScheduleSet extends ScheduleEntryLockCC {
 }
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCWeekDayScheduleSetOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCWeekDayScheduleSetOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ScheduleEntryLockCCWeekDayScheduleSetOptions = CCCommandOptions & ScheduleEntryLockSlotId & ({
@@ -13830,7 +13830,7 @@ export type ScheduleEntryLockCCWeekDayScheduleSetOptions = CCCommandOptions & Sc
     action: ScheduleEntryLockSetAction.Set;
 } & ScheduleEntryLockWeekDaySchedule));
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCYearDayScheduleGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCYearDayScheduleGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ScheduleEntryLockCCYearDayScheduleGet extends ScheduleEntryLockCC {
@@ -13846,7 +13846,7 @@ export class ScheduleEntryLockCCYearDayScheduleGet extends ScheduleEntryLockCC {
     userId: number;
 }
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCYearDayScheduleReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCYearDayScheduleReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ScheduleEntryLockCCYearDayScheduleReport extends ScheduleEntryLockCC {
@@ -13884,7 +13884,7 @@ export class ScheduleEntryLockCCYearDayScheduleReport extends ScheduleEntryLockC
     userId: number;
 }
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCYearDayScheduleSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCYearDayScheduleSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ScheduleEntryLockCCYearDayScheduleSet extends ScheduleEntryLockCC {
@@ -13922,7 +13922,7 @@ export class ScheduleEntryLockCCYearDayScheduleSet extends ScheduleEntryLockCC {
 }
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCYearDayScheduleSetOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockCCYearDayScheduleSetOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ScheduleEntryLockCCYearDayScheduleSetOptions = CCCommandOptions & ScheduleEntryLockSlotId & ({
@@ -13931,7 +13931,7 @@ export type ScheduleEntryLockCCYearDayScheduleSetOptions = CCCommandOptions & Sc
     action: ScheduleEntryLockSetAction.Set;
 } & ScheduleEntryLockYearDaySchedule));
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ScheduleEntryLockCommand {
@@ -13969,7 +13969,7 @@ export enum ScheduleEntryLockCommand {
     YearDayScheduleSet = 6
 }
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockDailyRepeatingSchedule" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockDailyRepeatingSchedule" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ScheduleEntryLockDailyRepeatingSchedule {
@@ -13985,7 +13985,7 @@ export interface ScheduleEntryLockDailyRepeatingSchedule {
     weekdays: ScheduleEntryLockWeekday[];
 }
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockScheduleKind" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockScheduleKind" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ScheduleEntryLockScheduleKind {
@@ -13997,7 +13997,7 @@ export enum ScheduleEntryLockScheduleKind {
     YearDay = 1
 }
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockSetAction" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockSetAction" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ScheduleEntryLockSetAction {
@@ -14007,7 +14007,7 @@ export enum ScheduleEntryLockSetAction {
     Set = 1
 }
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockSlotId" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockSlotId" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ScheduleEntryLockSlotId {
@@ -14017,7 +14017,7 @@ export interface ScheduleEntryLockSlotId {
     userId: number;
 }
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockWeekday" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockWeekday" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ScheduleEntryLockWeekday {
@@ -14037,7 +14037,7 @@ export enum ScheduleEntryLockWeekday {
     Wednesday = 3
 }
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockWeekDaySchedule" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockWeekDaySchedule" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ScheduleEntryLockWeekDaySchedule {
@@ -14053,7 +14053,7 @@ export interface ScheduleEntryLockWeekDaySchedule {
     weekday: ScheduleEntryLockWeekday;
 }
 
-// Warning: (ae-missing-release-tag) "ScheduleEntryLockYearDaySchedule" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleEntryLockYearDaySchedule" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ScheduleEntryLockYearDaySchedule {
@@ -14079,7 +14079,7 @@ export interface ScheduleEntryLockYearDaySchedule {
     stopYear: number;
 }
 
-// Warning: (ae-missing-release-tag) "ScheduleOverrideType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScheduleOverrideType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ScheduleOverrideType {
@@ -14091,7 +14091,7 @@ export enum ScheduleOverrideType {
     Temporary = 1
 }
 
-// Warning: (ae-missing-release-tag) "SchedulePollOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SchedulePollOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface SchedulePollOptions {
@@ -14101,7 +14101,7 @@ export interface SchedulePollOptions {
     transition?: "fast" | "slow";
 }
 
-// Warning: (ae-missing-release-tag) "Security2CC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Security2CC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class Security2CC extends CommandClass {
@@ -14118,13 +14118,13 @@ export class Security2CC extends CommandClass {
     static requiresEncapsulation(cc: CommandClass): boolean;
 }
 
-// Warning: (ae-missing-release-tag) "Security2CCCommandsSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Security2CCCommandsSupportedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class Security2CCCommandsSupportedGet extends Security2CC {
 }
 
-// Warning: (ae-missing-release-tag) "Security2CCCommandsSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Security2CCCommandsSupportedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class Security2CCCommandsSupportedReport extends Security2CC {
@@ -14138,7 +14138,7 @@ export class Security2CCCommandsSupportedReport extends Security2CC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "Security2CCKEXFail" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Security2CCKEXFail" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class Security2CCKEXFail extends Security2CC {
@@ -14152,13 +14152,13 @@ export class Security2CCKEXFail extends Security2CC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "Security2CCKEXGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Security2CCKEXGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class Security2CCKEXGet extends Security2CC {
 }
 
-// Warning: (ae-missing-release-tag) "Security2CCKEXReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Security2CCKEXReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class Security2CCKEXReport extends Security2CC {
@@ -14180,7 +14180,7 @@ export class Security2CCKEXReport extends Security2CC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "Security2CCKEXSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Security2CCKEXSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class Security2CCKEXSet extends Security2CC {
@@ -14202,7 +14202,7 @@ export class Security2CCKEXSet extends Security2CC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "Security2CCMessageEncapsulation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Security2CCMessageEncapsulation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class Security2CCMessageEncapsulation extends Security2CC {
@@ -14233,7 +14233,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
     readonly verifyDelivery: boolean;
 }
 
-// Warning: (ae-missing-release-tag) "Security2CCNetworkKeyGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Security2CCNetworkKeyGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class Security2CCNetworkKeyGet extends Security2CC {
@@ -14247,7 +14247,7 @@ export class Security2CCNetworkKeyGet extends Security2CC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "Security2CCNetworkKeyReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Security2CCNetworkKeyReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class Security2CCNetworkKeyReport extends Security2CC {
@@ -14263,13 +14263,13 @@ export class Security2CCNetworkKeyReport extends Security2CC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "Security2CCNetworkKeyVerify" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Security2CCNetworkKeyVerify" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class Security2CCNetworkKeyVerify extends Security2CC {
 }
 
-// Warning: (ae-missing-release-tag) "Security2CCNonceGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Security2CCNonceGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class Security2CCNonceGet extends Security2CC {
@@ -14285,7 +14285,7 @@ export class Security2CCNonceGet extends Security2CC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "Security2CCNonceReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Security2CCNonceReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class Security2CCNonceReport extends Security2CC {
@@ -14308,7 +14308,7 @@ export class Security2CCNonceReport extends Security2CC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "Security2CCPublicKeyReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Security2CCPublicKeyReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class Security2CCPublicKeyReport extends Security2CC {
@@ -14324,7 +14324,7 @@ export class Security2CCPublicKeyReport extends Security2CC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "Security2CCTransferEnd" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Security2CCTransferEnd" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class Security2CCTransferEnd extends Security2CC {
@@ -14340,7 +14340,7 @@ export class Security2CCTransferEnd extends Security2CC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "Security2Command" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Security2Command" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum Security2Command {
@@ -14374,7 +14374,7 @@ export enum Security2Command {
     TransferEnd = 12
 }
 
-// Warning: (ae-missing-release-tag) "Security2Extension" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Security2Extension" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class Security2Extension {
@@ -14400,7 +14400,7 @@ export class Security2Extension {
     type: S2ExtensionType;
 }
 
-// Warning: (ae-missing-release-tag) "SecurityCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SecurityCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SecurityCC extends CommandClass {
@@ -14418,7 +14418,7 @@ export class SecurityCC extends CommandClass {
     static requiresEncapsulation(cc: CommandClass): boolean;
 }
 
-// Warning: (ae-missing-release-tag) "SecurityCCCommandEncapsulation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SecurityCCCommandEncapsulation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SecurityCCCommandEncapsulation extends SecurityCC {
@@ -14444,19 +14444,19 @@ export class SecurityCCCommandEncapsulation extends SecurityCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "SecurityCCCommandEncapsulationNonceGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SecurityCCCommandEncapsulationNonceGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SecurityCCCommandEncapsulationNonceGet extends SecurityCCCommandEncapsulation {
 }
 
-// Warning: (ae-missing-release-tag) "SecurityCCCommandsSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SecurityCCCommandsSupportedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SecurityCCCommandsSupportedGet extends SecurityCC {
 }
 
-// Warning: (ae-missing-release-tag) "SecurityCCCommandsSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SecurityCCCommandsSupportedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SecurityCCCommandsSupportedReport extends SecurityCC {
@@ -14480,7 +14480,7 @@ export class SecurityCCCommandsSupportedReport extends SecurityCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "SecurityCCNetworkKeySet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SecurityCCNetworkKeySet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SecurityCCNetworkKeySet extends SecurityCC {
@@ -14492,19 +14492,19 @@ export class SecurityCCNetworkKeySet extends SecurityCC {
     serialize(): Buffer;
 }
 
-// Warning: (ae-missing-release-tag) "SecurityCCNetworkKeyVerify" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SecurityCCNetworkKeyVerify" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SecurityCCNetworkKeyVerify extends SecurityCC {
 }
 
-// Warning: (ae-missing-release-tag) "SecurityCCNonceGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SecurityCCNonceGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SecurityCCNonceGet extends SecurityCC {
 }
 
-// Warning: (ae-missing-release-tag) "SecurityCCNonceReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SecurityCCNonceReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SecurityCCNonceReport extends SecurityCC {
@@ -14518,7 +14518,7 @@ export class SecurityCCNonceReport extends SecurityCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "SecurityCCSchemeGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SecurityCCSchemeGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SecurityCCSchemeGet extends SecurityCC {
@@ -14529,7 +14529,7 @@ export class SecurityCCSchemeGet extends SecurityCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "SecurityCCSchemeInherit" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SecurityCCSchemeInherit" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SecurityCCSchemeInherit extends SecurityCC {
@@ -14540,14 +14540,14 @@ export class SecurityCCSchemeInherit extends SecurityCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "SecurityCCSchemeReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SecurityCCSchemeReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SecurityCCSchemeReport extends SecurityCC {
     constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
 }
 
-// Warning: (ae-missing-release-tag) "SecurityCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SecurityCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum SecurityCommand {
@@ -14575,27 +14575,27 @@ export enum SecurityCommand {
     SchemeReport = 5
 }
 
-// Warning: (ae-missing-release-tag) "SET_VALUE" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SET_VALUE" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const SET_VALUE: unique symbol;
 
-// Warning: (ae-missing-release-tag) "SET_VALUE_HOOKS" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SET_VALUE_HOOKS" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const SET_VALUE_HOOKS: unique symbol;
 
-// Warning: (ae-missing-release-tag) "SetbackSpecialState" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SetbackSpecialState" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type SetbackSpecialState = "Frost Protection" | "Energy Saving" | "Unused";
 
-// Warning: (ae-missing-release-tag) "SetbackState" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SetbackState" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type SetbackState = number | SetbackSpecialState;
 
-// Warning: (ae-missing-release-tag) "SetbackType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SetbackType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum SetbackType {
@@ -14608,17 +14608,17 @@ export enum SetbackType {
 }
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "SetValueAPIOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SetValueAPIOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export type SetValueAPIOptions = Partial<ValueChangeOptions>;
 
-// Warning: (ae-missing-release-tag) "SetValueImplementation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SetValueImplementation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type SetValueImplementation = (property: ValueIDProperties, value: unknown, options?: SetValueAPIOptions) => Promise<SupervisionResult_2 | undefined>;
 
-// Warning: (ae-missing-release-tag) "SetValueImplementationHooks" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SetValueImplementationHooks" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type SetValueImplementationHooks = AllOrNone_2<{
@@ -14631,18 +14631,18 @@ export type SetValueImplementationHooks = AllOrNone_2<{
     verifyChanges?: () => void | Promise<void>;
 };
 
-// Warning: (ae-missing-release-tag) "SetValueImplementationHooksFactory" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SetValueImplementationHooksFactory" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type SetValueImplementationHooksFactory = (property: ValueIDProperties, value: unknown, options?: SetValueAPIOptions) => SetValueImplementationHooks | undefined;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "shouldUseSupervision" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "shouldUseSupervision" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const shouldUseSupervision: (target: CommandClass) => boolean;
 
-// Warning: (ae-missing-release-tag) "SoundSwitchCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SoundSwitchCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SoundSwitchCC extends CommandClass {
@@ -14652,13 +14652,13 @@ export class SoundSwitchCC extends CommandClass {
     interview(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "SoundSwitchCCConfigurationGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SoundSwitchCCConfigurationGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SoundSwitchCCConfigurationGet extends SoundSwitchCC {
 }
 
-// Warning: (ae-missing-release-tag) "SoundSwitchCCConfigurationReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SoundSwitchCCConfigurationReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SoundSwitchCCConfigurationReport extends SoundSwitchCC {
@@ -14674,7 +14674,7 @@ export class SoundSwitchCCConfigurationReport extends SoundSwitchCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "SoundSwitchCCConfigurationSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SoundSwitchCCConfigurationSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SoundSwitchCCConfigurationSet extends SoundSwitchCC {
@@ -14690,7 +14690,7 @@ export class SoundSwitchCCConfigurationSet extends SoundSwitchCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "SoundSwitchCCToneInfoGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SoundSwitchCCToneInfoGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SoundSwitchCCToneInfoGet extends SoundSwitchCC {
@@ -14704,7 +14704,7 @@ export class SoundSwitchCCToneInfoGet extends SoundSwitchCC {
     toneId: number;
 }
 
-// Warning: (ae-missing-release-tag) "SoundSwitchCCToneInfoReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SoundSwitchCCToneInfoReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SoundSwitchCCToneInfoReport extends SoundSwitchCC {
@@ -14722,13 +14722,13 @@ export class SoundSwitchCCToneInfoReport extends SoundSwitchCC {
     readonly toneId: number;
 }
 
-// Warning: (ae-missing-release-tag) "SoundSwitchCCTonePlayGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SoundSwitchCCTonePlayGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SoundSwitchCCTonePlayGet extends SoundSwitchCC {
 }
 
-// Warning: (ae-missing-release-tag) "SoundSwitchCCTonePlayReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SoundSwitchCCTonePlayReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SoundSwitchCCTonePlayReport extends SoundSwitchCC {
@@ -14741,7 +14741,7 @@ export class SoundSwitchCCTonePlayReport extends SoundSwitchCC {
     volume?: number;
 }
 
-// Warning: (ae-missing-release-tag) "SoundSwitchCCTonePlaySet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SoundSwitchCCTonePlaySet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SoundSwitchCCTonePlaySet extends SoundSwitchCC {
@@ -14757,13 +14757,13 @@ export class SoundSwitchCCTonePlaySet extends SoundSwitchCC {
     volume?: number;
 }
 
-// Warning: (ae-missing-release-tag) "SoundSwitchCCTonesNumberGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SoundSwitchCCTonesNumberGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SoundSwitchCCTonesNumberGet extends SoundSwitchCC {
 }
 
-// Warning: (ae-missing-release-tag) "SoundSwitchCCTonesNumberReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SoundSwitchCCTonesNumberReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SoundSwitchCCTonesNumberReport extends SoundSwitchCC {
@@ -14777,7 +14777,7 @@ export class SoundSwitchCCTonesNumberReport extends SoundSwitchCC {
     toneCount: number;
 }
 
-// Warning: (ae-missing-release-tag) "SoundSwitchCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SoundSwitchCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const SoundSwitchCCValues: Readonly<{
@@ -14901,7 +14901,7 @@ export const SoundSwitchCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "SoundSwitchCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SoundSwitchCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum SoundSwitchCommand {
@@ -14927,7 +14927,7 @@ export enum SoundSwitchCommand {
     TonesNumberReport = 2
 }
 
-// Warning: (ae-missing-release-tag) "SPANExtension" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SPANExtension" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SPANExtension extends Security2Extension {
@@ -14941,7 +14941,7 @@ export class SPANExtension extends Security2Extension {
     toLogEntry(): string;
 }
 
-// Warning: (ae-missing-release-tag) "SubsystemState" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SubsystemState" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum SubsystemState {
@@ -14951,7 +14951,7 @@ export enum SubsystemState {
     On = 255
 }
 
-// Warning: (ae-missing-release-tag) "SubsystemType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SubsystemType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum SubsystemType {
@@ -14961,7 +14961,7 @@ export enum SubsystemType {
     Visual = 2
 }
 
-// Warning: (ae-missing-release-tag) "SupervisionCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SupervisionCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SupervisionCC extends CommandClass {
@@ -14977,7 +14977,7 @@ export class SupervisionCC extends CommandClass {
     static setCCSupportedWithSupervision(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2, ccId: CommandClasses, supported: boolean): void;
 }
 
-// Warning: (ae-missing-release-tag) "SupervisionCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SupervisionCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SupervisionCCGet extends SupervisionCC {
@@ -14997,7 +14997,7 @@ export class SupervisionCCGet extends SupervisionCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "SupervisionCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SupervisionCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SupervisionCCReport extends SupervisionCC {
@@ -15021,7 +15021,7 @@ export class SupervisionCCReport extends SupervisionCC {
     toSupervisionResult(): SupervisionResult;
 }
 
-// Warning: (ae-missing-release-tag) "SupervisionCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SupervisionCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const SupervisionCCValues: Readonly<{
@@ -15055,7 +15055,7 @@ export const SupervisionCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "SupervisionCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SupervisionCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum SupervisionCommand {
@@ -15065,7 +15065,7 @@ export enum SupervisionCommand {
     Report = 2
 }
 
-// Warning: (ae-missing-release-tag) "Switchpoint" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Switchpoint" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface Switchpoint {
@@ -15077,7 +15077,7 @@ export interface Switchpoint {
     state: SetbackState | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "SwitchType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SwitchType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum SwitchType {
@@ -15099,7 +15099,7 @@ export enum SwitchType {
     "Reverse/Forward" = 6
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatFanMode" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatFanMode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ThermostatFanMode {
@@ -15129,7 +15129,7 @@ export enum ThermostatFanMode {
     "Quiet" = 10
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatFanModeCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatFanModeCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatFanModeCC extends CommandClass {
@@ -15141,13 +15141,13 @@ export class ThermostatFanModeCC extends CommandClass {
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatFanModeCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatFanModeCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatFanModeCCGet extends ThermostatFanModeCC {
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatFanModeCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatFanModeCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatFanModeCCReport extends ThermostatFanModeCC {
@@ -15160,7 +15160,7 @@ export class ThermostatFanModeCCReport extends ThermostatFanModeCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatFanModeCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatFanModeCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatFanModeCCSet extends ThermostatFanModeCC {
@@ -15176,13 +15176,13 @@ export class ThermostatFanModeCCSet extends ThermostatFanModeCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatFanModeCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatFanModeCCSupportedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatFanModeCCSupportedGet extends ThermostatFanModeCC {
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatFanModeCCSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatFanModeCCSupportedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatFanModeCCSupportedReport extends ThermostatFanModeCC {
@@ -15195,7 +15195,7 @@ export class ThermostatFanModeCCSupportedReport extends ThermostatFanModeCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatFanModeCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatFanModeCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const ThermostatFanModeCCValues: Readonly<{
@@ -15283,7 +15283,7 @@ export const ThermostatFanModeCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "ThermostatFanModeCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatFanModeCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ThermostatFanModeCommand {
@@ -15299,7 +15299,7 @@ export enum ThermostatFanModeCommand {
     SupportedReport = 5
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatFanState" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatFanState" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ThermostatFanState {
@@ -15323,7 +15323,7 @@ export enum ThermostatFanState {
     "Up - down circulation mode" = 7
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatFanStateCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatFanStateCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatFanStateCC extends CommandClass {
@@ -15335,13 +15335,13 @@ export class ThermostatFanStateCC extends CommandClass {
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatFanStateCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatFanStateCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatFanStateCCGet extends ThermostatFanStateCC {
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatFanStateCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatFanStateCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatFanStateCCReport extends ThermostatFanStateCC {
@@ -15352,7 +15352,7 @@ export class ThermostatFanStateCCReport extends ThermostatFanStateCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatFanStateCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatFanStateCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const ThermostatFanStateCCValues: Readonly<{
@@ -15389,7 +15389,7 @@ export const ThermostatFanStateCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "ThermostatFanStateCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatFanStateCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ThermostatFanStateCommand {
@@ -15399,7 +15399,7 @@ export enum ThermostatFanStateCommand {
     Report = 3
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatMode" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatMode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ThermostatMode {
@@ -15437,7 +15437,7 @@ export enum ThermostatMode {
     "Off" = 0
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatModeCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatModeCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatModeCC extends CommandClass {
@@ -15449,13 +15449,13 @@ export class ThermostatModeCC extends CommandClass {
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatModeCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatModeCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatModeCCGet extends ThermostatModeCC {
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatModeCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatModeCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatModeCCReport extends ThermostatModeCC {
@@ -15470,7 +15470,7 @@ export class ThermostatModeCCReport extends ThermostatModeCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatModeCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatModeCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatModeCCSet extends ThermostatModeCC {
@@ -15486,13 +15486,13 @@ export class ThermostatModeCCSet extends ThermostatModeCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatModeCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatModeCCSupportedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatModeCCSupportedGet extends ThermostatModeCC {
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatModeCCSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatModeCCSupportedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatModeCCSupportedReport extends ThermostatModeCC {
@@ -15505,7 +15505,7 @@ export class ThermostatModeCCSupportedReport extends ThermostatModeCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatModeCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatModeCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const ThermostatModeCCValues: Readonly<{
@@ -15593,7 +15593,7 @@ export const ThermostatModeCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "ThermostatModeCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatModeCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ThermostatModeCommand {
@@ -15609,7 +15609,7 @@ export enum ThermostatModeCommand {
     SupportedReport = 5
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatOperatingState" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatOperatingState" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ThermostatOperatingState {
@@ -15639,7 +15639,7 @@ export enum ThermostatOperatingState {
     "Idle" = 0
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatOperatingStateCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatOperatingStateCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatOperatingStateCC extends CommandClass {
@@ -15651,13 +15651,13 @@ export class ThermostatOperatingStateCC extends CommandClass {
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatOperatingStateCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatOperatingStateCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatOperatingStateCCGet extends ThermostatOperatingStateCC {
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatOperatingStateCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatOperatingStateCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatOperatingStateCCReport extends ThermostatOperatingStateCC {
@@ -15668,7 +15668,7 @@ export class ThermostatOperatingStateCCReport extends ThermostatOperatingStateCC
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatOperatingStateCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatOperatingStateCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const ThermostatOperatingStateCCValues: Readonly<{
@@ -15705,7 +15705,7 @@ export const ThermostatOperatingStateCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "ThermostatOperatingStateCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatOperatingStateCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ThermostatOperatingStateCommand {
@@ -15715,7 +15715,7 @@ export enum ThermostatOperatingStateCommand {
     Report = 3
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatSetbackCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatSetbackCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatSetbackCC extends CommandClass {
@@ -15727,13 +15727,13 @@ export class ThermostatSetbackCC extends CommandClass {
     refreshValues(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatSetbackCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatSetbackCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatSetbackCCGet extends ThermostatSetbackCC {
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatSetbackCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatSetbackCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatSetbackCCReport extends ThermostatSetbackCC {
@@ -15746,7 +15746,7 @@ export class ThermostatSetbackCCReport extends ThermostatSetbackCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatSetbackCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatSetbackCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatSetbackCCSet extends ThermostatSetbackCC {
@@ -15761,7 +15761,7 @@ export class ThermostatSetbackCCSet extends ThermostatSetbackCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatSetbackCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatSetbackCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const ThermostatSetbackCCValues: Readonly<{
@@ -15821,7 +15821,7 @@ export const ThermostatSetbackCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "ThermostatSetbackCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatSetbackCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ThermostatSetbackCommand {
@@ -15833,7 +15833,7 @@ export enum ThermostatSetbackCommand {
     Set = 1
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatSetpointCapabilities" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatSetpointCapabilities" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ThermostatSetpointCapabilities {
@@ -15847,7 +15847,7 @@ export interface ThermostatSetpointCapabilities {
     minValueScale: number;
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatSetpointCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatSetpointCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatSetpointCC extends CommandClass {
@@ -15861,7 +15861,7 @@ export class ThermostatSetpointCC extends CommandClass {
     translatePropertyKey(applHost: ZWaveApplicationHost_2, property: string | number, propertyKey: string | number): string | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatSetpointCCCapabilitiesGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatSetpointCCCapabilitiesGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatSetpointCCCapabilitiesGet extends ThermostatSetpointCC {
@@ -15875,7 +15875,7 @@ export class ThermostatSetpointCCCapabilitiesGet extends ThermostatSetpointCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatSetpointCCCapabilitiesReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatSetpointCCCapabilitiesReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatSetpointCCCapabilitiesReport extends ThermostatSetpointCC {
@@ -15896,7 +15896,7 @@ export class ThermostatSetpointCCCapabilitiesReport extends ThermostatSetpointCC
     get type(): ThermostatSetpointType;
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatSetpointCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatSetpointCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatSetpointCCGet extends ThermostatSetpointCC {
@@ -15910,7 +15910,7 @@ export class ThermostatSetpointCCGet extends ThermostatSetpointCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatSetpointCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatSetpointCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatSetpointCCReport extends ThermostatSetpointCC {
@@ -15927,7 +15927,7 @@ export class ThermostatSetpointCCReport extends ThermostatSetpointCC {
     get value(): number;
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatSetpointCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatSetpointCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatSetpointCCSet extends ThermostatSetpointCC {
@@ -15945,13 +15945,13 @@ export class ThermostatSetpointCCSet extends ThermostatSetpointCC {
     value: number;
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatSetpointCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatSetpointCCSupportedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatSetpointCCSupportedGet extends ThermostatSetpointCC {
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatSetpointCCSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatSetpointCCSupportedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ThermostatSetpointCCSupportedReport extends ThermostatSetpointCC {
@@ -15962,7 +15962,7 @@ export class ThermostatSetpointCCSupportedReport extends ThermostatSetpointCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatSetpointCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatSetpointCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const ThermostatSetpointCCValues: Readonly<{
@@ -16078,7 +16078,7 @@ export const ThermostatSetpointCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "ThermostatSetpointCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatSetpointCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ThermostatSetpointCommand {
@@ -16098,7 +16098,7 @@ export enum ThermostatSetpointCommand {
     SupportedReport = 5
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatSetpointMetadata" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatSetpointMetadata" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ThermostatSetpointMetadata = ValueMetadata_2 & {
@@ -16107,7 +16107,7 @@ export type ThermostatSetpointMetadata = ValueMetadata_2 & {
     };
 };
 
-// Warning: (ae-missing-release-tag) "ThermostatSetpointType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatSetpointType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ThermostatSetpointType {
@@ -16137,7 +16137,7 @@ export enum ThermostatSetpointType {
     "Heating" = 1
 }
 
-// Warning: (ae-missing-release-tag) "ThermostatSetpointValue" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThermostatSetpointValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ThermostatSetpointValue {
@@ -16147,27 +16147,27 @@ export interface ThermostatSetpointValue {
     value: number;
 }
 
-// Warning: (ae-missing-release-tag) "throwMissingPropertyKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "throwMissingPropertyKey" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function throwMissingPropertyKey(cc: CommandClasses_2, property: string | number): never;
 
-// Warning: (ae-missing-release-tag) "throwUnsupportedProperty" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "throwUnsupportedProperty" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function throwUnsupportedProperty(cc: CommandClasses_2, property: string | number): never;
 
-// Warning: (ae-missing-release-tag) "throwUnsupportedPropertyKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "throwUnsupportedPropertyKey" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function throwUnsupportedPropertyKey(cc: CommandClasses_2, property: string | number, propertyKey: string | number): never;
 
-// Warning: (ae-missing-release-tag) "throwWrongValueType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "throwWrongValueType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function throwWrongValueType(cc: CommandClasses_2, property: string | number, expectedType: string, receivedType: string): never;
 
-// Warning: (ae-missing-release-tag) "TimeCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TimeCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class TimeCC extends CommandClass {
@@ -16177,13 +16177,13 @@ export class TimeCC extends CommandClass {
     interview(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "TimeCCDateGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TimeCCDateGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class TimeCCDateGet extends TimeCC {
 }
 
-// Warning: (ae-missing-release-tag) "TimeCCDateReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TimeCCDateReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class TimeCCDateReport extends TimeCC {
@@ -16201,19 +16201,19 @@ export class TimeCCDateReport extends TimeCC {
     year: number;
 }
 
-// Warning: (ae-missing-release-tag) "TimeCCTimeGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TimeCCTimeGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class TimeCCTimeGet extends TimeCC {
 }
 
-// Warning: (ae-missing-release-tag) "TimeCCTimeOffsetGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TimeCCTimeOffsetGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class TimeCCTimeOffsetGet extends TimeCC {
 }
 
-// Warning: (ae-missing-release-tag) "TimeCCTimeOffsetReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TimeCCTimeOffsetReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class TimeCCTimeOffsetReport extends TimeCC {
@@ -16233,7 +16233,7 @@ export class TimeCCTimeOffsetReport extends TimeCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "TimeCCTimeOffsetSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TimeCCTimeOffsetSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class TimeCCTimeOffsetSet extends TimeCC {
@@ -16253,7 +16253,7 @@ export class TimeCCTimeOffsetSet extends TimeCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "TimeCCTimeReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TimeCCTimeReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class TimeCCTimeReport extends TimeCC {
@@ -16271,7 +16271,7 @@ export class TimeCCTimeReport extends TimeCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "TimeCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TimeCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum TimeCommand {
@@ -16291,7 +16291,7 @@ export enum TimeCommand {
     TimeReport = 2
 }
 
-// Warning: (ae-missing-release-tag) "TimeParametersCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TimeParametersCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class TimeParametersCC extends CommandClass {
@@ -16301,13 +16301,13 @@ export class TimeParametersCC extends CommandClass {
     interview(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "TimeParametersCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TimeParametersCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class TimeParametersCCGet extends TimeParametersCC {
 }
 
-// Warning: (ae-missing-release-tag) "TimeParametersCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TimeParametersCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class TimeParametersCCReport extends TimeParametersCC {
@@ -16320,7 +16320,7 @@ export class TimeParametersCCReport extends TimeParametersCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "TimeParametersCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TimeParametersCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class TimeParametersCCSet extends TimeParametersCC {
@@ -16336,7 +16336,7 @@ export class TimeParametersCCSet extends TimeParametersCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "TimeParametersCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TimeParametersCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const TimeParametersCCValues: Readonly<{
@@ -16368,7 +16368,7 @@ export const TimeParametersCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "TimeParametersCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TimeParametersCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum TimeParametersCommand {
@@ -16380,7 +16380,7 @@ export enum TimeParametersCommand {
     Set = 1
 }
 
-// Warning: (ae-missing-release-tag) "Timezone" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Timezone" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface Timezone {
@@ -16390,7 +16390,7 @@ export interface Timezone {
     standardOffset: number;
 }
 
-// Warning: (ae-missing-release-tag) "ToneId" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ToneId" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ToneId {
@@ -16400,7 +16400,7 @@ export enum ToneId {
     Off = 0
 }
 
-// Warning: (ae-missing-release-tag) "TransportServiceCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TransportServiceCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class TransportServiceCC extends CommandClass implements SinglecastCC_2<TransportServiceCC> {
@@ -16419,7 +16419,7 @@ export class TransportServiceCC extends CommandClass implements SinglecastCC_2<T
     nodeId: number;
 }
 
-// Warning: (ae-missing-release-tag) "TransportServiceCCFirstSegment" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TransportServiceCCFirstSegment" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class TransportServiceCCFirstSegment extends TransportServiceCC {
@@ -16447,7 +16447,7 @@ export class TransportServiceCCFirstSegment extends TransportServiceCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "TransportServiceCCSegmentComplete" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TransportServiceCCSegmentComplete" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class TransportServiceCCSegmentComplete extends TransportServiceCC {
@@ -16461,7 +16461,7 @@ export class TransportServiceCCSegmentComplete extends TransportServiceCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "TransportServiceCCSegmentRequest" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TransportServiceCCSegmentRequest" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class TransportServiceCCSegmentRequest extends TransportServiceCC {
@@ -16477,7 +16477,7 @@ export class TransportServiceCCSegmentRequest extends TransportServiceCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "TransportServiceCCSegmentWait" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TransportServiceCCSegmentWait" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class TransportServiceCCSegmentWait extends TransportServiceCC {
@@ -16491,7 +16491,7 @@ export class TransportServiceCCSegmentWait extends TransportServiceCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "TransportServiceCCSubsequentSegment" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TransportServiceCCSubsequentSegment" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class TransportServiceCCSubsequentSegment extends TransportServiceCC {
@@ -16529,7 +16529,7 @@ export class TransportServiceCCSubsequentSegment extends TransportServiceCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "TransportServiceCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TransportServiceCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum TransportServiceCommand {
@@ -16546,7 +16546,7 @@ export enum TransportServiceCommand {
 }
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "TransportServiceTimeouts" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TransportServiceTimeouts" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const TransportServiceTimeouts: {
@@ -16558,7 +16558,7 @@ export const TransportServiceTimeouts: {
     relaxedTimingDelayR3: number;
 };
 
-// Warning: (ae-missing-release-tag) "UserCodeCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "UserCodeCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class UserCodeCC extends CommandClass {
@@ -16578,13 +16578,13 @@ export class UserCodeCC extends CommandClass {
     static supportsMultipleUserCodeSetCached(applHost: ZWaveApplicationHost_2, endpoint: IZWaveEndpoint_2): boolean;
 }
 
-// Warning: (ae-missing-release-tag) "UserCodeCCCapabilitiesGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "UserCodeCCCapabilitiesGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class UserCodeCCCapabilitiesGet extends UserCodeCC {
 }
 
-// Warning: (ae-missing-release-tag) "UserCodeCCCapabilitiesReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "UserCodeCCCapabilitiesReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class UserCodeCCCapabilitiesReport extends UserCodeCC {
@@ -16609,7 +16609,7 @@ export class UserCodeCCCapabilitiesReport extends UserCodeCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "UserCodeCCExtendedUserCodeGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "UserCodeCCExtendedUserCodeGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class UserCodeCCExtendedUserCodeGet extends UserCodeCC {
@@ -16625,7 +16625,7 @@ export class UserCodeCCExtendedUserCodeGet extends UserCodeCC {
     userId: number;
 }
 
-// Warning: (ae-missing-release-tag) "UserCodeCCExtendedUserCodeReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "UserCodeCCExtendedUserCodeReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class UserCodeCCExtendedUserCodeReport extends UserCodeCC {
@@ -16642,7 +16642,7 @@ export class UserCodeCCExtendedUserCodeReport extends UserCodeCC {
     readonly userCodes: readonly UserCode[];
 }
 
-// Warning: (ae-missing-release-tag) "UserCodeCCExtendedUserCodeSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "UserCodeCCExtendedUserCodeSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class UserCodeCCExtendedUserCodeSet extends UserCodeCC {
@@ -16658,7 +16658,7 @@ export class UserCodeCCExtendedUserCodeSet extends UserCodeCC {
     userCodes: UserCodeCCSetOptions[];
 }
 
-// Warning: (ae-missing-release-tag) "UserCodeCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "UserCodeCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class UserCodeCCGet extends UserCodeCC {
@@ -16672,13 +16672,13 @@ export class UserCodeCCGet extends UserCodeCC {
     userId: number;
 }
 
-// Warning: (ae-missing-release-tag) "UserCodeCCKeypadModeGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "UserCodeCCKeypadModeGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class UserCodeCCKeypadModeGet extends UserCodeCC {
 }
 
-// Warning: (ae-missing-release-tag) "UserCodeCCKeypadModeReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "UserCodeCCKeypadModeReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class UserCodeCCKeypadModeReport extends UserCodeCC {
@@ -16691,7 +16691,7 @@ export class UserCodeCCKeypadModeReport extends UserCodeCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "UserCodeCCKeypadModeSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "UserCodeCCKeypadModeSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class UserCodeCCKeypadModeSet extends UserCodeCC {
@@ -16705,13 +16705,13 @@ export class UserCodeCCKeypadModeSet extends UserCodeCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "UserCodeCCMasterCodeGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "UserCodeCCMasterCodeGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class UserCodeCCMasterCodeGet extends UserCodeCC {
 }
 
-// Warning: (ae-missing-release-tag) "UserCodeCCMasterCodeReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "UserCodeCCMasterCodeReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class UserCodeCCMasterCodeReport extends UserCodeCC {
@@ -16722,7 +16722,7 @@ export class UserCodeCCMasterCodeReport extends UserCodeCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "UserCodeCCMasterCodeSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "UserCodeCCMasterCodeSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class UserCodeCCMasterCodeSet extends UserCodeCC {
@@ -16737,7 +16737,7 @@ export class UserCodeCCMasterCodeSet extends UserCodeCC {
 }
 
 // Warning: (ae-forgotten-export) The symbol "NotificationEventPayload" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "UserCodeCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "UserCodeCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class UserCodeCCReport extends UserCodeCC implements NotificationEventPayload {
@@ -16758,7 +16758,7 @@ export class UserCodeCCReport extends UserCodeCC implements NotificationEventPay
     readonly userIdStatus: UserIDStatus;
 }
 
-// Warning: (ae-missing-release-tag) "UserCodeCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "UserCodeCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class UserCodeCCSet extends UserCodeCC {
@@ -16775,13 +16775,13 @@ export class UserCodeCCSet extends UserCodeCC {
     userIdStatus: UserIDStatus;
 }
 
-// Warning: (ae-missing-release-tag) "UserCodeCCUserCodeChecksumGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "UserCodeCCUserCodeChecksumGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class UserCodeCCUserCodeChecksumGet extends UserCodeCC {
 }
 
-// Warning: (ae-missing-release-tag) "UserCodeCCUserCodeChecksumReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "UserCodeCCUserCodeChecksumReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class UserCodeCCUserCodeChecksumReport extends UserCodeCC {
@@ -16792,13 +16792,13 @@ export class UserCodeCCUserCodeChecksumReport extends UserCodeCC {
     readonly userCodeChecksum: number;
 }
 
-// Warning: (ae-missing-release-tag) "UserCodeCCUsersNumberGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "UserCodeCCUsersNumberGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class UserCodeCCUsersNumberGet extends UserCodeCC {
 }
 
-// Warning: (ae-missing-release-tag) "UserCodeCCUsersNumberReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "UserCodeCCUsersNumberReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class UserCodeCCUsersNumberReport extends UserCodeCC {
@@ -16809,7 +16809,7 @@ export class UserCodeCCUsersNumberReport extends UserCodeCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "UserCodeCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "UserCodeCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const UserCodeCCValues: Readonly<{
@@ -17176,7 +17176,7 @@ export const UserCodeCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "UserCodeCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "UserCodeCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum UserCodeCommand {
@@ -17218,7 +17218,7 @@ export enum UserCodeCommand {
     UsersNumberReport = 5
 }
 
-// Warning: (ae-missing-release-tag) "UserIDStatus" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "UserIDStatus" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum UserIDStatus {
@@ -17237,7 +17237,7 @@ export enum UserIDStatus {
 }
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "useSupervision" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "useSupervision" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const useSupervision: <TTarget extends CommandClass>() => TypedClassDecorator_2<TTarget>;
@@ -17257,17 +17257,17 @@ declare namespace utils {
 }
 export { utils }
 
-// Warning: (ae-missing-release-tag) "ValueIDProperties" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ValueIDProperties" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ValueIDProperties = Pick<ValueID, "property" | "propertyKey">;
 
-// Warning: (ae-missing-release-tag) "ValveId" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ValveId" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ValveId = "master" | number;
 
-// Warning: (ae-missing-release-tag) "ValveTableEntry" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ValveTableEntry" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ValveTableEntry {
@@ -17277,7 +17277,7 @@ export interface ValveTableEntry {
     valveId: number;
 }
 
-// Warning: (ae-missing-release-tag) "ValveType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ValveType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ValveType {
@@ -17287,7 +17287,7 @@ export enum ValveType {
     ZoneValve = 0
 }
 
-// Warning: (ae-missing-release-tag) "VersionCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "VersionCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class VersionCC extends CommandClass {
@@ -17299,13 +17299,13 @@ export class VersionCC extends CommandClass {
     interview(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "VersionCCCapabilitiesGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "VersionCCCapabilitiesGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class VersionCCCapabilitiesGet extends VersionCC {
 }
 
-// Warning: (ae-missing-release-tag) "VersionCCCapabilitiesReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "VersionCCCapabilitiesReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class VersionCCCapabilitiesReport extends VersionCC {
@@ -17316,7 +17316,7 @@ export class VersionCCCapabilitiesReport extends VersionCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "VersionCCCommandClassGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "VersionCCCommandClassGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class VersionCCCommandClassGet extends VersionCC {
@@ -17330,7 +17330,7 @@ export class VersionCCCommandClassGet extends VersionCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "VersionCCCommandClassReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "VersionCCCommandClassReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class VersionCCCommandClassReport extends VersionCC {
@@ -17346,13 +17346,13 @@ export class VersionCCCommandClassReport extends VersionCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "VersionCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "VersionCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class VersionCCGet extends VersionCC {
 }
 
-// Warning: (ae-missing-release-tag) "VersionCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "VersionCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class VersionCCReport extends VersionCC {
@@ -17372,7 +17372,7 @@ export class VersionCCReport extends VersionCC {
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
 
-// Warning: (ae-missing-release-tag) "VersionCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "VersionCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const VersionCCValues: Readonly<{
@@ -17744,13 +17744,13 @@ export const VersionCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "VersionCCZWaveSoftwareGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "VersionCCZWaveSoftwareGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class VersionCCZWaveSoftwareGet extends VersionCC {
 }
 
-// Warning: (ae-missing-release-tag) "VersionCCZWaveSoftwareReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "VersionCCZWaveSoftwareReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class VersionCCZWaveSoftwareReport extends VersionCC {
@@ -17777,7 +17777,7 @@ export class VersionCCZWaveSoftwareReport extends VersionCC {
     readonly zWaveProtocolVersion: string;
 }
 
-// Warning: (ae-missing-release-tag) "VersionCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "VersionCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum VersionCommand {
@@ -17799,7 +17799,7 @@ export enum VersionCommand {
     ZWaveSoftwareReport = 24
 }
 
-// Warning: (ae-missing-release-tag) "WakeUpCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WakeUpCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class WakeUpCC extends CommandClass {
@@ -17809,13 +17809,13 @@ export class WakeUpCC extends CommandClass {
     interview(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "WakeUpCCIntervalCapabilitiesGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WakeUpCCIntervalCapabilitiesGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class WakeUpCCIntervalCapabilitiesGet extends WakeUpCC {
 }
 
-// Warning: (ae-missing-release-tag) "WakeUpCCIntervalCapabilitiesReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WakeUpCCIntervalCapabilitiesReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class WakeUpCCIntervalCapabilitiesReport extends WakeUpCC {
@@ -17836,13 +17836,13 @@ export class WakeUpCCIntervalCapabilitiesReport extends WakeUpCC {
     readonly wakeUpOnDemandSupported: boolean;
 }
 
-// Warning: (ae-missing-release-tag) "WakeUpCCIntervalGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WakeUpCCIntervalGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class WakeUpCCIntervalGet extends WakeUpCC {
 }
 
-// Warning: (ae-missing-release-tag) "WakeUpCCIntervalReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WakeUpCCIntervalReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class WakeUpCCIntervalReport extends WakeUpCC {
@@ -17855,7 +17855,7 @@ export class WakeUpCCIntervalReport extends WakeUpCC {
     readonly wakeUpInterval: number;
 }
 
-// Warning: (ae-missing-release-tag) "WakeUpCCIntervalSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WakeUpCCIntervalSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class WakeUpCCIntervalSet extends WakeUpCC {
@@ -17871,13 +17871,13 @@ export class WakeUpCCIntervalSet extends WakeUpCC {
     wakeUpInterval: number;
 }
 
-// Warning: (ae-missing-release-tag) "WakeUpCCNoMoreInformation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WakeUpCCNoMoreInformation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class WakeUpCCNoMoreInformation extends WakeUpCC {
 }
 
-// Warning: (ae-missing-release-tag) "WakeUpCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WakeUpCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const WakeUpCCValues: Readonly<{
@@ -17962,13 +17962,13 @@ export const WakeUpCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "WakeUpCCWakeUpNotification" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WakeUpCCWakeUpNotification" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class WakeUpCCWakeUpNotification extends WakeUpCC {
 }
 
-// Warning: (ae-missing-release-tag) "WakeUpCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WakeUpCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum WakeUpCommand {
@@ -17988,7 +17988,7 @@ export enum WakeUpCommand {
     WakeUpNotification = 7
 }
 
-// Warning: (ae-missing-release-tag) "WakeUpTime" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WakeUpTime" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum WakeUpTime {
@@ -18000,12 +18000,12 @@ export enum WakeUpTime {
     None = 0
 }
 
-// Warning: (ae-missing-release-tag) "wakeUpTime2FLiRS" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "wakeUpTime2FLiRS" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function wakeUpTime2FLiRS(value: WakeUpTime): FLiRS_2;
 
-// Warning: (ae-missing-release-tag) "Weekday" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Weekday" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum Weekday {
@@ -18027,7 +18027,7 @@ export enum Weekday {
     Wednesday = 3
 }
 
-// Warning: (ae-missing-release-tag) "WindowCoveringCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WindowCoveringCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class WindowCoveringCC extends CommandClass {
@@ -18039,7 +18039,7 @@ export class WindowCoveringCC extends CommandClass {
     translatePropertyKey(_applHost: ZWaveApplicationHost, _property: string | number, propertyKey: string | number): string | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "WindowCoveringCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WindowCoveringCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class WindowCoveringCCGet extends WindowCoveringCC {
@@ -18053,7 +18053,7 @@ export class WindowCoveringCCGet extends WindowCoveringCC {
     toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "WindowCoveringCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WindowCoveringCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class WindowCoveringCCReport extends WindowCoveringCC {
@@ -18070,7 +18070,7 @@ export class WindowCoveringCCReport extends WindowCoveringCC {
     toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "WindowCoveringCCSet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WindowCoveringCCSet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class WindowCoveringCCSet extends WindowCoveringCC {
@@ -18089,7 +18089,7 @@ export class WindowCoveringCCSet extends WindowCoveringCC {
     toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "WindowCoveringCCStartLevelChange" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WindowCoveringCCStartLevelChange" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class WindowCoveringCCStartLevelChange extends WindowCoveringCC {
@@ -18107,7 +18107,7 @@ export class WindowCoveringCCStartLevelChange extends WindowCoveringCC {
     toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "WindowCoveringCCStopLevelChange" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WindowCoveringCCStopLevelChange" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class WindowCoveringCCStopLevelChange extends WindowCoveringCC {
@@ -18121,13 +18121,13 @@ export class WindowCoveringCCStopLevelChange extends WindowCoveringCC {
     toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "WindowCoveringCCSupportedGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WindowCoveringCCSupportedGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class WindowCoveringCCSupportedGet extends WindowCoveringCC {
 }
 
-// Warning: (ae-missing-release-tag) "WindowCoveringCCSupportedReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WindowCoveringCCSupportedReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class WindowCoveringCCSupportedReport extends WindowCoveringCC {
@@ -18141,7 +18141,7 @@ export class WindowCoveringCCSupportedReport extends WindowCoveringCC {
     toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry;
 }
 
-// Warning: (ae-missing-release-tag) "WindowCoveringCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WindowCoveringCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const WindowCoveringCCValues: Readonly<{
@@ -18354,7 +18354,7 @@ export const WindowCoveringCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "WindowCoveringCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WindowCoveringCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum WindowCoveringCommand {
@@ -18374,7 +18374,7 @@ export enum WindowCoveringCommand {
     SupportedReport = 2
 }
 
-// Warning: (ae-missing-release-tag) "WindowCoveringParameter" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WindowCoveringParameter" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum WindowCoveringParameter {
@@ -18428,14 +18428,14 @@ export enum WindowCoveringParameter {
     "Vertical Slats Angle" = 11
 }
 
-// Warning: (ae-missing-release-tag) "WithTXReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WithTXReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type WithTXReport<API extends CCAPI> = Omit<API, keyof OwnMethodsOf<API> | "withOptions" | "withTXReport"> & {
     [K in keyof OwnMethodsOf<API>]: API[K] extends (...args: any[]) => any ? (...args: Parameters<API[K]>) => WrapWithTXReport<ReturnType<API[K]>> : never;
 };
 
-// Warning: (ae-missing-release-tag) "WrapWithTXReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WrapWithTXReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type WrapWithTXReport<T> = [T] extends [Promise<infer U>] ? Promise<WrapWithTXReport<U>> : [T] extends [void] ? {
@@ -18445,12 +18445,12 @@ export type WrapWithTXReport<T> = [T] extends [Promise<infer U>] ? Promise<WrapW
     txReport: TXReport | undefined;
 };
 
-// Warning: (ae-missing-release-tag) "ZWaveDataRate2DataRate" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveDataRate2DataRate" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function ZWaveDataRate2DataRate(zdr: ZWaveDataRate_2): DataRate_2;
 
-// Warning: (ae-missing-release-tag) "ZWavePlusCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWavePlusCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWavePlusCC extends CommandClass {
@@ -18460,13 +18460,13 @@ export class ZWavePlusCC extends CommandClass {
     interview(applHost: ZWaveApplicationHost_2): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "ZWavePlusCCGet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWavePlusCCGet" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWavePlusCCGet extends ZWavePlusCC {
 }
 
-// Warning: (ae-missing-release-tag) "ZWavePlusCCReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWavePlusCCReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWavePlusCCReport extends ZWavePlusCC {
@@ -18488,7 +18488,7 @@ export class ZWavePlusCCReport extends ZWavePlusCC {
     zwavePlusVersion: number;
 }
 
-// Warning: (ae-missing-release-tag) "ZWavePlusCCValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWavePlusCCValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const ZWavePlusCCValues: Readonly<{
@@ -18619,7 +18619,7 @@ export const ZWavePlusCCValues: Readonly<{
     };
 }>;
 
-// Warning: (ae-missing-release-tag) "ZWavePlusCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWavePlusCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ZWavePlusCommand {
@@ -18629,7 +18629,7 @@ export enum ZWavePlusCommand {
     Report = 2
 }
 
-// Warning: (ae-missing-release-tag) "ZWavePlusNodeType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWavePlusNodeType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ZWavePlusNodeType {
@@ -18639,7 +18639,7 @@ export enum ZWavePlusNodeType {
     Node = 0
 }
 
-// Warning: (ae-missing-release-tag) "ZWavePlusRoleType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWavePlusRoleType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ZWavePlusRoleType {
@@ -18663,7 +18663,7 @@ export enum ZWavePlusRoleType {
     SubStaticController = 1
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCC extends CommandClass {
@@ -18671,7 +18671,7 @@ export class ZWaveProtocolCC extends CommandClass {
     ccCommand: ZWaveProtocolCommand;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCAcceptLost" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCAcceptLost" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCAcceptLost extends ZWaveProtocolCC {
@@ -18683,7 +18683,7 @@ export class ZWaveProtocolCCAcceptLost extends ZWaveProtocolCC {
     serialize(): Buffer;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCAssignIDs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCAssignIDs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCAssignIDs extends ZWaveProtocolCC {
@@ -18697,7 +18697,7 @@ export class ZWaveProtocolCCAssignIDs extends ZWaveProtocolCC {
     serialize(): Buffer;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCAssignReturnRoute" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCAssignReturnRoute" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCAssignReturnRoute extends ZWaveProtocolCC {
@@ -18717,7 +18717,7 @@ export class ZWaveProtocolCCAssignReturnRoute extends ZWaveProtocolCC {
     serialize(): Buffer;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCAssignReturnRoutePriority" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCAssignReturnRoutePriority" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCAssignReturnRoutePriority extends ZWaveProtocolCC {
@@ -18731,25 +18731,25 @@ export class ZWaveProtocolCCAssignReturnRoutePriority extends ZWaveProtocolCC {
     targetNodeId: number;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCAssignSUCReturnRoute" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCAssignSUCReturnRoute" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCAssignSUCReturnRoute extends ZWaveProtocolCCAssignReturnRoute {
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCAssignSUCReturnRoutePriority" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCAssignSUCReturnRoutePriority" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCAssignSUCReturnRoutePriority extends ZWaveProtocolCCAssignReturnRoutePriority {
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCAutomaticControllerUpdateStart" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCAutomaticControllerUpdateStart" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCAutomaticControllerUpdateStart extends ZWaveProtocolCC {
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCCommandComplete" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCCommandComplete" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCCommandComplete extends ZWaveProtocolCC {
@@ -18761,13 +18761,13 @@ export class ZWaveProtocolCCCommandComplete extends ZWaveProtocolCC {
     serialize(): Buffer;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCExcludeRequest" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCExcludeRequest" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCExcludeRequest extends ZWaveProtocolCCNodeInformationFrame {
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCFindNodesInRange" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCFindNodesInRange" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCFindNodesInRange extends ZWaveProtocolCC {
@@ -18783,13 +18783,13 @@ export class ZWaveProtocolCCFindNodesInRange extends ZWaveProtocolCC {
     wakeUpTime: WakeUpTime;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCGetNodesInRange" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCGetNodesInRange" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCGetNodesInRange extends ZWaveProtocolCC {
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCLost" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCLost" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCLost extends ZWaveProtocolCC {
@@ -18801,7 +18801,7 @@ export class ZWaveProtocolCCLost extends ZWaveProtocolCC {
     serialize(): Buffer;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCNewNodeRegistered" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCNewNodeRegistered" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCNewNodeRegistered extends ZWaveProtocolCC implements NodeInformationFrame {
@@ -18839,7 +18839,7 @@ export class ZWaveProtocolCCNewNodeRegistered extends ZWaveProtocolCC implements
     supportsSecurity: boolean;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCNewRangeRegistered" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCNewRangeRegistered" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCNewRangeRegistered extends ZWaveProtocolCC {
@@ -18853,7 +18853,7 @@ export class ZWaveProtocolCCNewRangeRegistered extends ZWaveProtocolCC {
     serialize(): Buffer;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCNodeInformationFrame" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCNodeInformationFrame" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCNodeInformationFrame extends ZWaveProtocolCC implements NodeInformationFrame {
@@ -18889,7 +18889,7 @@ export class ZWaveProtocolCCNodeInformationFrame extends ZWaveProtocolCC impleme
     supportsSecurity: boolean;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCNodesExist" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCNodesExist" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCNodesExist extends ZWaveProtocolCC {
@@ -18903,7 +18903,7 @@ export class ZWaveProtocolCCNodesExist extends ZWaveProtocolCC {
     serialize(): Buffer;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCNodesExistReply" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCNodesExistReply" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCNodesExistReply extends ZWaveProtocolCC {
@@ -18917,7 +18917,7 @@ export class ZWaveProtocolCCNodesExistReply extends ZWaveProtocolCC {
     serialize(): Buffer;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCNOPPower" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCNOPPower" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCNOPPower extends ZWaveProtocolCC {
@@ -18929,7 +18929,7 @@ export class ZWaveProtocolCCNOPPower extends ZWaveProtocolCC {
     serialize(): Buffer;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCRangeInfo" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCRangeInfo" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCRangeInfo extends ZWaveProtocolCC {
@@ -18943,13 +18943,13 @@ export class ZWaveProtocolCCRangeInfo extends ZWaveProtocolCC {
     wakeUpTime?: WakeUpTime;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCRequestNodeInformationFrame" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCRequestNodeInformationFrame" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCRequestNodeInformationFrame extends ZWaveProtocolCC {
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCReservedIDs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCReservedIDs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCReservedIDs extends ZWaveProtocolCC {
@@ -18961,7 +18961,7 @@ export class ZWaveProtocolCCReservedIDs extends ZWaveProtocolCC {
     serialize(): Buffer;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCReserveNodeIDs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCReserveNodeIDs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCReserveNodeIDs extends ZWaveProtocolCC {
@@ -18973,7 +18973,7 @@ export class ZWaveProtocolCCReserveNodeIDs extends ZWaveProtocolCC {
     serialize(): Buffer;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCSetNWIMode" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCSetNWIMode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCSetNWIMode extends ZWaveProtocolCC {
@@ -18987,7 +18987,7 @@ export class ZWaveProtocolCCSetNWIMode extends ZWaveProtocolCC {
     timeoutMinutes?: number;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCSetSUC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCSetSUC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCSetSUC extends ZWaveProtocolCC {
@@ -18999,7 +18999,7 @@ export class ZWaveProtocolCCSetSUC extends ZWaveProtocolCC {
     serialize(): Buffer;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCSetSUCAck" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCSetSUCAck" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCSetSUCAck extends ZWaveProtocolCC {
@@ -19013,7 +19013,7 @@ export class ZWaveProtocolCCSetSUCAck extends ZWaveProtocolCC {
     serialize(): Buffer;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCSmartStartIncludedNodeInformation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCSmartStartIncludedNodeInformation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCSmartStartIncludedNodeInformation extends ZWaveProtocolCC {
@@ -19025,19 +19025,19 @@ export class ZWaveProtocolCCSmartStartIncludedNodeInformation extends ZWaveProto
     serialize(): Buffer;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCSmartStartInclusionRequest" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCSmartStartInclusionRequest" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCSmartStartInclusionRequest extends ZWaveProtocolCCNodeInformationFrame {
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCSmartStartPrime" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCSmartStartPrime" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCSmartStartPrime extends ZWaveProtocolCCNodeInformationFrame {
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCStaticRouteRequest" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCStaticRouteRequest" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCStaticRouteRequest extends ZWaveProtocolCC {
@@ -19049,7 +19049,7 @@ export class ZWaveProtocolCCStaticRouteRequest extends ZWaveProtocolCC {
     serialize(): Buffer;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCSUCNodeID" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCSUCNodeID" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCSUCNodeID extends ZWaveProtocolCC {
@@ -19063,7 +19063,7 @@ export class ZWaveProtocolCCSUCNodeID extends ZWaveProtocolCC {
     sucNodeId: number;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCTransferEnd" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCTransferEnd" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCTransferEnd extends ZWaveProtocolCC {
@@ -19075,7 +19075,7 @@ export class ZWaveProtocolCCTransferEnd extends ZWaveProtocolCC {
     status: NetworkTransferStatus;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCTransferNewPrimaryControllerComplete" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCTransferNewPrimaryControllerComplete" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCTransferNewPrimaryControllerComplete extends ZWaveProtocolCC {
@@ -19087,7 +19087,7 @@ export class ZWaveProtocolCCTransferNewPrimaryControllerComplete extends ZWavePr
     serialize(): Buffer;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCTransferNodeInformation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCTransferNodeInformation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCTransferNodeInformation extends ZWaveProtocolCC implements NodeProtocolInfoAndDeviceClass {
@@ -19125,7 +19125,7 @@ export class ZWaveProtocolCCTransferNodeInformation extends ZWaveProtocolCC impl
     supportsSecurity: boolean;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCTransferPresentation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCTransferPresentation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCTransferPresentation extends ZWaveProtocolCC {
@@ -19141,7 +19141,7 @@ export class ZWaveProtocolCCTransferPresentation extends ZWaveProtocolCC {
     supportsNWI: boolean;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCCTransferRangeInformation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCCTransferRangeInformation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveProtocolCCTransferRangeInformation extends ZWaveProtocolCC {
@@ -19157,7 +19157,7 @@ export class ZWaveProtocolCCTransferRangeInformation extends ZWaveProtocolCC {
     serialize(): Buffer;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveProtocolCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveProtocolCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ZWaveProtocolCommand {

--- a/packages/cc/package.json
+++ b/packages/cc/package.json
@@ -72,7 +72,7 @@
     "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "*",
+    "@microsoft/api-extractor": "^7.35.0",
     "@types/fs-extra": "^9.0.13",
     "@types/node": "^14.18.43",
     "@zwave-js/maintenance": "workspace:*",

--- a/packages/config/api.md
+++ b/packages/config/api.md
@@ -14,12 +14,12 @@ import type { ValueID } from '@zwave-js/core/safe';
 import type { ValueType } from '@zwave-js/core/safe';
 import { ZWaveLogContainer } from '@zwave-js/core';
 
-// Warning: (ae-missing-release-tag) "AssociationConfig" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AssociationConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type AssociationConfig = Omit<ConditionalAssociationConfig, "condition" | "evaluateCondition">;
 
-// Warning: (ae-missing-release-tag) "BasicDeviceClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BasicDeviceClass" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface BasicDeviceClass {
@@ -29,12 +29,12 @@ export interface BasicDeviceClass {
     label: string;
 }
 
-// Warning: (ae-missing-release-tag) "BasicDeviceClassMap" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BasicDeviceClassMap" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type BasicDeviceClassMap = ReadonlyMap<number, string>;
 
-// Warning: (ae-missing-release-tag) "CompatAddCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CompatAddCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class CompatAddCC {
@@ -43,12 +43,12 @@ export class CompatAddCC {
     readonly endpoints: ReadonlyMap<number, Partial<CommandClassInfo>>;
 }
 
-// Warning: (ae-missing-release-tag) "CompatConfig" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CompatConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type CompatConfig = Omit<ConditionalCompatConfig, "condition" | "evaluateCondition">;
 
-// Warning: (ae-missing-release-tag) "CompatMapAlarm" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CompatMapAlarm" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class CompatMapAlarm {
@@ -59,7 +59,7 @@ export class CompatMapAlarm {
     readonly to: CompatMapAlarmTo;
 }
 
-// Warning: (ae-missing-release-tag) "CompatMapAlarmFrom" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CompatMapAlarmFrom" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface CompatMapAlarmFrom {
@@ -69,7 +69,7 @@ export interface CompatMapAlarmFrom {
     alarmType: number;
 }
 
-// Warning: (ae-missing-release-tag) "CompatMapAlarmTo" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CompatMapAlarmTo" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface CompatMapAlarmTo {
@@ -82,7 +82,7 @@ export interface CompatMapAlarmTo {
 }
 
 // Warning: (ae-forgotten-export) The symbol "ConditionalItem" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "ConditionalAssociationConfig" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConditionalAssociationConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ConditionalAssociationConfig implements ConditionalItem<AssociationConfig> {
@@ -103,7 +103,7 @@ export class ConditionalAssociationConfig implements ConditionalItem<Association
     readonly multiChannel: boolean | "auto";
 }
 
-// Warning: (ae-missing-release-tag) "ConditionalCompatConfig" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConditionalCompatConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ConditionalCompatConfig implements ConditionalItem<CompatConfig> {
@@ -167,7 +167,7 @@ export class ConditionalCompatConfig implements ConditionalItem<CompatConfig> {
     readonly treatMultilevelSwitchSetAsEvent?: boolean;
 }
 
-// Warning: (ae-missing-release-tag) "ConditionalConfigOption" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConditionalConfigOption" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ConditionalConfigOption implements ConditionalItem<ConfigOption> {
@@ -182,7 +182,7 @@ export class ConditionalConfigOption implements ConditionalItem<ConfigOption> {
     readonly value: number;
 }
 
-// Warning: (ae-missing-release-tag) "ConditionalDeviceComment" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConditionalDeviceComment" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ConditionalDeviceComment implements ConditionalItem<DeviceComment> {
@@ -197,7 +197,7 @@ export class ConditionalDeviceComment implements ConditionalItem<DeviceComment> 
     readonly text: string;
 }
 
-// Warning: (ae-missing-release-tag) "ConditionalDeviceConfig" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConditionalDeviceConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export class ConditionalDeviceConfig {
@@ -241,7 +241,7 @@ export class ConditionalDeviceConfig {
     readonly proprietary?: Record<string, unknown>;
 }
 
-// Warning: (ae-missing-release-tag) "ConditionalDeviceMetadata" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConditionalDeviceMetadata" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ConditionalDeviceMetadata implements ConditionalItem<DeviceMetadata> {
@@ -258,7 +258,7 @@ export class ConditionalDeviceMetadata implements ConditionalItem<DeviceMetadata
     readonly wakeup?: ConditionalPrimitive<string>;
 }
 
-// Warning: (ae-missing-release-tag) "ConditionalEndpointConfig" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConditionalEndpointConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ConditionalEndpointConfig implements ConditionalItem<EndpointConfig> {
@@ -275,7 +275,7 @@ export class ConditionalEndpointConfig implements ConditionalItem<EndpointConfig
     readonly label?: string;
 }
 
-// Warning: (ae-missing-release-tag) "ConditionalParamInfoMap" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConditionalParamInfoMap" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ConditionalParamInfoMap = ReadonlyObjectKeyMap<{
@@ -283,7 +283,7 @@ export type ConditionalParamInfoMap = ReadonlyObjectKeyMap<{
     valueBitMask?: number;
 }, ConditionalParamInformation[]>;
 
-// Warning: (ae-missing-release-tag) "ConditionalParamInformation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConditionalParamInformation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ConditionalParamInformation implements ConditionalItem<ParamInformation> {
@@ -322,22 +322,22 @@ export class ConditionalParamInformation implements ConditionalItem<ParamInforma
     readonly writeOnly?: true;
 }
 
-// Warning: (ae-missing-release-tag) "CONFIG_LABEL" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CONFIG_LABEL" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const CONFIG_LABEL = "CONFIG";
 
-// Warning: (ae-missing-release-tag) "CONFIG_LOGLEVEL" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CONFIG_LOGLEVEL" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const CONFIG_LOGLEVEL = "debug";
 
-// Warning: (ae-missing-release-tag) "ConfigLogContext" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigLogContext" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ConfigLogContext = LogContext<"config">;
 
-// Warning: (ae-missing-release-tag) "ConfigManager" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigManager" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ConfigManager {
@@ -428,7 +428,7 @@ export class ConfigManager {
     get useExternalConfig(): boolean;
 }
 
-// Warning: (ae-missing-release-tag) "ConfigManagerOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigManagerOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ConfigManagerOptions {
@@ -438,7 +438,7 @@ export interface ConfigManagerOptions {
     logContainer?: ZWaveLogContainer;
 }
 
-// Warning: (ae-missing-release-tag) "ConfigOption" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigOption" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ConfigOption {
@@ -448,7 +448,7 @@ export interface ConfigOption {
     value: number;
 }
 
-// Warning: (ae-missing-release-tag) "DeviceComment" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DeviceComment" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface DeviceComment {
@@ -458,7 +458,7 @@ export interface DeviceComment {
     text: string;
 }
 
-// Warning: (ae-missing-release-tag) "DeviceConfig" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DeviceConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class DeviceConfig {
@@ -508,12 +508,12 @@ export class DeviceConfig {
     readonly proprietary?: Record<string, unknown> | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "DeviceConfigIndex" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DeviceConfigIndex" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type DeviceConfigIndex = DeviceConfigIndexEntry[];
 
-// Warning: (ae-missing-release-tag) "DeviceConfigIndexEntry" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DeviceConfigIndexEntry" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface DeviceConfigIndexEntry {
@@ -533,7 +533,7 @@ export interface DeviceConfigIndexEntry {
     rootDir?: string;
 }
 
-// Warning: (ae-missing-release-tag) "DeviceID" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DeviceID" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface DeviceID {
@@ -547,7 +547,7 @@ export interface DeviceID {
     productType: number;
 }
 
-// Warning: (ae-missing-release-tag) "DeviceMetadata" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DeviceMetadata" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface DeviceMetadata {
@@ -565,24 +565,24 @@ export interface DeviceMetadata {
     wakeup?: string;
 }
 
-// Warning: (ae-missing-release-tag) "embeddedDevicesDir" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "embeddedDevicesDir" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const embeddedDevicesDir: string;
 
-// Warning: (ae-missing-release-tag) "EndpointConfig" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EndpointConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type EndpointConfig = Omit<ConditionalEndpointConfig, "condition" | "evaluateCondition" | "associations"> & {
     associations?: Map<number, AssociationConfig> | undefined;
 };
 
-// Warning: (ae-missing-release-tag) "externalConfigDir" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "externalConfigDir" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function externalConfigDir(): string | undefined;
 
-// Warning: (ae-missing-release-tag) "FirmwareVersionRange" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareVersionRange" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface FirmwareVersionRange {
@@ -592,12 +592,12 @@ export interface FirmwareVersionRange {
     min: string;
 }
 
-// Warning: (ae-missing-release-tag) "FulltextDeviceConfigIndex" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FulltextDeviceConfigIndex" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type FulltextDeviceConfigIndex = FulltextDeviceConfigIndexEntry[];
 
-// Warning: (ae-missing-release-tag) "FulltextDeviceConfigIndexEntry" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FulltextDeviceConfigIndexEntry" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface FulltextDeviceConfigIndexEntry {
@@ -623,7 +623,7 @@ export interface FulltextDeviceConfigIndexEntry {
     rootDir?: string;
 }
 
-// Warning: (ae-missing-release-tag) "GenericDeviceClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "GenericDeviceClass" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class GenericDeviceClass {
@@ -642,32 +642,32 @@ export class GenericDeviceClass {
     readonly supportedCCs: readonly CommandClasses[];
 }
 
-// Warning: (ae-missing-release-tag) "GenericDeviceClassMap" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "GenericDeviceClassMap" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type GenericDeviceClassMap = ReadonlyMap<number, GenericDeviceClass>;
 
-// Warning: (ae-missing-release-tag) "getDefaultGenericDeviceClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getDefaultGenericDeviceClass" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function getDefaultGenericDeviceClass(key: number): GenericDeviceClass;
 
-// Warning: (ae-missing-release-tag) "getDefaultMeterScale" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getDefaultMeterScale" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function getDefaultMeterScale(scale: number): MeterScale;
 
-// Warning: (ae-missing-release-tag) "getDefaultScale" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getDefaultScale" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function getDefaultScale(scale: number): Scale;
 
-// Warning: (ae-missing-release-tag) "getDefaultSpecificDeviceClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getDefaultSpecificDeviceClass" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function getDefaultSpecificDeviceClass(generic: GenericDeviceClass, key: number): SpecificDeviceClass;
 
-// Warning: (ae-missing-release-tag) "getDevicesPaths" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getDevicesPaths" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function getDevicesPaths(configDir: string): {
@@ -675,17 +675,17 @@ export function getDevicesPaths(configDir: string): {
     indexPath: string;
 };
 
-// Warning: (ae-missing-release-tag) "IndicatorMap" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IndicatorMap" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type IndicatorMap = ReadonlyMap<number, string>;
 
-// Warning: (ae-missing-release-tag) "IndicatorPropertiesMap" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IndicatorPropertiesMap" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type IndicatorPropertiesMap = ReadonlyMap<number, IndicatorProperty>;
 
-// Warning: (ae-missing-release-tag) "IndicatorProperty" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IndicatorProperty" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class IndicatorProperty {
@@ -706,12 +706,12 @@ export class IndicatorProperty {
     readonly type: ValueType | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "ManufacturersMap" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ManufacturersMap" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ManufacturersMap = Map<number, string>;
 
-// Warning: (ae-missing-release-tag) "Meter" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Meter" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class Meter {
@@ -724,12 +724,12 @@ export class Meter {
     readonly scales: ReadonlyMap<number, MeterScale>;
 }
 
-// Warning: (ae-missing-release-tag) "MeterMap" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MeterMap" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type MeterMap = ReadonlyMap<number, Meter>;
 
-// Warning: (ae-missing-release-tag) "MeterScale" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MeterScale" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MeterScale {
@@ -740,12 +740,12 @@ export class MeterScale {
     readonly label: string;
 }
 
-// Warning: (ae-missing-release-tag) "NamedScalesGroupMap" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NamedScalesGroupMap" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type NamedScalesGroupMap = ReadonlyMap<string, ScaleGroup>;
 
-// Warning: (ae-missing-release-tag) "Notification" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Notification" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class Notification {
@@ -762,7 +762,7 @@ export class Notification {
     readonly variables: readonly NotificationVariable[];
 }
 
-// Warning: (ae-missing-release-tag) "NotificationEvent" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NotificationEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class NotificationEvent {
@@ -779,33 +779,33 @@ export class NotificationEvent {
     readonly parameter?: NotificationParameter;
 }
 
-// Warning: (ae-missing-release-tag) "NotificationMap" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NotificationMap" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type NotificationMap = ReadonlyMap<number, Notification>;
 
-// Warning: (ae-missing-release-tag) "NotificationParameter" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NotificationParameter" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class NotificationParameter {
     constructor(definition: JSONObject);
 }
 
-// Warning: (ae-missing-release-tag) "NotificationParameterWithCommandClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NotificationParameterWithCommandClass" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export class NotificationParameterWithCommandClass {
     constructor(_definition: JSONObject);
 }
 
-// Warning: (ae-missing-release-tag) "NotificationParameterWithDuration" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NotificationParameterWithDuration" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export class NotificationParameterWithDuration {
     constructor(_definition: JSONObject);
 }
 
-// Warning: (ae-missing-release-tag) "NotificationParameterWithEnum" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NotificationParameterWithEnum" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export class NotificationParameterWithEnum {
@@ -814,7 +814,7 @@ export class NotificationParameterWithEnum {
     readonly values: ReadonlyMap<number, string>;
 }
 
-// Warning: (ae-missing-release-tag) "NotificationParameterWithValue" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NotificationParameterWithValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export class NotificationParameterWithValue {
@@ -823,7 +823,7 @@ export class NotificationParameterWithValue {
     readonly propertyName: string;
 }
 
-// Warning: (ae-missing-release-tag) "NotificationState" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NotificationState" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class NotificationState {
@@ -840,7 +840,7 @@ export class NotificationState {
 
 // Warning: (ae-forgotten-export) The symbol "NotificationStateDefinition" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "NotificationEventDefinition" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "NotificationValueDefinition" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NotificationValueDefinition" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type NotificationValueDefinition = (NotificationStateDefinition | NotificationEventDefinition) & {
@@ -850,7 +850,7 @@ export type NotificationValueDefinition = (NotificationStateDefinition | Notific
     idleVariables?: number[];
 };
 
-// Warning: (ae-missing-release-tag) "NotificationVariable" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NotificationVariable" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class NotificationVariable {
@@ -862,7 +862,7 @@ export class NotificationVariable {
     readonly states: ReadonlyMap<number, NotificationState>;
 }
 
-// Warning: (ae-missing-release-tag) "ParamInfoMap" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ParamInfoMap" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ParamInfoMap = ReadonlyObjectKeyMap<{
@@ -870,7 +870,7 @@ export type ParamInfoMap = ReadonlyObjectKeyMap<{
     valueBitMask?: number;
 }, ParamInformation>;
 
-// Warning: (ae-missing-release-tag) "ParamInformation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ParamInformation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ParamInformation = Omit<ConditionalParamInformation, "condition" | "evaluateCondition" | "options" | "minValue" | "maxValue"> & {
@@ -879,12 +879,12 @@ export type ParamInformation = Omit<ConditionalParamInformation, "condition" | "
     maxValue: NonNullable<ConditionalParamInformation["maxValue"]>;
 };
 
-// Warning: (ae-missing-release-tag) "saveManufacturersInternal" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "saveManufacturersInternal" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function saveManufacturersInternal(manufacturers: ManufacturersMap): Promise<void>;
 
-// Warning: (ae-missing-release-tag) "Scale" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Scale" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class Scale {
@@ -899,14 +899,14 @@ export class Scale {
     readonly unit: string | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "ScaleGroup" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ScaleGroup" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ScaleGroup = ReadonlyMap<number, Scale> & {
     readonly name?: string;
 };
 
-// Warning: (ae-missing-release-tag) "SensorType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SensorType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SensorType {
@@ -919,12 +919,12 @@ export class SensorType {
     readonly scales: ScaleGroup;
 }
 
-// Warning: (ae-missing-release-tag) "SensorTypeMap" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SensorTypeMap" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type SensorTypeMap = ReadonlyMap<number, SensorType>;
 
-// Warning: (ae-missing-release-tag) "SpecificDeviceClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SpecificDeviceClass" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SpecificDeviceClass {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@esm2cjs/got": "^12.5.3",
-    "@microsoft/api-extractor": "*",
+    "@microsoft/api-extractor": "^7.35.0",
     "@types/fs-extra": "^9.0.13",
     "@types/js-levenshtein": "^1.1.1",
     "@types/json-logic-js": "^2.0.2",

--- a/packages/core/api.md
+++ b/packages/core/api.md
@@ -18,22 +18,22 @@ import type { TypedClassDecorator } from '@zwave-js/shared';
 import { TypedEventEmitter } from '@zwave-js/shared';
 import winston from 'winston';
 
-// Warning: (ae-missing-release-tag) "actuatorCCs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "actuatorCCs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const actuatorCCs: readonly CommandClasses[];
 
-// Warning: (ae-missing-release-tag) "allCCs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "allCCs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const allCCs: readonly CommandClasses[];
 
-// Warning: (ae-missing-release-tag) "applicationCCs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "applicationCCs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const applicationCCs: readonly CommandClasses[];
 
-// Warning: (ae-missing-release-tag) "ApplicationNodeInformation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ApplicationNodeInformation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ApplicationNodeInformation {
@@ -45,19 +45,19 @@ export interface ApplicationNodeInformation {
     supportedCCs: CommandClasses[];
 }
 
-// Warning: (ae-missing-release-tag) "assertValueID" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "assertValueID" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function assertValueID(param: Record<any, any>): asserts param is ValueID;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// Warning: (ae-missing-release-tag) "assertZWaveError" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "assertZWaveError" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function assertZWaveError<T>(t: ExecutionContext, valueOrFactory: T, options?: AssertZWaveErrorOptions): T extends () => PromiseLike<any> ? Promise<void> : void;
 
-// Warning: (ae-missing-release-tag) "AssertZWaveErrorOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AssertZWaveErrorOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface AssertZWaveErrorOptions {
@@ -69,24 +69,24 @@ export interface AssertZWaveErrorOptions {
     messageMatches?: string | RegExp;
 }
 
-// Warning: (ae-missing-release-tag) "authHomeIdFromDSK" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "authHomeIdFromDSK" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function authHomeIdFromDSK(dsk: Buffer): Buffer;
 
-// Warning: (ae-missing-release-tag) "averageRSSI" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "averageRSSI" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function averageRSSI(acc: number | undefined, rssi: RSSI, weight: number): number;
 
-// Warning: (ae-missing-release-tag) "BroadcastCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BroadcastCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type BroadcastCC<T extends ICommandClass = ICommandClass> = T & {
     nodeId: typeof NODE_ID_BROADCAST;
 };
 
-// Warning: (ae-missing-release-tag) "CacheBackedMap" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CacheBackedMap" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export class CacheBackedMap<K extends string | number, V> implements Map<K, V> {
@@ -117,7 +117,7 @@ export class CacheBackedMap<K extends string | number, V> implements Map<K, V> {
     values: () => IterableIterator<V>;
 }
 
-// Warning: (ae-missing-release-tag) "CacheBackedMapKeys" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CacheBackedMapKeys" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface CacheBackedMapKeys<K extends string | number> {
@@ -126,7 +126,7 @@ export interface CacheBackedMapKeys<K extends string | number> {
     suffixSerializer: (suffix: K) => string;
 }
 
-// Warning: (ae-missing-release-tag) "CacheMetadata" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CacheMetadata" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface CacheMetadata extends Pick<ValueID, "endpoint" | "property" | "propertyKey"> {
@@ -134,7 +134,7 @@ export interface CacheMetadata extends Pick<ValueID, "endpoint" | "property" | "
     metadata: ValueMetadata;
 }
 
-// Warning: (ae-missing-release-tag) "CacheValue" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CacheValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface CacheValue extends Pick<ValueID, "endpoint" | "property" | "propertyKey"> {
@@ -150,7 +150,7 @@ export interface CacheValue extends Pick<ValueID, "endpoint" | "property" | "pro
 export const channelPadding: string;
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "CommandClasses" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CommandClasses" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export enum CommandClasses {
@@ -402,7 +402,7 @@ export enum CommandClasses {
     "Version" = 134
 }
 
-// Warning: (ae-missing-release-tag) "CommandClassInfo" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CommandClassInfo" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface CommandClassInfo {
@@ -412,27 +412,27 @@ export interface CommandClassInfo {
     version: number;
 }
 
-// Warning: (ae-missing-release-tag) "computeCMAC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "computeCMAC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function computeCMAC(message: Buffer, key: Buffer): Buffer;
 
-// Warning: (ae-missing-release-tag) "computeMAC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "computeMAC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function computeMAC(authData: Buffer, key: Buffer, iv?: Buffer): Buffer;
 
-// Warning: (ae-missing-release-tag) "computeNoncePRK" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "computeNoncePRK" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function computeNoncePRK(senderEI: Buffer, receiverEI: Buffer): Buffer;
 
-// Warning: (ae-missing-release-tag) "computePRK" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "computePRK" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function computePRK(ecdhSharedSecret: Buffer, pubKeyA: Buffer, pubKeyB: Buffer): Buffer;
 
-// Warning: (ae-missing-release-tag) "ConfigurationMetadata" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigurationMetadata" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ConfigurationMetadata extends ValueMetadataAny {
@@ -473,12 +473,12 @@ export interface ConfigurationMetadata extends ValueMetadataAny {
 }
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
-// Warning: (ae-missing-release-tag) "ConfigValue" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export type ConfigValue = number | Set<number>;
 
-// Warning: (ae-missing-release-tag) "ConfigValueFormat" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigValueFormat" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export enum ConfigValueFormat {
@@ -492,17 +492,17 @@ export enum ConfigValueFormat {
     UnsignedInteger = 1
 }
 
-// Warning: (ae-missing-release-tag) "CONTROL_CHAR_WIDTH" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CONTROL_CHAR_WIDTH" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const CONTROL_CHAR_WIDTH = 2;
 
-// Warning: (ae-missing-release-tag) "CONTROLLER_LABEL" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CONTROLLER_LABEL" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const CONTROLLER_LABEL = "CNTRLR";
 
-// Warning: (ae-missing-release-tag) "ControllerCapabilityFlags" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ControllerCapabilityFlags" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ControllerCapabilityFlags {
@@ -520,12 +520,12 @@ export enum ControllerCapabilityFlags {
     WasRealPrimary = 8
 }
 
-// Warning: (ae-missing-release-tag) "ControllerLogContext" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ControllerLogContext" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ControllerLogContext = ControllerSelfLogContext | ControllerNodeLogContext | ControllerValueLogContext;
 
-// Warning: (ae-missing-release-tag) "ControllerLogger" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ControllerLogger" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ControllerLogger extends ZWaveLoggerBase<ControllerLogContext> {
@@ -557,7 +557,7 @@ export class ControllerLogger extends ZWaveLoggerBase<ControllerLogContext> {
     }>;
 }
 
-// Warning: (ae-missing-release-tag) "ControllerNodeLogContext" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ControllerNodeLogContext" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ControllerNodeLogContext = LogContext<"controller"> & NodeLogContext & {
@@ -565,14 +565,14 @@ export type ControllerNodeLogContext = LogContext<"controller"> & NodeLogContext
     direction: string;
 };
 
-// Warning: (ae-missing-release-tag) "ControllerSelfLogContext" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ControllerSelfLogContext" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ControllerSelfLogContext = LogContext<"controller"> & {
     type: "controller";
 };
 
-// Warning: (ae-missing-release-tag) "ControllerValueLogContext" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ControllerValueLogContext" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ControllerValueLogContext = LogContext<"controller"> & ValueLogContext & {
@@ -581,33 +581,33 @@ export type ControllerValueLogContext = LogContext<"controller"> & ValueLogConte
     internal?: boolean;
 };
 
-// Warning: (ae-missing-release-tag) "CRC16_CCITT" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CRC16_CCITT" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function CRC16_CCITT(data: Buffer, startValue?: number): number;
 
-// Warning: (ae-missing-release-tag) "createDefaultTransportFormat" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "createDefaultTransportFormat" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function createDefaultTransportFormat(colorize: boolean, shortTimestamps: boolean): Format;
 
-// Warning: (ae-missing-release-tag) "createLoggerFormat" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "createLoggerFormat" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function createLoggerFormat(channel: string): Format;
 
-// Warning: (ae-missing-release-tag) "createLogMessagePrinter" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "createLogMessagePrinter" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function createLogMessagePrinter(shortTimestamps: boolean): Format;
 
 // Warning: (ae-forgotten-export) The symbol "Constructor" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "createReflectionDecorator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "createReflectionDecorator" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function createReflectionDecorator<TBase extends Object, TArgs extends any[], TValue, TConstructor extends Constructor<TBase> = Constructor<TBase>>({ name, valueFromArgs, constructorLookupKey, }: CreateReflectionDecoratorOptions<TBase, TArgs, TValue, TConstructor>): ReflectionDecorator<TBase, TArgs, TValue, TConstructor>;
 
-// Warning: (ae-missing-release-tag) "CreateReflectionDecoratorOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CreateReflectionDecoratorOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface CreateReflectionDecoratorOptions<TBase extends Object, TArgs extends any[], TValue, TConstructor extends Constructor<TBase> = Constructor<TBase>> {
@@ -616,12 +616,12 @@ export interface CreateReflectionDecoratorOptions<TBase extends Object, TArgs ex
     valueFromArgs: (...args: TArgs) => TValue;
 }
 
-// Warning: (ae-missing-release-tag) "createReflectionDecoratorPair" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "createReflectionDecoratorPair" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function createReflectionDecoratorPair<TBase extends Object, TSuperArgs extends [any], TSubArgs extends [any], TConstructor extends Constructor<TBase> = Constructor<TBase>>({ superName, subName, }: CreateReflectionDecoratorPairOptions): ReflectionDecoratorPair<TBase, TSuperArgs, TSubArgs, TConstructor>;
 
-// Warning: (ae-missing-release-tag) "CreateReflectionDecoratorPairOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CreateReflectionDecoratorPairOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface CreateReflectionDecoratorPairOptions {
@@ -629,31 +629,31 @@ export interface CreateReflectionDecoratorPairOptions {
     superName: string;
 }
 
-// Warning: (ae-missing-release-tag) "createSimpleReflectionDecorator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "createSimpleReflectionDecorator" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function createSimpleReflectionDecorator<TBase extends Object, TArgs extends [any], TConstructor extends Constructor<TBase> = Constructor<TBase>>({ name, }: CreateSimpleReflectionDecoratorOptions): SimpleReflectionDecorator<TBase, TArgs, TConstructor>;
 
-// Warning: (ae-missing-release-tag) "CreateSimpleReflectionDecoratorOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CreateSimpleReflectionDecoratorOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface CreateSimpleReflectionDecoratorOptions {
     name: string;
 }
 
-// Warning: (ae-missing-release-tag) "createValuelessReflectionDecorator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "createValuelessReflectionDecorator" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function createValuelessReflectionDecorator<TBase extends Object>({ name, }: CreateValuelessReflectionDecoratorOptions): ValuelessReflectionDecorator<TBase>;
 
-// Warning: (ae-missing-release-tag) "CreateValuelessReflectionDecoratorOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CreateValuelessReflectionDecoratorOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface CreateValuelessReflectionDecoratorOptions {
     name: string;
 }
 
-// Warning: (ae-missing-release-tag) "CtrDRBG" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CtrDRBG" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class CtrDRBG {
@@ -672,31 +672,31 @@ export class CtrDRBG {
     update(seed?: Buffer): this;
 }
 
-// Warning: (ae-missing-release-tag) "DataDirection" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DataDirection" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type DataDirection = "inbound" | "outbound" | "none";
 
-// Warning: (ae-missing-release-tag) "DataRate" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DataRate" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type DataRate = 9600 | 40000 | 100000;
 
 // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
 // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-// Warning: (ae-missing-release-tag) "dbKeyToValueIdFast" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "dbKeyToValueIdFast" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function dbKeyToValueIdFast(key: string): {
     nodeId: number;
 } & ValueID;
 
-// Warning: (ae-missing-release-tag) "decodeX25519KeyDER" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "decodeX25519KeyDER" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function decodeX25519KeyDER(key: Buffer): Buffer;
 
-// Warning: (ae-missing-release-tag) "decryptAES128CCM" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "decryptAES128CCM" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function decryptAES128CCM(key: Buffer, iv: Buffer, ciphertext: Buffer, additionalData: Buffer, authTag: Buffer): {
@@ -704,17 +704,17 @@ export function decryptAES128CCM(key: Buffer, iv: Buffer, ciphertext: Buffer, ad
     authOK: boolean;
 };
 
-// Warning: (ae-missing-release-tag) "decryptAES128OFB" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "decryptAES128OFB" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const decryptAES128OFB: (input: Buffer, key: Buffer, iv: Buffer) => Buffer;
 
-// Warning: (ae-missing-release-tag) "deriveMEI" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "deriveMEI" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function deriveMEI(noncePRK: Buffer): Buffer;
 
-// Warning: (ae-missing-release-tag) "deriveNetworkKeys" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "deriveNetworkKeys" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function deriveNetworkKeys(PNK: Buffer): {
@@ -723,7 +723,7 @@ export function deriveNetworkKeys(PNK: Buffer): {
     personalizationString: Buffer;
 };
 
-// Warning: (ae-missing-release-tag) "deriveTempKeys" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "deriveTempKeys" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function deriveTempKeys(PRK: Buffer): {
@@ -731,27 +731,27 @@ export function deriveTempKeys(PRK: Buffer): {
     tempPersonalizationString: Buffer;
 };
 
-// Warning: (ae-missing-release-tag) "deserializeCacheValue" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "deserializeCacheValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function deserializeCacheValue(value: SerializedValue): unknown;
 
-// Warning: (ae-missing-release-tag) "directionPrefixPadding" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "directionPrefixPadding" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const directionPrefixPadding: string;
 
-// Warning: (ae-missing-release-tag) "dskFromString" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "dskFromString" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function dskFromString(dsk: string): Buffer;
 
-// Warning: (ae-missing-release-tag) "dskToString" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "dskToString" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function dskToString(dsk: Buffer): string;
 
-// Warning: (ae-missing-release-tag) "DSTInfo" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DSTInfo" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface DSTInfo {
@@ -765,7 +765,7 @@ export interface DSTInfo {
     startDate: Date;
 }
 
-// Warning: (ae-missing-release-tag) "Duration" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Duration" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export class Duration {
@@ -795,17 +795,17 @@ export class Duration {
     set value(v: number);
 }
 
-// Warning: (ae-missing-release-tag) "DurationUnit" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DurationUnit" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type DurationUnit = "seconds" | "minutes" | "unknown" | "default";
 
-// Warning: (ae-missing-release-tag) "encapsulationCCs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "encapsulationCCs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const encapsulationCCs: readonly CommandClasses[];
 
-// Warning: (ae-missing-release-tag) "EncapsulationFlags" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EncapsulationFlags" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum EncapsulationFlags {
@@ -819,33 +819,33 @@ export enum EncapsulationFlags {
     Supervision = 1
 }
 
-// Warning: (ae-missing-release-tag) "encodeApplicationNodeInformation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "encodeApplicationNodeInformation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function encodeApplicationNodeInformation(nif: ApplicationNodeInformation): Buffer;
 
-// Warning: (ae-missing-release-tag) "encodeBitMask" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "encodeBitMask" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function encodeBitMask(values: readonly number[], maxValue?: number, startValue?: number): Buffer;
 
-// Warning: (ae-missing-release-tag) "encodeBoolean" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "encodeBoolean" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function encodeBoolean(val: boolean): number;
 
-// Warning: (ae-missing-release-tag) "encodeCCId" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "encodeCCId" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function encodeCCId(ccId: CommandClasses, payload: Buffer, offset?: number): number;
 
-// Warning: (ae-missing-release-tag) "encodeCCList" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "encodeCCList" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function encodeCCList(supportedCCs: readonly CommandClasses[], controlledCCs: readonly CommandClasses[]): Buffer;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// Warning: (ae-missing-release-tag) "encodeFloatWithScale" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "encodeFloatWithScale" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function encodeFloatWithScale(value: number, scale: number, override?: {
@@ -853,32 +853,32 @@ export function encodeFloatWithScale(value: number, scale: number, override?: {
     precision?: number;
 }): Buffer;
 
-// Warning: (ae-missing-release-tag) "encodeMaybeBoolean" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "encodeMaybeBoolean" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function encodeMaybeBoolean(val: Maybe<boolean>): number;
 
-// Warning: (ae-missing-release-tag) "encodeNodeBitMask" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "encodeNodeBitMask" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function encodeNodeBitMask(nodeIDs: readonly number[]): Buffer;
 
-// Warning: (ae-missing-release-tag) "encodeNodeInformationFrame" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "encodeNodeInformationFrame" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function encodeNodeInformationFrame(info: NodeInformationFrame): Buffer;
 
-// Warning: (ae-missing-release-tag) "encodeNodeProtocolInfo" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "encodeNodeProtocolInfo" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function encodeNodeProtocolInfo(info: NodeProtocolInfo): Buffer;
 
-// Warning: (ae-missing-release-tag) "encodeNodeProtocolInfoAndDeviceClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "encodeNodeProtocolInfoAndDeviceClass" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function encodeNodeProtocolInfoAndDeviceClass(info: NodeProtocolInfoAndDeviceClass): Buffer;
 
-// Warning: (ae-missing-release-tag) "encodeNodeUpdatePayload" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "encodeNodeUpdatePayload" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function encodeNodeUpdatePayload(nif: NodeUpdatePayload): Buffer;
@@ -886,22 +886,22 @@ export function encodeNodeUpdatePayload(nif: NodeUpdatePayload): Buffer;
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// Warning: (ae-missing-release-tag) "encodePartial" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "encodePartial" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function encodePartial(fullValue: number, partialValue: number, bitMask: number): number;
 
-// Warning: (ae-missing-release-tag) "encodeX25519KeyDERPKCS8" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "encodeX25519KeyDERPKCS8" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function encodeX25519KeyDERPKCS8(key: Buffer): Buffer;
 
-// Warning: (ae-missing-release-tag) "encodeX25519KeyDERSPKI" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "encodeX25519KeyDERSPKI" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function encodeX25519KeyDERSPKI(key: Buffer): Buffer;
 
-// Warning: (ae-missing-release-tag) "encryptAES128CCM" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "encryptAES128CCM" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function encryptAES128CCM(key: Buffer, iv: Buffer, plaintext: Buffer, additionalData: Buffer, authTagLength: number): {
@@ -909,27 +909,27 @@ export function encryptAES128CCM(key: Buffer, iv: Buffer, plaintext: Buffer, add
     authTag: Buffer;
 };
 
-// Warning: (ae-missing-release-tag) "encryptAES128ECB" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "encryptAES128ECB" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function encryptAES128ECB(plaintext: Buffer, key: Buffer): Buffer;
 
-// Warning: (ae-missing-release-tag) "encryptAES128OFB" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "encryptAES128OFB" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const encryptAES128OFB: (input: Buffer, key: Buffer, iv: Buffer) => Buffer;
 
-// Warning: (ae-missing-release-tag) "enumValuesToMetadataStates" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "enumValuesToMetadataStates" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function enumValuesToMetadataStates<T extends Record<string, any>>(enumeration: T, values?: readonly number[]): Record<number, string>;
 
-// Warning: (ae-missing-release-tag) "extractFirmware" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "extractFirmware" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function extractFirmware(rawData: Buffer, format: FirmwareFileFormat): Firmware;
 
-// Warning: (ae-missing-release-tag) "Firmware" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Firmware" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface Firmware {
@@ -939,72 +939,72 @@ export interface Firmware {
     firmwareTarget?: number;
 }
 
-// Warning: (ae-missing-release-tag) "FirmwareFileFormat" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareFileFormat" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type FirmwareFileFormat = "aeotec" | "otz" | "ota" | "hex" | "hec" | "gecko" | "bin";
 
-// Warning: (ae-missing-release-tag) "FLiRS" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FLiRS" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type FLiRS = false | "250ms" | "1000ms";
 
-// Warning: (ae-missing-release-tag) "formatDate" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "formatDate" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function formatDate(date: Date, format: string): string;
 
-// Warning: (ae-missing-release-tag) "FrameType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FrameType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type FrameType = "singlecast" | "broadcast" | "multicast";
 
-// Warning: (ae-missing-release-tag) "generateAuthKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "generateAuthKey" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function generateAuthKey(networkKey: Buffer): Buffer;
 
-// Warning: (ae-missing-release-tag) "generateEncryptionKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "generateEncryptionKey" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function generateEncryptionKey(networkKey: Buffer): Buffer;
 
-// Warning: (ae-missing-release-tag) "getBitMaskWidth" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getBitMaskWidth" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getBitMaskWidth(mask: number): number;
 
-// Warning: (ae-missing-release-tag) "getCCName" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getCCName" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function getCCName(cc: number): string;
 
-// Warning: (ae-missing-release-tag) "getDefaultDSTInfo" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getDefaultDSTInfo" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getDefaultDSTInfo(defaultOffset?: number): DSTInfo;
 
-// Warning: (ae-missing-release-tag) "getDirectionPrefix" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getDirectionPrefix" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function getDirectionPrefix(direction: DataDirection): "« " | "» " | "  ";
 
-// Warning: (ae-missing-release-tag) "getDSTInfo" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getDSTInfo" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getDSTInfo(now?: Date): DSTInfo;
 
-// Warning: (ae-missing-release-tag) "getErrorSuffix" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getErrorSuffix" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function getErrorSuffix(code: ZWaveErrorCodes): string;
 
-// Warning: (ae-missing-release-tag) "getHighestSecurityClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getHighestSecurityClass" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function getHighestSecurityClass(securityClasses: SecurityClass[]): SecurityClass;
 
-// Warning: (ae-missing-release-tag) "getIntegerLimits" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getIntegerLimits" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function getIntegerLimits(size: 1 | 2 | 3 | 4, signed: boolean): {
@@ -1012,32 +1012,32 @@ export function getIntegerLimits(size: 1 | 2 | 3 | 4, signed: boolean): {
     max: number;
 };
 
-// Warning: (ae-missing-release-tag) "getLegalRangeForBitMask" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getLegalRangeForBitMask" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getLegalRangeForBitMask(mask: number, unsigned: boolean): [min: number, max: number];
 
-// Warning: (ae-missing-release-tag) "getMinimumShiftForBitMask" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getMinimumShiftForBitMask" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getMinimumShiftForBitMask(mask: number): number;
 
-// Warning: (ae-missing-release-tag) "getMinIntegerSize" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getMinIntegerSize" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function getMinIntegerSize(value: number, signed: boolean): 1 | 2 | 4 | undefined;
 
-// Warning: (ae-missing-release-tag) "getNodeTag" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getNodeTag" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getNodeTag(nodeId: number): string;
 
-// Warning: (ae-missing-release-tag) "getNumericEnumValues" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getNumericEnumValues" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getNumericEnumValues<T extends Record<string, any>>(enumeration: T): readonly number[];
 
-// Warning: (ae-missing-release-tag) "GraphNode" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "GraphNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class GraphNode<T> {
@@ -1048,22 +1048,22 @@ export class GraphNode<T> {
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// Warning: (ae-missing-release-tag) "guessFirmwareFileFormat" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "guessFirmwareFileFormat" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function guessFirmwareFileFormat(filename: string, rawData: Buffer): FirmwareFileFormat;
 
-// Warning: (ae-missing-release-tag) "highResTimestamp" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "highResTimestamp" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function highResTimestamp(): number;
 
-// Warning: (ae-missing-release-tag) "HOMEID_BYTES" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HOMEID_BYTES" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const HOMEID_BYTES = 4;
 
-// Warning: (ae-missing-release-tag) "ICommandClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ICommandClass" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface ICommandClass {
@@ -1081,12 +1081,12 @@ export interface ICommandClass {
     serialize(): Buffer;
 }
 
-// Warning: (ae-missing-release-tag) "indexDBsByNode" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "indexDBsByNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function indexDBsByNode(databases: JsonlDB[]): Map<number, Set<string>>;
 
-// Warning: (ae-missing-release-tag) "IntegerLimits" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IntegerLimits" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const IntegerLimits: Readonly<{
@@ -1124,7 +1124,7 @@ export const IntegerLimits: Readonly<{
     }>;
 }>;
 
-// Warning: (ae-missing-release-tag) "Interviewable" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Interviewable" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface Interviewable {
@@ -1134,7 +1134,7 @@ export interface Interviewable {
     interviewStage: InterviewStage;
 }
 
-// Warning: (ae-missing-release-tag) "InterviewStage" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "InterviewStage" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum InterviewStage {
@@ -1146,66 +1146,66 @@ export enum InterviewStage {
     ProtocolInfo = 1
 }
 
-// Warning: (ae-missing-release-tag) "isConsecutiveArray" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isConsecutiveArray" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function isConsecutiveArray(values: number[]): boolean;
 
-// Warning: (ae-missing-release-tag) "isExtendedCCId" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isExtendedCCId" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function isExtendedCCId(ccId: CommandClasses): boolean;
 
-// Warning: (ae-missing-release-tag) "isMessagePriority" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isMessagePriority" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function isMessagePriority(val: unknown): val is MessagePriority;
 
-// Warning: (ae-missing-release-tag) "isRecoverableZWaveError" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isRecoverableZWaveError" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function isRecoverableZWaveError(e: unknown): e is ZWaveError;
 
-// Warning: (ae-missing-release-tag) "isRssiError" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isRssiError" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function isRssiError(rssi: RSSI): rssi is RssiError;
 
-// Warning: (ae-missing-release-tag) "isSupervisionResult" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isSupervisionResult" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function isSupervisionResult(obj: unknown): obj is SupervisionResult;
 
-// Warning: (ae-missing-release-tag) "isTransmissionError" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isTransmissionError" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function isTransmissionError(e: unknown): e is ZWaveError & {
     code: ZWaveErrorCodes.Controller_Timeout | ZWaveErrorCodes.Controller_MessageDropped | ZWaveErrorCodes.Controller_CallbackNOK | ZWaveErrorCodes.Controller_ResponseNOK | ZWaveErrorCodes.Controller_NodeTimeout | ZWaveErrorCodes.Security2CC_CannotDecode;
 };
 
-// Warning: (ae-missing-release-tag) "isUnsupervisedOrSucceeded" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isUnsupervisedOrSucceeded" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function isUnsupervisedOrSucceeded(result: SupervisionResult | undefined): result is undefined | (SupervisionResult & {
     status: SupervisionStatus.Success | SupervisionStatus.Working;
 });
 
-// Warning: (ae-missing-release-tag) "isValidDSK" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isValidDSK" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function isValidDSK(dsk: string): boolean;
 
-// Warning: (ae-missing-release-tag) "isValueID" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isValueID" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function isValueID(param: Record<any, any>): param is ValueID;
 
-// Warning: (ae-missing-release-tag) "isZWaveError" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isZWaveError" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function isZWaveError(e: unknown): e is ZWaveError;
 
-// Warning: (ae-missing-release-tag) "IVirtualEndpoint" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IVirtualEndpoint" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface IVirtualEndpoint {
@@ -1223,7 +1223,7 @@ export interface IVirtualEndpoint {
     readonly virtual: true;
 }
 
-// Warning: (ae-missing-release-tag) "IVirtualNode" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IVirtualNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface IVirtualNode extends IVirtualEndpoint {
@@ -1239,7 +1239,7 @@ export interface IVirtualNode extends IVirtualEndpoint {
     readonly physicalNodes: readonly IZWaveNode[];
 }
 
-// Warning: (ae-missing-release-tag) "IZWaveEndpoint" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IZWaveEndpoint" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface IZWaveEndpoint {
@@ -1267,7 +1267,7 @@ export interface IZWaveEndpoint {
     readonly virtual: false;
 }
 
-// Warning: (ae-missing-release-tag) "IZWaveNode" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IZWaveNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface IZWaveNode extends IZWaveEndpoint, SecurityClassOwner {
@@ -1295,17 +1295,17 @@ export interface IZWaveNode extends IZWaveEndpoint, SecurityClassOwner {
     readonly status: NodeStatus;
 }
 
-// Warning: (ae-missing-release-tag) "LOG_PREFIX_WIDTH" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "LOG_PREFIX_WIDTH" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const LOG_PREFIX_WIDTH = 20;
 
-// Warning: (ae-missing-release-tag) "LOG_WIDTH" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "LOG_WIDTH" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const LOG_WIDTH = 80;
 
-// Warning: (ae-missing-release-tag) "LogConfig" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "LogConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface LogConfig {
@@ -1327,7 +1327,7 @@ export interface LogConfig {
     transports: Transport[];
 }
 
-// Warning: (ae-missing-release-tag) "LogContext" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "LogContext" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface LogContext<T extends string = string> {
@@ -1335,12 +1335,12 @@ export interface LogContext<T extends string = string> {
     type?: string;
 }
 
-// Warning: (ae-missing-release-tag) "logMessageFormatter" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "logMessageFormatter" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const logMessageFormatter: Format;
 
-// Warning: (ae-missing-release-tag) "LogNodeOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "LogNodeOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface LogNodeOptions {
@@ -1354,7 +1354,7 @@ export interface LogNodeOptions {
     message: string;
 }
 
-// Warning: (ae-missing-release-tag) "LogValueArgs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "LogValueArgs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type LogValueArgs<T> = T & {
@@ -1362,50 +1362,50 @@ export type LogValueArgs<T> = T & {
     internal?: boolean;
 };
 
-// Warning: (ae-missing-release-tag) "managementCCs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "managementCCs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const managementCCs: readonly CommandClasses[];
 
-// Warning: (ae-missing-release-tag) "MAX_NODES" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MAX_NODES" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const MAX_NODES = 232;
 
-// Warning: (ae-missing-release-tag) "MAX_REPEATERS" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MAX_REPEATERS" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const MAX_REPEATERS = 4;
 
-// Warning: (ae-missing-release-tag) "MAX_SUPERVISION_SESSION_ID" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MAX_SUPERVISION_SESSION_ID" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const MAX_SUPERVISION_SESSION_ID = 63;
 
-// Warning: (ae-missing-release-tag) "MAX_TRANSPORT_SERVICE_SESSION_ID" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MAX_TRANSPORT_SERVICE_SESSION_ID" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const MAX_TRANSPORT_SERVICE_SESSION_ID = 15;
 
 // Warning: (ae-forgotten-export) The symbol "BrandedUnknown" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "Maybe" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Maybe" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type Maybe<T> = T | BrandedUnknown<T>;
 
-// Warning: (ae-missing-release-tag) "mergeSupervisionResults" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "mergeSupervisionResults" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function mergeSupervisionResults(results: unknown[]): SupervisionResult | undefined;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// Warning: (ae-missing-release-tag) "messageFitsIntoOneLine" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "messageFitsIntoOneLine" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function messageFitsIntoOneLine(info: ZWaveLogInfo, messageLength: number): boolean;
 
-// Warning: (ae-missing-release-tag) "MessageOrCCLogEntry" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MessageOrCCLogEntry" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface MessageOrCCLogEntry {
@@ -1416,7 +1416,7 @@ export interface MessageOrCCLogEntry {
 }
 
 // Warning: (tsdoc-escape-greater-than) The ">" character should be escaped using a backslash to avoid confusion with an HTML tag
-// Warning: (ae-missing-release-tag) "MessagePriority" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MessagePriority" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export enum MessagePriority {
@@ -1440,22 +1440,22 @@ export enum MessagePriority {
     WakeUp = 5
 }
 
-// Warning: (ae-missing-release-tag) "MessageRecord" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MessageRecord" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type MessageRecord = Record<string, string | number | boolean | null | undefined>;
 
-// Warning: (ae-missing-release-tag) "messageRecordToLines" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "messageRecordToLines" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function messageRecordToLines(message: MessageRecord): string[];
 
-// Warning: (ae-missing-release-tag) "messageToLines" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "messageToLines" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function messageToLines(message: string | string[]): string[];
 
-// Warning: (ae-missing-release-tag) "MetadataUpdatedArgs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MetadataUpdatedArgs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface MetadataUpdatedArgs extends ValueID {
@@ -1463,7 +1463,7 @@ export interface MetadataUpdatedArgs extends ValueID {
     metadata: ValueMetadata | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "MPANState" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MPANState" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum MPANState {
@@ -1472,7 +1472,7 @@ export enum MPANState {
     OutOfSync = 1
 }
 
-// Warning: (ae-missing-release-tag) "MPANTableEntry" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MPANTableEntry" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type MPANTableEntry = {
@@ -1482,19 +1482,19 @@ export type MPANTableEntry = {
     currentMPAN: Buffer;
 };
 
-// Warning: (ae-missing-release-tag) "MulticastCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MulticastCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type MulticastCC<T extends ICommandClass = ICommandClass> = T & {
     nodeId: MulticastDestination;
 };
 
-// Warning: (ae-missing-release-tag) "MulticastDestination" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MulticastDestination" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type MulticastDestination = [number, number, ...number[]];
 
-// Warning: (ae-missing-release-tag) "MulticastGroup" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MulticastGroup" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface MulticastGroup {
@@ -1506,22 +1506,22 @@ export interface MulticastGroup {
     sequenceNumber: number;
 }
 
-// Warning: (ae-missing-release-tag) "NODE_ID_BROADCAST" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NODE_ID_BROADCAST" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const NODE_ID_BROADCAST = 255;
 
-// Warning: (ae-missing-release-tag) "NODE_ID_MAX" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NODE_ID_MAX" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const NODE_ID_MAX = 232;
 
-// Warning: (ae-missing-release-tag) "NodeInformationFrame" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NodeInformationFrame" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type NodeInformationFrame = NodeProtocolInfoAndDeviceClass & ApplicationNodeInformation;
 
-// Warning: (ae-missing-release-tag) "NodeLogContext" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NodeLogContext" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type NodeLogContext = LogContext & {
@@ -1529,7 +1529,7 @@ export type NodeLogContext = LogContext & {
     type: "node";
 };
 
-// Warning: (ae-missing-release-tag) "NodeProtocolInfo" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NodeProtocolInfo" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface NodeProtocolInfo {
@@ -1547,7 +1547,7 @@ export interface NodeProtocolInfo {
     supportsSecurity: boolean;
 }
 
-// Warning: (ae-missing-release-tag) "NodeProtocolInfoAndDeviceClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NodeProtocolInfoAndDeviceClass" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface NodeProtocolInfoAndDeviceClass extends Omit<NodeProtocolInfo, "hasSpecificDeviceClass"> {
@@ -1559,7 +1559,7 @@ export interface NodeProtocolInfoAndDeviceClass extends Omit<NodeProtocolInfo, "
     specificDeviceClass: number;
 }
 
-// Warning: (ae-missing-release-tag) "NodeStatus" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NodeStatus" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum NodeStatus {
@@ -1575,7 +1575,7 @@ export enum NodeStatus {
     Unknown = 0
 }
 
-// Warning: (ae-missing-release-tag) "NodeType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NodeType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum NodeType {
@@ -1587,7 +1587,7 @@ export enum NodeType {
     Controller = 0
 }
 
-// Warning: (ae-missing-release-tag) "NodeUpdatePayload" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NodeUpdatePayload" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface NodeUpdatePayload extends ApplicationNodeInformation {
@@ -1597,7 +1597,7 @@ export interface NodeUpdatePayload extends ApplicationNodeInformation {
     nodeId: number;
 }
 
-// Warning: (ae-missing-release-tag) "nonApplicationCCs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "nonApplicationCCs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const nonApplicationCCs: readonly CommandClasses[];
@@ -1607,38 +1607,38 @@ export const nonApplicationCCs: readonly CommandClasses[];
 // @internal (undocumented)
 export const nonUndefinedLogConfigKeys: readonly ["enabled", "level", "transports", "logToFile", "maxFiles", "filename", "forceConsole"];
 
-// Warning: (ae-missing-release-tag) "normalizeValueID" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "normalizeValueID" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function normalizeValueID(valueID: ValueID): ValueID;
 
-// Warning: (ae-missing-release-tag) "NUM_NODEMASK_BYTES" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NUM_NODEMASK_BYTES" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const NUM_NODEMASK_BYTES: number;
 
-// Warning: (ae-missing-release-tag) "nwiHomeIdFromDSK" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "nwiHomeIdFromDSK" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function nwiHomeIdFromDSK(dsk: Buffer): Buffer;
 
-// Warning: (ae-missing-release-tag) "parseApplicationNodeInformation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "parseApplicationNodeInformation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function parseApplicationNodeInformation(nif: Buffer): ApplicationNodeInformation;
 
-// Warning: (ae-missing-release-tag) "parseBitMask" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "parseBitMask" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function parseBitMask(mask: Buffer, startValue?: number): number[];
 
-// Warning: (ae-missing-release-tag) "parseBoolean" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "parseBoolean" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function parseBoolean(val: number): boolean | undefined;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// Warning: (ae-missing-release-tag) "parseCCId" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "parseCCId" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function parseCCId(payload: Buffer, offset?: number): {
@@ -1646,7 +1646,7 @@ export function parseCCId(payload: Buffer, offset?: number): {
     bytesRead: number;
 };
 
-// Warning: (ae-missing-release-tag) "parseCCList" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "parseCCList" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function parseCCList(payload: Buffer): {
@@ -1654,8 +1654,8 @@ export function parseCCList(payload: Buffer): {
     controlledCCs: CommandClasses[];
 };
 
-// Warning: (ae-missing-release-tag) "parseFloatWithScale" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "parseFloatWithScale" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "parseFloatWithScale" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "parseFloatWithScale" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function parseFloatWithScale(payload: Buffer, allowEmpty?: false): {
@@ -1673,32 +1673,32 @@ export function parseFloatWithScale(payload: Buffer, allowEmpty: true): {
     bytesRead: number;
 };
 
-// Warning: (ae-missing-release-tag) "parseMaybeBoolean" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "parseMaybeBoolean" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function parseMaybeBoolean(val: number, preserveUnknown?: boolean): Maybe<boolean> | undefined;
 
-// Warning: (ae-missing-release-tag) "parseMaybeNumber" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "parseMaybeNumber" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function parseMaybeNumber(val: number): Maybe<number> | undefined;
 
-// Warning: (ae-missing-release-tag) "parseNodeBitMask" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "parseNodeBitMask" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function parseNodeBitMask(mask: Buffer): number[];
 
-// Warning: (ae-missing-release-tag) "parseNodeInformationFrame" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "parseNodeInformationFrame" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function parseNodeInformationFrame(buffer: Buffer): NodeInformationFrame;
 
-// Warning: (ae-missing-release-tag) "parseNodeProtocolInfo" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "parseNodeProtocolInfo" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function parseNodeProtocolInfo(buffer: Buffer, offset: number): NodeProtocolInfo;
 
-// Warning: (ae-missing-release-tag) "parseNodeProtocolInfoAndDeviceClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "parseNodeProtocolInfoAndDeviceClass" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function parseNodeProtocolInfoAndDeviceClass(buffer: Buffer): {
@@ -1706,12 +1706,12 @@ export function parseNodeProtocolInfoAndDeviceClass(buffer: Buffer): {
     bytesRead: number;
 };
 
-// Warning: (ae-missing-release-tag) "parseNodeUpdatePayload" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "parseNodeUpdatePayload" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function parseNodeUpdatePayload(nif: Buffer): NodeUpdatePayload;
 
-// Warning: (ae-missing-release-tag) "parseNumber" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "parseNumber" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function parseNumber(val: number): number | undefined;
@@ -1719,17 +1719,17 @@ export function parseNumber(val: number): number | undefined;
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// Warning: (ae-missing-release-tag) "parsePartial" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "parsePartial" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function parsePartial(value: number, bitMask: number, signed: boolean): number;
 
-// Warning: (ae-missing-release-tag) "parseQRCodeString" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "parseQRCodeString" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function parseQRCodeString(qr: string): QRProvisioningInformation;
 
-// Warning: (ae-missing-release-tag) "ProtocolDataRate" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProtocolDataRate" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ProtocolDataRate {
@@ -1743,17 +1743,17 @@ export enum ProtocolDataRate {
     ZWave_9k6 = 1
 }
 
-// Warning: (ae-missing-release-tag) "protocolDataRateMask" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "protocolDataRateMask" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const protocolDataRateMask = 7;
 
-// Warning: (ae-missing-release-tag) "protocolDataRateToString" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "protocolDataRateToString" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function protocolDataRateToString(rate: ProtocolDataRate): string;
 
-// Warning: (ae-missing-release-tag) "Protocols" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Protocols" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum Protocols {
@@ -1763,7 +1763,7 @@ export enum Protocols {
     ZWaveLongRange = 1
 }
 
-// Warning: (ae-missing-release-tag) "ProtocolType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProtocolType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ProtocolType {
@@ -1775,7 +1775,7 @@ export enum ProtocolType {
     "Z-Wave" = 0
 }
 
-// Warning: (ae-missing-release-tag) "ProtocolVersion" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProtocolVersion" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ProtocolVersion {
@@ -1789,7 +1789,7 @@ export enum ProtocolVersion {
     "unknown" = 0
 }
 
-// Warning: (ae-missing-release-tag) "ProvisioningInformation_MaxInclusionRequestInterval" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProvisioningInformation_MaxInclusionRequestInterval" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ProvisioningInformation_MaxInclusionRequestInterval {
@@ -1797,7 +1797,7 @@ export interface ProvisioningInformation_MaxInclusionRequestInterval {
     maxInclusionRequestInterval: number;
 }
 
-// Warning: (ae-missing-release-tag) "ProvisioningInformation_ProductId" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProvisioningInformation_ProductId" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ProvisioningInformation_ProductId {
@@ -1811,7 +1811,7 @@ export interface ProvisioningInformation_ProductId {
     productType: number;
 }
 
-// Warning: (ae-missing-release-tag) "ProvisioningInformation_ProductType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProvisioningInformation_ProductType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ProvisioningInformation_ProductType {
@@ -1823,7 +1823,7 @@ export interface ProvisioningInformation_ProductType {
     specificDeviceClass: number;
 }
 
-// Warning: (ae-missing-release-tag) "ProvisioningInformation_SupportedProtocols" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProvisioningInformation_SupportedProtocols" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ProvisioningInformation_SupportedProtocols {
@@ -1831,7 +1831,7 @@ export interface ProvisioningInformation_SupportedProtocols {
     supportedProtocols: Protocols[];
 }
 
-// Warning: (ae-missing-release-tag) "ProvisioningInformation_UUID16" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProvisioningInformation_UUID16" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ProvisioningInformation_UUID16 {
@@ -1839,7 +1839,7 @@ export interface ProvisioningInformation_UUID16 {
     uuid: string;
 }
 
-// Warning: (ae-missing-release-tag) "ProvisioningInformationType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProvisioningInformationType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ProvisioningInformationType {
@@ -1867,7 +1867,7 @@ export enum ProvisioningInformationType {
     UUID16 = 3
 }
 
-// Warning: (ae-missing-release-tag) "QRCodeVersion" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "QRCodeVersion" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum QRCodeVersion {
@@ -1877,7 +1877,7 @@ export enum QRCodeVersion {
     SmartStart = 1
 }
 
-// Warning: (ae-missing-release-tag) "QRProvisioningInformation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "QRProvisioningInformation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type QRProvisioningInformation = {
@@ -1887,7 +1887,7 @@ export type QRProvisioningInformation = {
     dsk: string;
 } & ProvisioningInformation_ProductType & ProvisioningInformation_ProductId & Partial<ProvisioningInformation_MaxInclusionRequestInterval> & Partial<ProvisioningInformation_UUID16> & Partial<ProvisioningInformation_SupportedProtocols>;
 
-// Warning: (ae-missing-release-tag) "ReflectionDecorator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ReflectionDecorator" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ReflectionDecorator<TBase extends Object, TArgs extends any[], TValue, TConstructor extends Constructor<TBase> = Constructor<TBase>> {
@@ -1898,7 +1898,7 @@ export interface ReflectionDecorator<TBase extends Object, TArgs extends any[], 
     lookupValueStatic: (constr: Function) => TValue | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "ReflectionDecoratorPair" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ReflectionDecoratorPair" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ReflectionDecoratorPair<TBase extends Object, TSuperArgs extends [any], TSubArgs extends [any], TConstructor extends Constructor<TBase> = Constructor<TBase>> {
@@ -1912,12 +1912,12 @@ export interface ReflectionDecoratorPair<TBase extends Object, TSuperArgs extend
     superDecorator: <TTarget extends TBase>(...args: TSuperArgs) => TypedClassDecorator<TTarget>;
 }
 
-// Warning: (ae-missing-release-tag) "restoreSilence" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "restoreSilence" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function restoreSilence(logger: winston.Logger, original: boolean): void;
 
-// Warning: (ae-missing-release-tag) "RFRegion" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "RFRegion" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum RFRegion {
@@ -1949,7 +1949,7 @@ export enum RFRegion {
     "USA" = 1
 }
 
-// Warning: (ae-missing-release-tag) "RouteKind" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "RouteKind" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum RouteKind {
@@ -1960,7 +1960,7 @@ export enum RouteKind {
     None = 0
 }
 
-// Warning: (ae-missing-release-tag) "RouteProtocolDataRate" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "RouteProtocolDataRate" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum RouteProtocolDataRate {
@@ -1976,12 +1976,12 @@ export enum RouteProtocolDataRate {
     ZWave_9k6 = 1
 }
 
-// Warning: (ae-missing-release-tag) "RSSI" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "RSSI" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export type RSSI = number | RssiError;
 
-// Warning: (ae-missing-release-tag) "RssiError" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "RssiError" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum RssiError {
@@ -1993,22 +1993,22 @@ export enum RssiError {
     ReceiverSaturated = 126
 }
 
-// Warning: (ae-missing-release-tag) "rssiToString" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "rssiToString" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function rssiToString(rssi: RSSI): string;
 
-// Warning: (ae-missing-release-tag) "S2SecurityClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "S2SecurityClass" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type S2SecurityClass = SecurityClass.S2_Unauthenticated | SecurityClass.S2_Authenticated | SecurityClass.S2_AccessControl;
 
-// Warning: (ae-missing-release-tag) "SECURITY_S2_AUTH_TAG_LENGTH" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SECURITY_S2_AUTH_TAG_LENGTH" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const SECURITY_S2_AUTH_TAG_LENGTH = 8;
 
-// Warning: (ae-missing-release-tag) "SecurityClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SecurityClass" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum SecurityClass {
@@ -2024,18 +2024,18 @@ export enum SecurityClass {
     Temporary = -2
 }
 
-// Warning: (ae-missing-release-tag) "securityClassIsS2" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "securityClassIsS2" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function securityClassIsS2(secClass: SecurityClass | undefined): secClass is S2SecurityClass;
 
 // Warning: (tsdoc-escape-greater-than) The ">" character should be escaped using a backslash to avoid confusion with an HTML tag
-// Warning: (ae-missing-release-tag) "securityClassOrder" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "securityClassOrder" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const securityClassOrder: readonly [SecurityClass.S2_AccessControl, SecurityClass.S2_Authenticated, SecurityClass.S2_Unauthenticated, SecurityClass.S0_Legacy];
 
-// Warning: (ae-missing-release-tag) "SecurityClassOwner" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SecurityClassOwner" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface SecurityClassOwner {
@@ -2049,7 +2049,7 @@ export interface SecurityClassOwner {
     setSecurityClass(securityClass: SecurityClass, granted: boolean): void;
 }
 
-// Warning: (ae-missing-release-tag) "SecurityManager" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SecurityManager" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SecurityManager {
@@ -2080,7 +2080,7 @@ export class SecurityManager {
     setNonce(id: number | NonceKey, entry: NonceEntry, { free }?: SetNonceOptions): void;
 }
 
-// Warning: (ae-missing-release-tag) "SecurityManager2" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SecurityManager2" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SecurityManager2 {
@@ -2137,7 +2137,7 @@ export class SecurityManager2 {
     tryIncrementPeerMPAN(peerNodeId: number, groupId: number): void;
 }
 
-// Warning: (ae-missing-release-tag) "SecurityManagerOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SecurityManagerOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface SecurityManagerOptions {
@@ -2149,7 +2149,7 @@ export interface SecurityManagerOptions {
     ownNodeId: number;
 }
 
-// Warning: (ae-missing-release-tag) "SendCommandOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SendCommandOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type SendCommandOptions = SendMessageOptions & SupervisionOptions & SendCommandSecurityS2Options & {
@@ -2159,12 +2159,12 @@ export type SendCommandOptions = SendMessageOptions & SupervisionOptions & SendC
     transmitOptions?: TransmitOptions;
 };
 
-// Warning: (ae-missing-release-tag) "SendCommandReturnType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SendCommandReturnType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type SendCommandReturnType<TResponse extends ICommandClass | undefined> = undefined extends TResponse ? SupervisionResult | undefined : TResponse | undefined;
 
-// Warning: (ae-missing-release-tag) "SendCommandSecurityS2Options" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SendCommandSecurityS2Options" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type SendCommandSecurityS2Options = {
@@ -2173,7 +2173,7 @@ export type SendCommandSecurityS2Options = {
     s2MulticastGroupId?: number;
 };
 
-// Warning: (ae-missing-release-tag) "SendMessageOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SendMessageOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface SendMessageOptions {
@@ -2189,17 +2189,17 @@ export interface SendMessageOptions {
     tag?: any;
 }
 
-// Warning: (ae-missing-release-tag) "sensorCCs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "sensorCCs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const sensorCCs: readonly CommandClasses[];
 
-// Warning: (ae-missing-release-tag) "serializeCacheValue" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "serializeCacheValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function serializeCacheValue(value: unknown): SerializedValue;
 
-// Warning: (ae-missing-release-tag) "SetNonceOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SetNonceOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface SetNonceOptions {
@@ -2207,7 +2207,7 @@ export interface SetNonceOptions {
     free?: boolean;
 }
 
-// Warning: (ae-missing-release-tag) "SetValueOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SetValueOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface SetValueOptions {
@@ -2218,7 +2218,7 @@ export interface SetValueOptions {
     updateTimestamp?: boolean;
 }
 
-// Warning: (ae-missing-release-tag) "SimpleReflectionDecorator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SimpleReflectionDecorator" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface SimpleReflectionDecorator<TBase extends Object, TArgs extends [any], TConstructor extends Constructor<TBase> = Constructor<TBase>> {
@@ -2228,14 +2228,14 @@ export interface SimpleReflectionDecorator<TBase extends Object, TArgs extends [
     lookupValueStatic: (constr: Function) => TArgs[0] | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "SinglecastCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SinglecastCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type SinglecastCC<T extends ICommandClass = ICommandClass> = T & {
     nodeId: number;
 };
 
-// Warning: (ae-missing-release-tag) "SPANState" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SPANState" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum SPANState {
@@ -2248,7 +2248,7 @@ export enum SPANState {
     SPAN = 3
 }
 
-// Warning: (ae-missing-release-tag) "SPANTableEntry" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SPANTableEntry" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type SPANTableEntry = {
@@ -2272,26 +2272,26 @@ export type SPANTableEntry = {
 // @internal (undocumented)
 export function stringToNodeList(nodes?: string): number[] | undefined;
 
-// Warning: (ae-missing-release-tag) "stripUndefined" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "stripUndefined" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function stripUndefined<T>(obj: Record<string, T>): Record<string, T>;
 
-// Warning: (ae-missing-release-tag) "supervisedCommandFailed" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "supervisedCommandFailed" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function supervisedCommandFailed(result: unknown): result is SupervisionResult & {
     status: SupervisionStatus.Fail | SupervisionStatus.NoSupport;
 };
 
-// Warning: (ae-missing-release-tag) "supervisedCommandSucceeded" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "supervisedCommandSucceeded" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function supervisedCommandSucceeded(result: unknown): result is SupervisionResult & {
     status: SupervisionStatus.Success | SupervisionStatus.Working;
 };
 
-// Warning: (ae-missing-release-tag) "SupervisionOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SupervisionOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type SupervisionOptions = ({
@@ -2305,7 +2305,7 @@ export type SupervisionOptions = ({
     useSupervision: false;
 };
 
-// Warning: (ae-missing-release-tag) "SupervisionResult" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SupervisionResult" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type SupervisionResult = {
@@ -2316,7 +2316,7 @@ export type SupervisionResult = {
     remainingDuration: Duration;
 };
 
-// Warning: (ae-missing-release-tag) "SupervisionStatus" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SupervisionStatus" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum SupervisionStatus {
@@ -2330,17 +2330,17 @@ export enum SupervisionStatus {
     Working = 1
 }
 
-// Warning: (ae-missing-release-tag) "SupervisionUpdateHandler" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SupervisionUpdateHandler" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type SupervisionUpdateHandler = (update: SupervisionResult) => void;
 
-// Warning: (ae-missing-release-tag) "tagify" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "tagify" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function tagify(tags: string[]): string;
 
-// Warning: (ae-missing-release-tag) "Timeout" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Timeout" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export class Timeout {
@@ -2362,12 +2362,12 @@ export class Timeout {
     set value(v: number);
 }
 
-// Warning: (ae-missing-release-tag) "TimeoutUnit" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TimeoutUnit" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type TimeoutUnit = "seconds" | "minutes" | "none" | "infinite";
 
-// Warning: (ae-missing-release-tag) "timespan" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "timespan" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const timespan: Readonly<{
@@ -2377,27 +2377,27 @@ export const timespan: Readonly<{
     days: (num: number) => number;
 }>;
 
-// Warning: (ae-missing-release-tag) "timestampFormatShort" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "timestampFormatShort" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const timestampFormatShort = "HH:mm:ss.SSS";
 
-// Warning: (ae-missing-release-tag) "timestampPadding" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "timestampPadding" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const timestampPadding: string;
 
-// Warning: (ae-missing-release-tag) "timestampPaddingShort" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "timestampPaddingShort" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const timestampPaddingShort: string;
 
-// Warning: (ae-missing-release-tag) "topologicalSort" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "topologicalSort" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function topologicalSort<T>(graph: GraphNode<T>[]): T[];
 
-// Warning: (ae-missing-release-tag) "TranslatedValueID" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TranslatedValueID" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface TranslatedValueID extends ValueID {
@@ -2409,7 +2409,7 @@ export interface TranslatedValueID extends ValueID {
     propertyName?: string;
 }
 
-// Warning: (ae-missing-release-tag) "TransmitOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TransmitOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum TransmitOptions {
@@ -2431,7 +2431,7 @@ export enum TransmitOptions {
     NotSet = 0
 }
 
-// Warning: (ae-missing-release-tag) "TransmitStatus" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TransmitStatus" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum TransmitStatus {
@@ -2447,12 +2447,12 @@ export enum TransmitStatus {
     OK = 0
 }
 
-// Warning: (ae-missing-release-tag) "tryParseDSKFromQRCodeString" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "tryParseDSKFromQRCodeString" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function tryParseDSKFromQRCodeString(qr: string): string | undefined;
 
-// Warning: (ae-missing-release-tag) "TXReport" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TXReport" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface TXReport {
@@ -2477,28 +2477,28 @@ export interface TXReport {
     txTicks: number;
 }
 
-// Warning: (ae-missing-release-tag) "unknownBoolean" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "unknownBoolean" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const unknownBoolean: Maybe<boolean>;
 
-// Warning: (ae-missing-release-tag) "unknownNumber" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "unknownNumber" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const unknownNumber: Maybe<number>;
 
-// Warning: (ae-missing-release-tag) "unsilence" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "unsilence" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function unsilence(logger: winston.Logger): boolean;
 
 // Warning: (ae-forgotten-export) The symbol "ValidatePayload" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "validatePayload" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "validatePayload" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const validatePayload: ValidatePayload;
 
-// Warning: (ae-missing-release-tag) "ValueAddedArgs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ValueAddedArgs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ValueAddedArgs extends ValueID {
@@ -2506,7 +2506,7 @@ export interface ValueAddedArgs extends ValueID {
     newValue: unknown;
 }
 
-// Warning: (ae-missing-release-tag) "ValueChangeOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ValueChangeOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface ValueChangeOptions {
@@ -2515,7 +2515,7 @@ export interface ValueChangeOptions {
 }
 
 // Warning: (ae-forgotten-export) The symbol "ValueDBEventCallbacks" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "ValueDB" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ValueDB" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export class ValueDB extends TypedEventEmitter<ValueDBEventCallbacks> {
@@ -2547,7 +2547,7 @@ export class ValueDB extends TypedEventEmitter<ValueDBEventCallbacks> {
     setValue(valueId: ValueID, value: unknown, options?: SetValueOptions): void;
 }
 
-// Warning: (ae-missing-release-tag) "ValueID" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ValueID" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface ValueID {
@@ -2561,12 +2561,12 @@ export interface ValueID {
     propertyKey?: string | number;
 }
 
-// Warning: (ae-missing-release-tag) "valueIdToString" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "valueIdToString" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function valueIdToString(valueID: ValueID): string;
 
-// Warning: (ae-missing-release-tag) "ValuelessReflectionDecorator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ValuelessReflectionDecorator" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ValuelessReflectionDecorator<TBase extends Object> {
@@ -2575,7 +2575,7 @@ export interface ValuelessReflectionDecorator<TBase extends Object> {
     isDecoratedStatic: (constr: Function) => boolean;
 }
 
-// Warning: (ae-missing-release-tag) "ValueLogContext" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ValueLogContext" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ValueLogContext = LogContext & ValueID & {
@@ -2583,8 +2583,8 @@ export type ValueLogContext = LogContext & ValueID & {
     type: "value";
 };
 
-// Warning: (ae-missing-release-tag) "ValueMetadata" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "ValueMetadata" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ValueMetadata" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ValueMetadata" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ValueMetadata = ValueMetadataAny | ValueMetadataNumeric | ValueMetadataBoolean | ValueMetadataString | ValueMetadataDuration | ValueMetadataBuffer | ConfigurationMetadata;
@@ -2887,7 +2887,7 @@ export const ValueMetadata: {
     }>;
 };
 
-// Warning: (ae-missing-release-tag) "ValueMetadataAny" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ValueMetadataAny" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ValueMetadataAny {
@@ -2903,7 +2903,7 @@ export interface ValueMetadataAny {
     writeable: boolean;
 }
 
-// Warning: (ae-missing-release-tag) "ValueMetadataBoolean" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ValueMetadataBoolean" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ValueMetadataBoolean extends ValueMetadataAny {
@@ -2916,7 +2916,7 @@ export interface ValueMetadataBoolean extends ValueMetadataAny {
     type: "boolean";
 }
 
-// Warning: (ae-missing-release-tag) "ValueMetadataBuffer" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ValueMetadataBuffer" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ValueMetadataBuffer extends ValueMetadataAny {
@@ -2926,7 +2926,7 @@ export interface ValueMetadataBuffer extends ValueMetadataAny {
     type: "buffer";
 }
 
-// Warning: (ae-missing-release-tag) "ValueMetadataDuration" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ValueMetadataDuration" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ValueMetadataDuration extends ValueMetadataAny {
@@ -2936,7 +2936,7 @@ export interface ValueMetadataDuration extends ValueMetadataAny {
     type: "duration";
 }
 
-// Warning: (ae-missing-release-tag) "ValueMetadataNumeric" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ValueMetadataNumeric" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ValueMetadataNumeric extends ValueMetadataAny {
@@ -2951,7 +2951,7 @@ export interface ValueMetadataNumeric extends ValueMetadataAny {
     unit?: string;
 }
 
-// Warning: (ae-missing-release-tag) "ValueMetadataString" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ValueMetadataString" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ValueMetadataString extends ValueMetadataAny {
@@ -2962,7 +2962,7 @@ export interface ValueMetadataString extends ValueMetadataAny {
     type: "string" | "color";
 }
 
-// Warning: (ae-missing-release-tag) "ValueNotificationArgs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ValueNotificationArgs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ValueNotificationArgs extends ValueID {
@@ -2970,7 +2970,7 @@ export interface ValueNotificationArgs extends ValueID {
     value: unknown;
 }
 
-// Warning: (ae-missing-release-tag) "ValueRemovedArgs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ValueRemovedArgs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ValueRemovedArgs extends ValueID {
@@ -2978,12 +2978,12 @@ export interface ValueRemovedArgs extends ValueID {
     prevValue: unknown;
 }
 
-// Warning: (ae-missing-release-tag) "ValueType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ValueType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ValueType = "number" | "boolean" | "string" | "number[]" | "boolean[]" | "string[]" | "duration" | "color" | "buffer" | "any";
 
-// Warning: (ae-missing-release-tag) "ValueUpdatedArgs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ValueUpdatedArgs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ValueUpdatedArgs extends ValueID {
@@ -2994,7 +2994,7 @@ export interface ValueUpdatedArgs extends ValueID {
     source?: "driver" | "node";
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveApiVersion" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveApiVersion" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ZWaveApiVersion {
@@ -3004,7 +3004,7 @@ export interface ZWaveApiVersion {
     version: number;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveDataRate" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveDataRate" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ZWaveDataRate {
@@ -3016,7 +3016,7 @@ export enum ZWaveDataRate {
     "9k6" = 1
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveError" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveError" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export class ZWaveError extends Error {
@@ -3031,7 +3031,7 @@ export class ZWaveError extends Error {
     readonly transactionSource?: string | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveErrorCodes" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveErrorCodes" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export enum ZWaveErrorCodes {
@@ -3153,7 +3153,7 @@ export enum ZWaveErrorCodes {
     Unsupported_Firmware_Format = 1507
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveLibraryTypes" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveLibraryTypes" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ZWaveLibraryTypes {
@@ -3183,7 +3183,7 @@ export enum ZWaveLibraryTypes {
     "Unknown" = 0
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveLogContainer" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveLogContainer" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveLogContainer extends winston.Container {
@@ -3200,14 +3200,14 @@ export class ZWaveLogContainer extends winston.Container {
     updateConfiguration(config: DeepPartial<LogConfig>): void;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveLogger" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveLogger" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ZWaveLogger<TContext extends LogContext = LogContext> = Omit<Logger, "log"> & {
     log: <T extends TContext>(info: ZWaveLogInfo<T>) => void;
 };
 
-// Warning: (ae-missing-release-tag) "ZWaveLoggerBase" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveLoggerBase" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ZWaveLoggerBase<TContext extends LogContext = LogContext> {
@@ -3218,7 +3218,7 @@ export class ZWaveLoggerBase<TContext extends LogContext = LogContext> {
     logger: ZWaveLogger<TContext>;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveLogInfo" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveLogInfo" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ZWaveLogInfo<TContext extends LogContext = LogContext> extends Omit<TransformableInfo, "message"> {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -72,7 +72,7 @@
     "winston-transport": "^4.5.0"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "*",
+    "@microsoft/api-extractor": "^7.35.0",
     "@types/node": "^14.18.43",
     "@types/sinon": "^10.0.14",
     "@types/triple-beam": "^1.3.2",

--- a/packages/host/api.md
+++ b/packages/host/api.md
@@ -24,12 +24,12 @@ import { ThrowingMap } from '@zwave-js/shared';
 import type { ValueDB } from '@zwave-js/core';
 import type { ValueID } from '@zwave-js/core';
 
-// Warning: (ae-missing-release-tag) "createTestingHost" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "createTestingHost" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function createTestingHost(options?: Partial<CreateTestingHostOptions>): TestingHost;
 
-// Warning: (ae-missing-release-tag) "CreateTestingHostOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CreateTestingHostOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface CreateTestingHostOptions {
@@ -43,7 +43,7 @@ export interface CreateTestingHostOptions {
     ownNodeId: ZWaveHost["ownNodeId"];
 }
 
-// Warning: (ae-missing-release-tag) "FileSystem" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FileSystem" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface FileSystem {
@@ -59,7 +59,7 @@ export interface FileSystem {
     } | string): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "NodeSchedulePollOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NodeSchedulePollOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface NodeSchedulePollOptions {
@@ -67,14 +67,14 @@ export interface NodeSchedulePollOptions {
     timeoutMs?: number;
 }
 
-// Warning: (ae-missing-release-tag) "TestingHost" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TestingHost" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type TestingHost = Overwrite<Omit<ZWaveApplicationHost, "__internalIsMockNode">, {
     nodes: ThrowingMap<number, IZWaveNode>;
 }>;
 
-// Warning: (ae-missing-release-tag) "ZWaveApplicationHost" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveApplicationHost" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface ZWaveApplicationHost extends ZWaveHost {
@@ -95,7 +95,7 @@ export interface ZWaveApplicationHost extends ZWaveHost {
     waitForCommand<T extends ICommandClass>(predicate: (cc: ICommandClass) => boolean, timeout: number): Promise<T>;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveHost" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveHost" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface ZWaveHost {
@@ -120,7 +120,7 @@ export interface ZWaveHost {
     setSecurityClass(nodeId: number, securityClass: SecurityClass, granted: boolean): void;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveHostOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveHostOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ZWaveHostOptions {

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -58,7 +58,7 @@
     "alcalzone-shared": "^4.0.8"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "*",
+    "@microsoft/api-extractor": "^7.35.0",
     "@types/node": "^14.18.43",
     "del-cli": "^5.0.0",
     "prettier": "^2.8.8",

--- a/packages/nvmedit/api.md
+++ b/packages/nvmedit/api.md
@@ -12,7 +12,7 @@ import { NodeProtocolInfo } from '@zwave-js/core/safe';
 import { RFRegion } from '@zwave-js/core/safe';
 import { RouteProtocolDataRate } from '@zwave-js/core/safe';
 
-// Warning: (ae-missing-release-tag) "FragmentType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FragmentType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum FragmentType {
@@ -26,32 +26,32 @@ export enum FragmentType {
     None = 0
 }
 
-// Warning: (ae-missing-release-tag) "json500To700" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "json500To700" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function json500To700(json: NVM500JSON, truncateApplicationData?: boolean): NVMJSON;
 
-// Warning: (ae-missing-release-tag) "json700To500" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "json700To500" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function json700To500(json: NVMJSON): NVM500JSON;
 
-// Warning: (ae-missing-release-tag) "jsonToNVM" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "jsonToNVM" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function jsonToNVM(json: Required<NVMJSON>, targetSDKVersion: string): Buffer;
 
-// Warning: (ae-missing-release-tag) "jsonToNVM500" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "jsonToNVM500" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function jsonToNVM500(json: Required<NVM500JSON>, protocolVersion: string): Buffer;
 
-// Warning: (ae-missing-release-tag) "migrateNVM" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "migrateNVM" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function migrateNVM(sourceNVM: Buffer, targetNVM: Buffer): Buffer;
 
-// Warning: (ae-missing-release-tag) "NVM500JSON" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NVM500JSON" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface NVM500JSON {
@@ -65,7 +65,7 @@ export interface NVM500JSON {
     nodes: Record<number, NVM500JSONNode>;
 }
 
-// Warning: (ae-missing-release-tag) "NVM500JSONController" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NVM500JSONController" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface NVM500JSONController {
@@ -109,7 +109,7 @@ export interface NVM500JSONController {
     watchdogStarted: number;
 }
 
-// Warning: (ae-missing-release-tag) "NVM500JSONControllerRFConfig" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NVM500JSONControllerRFConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface NVM500JSONControllerRFConfig {
@@ -125,13 +125,13 @@ export interface NVM500JSONControllerRFConfig {
     powerModeWutTimeout: number;
 }
 
-// Warning: (ae-missing-release-tag) "NVM500JSONNode" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NVM500JSONNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type NVM500JSONNode = NVM500JSONNodeWithInfo | NVM500JSONVirtualNode;
 
 // Warning: (ae-forgotten-export) The symbol "NVM500NodeInfo" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "NVM500JSONNodeWithInfo" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NVM500JSONNodeWithInfo" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface NVM500JSONNodeWithInfo extends NVM500NodeInfo {
@@ -157,7 +157,7 @@ export interface NVM500JSONNodeWithInfo extends NVM500NodeInfo {
     sucUpdateIndex: number;
 }
 
-// Warning: (ae-missing-release-tag) "NVM500JSONVirtualNode" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NVM500JSONVirtualNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface NVM500JSONVirtualNode {
@@ -165,7 +165,7 @@ export interface NVM500JSONVirtualNode {
     isVirtual: true;
 }
 
-// Warning: (ae-missing-release-tag) "NVM500Meta" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NVM500Meta" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface NVM500Meta {
@@ -183,12 +183,12 @@ export interface NVM500Meta {
     productType: number;
 }
 
-// Warning: (ae-missing-release-tag) "nvm500ToJSON" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "nvm500ToJSON" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function nvm500ToJSON(buffer: Buffer): Required<NVM500JSON>;
 
-// Warning: (ae-missing-release-tag) "NVMJSON" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NVMJSON" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface NVMJSON {
@@ -202,7 +202,7 @@ export interface NVMJSON {
     nodes: Record<number, NVMJSONNode>;
 }
 
-// Warning: (ae-missing-release-tag) "NVMJSONController" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NVMJSONController" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface NVMJSONController {
@@ -264,7 +264,7 @@ export interface NVMJSONController {
     systemState: number;
 }
 
-// Warning: (ae-missing-release-tag) "NVMJSONControllerRFConfig" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NVMJSONControllerRFConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface NVMJSONControllerRFConfig {
@@ -280,12 +280,12 @@ export interface NVMJSONControllerRFConfig {
     txPower: number;
 }
 
-// Warning: (ae-missing-release-tag) "NVMJSONNode" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NVMJSONNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type NVMJSONNode = NVMJSONNodeWithInfo | NVMJSONVirtualNode;
 
-// Warning: (ae-missing-release-tag) "NVMJSONNodeWithInfo" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NVMJSONNodeWithInfo" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface NVMJSONNodeWithInfo extends Omit<NodeProtocolInfo, "hasSpecificDeviceClass"> {
@@ -313,7 +313,7 @@ export interface NVMJSONNodeWithInfo extends Omit<NodeProtocolInfo, "hasSpecific
     sucUpdateIndex: number;
 }
 
-// Warning: (ae-missing-release-tag) "NVMJSONVirtualNode" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NVMJSONVirtualNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface NVMJSONVirtualNode {
@@ -321,7 +321,7 @@ export interface NVMJSONVirtualNode {
     isVirtual: true;
 }
 
-// Warning: (ae-missing-release-tag) "NVMMeta" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NVMMeta" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface NVMMeta {
@@ -335,7 +335,7 @@ export interface NVMMeta {
     writeSize: PageWriteSize;
 }
 
-// Warning: (ae-missing-release-tag) "NVM3Object" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NVM3Object" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface NVMObject {
@@ -349,7 +349,7 @@ export interface NVMObject {
     type: ObjectType;
 }
 
-// Warning: (ae-missing-release-tag) "NVM3Page" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NVM3Page" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface NVMPage {
@@ -359,12 +359,12 @@ export interface NVMPage {
     objects: NVMObject[];
 }
 
-// Warning: (ae-missing-release-tag) "nvmToJSON" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "nvmToJSON" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function nvmToJSON(buffer: Buffer, debugLogs?: boolean): Required<NVMJSON>;
 
-// Warning: (ae-missing-release-tag) "ObjectType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ObjectType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ObjectType {
@@ -380,7 +380,7 @@ export enum ObjectType {
     Deleted = 3
 }
 
-// Warning: (ae-missing-release-tag) "NVM3PageHeader" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NVM3PageHeader" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface PageHeader {
@@ -404,7 +404,7 @@ export interface PageHeader {
     writeSize: PageWriteSize;
 }
 
-// Warning: (ae-missing-release-tag) "PageStatus" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "PageStatus" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum PageStatus {
@@ -418,7 +418,7 @@ export enum PageStatus {
     OK_ErasePending = 4294944165
 }
 
-// Warning: (ae-missing-release-tag) "PageWriteSize" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "PageWriteSize" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum PageWriteSize {

--- a/packages/nvmedit/package.json
+++ b/packages/nvmedit/package.json
@@ -65,7 +65,7 @@
     "test:dirty": "node -r ../../maintenance/esbuild-register.js ../maintenance/src/resolveDirtyTests.ts --run"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "*",
+    "@microsoft/api-extractor": "^7.35.0",
     "@types/fs-extra": "^9.0.13",
     "@types/node": "^14.18.43",
     "@types/semver": "^7.3.13",

--- a/packages/serial/api.md
+++ b/packages/serial/api.md
@@ -26,7 +26,7 @@ import type { ZWaveHost } from '@zwave-js/host';
 import { ZWaveLogContainer } from '@zwave-js/core';
 import { ZWaveLoggerBase } from '@zwave-js/core';
 
-// Warning: (ae-missing-release-tag) "BootloaderChunk" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BootloaderChunk" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type BootloaderChunk = {
@@ -50,7 +50,7 @@ export type BootloaderChunk = {
     command: XModemMessageHeaders.ACK | XModemMessageHeaders.NAK | XModemMessageHeaders.CAN | XModemMessageHeaders.C;
 };
 
-// Warning: (ae-missing-release-tag) "BootloaderChunkType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BootloaderChunkType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum BootloaderChunkType {
@@ -64,12 +64,12 @@ export enum BootloaderChunkType {
     Message = 2
 }
 
-// Warning: (ae-missing-release-tag) "bootloaderMenuPreamble" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "bootloaderMenuPreamble" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const bootloaderMenuPreamble = "Gecko Bootloader";
 
-// Warning: (ae-missing-release-tag) "BootloaderParser" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BootloaderParser" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export class BootloaderParser extends Transform {
@@ -78,7 +78,7 @@ export class BootloaderParser extends Transform {
     _transform(chunk: any, encoding: string, callback: TransformCallback): void;
 }
 
-// Warning: (ae-missing-release-tag) "BootloaderScreenParser" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "BootloaderScreenParser" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export class BootloaderScreenParser extends Transform {
@@ -87,22 +87,22 @@ export class BootloaderScreenParser extends Transform {
     _transform(chunk: any, encoding: string, callback: TransformCallback): void;
 }
 
-// Warning: (ae-missing-release-tag) "DeserializingMessageConstructor" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DeserializingMessageConstructor" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type DeserializingMessageConstructor<T extends Message> = new (host: ZWaveHost, options: MessageDeserializationOptions) => T;
 
-// Warning: (ae-missing-release-tag) "expectedCallback" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "expectedCallback" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function expectedCallback<TSent extends Message>(typeOrPredicate: FunctionType | typeof Message | ResponsePredicate<TSent>): TypedClassDecorator<Message>;
 
-// Warning: (ae-missing-release-tag) "expectedResponse" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "expectedResponse" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const expectedResponse: <TTarget extends Message>(typeOrPredicate: FunctionType | typeof Message | ResponsePredicate<Message>) => TypedClassDecorator<TTarget>;
 
-// Warning: (ae-missing-release-tag) "FunctionType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FunctionType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export enum FunctionType {
@@ -356,62 +356,62 @@ export enum FunctionType {
     UNKNOWN_FUNC_ZMESerialAPIOptions = 248
 }
 
-// Warning: (ae-missing-release-tag) "getDefaultPriority" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getDefaultPriority" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getDefaultPriority<T extends Message>(messageClass: T): MessagePriority | undefined;
 
-// Warning: (ae-missing-release-tag) "getDefaultPriorityStatic" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getDefaultPriorityStatic" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getDefaultPriorityStatic<T extends MessageConstructor<Message>>(classConstructor: T): MessagePriority | undefined;
 
-// Warning: (ae-missing-release-tag) "getExpectedCallback" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getExpectedCallback" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getExpectedCallback<T extends Message>(messageClass: T): FunctionType | typeof Message | ResponsePredicate | undefined;
 
-// Warning: (ae-missing-release-tag) "getExpectedCallbackStatic" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getExpectedCallbackStatic" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getExpectedCallbackStatic<T extends MessageConstructor<Message>>(classConstructor: T): FunctionType | typeof Message | ResponsePredicate | undefined;
 
-// Warning: (ae-missing-release-tag) "getExpectedResponse" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getExpectedResponse" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getExpectedResponse<T extends Message>(messageClass: T): FunctionType | typeof Message | ResponsePredicate | undefined;
 
-// Warning: (ae-missing-release-tag) "getExpectedResponseStatic" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getExpectedResponseStatic" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getExpectedResponseStatic<T extends MessageConstructor<Message>>(classConstructor: T): FunctionType | typeof Message | ResponsePredicate | undefined;
 
-// Warning: (ae-missing-release-tag) "getFunctionType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getFunctionType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getFunctionType<T extends Message>(messageClass: T): FunctionType | undefined;
 
-// Warning: (ae-missing-release-tag) "getFunctionTypeStatic" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getFunctionTypeStatic" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getFunctionTypeStatic<T extends MessageConstructor<Message>>(classConstructor: T): FunctionType | undefined;
 
-// Warning: (ae-missing-release-tag) "getMessageType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getMessageType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getMessageType<T extends Message>(messageClass: T): MessageType | undefined;
 
-// Warning: (ae-missing-release-tag) "getMessageTypeStatic" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getMessageTypeStatic" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getMessageTypeStatic<T extends MessageConstructor<Message>>(classConstructor: T): MessageType | undefined;
 
-// Warning: (ae-missing-release-tag) "gotDeserializationOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "gotDeserializationOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function gotDeserializationOptions(options: Record<any, any> | undefined): options is MessageDeserializationOptions;
 
-// Warning: (ae-missing-release-tag) "INodeQuery" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "INodeQuery" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface INodeQuery {
@@ -419,27 +419,27 @@ export interface INodeQuery {
     nodeId: number;
 }
 
-// Warning: (ae-missing-release-tag) "isMultiStageCallback" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isMultiStageCallback" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function isMultiStageCallback<T extends Message>(msg: T): msg is T & MultiStageCallback;
 
-// Warning: (ae-missing-release-tag) "isNodeQuery" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isNodeQuery" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function isNodeQuery<T extends Message>(msg: T): msg is T & INodeQuery;
 
-// Warning: (ae-missing-release-tag) "isSuccessIndicator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isSuccessIndicator" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function isSuccessIndicator<T extends Message>(msg: T): msg is T & SuccessIndicator;
 
-// Warning: (ae-missing-release-tag) "isZWaveSerialPortImplementation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isZWaveSerialPortImplementation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function isZWaveSerialPortImplementation(obj: unknown): obj is ZWaveSerialPortImplementation;
 
-// Warning: (ae-missing-release-tag) "Message" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Message" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export class Message {
@@ -487,7 +487,7 @@ export class Message {
     type: MessageType;
 }
 
-// Warning: (ae-missing-release-tag) "MessageBaseOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MessageBaseOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface MessageBaseOptions {
@@ -495,12 +495,12 @@ export interface MessageBaseOptions {
     callbackId?: number;
 }
 
-// Warning: (ae-missing-release-tag) "MessageConstructor" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MessageConstructor" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type MessageConstructor<T extends Message> = new (host: ZWaveHost, options?: MessageOptions) => T;
 
-// Warning: (ae-missing-release-tag) "MessageCreationOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MessageCreationOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface MessageCreationOptions extends MessageBaseOptions {
@@ -516,7 +516,7 @@ export interface MessageCreationOptions extends MessageBaseOptions {
     type?: MessageType;
 }
 
-// Warning: (ae-missing-release-tag) "MessageDeserializationOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MessageDeserializationOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface MessageDeserializationOptions {
@@ -528,7 +528,7 @@ export interface MessageDeserializationOptions {
     sdkVersion?: string;
 }
 
-// Warning: (ae-missing-release-tag) "MessageHeaders" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MessageHeaders" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum MessageHeaders {
@@ -542,12 +542,12 @@ export enum MessageHeaders {
     SOF = 1
 }
 
-// Warning: (ae-missing-release-tag) "MessageOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MessageOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type MessageOptions = MessageCreationOptions | MessageDeserializationOptions;
 
-// Warning: (ae-missing-release-tag) "MessageOrigin" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MessageOrigin" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export enum MessageOrigin {
@@ -557,7 +557,7 @@ export enum MessageOrigin {
     Host = 1
 }
 
-// Warning: (ae-missing-release-tag) "MessageType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MessageType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export enum MessageType {
@@ -567,34 +567,34 @@ export enum MessageType {
     Response = 1
 }
 
-// Warning: (ae-missing-release-tag) "messageTypes" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "messageTypes" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const messageTypes: <TTarget extends Message>(messageType: MessageType, functionType: FunctionType) => TypedClassDecorator<TTarget>;
 
-// Warning: (ae-missing-release-tag) "MultiStageCallback" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MultiStageCallback" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface MultiStageCallback {
     isFinal(): boolean;
 }
 
-// Warning: (ae-missing-release-tag) "priority" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "priority" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const priority: <TTarget extends Message>(prio: MessagePriority) => TypedClassDecorator<TTarget>;
 
-// Warning: (ae-missing-release-tag) "ResponsePredicate" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ResponsePredicate" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export type ResponsePredicate<TSent extends Message = Message> = (sentMessage: TSent, receivedMessage: Message) => boolean;
 
-// Warning: (ae-missing-release-tag) "ResponseRole" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ResponseRole" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ResponseRole = "unexpected" | "confirmation" | "final" | "fatal_controller" | "fatal_node";
 
-// Warning: (ae-missing-release-tag) "SerialAPIParser" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SerialAPIParser" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SerialAPIParser extends Transform {
@@ -603,7 +603,7 @@ export class SerialAPIParser extends Transform {
     _transform(chunk: any, encoding: string, callback: TransformCallback): void;
 }
 
-// Warning: (ae-missing-release-tag) "SerialLogContext" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SerialLogContext" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface SerialLogContext extends LogContext<"serial"> {
@@ -613,7 +613,7 @@ export interface SerialLogContext extends LogContext<"serial"> {
     header?: string;
 }
 
-// Warning: (ae-missing-release-tag) "SerialLogger" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SerialLogger" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class SerialLogger extends ZWaveLoggerBase<SerialLogContext> {
@@ -634,19 +634,19 @@ export class SerialLogger extends ZWaveLoggerBase<SerialLogContext> {
     NAK(direction: DataDirection_2): void;
 }
 
-// Warning: (ae-missing-release-tag) "skipBytes" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "skipBytes" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function skipBytes(buf: Buffer, n: number): Buffer;
 
-// Warning: (ae-missing-release-tag) "SuccessIndicator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SuccessIndicator" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface SuccessIndicator {
     isOK(): boolean;
 }
 
-// Warning: (ae-missing-release-tag) "XModemMessageHeaders" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "XModemMessageHeaders" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum XModemMessageHeaders {
@@ -664,12 +664,12 @@ export enum XModemMessageHeaders {
     SOF = 1
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveSerialChunk" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveSerialChunk" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ZWaveSerialChunk = MessageHeaders.ACK | MessageHeaders.NAK | MessageHeaders.CAN | Buffer;
 
-// Warning: (ae-missing-release-tag) "ZWaveSerialMode" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveSerialMode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ZWaveSerialMode {
@@ -679,7 +679,7 @@ export enum ZWaveSerialMode {
     SerialAPI = 0
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveSerialPort" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveSerialPort" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export class ZWaveSerialPort extends ZWaveSerialPortBase {
@@ -688,8 +688,8 @@ export class ZWaveSerialPort extends ZWaveSerialPortBase {
     get isOpen(): boolean;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveSerialPortBase" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "ZWaveSerialPortBase" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveSerialPortBase" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveSerialPortBase" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ZWaveSerialPortBase {
@@ -730,7 +730,7 @@ export class ZWaveSerialPortBase extends PassThrough {
     writeAsync(data: Buffer): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveSerialPortEventCallbacks" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveSerialPortEventCallbacks" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ZWaveSerialPortEventCallbacks {
@@ -744,12 +744,12 @@ export interface ZWaveSerialPortEventCallbacks {
     error: (e: Error) => void;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveSerialPortEvents" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveSerialPortEvents" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ZWaveSerialPortEvents = Extract<keyof ZWaveSerialPortEventCallbacks, string>;
 
-// Warning: (ae-missing-release-tag) "ZWaveSerialPortImplementation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveSerialPortImplementation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ZWaveSerialPortImplementation {
@@ -761,14 +761,14 @@ export interface ZWaveSerialPortImplementation {
     open(port: ReturnType<ZWaveSerialPortImplementation["create"]>): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveSocket" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveSocket" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export class ZWaveSocket extends ZWaveSerialPortBase {
     constructor(socketOptions: ZWaveSocketOptions, loggers: ZWaveLogContainer);
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveSocketOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveSocketOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ZWaveSocketOptions = Omit<net.TcpSocketConnectOpts, "onread"> | Omit<net.IpcSocketConnectOpts, "onread">;

--- a/packages/serial/package.json
+++ b/packages/serial/package.json
@@ -68,7 +68,7 @@
     "winston": "^3.8.2"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "*",
+    "@microsoft/api-extractor": "^7.35.0",
     "@serialport/binding-mock": "^10.2.2",
     "@serialport/bindings-interface": "*",
     "@types/node": "^14.18.43",

--- a/packages/shared/api.md
+++ b/packages/shared/api.md
@@ -7,182 +7,182 @@
 /// <reference types="node" />
 
 // Warning: (ae-forgotten-export) The symbol "Constructors" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "AllOf" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AllOf" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function AllOf<T extends any[]>(...BaseClasses: Constructors<T>): Constructor<UnionToIntersection<T[number]>>;
 
-// Warning: (ae-missing-release-tag) "AllOrNone" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "AllOrNone" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export type AllOrNone<T extends Record<string, any>> = T | {
     [key in keyof T]?: undefined;
 };
 
-// Warning: (ae-missing-release-tag) "applyMixin" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "applyMixin" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function applyMixin(target: Constructor, mixin: Constructor, includeConstructor?: boolean): void;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// Warning: (ae-missing-release-tag) "buffer2hex" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "buffer2hex" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function buffer2hex(buffer: Buffer, uppercase?: boolean): string;
 
-// Warning: (ae-missing-release-tag) "cloneDeep" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "cloneDeep" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function cloneDeep<T>(source: T): T;
 
-// Warning: (ae-missing-release-tag) "compareStrings" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "compareStrings" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function compareStrings(a: string, b: string): number;
 
-// Warning: (ae-missing-release-tag) "Constructor" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Constructor" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type Constructor<T = {}> = new (...args: any[]) => T;
 
-// Warning: (ae-missing-release-tag) "cpp2js" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "cpp2js" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function cpp2js(str: string): string;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// Warning: (ae-missing-release-tag) "createThrowingMap" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "createThrowingMap" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function createThrowingMap<K, V>(throwKeyNotFound?: (key: K) => never): ThrowingMap<K, V>;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// Warning: (ae-missing-release-tag) "createWrappingCounter" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "createWrappingCounter" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function createWrappingCounter(maxValue: number, randomSeed?: boolean): () => number;
 
-// Warning: (ae-missing-release-tag) "DeepPartial" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DeepPartial" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type DeepPartial<T> = {
     [P in keyof T]+?: DeepPartial<T[P]>;
 };
 
-// Warning: (ae-missing-release-tag) "discreteBinarySearch" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "discreteBinarySearch" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function discreteBinarySearch(rangeMin: number, rangeMax: number, executor: (value: number) => boolean | PromiseLike<boolean>): Promise<number | undefined>;
 
-// Warning: (ae-missing-release-tag) "discreteLinearSearch" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "discreteLinearSearch" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function discreteLinearSearch(rangeMin: number, rangeMax: number, executor: (value: number) => boolean | PromiseLike<boolean>): Promise<number | undefined>;
 
-// Warning: (ae-missing-release-tag) "enumFilesRecursive" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "enumFilesRecursive" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function enumFilesRecursive(rootDir: string, predicate?: (filename: string) => boolean): Promise<string[]>;
 
-// Warning: (ae-missing-release-tag) "EventHandler" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EventHandler" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type EventHandler = ((arg1: any, arg2: any, arg3: any, arg4: any) => void) | ((arg1: any, arg2: any, arg3: any) => void) | ((arg1: any, arg2: any) => void) | ((arg1: any) => void) | ((...args: any[]) => void);
 
-// Warning: (ae-missing-release-tag) "flatMap" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "flatMap" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function flatMap<U, T extends any[]>(array: T[], callbackfn: (value: T, index: number, array: T[]) => U[]): U[];
 
-// Warning: (ae-missing-release-tag) "formatDate" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "formatDate" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function formatDate(year: number, month: number, day: number): string;
 
-// Warning: (ae-missing-release-tag) "formatId" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "formatId" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function formatId(id: number | string): string;
 
-// Warning: (ae-missing-release-tag) "formatTime" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "formatTime" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function formatTime(hour: number, minute: number): string;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// Warning: (ae-missing-release-tag) "getEnumMemberName" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getEnumMemberName" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function getEnumMemberName(enumeration: unknown, value: number): string;
 
-// Warning: (ae-missing-release-tag) "getErrorMessage" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "getErrorMessage" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function getErrorMessage(e: unknown, includeStack?: boolean): string;
 
-// Warning: (ae-missing-release-tag) "IsAny" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IsAny" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type IsAny<T> = 0 extends 1 & T ? true : false;
 
-// Warning: (ae-missing-release-tag) "isDocker" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isDocker" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function isDocker(): boolean;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// Warning: (ae-missing-release-tag) "isEnumMember" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isEnumMember" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function isEnumMember(enumeration: unknown, value: number): boolean;
 
-// Warning: (ae-missing-release-tag) "isPrintableASCII" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isPrintableASCII" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function isPrintableASCII(text: string): boolean;
 
-// Warning: (ae-missing-release-tag) "isPrintableASCIIWithNewlines" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "isPrintableASCIIWithNewlines" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function isPrintableASCIIWithNewlines(text: string): boolean;
 
-// Warning: (ae-missing-release-tag) "JSONObject" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "JSONObject" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type JSONObject = Record<string, any>;
 
-// Warning: (ae-missing-release-tag) "keysOf" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "keysOf" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function keysOf<T extends {}>(obj: T): (keyof T)[];
 
-// Warning: (ae-missing-release-tag) "mergeDeep" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "mergeDeep" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function mergeDeep(target: Record<string, any> | undefined, source: Record<string, any>, overwrite?: boolean): Record<string, any>;
 
-// Warning: (ae-missing-release-tag) "MethodsNamesOf" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MethodsNamesOf" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type MethodsNamesOf<T> = OnlyMethods<T>[keyof T];
 
-// Warning: (ae-missing-release-tag) "Mixin" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Mixin" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function Mixin(baseCtors: Constructor[]): (derivedCtor: Constructor) => void;
 
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// Warning: (ae-missing-release-tag) "num2hex" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "num2hex" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function num2hex(val: number | undefined | null, uppercase?: boolean): string;
 
-// Warning: (ae-missing-release-tag) "ObjectKeyMap" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ObjectKeyMap" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class ObjectKeyMap<TKey extends Record<string | number, any>, TValue> {
@@ -211,74 +211,74 @@ export class ObjectKeyMap<TKey extends Record<string | number, any>, TValue> {
     values(): IterableIterator<TValue>;
 }
 
-// Warning: (ae-missing-release-tag) "OnlyMethods" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "OnlyMethods" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type OnlyMethods<T> = {
     [K in keyof T]: T[K] extends (...args: any[]) => any ? T[K] : never;
 };
 
-// Warning: (ae-missing-release-tag) "padVersion" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "padVersion" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function padVersion(version: string): string;
 
-// Warning: (ae-missing-release-tag) "pick" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "pick" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function pick<T extends Record<any, any>, K extends keyof T>(obj: T, keys: readonly K[]): Pick<T, K>;
 
-// Warning: (ae-missing-release-tag) "pickDeep" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "pickDeep" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function pickDeep<T = unknown>(object: Record<string, any>, path: string): T;
 
 // Warning: (ae-forgotten-export) The symbol "PickSymbolIterator" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "ReadonlyObjectKeyMap" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ReadonlyObjectKeyMap" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ReadonlyObjectKeyMap<TKey extends Record<string | number, any>, TValue> = Pick<ObjectKeyMap<TKey, TValue>, "has" | "get" | "entries" | "keys" | "values" | "size"> & PickSymbolIterator<ObjectKeyMap<TKey, TValue>>;
 
-// Warning: (ae-missing-release-tag) "ReadonlyThrowingMap" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ReadonlyThrowingMap" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ReadonlyThrowingMap<K, V> = ReadonlyMap<K, V> & {
     getOrThrow(key: K): V;
 };
 
-// Warning: (ae-missing-release-tag) "skipBytes" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "skipBytes" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function skipBytes(buf: Buffer, n: number): Buffer;
 
-// Warning: (ae-missing-release-tag) "staticExtends" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "staticExtends" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function staticExtends<T extends new (...args: any[]) => any>(constructor: unknown, base: T): constructor is T;
 
-// Warning: (ae-missing-release-tag) "stringify" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "stringify" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function stringify(arg: unknown, space?: 4 | "\t"): string;
 
-// Warning: (ae-missing-release-tag) "sum" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "sum" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function sum(values: number[]): number;
 
-// Warning: (ae-missing-release-tag) "throttle" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "throttle" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function throttle<T extends any[]>(fn: (...args: T) => void, intervalMs: number, trailing?: boolean): (...args: T) => void;
 
-// Warning: (ae-missing-release-tag) "ThrowingMap" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ThrowingMap" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ThrowingMap<K, V> = Map<K, V> & {
     getOrThrow(key: K): V;
 };
 
-// Warning: (ae-missing-release-tag) "TimedExpectation" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TimedExpectation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export class TimedExpectation<TResult = void, TPredicate = never> implements PromiseLike<TResult> {
@@ -292,13 +292,13 @@ export class TimedExpectation<TResult = void, TPredicate = never> implements Pro
     then<TResult1 = TResult, TResult2 = never>(onfulfilled?: ((value: TResult) => TResult1 | PromiseLike<TResult1>) | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null): PromiseLike<TResult1 | TResult2>;
 }
 
-// Warning: (ae-missing-release-tag) "TypedClassDecorator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TypedClassDecorator" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type TypedClassDecorator<TTarget extends Object> = <T extends TTarget, TConstructor extends new (...args: any[]) => T>(apiClass: TConstructor) => TConstructor | void;
 
-// Warning: (ae-missing-release-tag) "TypedEventEmitter" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "TypedEventEmitter" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TypedEventEmitter" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TypedEventEmitter" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface TypedEventEmitter<TEvents extends Record<keyof TEvents, EventHandler>> {
@@ -320,12 +320,12 @@ export interface TypedEventEmitter<TEvents extends Record<keyof TEvents, EventHa
 export class TypedEventEmitter<TEvents extends Record<keyof TEvents, EventHandler>> {
 }
 
-// Warning: (ae-missing-release-tag) "TypedPropertyDecorator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "TypedPropertyDecorator" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type TypedPropertyDecorator<TTarget extends Object> = <T extends TTarget>(target: T, propertyKey: string | symbol) => void;
 
-// Warning: (ae-missing-release-tag) "UnionToIntersection" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "UnionToIntersection" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type UnionToIntersection<T> = (T extends any ? (x: T) => any : never) extends (x: infer R) => any ? R : never;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -58,7 +58,7 @@
     "test:dirty": "node -r ../../maintenance/esbuild-register.js ../maintenance/src/resolveDirtyTests.ts --run"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "*",
+    "@microsoft/api-extractor": "^7.35.0",
     "@types/fs-extra": "^9.0.13",
     "@types/node": "^14.18.43",
     "@types/sinon": "^10.0.14",

--- a/packages/testing/api.md
+++ b/packages/testing/api.md
@@ -19,17 +19,17 @@ import { ZWaveApiVersion } from '@zwave-js/core/safe';
 import type { ZWaveHost } from '@zwave-js/host';
 import { ZWaveLibraryTypes } from '@zwave-js/core/safe';
 
-// Warning: (ae-missing-release-tag) "ccCaps" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ccCaps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function ccCaps<T extends CommandClasses>(caps: PartialCCCapabilities<T>): PartialCCCapabilities<T>;
 
-// Warning: (ae-missing-release-tag) "CCIdToCapabilities" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CCIdToCapabilities" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type CCIdToCapabilities<T extends CommandClasses = CommandClasses> = T extends keyof CCSpecificCapabilities ? CCSpecificCapabilities[T] : never;
 
-// Warning: (ae-missing-release-tag) "CCSpecificCapabilities" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "CCSpecificCapabilities" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type CCSpecificCapabilities = {
@@ -40,7 +40,7 @@ export type CCSpecificCapabilities = {
     [144]: EnergyProductionCCCapabilities;
 };
 
-// Warning: (ae-missing-release-tag) "ConfigurationCCCapabilities" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ConfigurationCCCapabilities" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ConfigurationCCCapabilities {
@@ -62,17 +62,17 @@ export interface ConfigurationCCCapabilities {
     }[];
 }
 
-// Warning: (ae-missing-release-tag) "createMockZWaveAckFrame" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "createMockZWaveAckFrame" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function createMockZWaveAckFrame(options?: Partial<Omit<MockZWaveAckFrame, "direction" | "payload">>): MockZWaveAckFrame;
 
-// Warning: (ae-missing-release-tag) "createMockZWaveRequestFrame" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "createMockZWaveRequestFrame" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function createMockZWaveRequestFrame(payload: ICommandClass, options?: Partial<Omit<MockZWaveRequestFrame, "direction" | "payload">>): MockZWaveRequestFrame;
 
-// Warning: (ae-missing-release-tag) "EnergyProductionCCCapabilities" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EnergyProductionCCCapabilities" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface EnergyProductionCCCapabilities {
@@ -97,12 +97,12 @@ export interface EnergyProductionCCCapabilities {
     };
 }
 
-// Warning: (ae-missing-release-tag) "MOCK_FRAME_ACK_TIMEOUT" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MOCK_FRAME_ACK_TIMEOUT" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export const MOCK_FRAME_ACK_TIMEOUT = 1000;
 
-// Warning: (ae-missing-release-tag) "MockController" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MockController" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@zwave-js/testing" does not have an export "MockSerialPort"
 //
 // @public
@@ -146,7 +146,7 @@ export class MockController {
     readonly state: Map<string, unknown>;
 }
 
-// Warning: (ae-missing-release-tag) "MockControllerBehavior" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MockControllerBehavior" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface MockControllerBehavior {
@@ -154,7 +154,7 @@ export interface MockControllerBehavior {
     onNodeFrame?: (host: ZWaveHost, controller: MockController, node: MockNode, frame: MockZWaveFrame) => Promise<boolean | undefined> | boolean | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "MockControllerOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MockControllerOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface MockControllerOptions {
@@ -168,7 +168,7 @@ export interface MockControllerOptions {
     serial: MockPortBinding;
 }
 
-// Warning: (ae-missing-release-tag) "MockEndpoint" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MockEndpoint" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class MockEndpoint {
@@ -187,7 +187,7 @@ export class MockEndpoint {
     removeCC(cc: CommandClasses): void;
 }
 
-// Warning: (ae-missing-release-tag) "MockEndpointOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MockEndpointOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface MockEndpointOptions {
@@ -201,7 +201,7 @@ export interface MockEndpointOptions {
     node: MockNode;
 }
 
-// Warning: (ae-missing-release-tag) "MockNode" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MockNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export class MockNode {
@@ -247,14 +247,14 @@ export class MockNode {
     readonly state: Map<string, unknown>;
 }
 
-// Warning: (ae-missing-release-tag) "MockNodeBehavior" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MockNodeBehavior" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface MockNodeBehavior {
     onControllerFrame?: (controller: MockController, self: MockNode, frame: MockZWaveFrame) => Promise<boolean | undefined> | boolean | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "MockNodeOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MockNodeOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface MockNodeOptions {
@@ -271,7 +271,7 @@ export interface MockNodeOptions {
     id: number;
 }
 
-// Warning: (ae-missing-release-tag) "MockZWaveAckFrame" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MockZWaveAckFrame" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface MockZWaveAckFrame {
@@ -282,12 +282,12 @@ export interface MockZWaveAckFrame {
     type: MockZWaveFrameType.ACK;
 }
 
-// Warning: (ae-missing-release-tag) "MockZWaveFrame" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MockZWaveFrame" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export type MockZWaveFrame = MockZWaveRequestFrame | MockZWaveAckFrame;
 
-// Warning: (ae-missing-release-tag) "MockZWaveFrameType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MockZWaveFrameType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum MockZWaveFrameType {
@@ -297,7 +297,7 @@ export enum MockZWaveFrameType {
     Request = 0
 }
 
-// Warning: (ae-missing-release-tag) "MockZWaveRequestFrame" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MockZWaveRequestFrame" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface MockZWaveRequestFrame {
@@ -308,7 +308,7 @@ export interface MockZWaveRequestFrame {
     type: MockZWaveFrameType.Request;
 }
 
-// Warning: (ae-missing-release-tag) "NotificationCCCapabilities" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NotificationCCCapabilities" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface NotificationCCCapabilities {
@@ -318,14 +318,14 @@ export interface NotificationCCCapabilities {
     supportsV1Alarm: false;
 }
 
-// Warning: (ae-missing-release-tag) "PartialCCCapabilities" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "PartialCCCapabilities" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type PartialCCCapabilities<T extends CommandClasses = CommandClasses> = T | ({
     ccId: T;
 } & Partial<CommandClassInfo> & Partial<CCIdToCapabilities<T>>);
 
-// Warning: (ae-missing-release-tag) "SoundSwitchCCCapabilities" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SoundSwitchCCCapabilities" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface SoundSwitchCCCapabilities {
@@ -340,7 +340,7 @@ export interface SoundSwitchCCCapabilities {
     }[];
 }
 
-// Warning: (ae-missing-release-tag) "WindowCoveringCCCapabilities" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "WindowCoveringCCCapabilities" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface WindowCoveringCCCapabilities {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -47,7 +47,7 @@
     "ansi-colors": "^4.1.3"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "*",
+    "@microsoft/api-extractor": "^7.35.0",
     "@types/node": "^14.18.43",
     "@types/triple-beam": "^1.3.2",
     "del-cli": "^5.0.0",

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -166,12 +166,12 @@ import { ZWaveSerialPortImplementation } from '@zwave-js/serial';
 export { buffer2hex }
 
 // Warning: (ae-forgotten-export) The symbol "ControllerEventCallbacks" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "ControllerEvents" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ControllerEvents" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ControllerEvents = Extract<keyof ControllerEventCallbacks, string>;
 
-// Warning: (ae-missing-release-tag) "ControllerFirmwareUpdateProgress" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ControllerFirmwareUpdateProgress" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ControllerFirmwareUpdateProgress {
@@ -180,7 +180,7 @@ export interface ControllerFirmwareUpdateProgress {
     totalFragments: number;
 }
 
-// Warning: (ae-missing-release-tag) "ControllerFirmwareUpdateResult" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ControllerFirmwareUpdateResult" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ControllerFirmwareUpdateResult {
@@ -190,7 +190,7 @@ export interface ControllerFirmwareUpdateResult {
     success: boolean;
 }
 
-// Warning: (ae-missing-release-tag) "ControllerFirmwareUpdateStatus" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ControllerFirmwareUpdateStatus" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ControllerFirmwareUpdateStatus {
@@ -209,7 +209,7 @@ export { ControllerNodeLogContext }
 
 export { ControllerSelfLogContext }
 
-// Warning: (ae-missing-release-tag) "ControllerStatistics" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ControllerStatistics" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface ControllerStatistics {
@@ -241,19 +241,19 @@ export interface ControllerStatistics {
 
 export { ControllerValueLogContext }
 
-// Warning: (ae-missing-release-tag) "createDefaultBehaviors" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "createDefaultBehaviors" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function createDefaultMockControllerBehaviors(): MockControllerBehavior[];
 
-// Warning: (ae-missing-release-tag) "createDefaultBehaviors" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "createDefaultBehaviors" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function createDefaultMockNodeBehaviors(): MockNodeBehavior[];
 
 export { DataRate }
 
-// Warning: (ae-missing-release-tag) "DeviceClass" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DeviceClass" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class DeviceClass {
@@ -273,7 +273,7 @@ export class DeviceClass {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DriverEventCallbacks" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "Driver" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Driver" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export class Driver extends TypedEventEmitter<DriverEventCallbacks> implements ZWaveApplicationHost {
@@ -400,7 +400,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> implements Z
     waitForMessage<T extends Message>(predicate: (msg: Message) => boolean, timeout: number, refreshPredicate?: (msg: Message) => boolean): Promise<T>;
 }
 
-// Warning: (ae-missing-release-tag) "DriverLogContext" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "DriverLogContext" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface DriverLogContext extends LogContext<"driver"> {
@@ -412,14 +412,14 @@ export { Duration }
 
 export { DurationUnit }
 
-// Warning: (ae-missing-release-tag) "EditableZWaveOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "EditableZWaveOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type EditableZWaveOptions = Pick<ZWaveOptions, "disableOptimisticValueUpdate" | "emitValueUpdateAfterSetValue" | "inclusionUserCallbacks" | "interview" | "logConfig" | "preferences" | "preserveUnknownValues"> & {
     userAgent?: Record<string, string | null | undefined>;
 };
 
-// Warning: (ae-missing-release-tag) "Endpoint" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "Endpoint" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export class Endpoint implements IZWaveEndpoint {
@@ -466,14 +466,14 @@ export { EntryControlDataTypes }
 
 export { EntryControlEventTypes }
 
-// Warning: (ae-missing-release-tag) "ExclusionOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ExclusionOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ExclusionOptions = {
     strategy: ExclusionStrategy.ExcludeOnly | ExclusionStrategy.DisableProvisioningEntry | ExclusionStrategy.Unprovision;
 };
 
-// Warning: (ae-missing-release-tag) "ExclusionStrategy" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ExclusionStrategy" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ExclusionStrategy {
@@ -490,7 +490,7 @@ export { Firmware }
 
 export { FirmwareFileFormat }
 
-// Warning: (ae-missing-release-tag) "FirmwareUpdateFileInfo" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateFileInfo" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface FirmwareUpdateFileInfo {
@@ -502,7 +502,7 @@ export interface FirmwareUpdateFileInfo {
     url: string;
 }
 
-// Warning: (ae-missing-release-tag) "FirmwareUpdateInfo" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FirmwareUpdateInfo" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface FirmwareUpdateInfo {
@@ -526,27 +526,27 @@ export { FLiRS }
 
 export { formatId }
 
-// Warning: (ae-missing-release-tag) "formatLifelineHealthCheckRound" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "formatLifelineHealthCheckRound" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function formatLifelineHealthCheckRound(round: number, numRounds: number, result: LifelineHealthCheckResult): string;
 
-// Warning: (ae-missing-release-tag) "formatLifelineHealthCheckSummary" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "formatLifelineHealthCheckSummary" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function formatLifelineHealthCheckSummary(summary: LifelineHealthCheckSummary): string;
 
-// Warning: (ae-missing-release-tag) "formatRouteHealthCheckRound" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "formatRouteHealthCheckRound" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function formatRouteHealthCheckRound(sourceNodeId: number, targetNodeId: number, round: number, numRounds: number, result: RouteHealthCheckResult): string;
 
-// Warning: (ae-missing-release-tag) "formatRouteHealthCheckSummary" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "formatRouteHealthCheckSummary" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function formatRouteHealthCheckSummary(sourceNodeId: number, targetNodeId: number, summary: RouteHealthCheckSummary): string;
 
-// Warning: (ae-missing-release-tag) "FoundNode" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "FoundNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface FoundNode {
@@ -564,7 +564,7 @@ export { FunctionType }
 
 export { getEnumMemberName }
 
-// Warning: (ae-missing-release-tag) "GetFirmwareUpdatesOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "GetFirmwareUpdatesOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface GetFirmwareUpdatesOptions {
@@ -575,24 +575,24 @@ export interface GetFirmwareUpdatesOptions {
 
 export { guessFirmwareFileFormat }
 
-// Warning: (ae-missing-release-tag) "HealNetworkOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HealNetworkOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface HealNetworkOptions {
     includeSleeping?: boolean;
 }
 
-// Warning: (ae-missing-release-tag) "HealNodeStatus" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "HealNodeStatus" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type HealNodeStatus = "pending" | "done" | "failed" | "skipped";
 
-// Warning: (ae-missing-release-tag) "healthCheckRatingToWord" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "healthCheckRatingToWord" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function healthCheckRatingToWord(rating: number): string;
 
-// Warning: (ae-missing-release-tag) "IncludedProvisioningEntry" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "IncludedProvisioningEntry" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface IncludedProvisioningEntry extends PlannedProvisioningEntry {
@@ -600,7 +600,7 @@ export interface IncludedProvisioningEntry extends PlannedProvisioningEntry {
     nodeId: number;
 }
 
-// Warning: (ae-missing-release-tag) "InclusionGrant" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "InclusionGrant" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface InclusionGrant {
@@ -608,7 +608,7 @@ export interface InclusionGrant {
     securityClasses: SecurityClass[];
 }
 
-// Warning: (ae-missing-release-tag) "InclusionOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "InclusionOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export type InclusionOptions = {
@@ -626,7 +626,7 @@ export type InclusionOptions = {
     strategy: InclusionStrategy.Insecure | InclusionStrategy.Security_S0;
 };
 
-// Warning: (ae-missing-release-tag) "InclusionResult" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "InclusionResult" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export type InclusionResult = {
@@ -636,7 +636,7 @@ export type InclusionResult = {
     lowSecurityReason: SecurityBootstrapFailure;
 };
 
-// Warning: (ae-missing-release-tag) "InclusionState" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "InclusionState" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum InclusionState {
@@ -647,7 +647,7 @@ export enum InclusionState {
     SmartStart = 4
 }
 
-// Warning: (ae-missing-release-tag) "InclusionStrategy" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "InclusionStrategy" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum InclusionStrategy {
@@ -658,7 +658,7 @@ export enum InclusionStrategy {
     SmartStart = 1
 }
 
-// Warning: (ae-missing-release-tag) "InclusionUserCallbacks" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "InclusionUserCallbacks" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface InclusionUserCallbacks {
@@ -672,17 +672,17 @@ export { InterviewStage }
 
 export { isRssiError }
 
-// Warning: (ae-missing-release-tag) "libName" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "libName" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const libName: string;
 
-// Warning: (ae-missing-release-tag) "libVersion" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "libVersion" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const libVersion: string;
 
-// Warning: (ae-missing-release-tag) "LifelineHealthCheckResult" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "LifelineHealthCheckResult" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface LifelineHealthCheckResult {
@@ -697,7 +697,7 @@ export interface LifelineHealthCheckResult {
     snrMargin?: number;
 }
 
-// Warning: (ae-missing-release-tag) "LifelineHealthCheckSummary" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "LifelineHealthCheckSummary" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface LifelineHealthCheckSummary {
@@ -709,7 +709,7 @@ export interface LifelineHealthCheckSummary {
     results: LifelineHealthCheckResult[];
 }
 
-// Warning: (ae-missing-release-tag) "LifelineRoutes" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "LifelineRoutes" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface LifelineRoutes {
@@ -731,7 +731,7 @@ export { NODE_ID_BROADCAST }
 
 export { NODE_ID_MAX }
 
-// Warning: (ae-missing-release-tag) "NodeInterviewFailedEventArgs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NodeInterviewFailedEventArgs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type NodeInterviewFailedEventArgs = {
@@ -742,7 +742,7 @@ export type NodeInterviewFailedEventArgs = {
     maxAttempts: number;
 } | {});
 
-// Warning: (ae-missing-release-tag) "NodeStatistics" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "NodeStatistics" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface NodeStatistics {
@@ -765,7 +765,7 @@ export { num2hex }
 
 export { parseQRCodeString }
 
-// Warning: (ae-missing-release-tag) "PlannedProvisioningEntry" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "PlannedProvisioningEntry" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface PlannedProvisioningEntry {
@@ -791,7 +791,7 @@ export { ProtocolType }
 
 export { ProtocolVersion }
 
-// Warning: (ae-missing-release-tag) "ProvisioningEntryStatus" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ProvisioningEntryStatus" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum ProvisioningEntryStatus {
@@ -805,7 +805,7 @@ export { QRCodeVersion }
 
 export { QRProvisioningInformation }
 
-// Warning: (ae-missing-release-tag) "RefreshInfoOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "RefreshInfoOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface RefreshInfoOptions {
@@ -813,7 +813,7 @@ export interface RefreshInfoOptions {
     waitForWakeup?: boolean;
 }
 
-// Warning: (ae-missing-release-tag) "ReplaceNodeOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ReplaceNodeOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export type ReplaceNodeOptions = {
@@ -832,7 +832,7 @@ export { ResponseRole }
 
 export { RFRegion }
 
-// Warning: (ae-missing-release-tag) "RouteHealthCheckResult" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "RouteHealthCheckResult" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface RouteHealthCheckResult {
@@ -845,7 +845,7 @@ export interface RouteHealthCheckResult {
     rating: number;
 }
 
-// Warning: (ae-missing-release-tag) "RouteHealthCheckSummary" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "RouteHealthCheckSummary" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface RouteHealthCheckSummary {
@@ -857,7 +857,7 @@ export interface RouteHealthCheckSummary {
 
 export { RouteProtocolDataRate }
 
-// Warning: (ae-missing-release-tag) "RouteStatistics" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "RouteStatistics" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface RouteStatistics {
@@ -876,12 +876,12 @@ export { rssiToString }
 
 export { Scale }
 
-// Warning: (ae-missing-release-tag) "SDKVersion" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SDKVersion" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type SDKVersion = `${number}.${number}` | `${number}.${number}.${number}`;
 
-// Warning: (ae-missing-release-tag) "SecurityBootstrapFailure" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SecurityBootstrapFailure" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum SecurityBootstrapFailure {
@@ -900,7 +900,7 @@ export { SendMessageOptions }
 
 export { SensorType }
 
-// Warning: (ae-missing-release-tag) "SerialAPISetupCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SerialAPISetupCommand" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export enum SerialAPISetupCommand {
@@ -936,7 +936,7 @@ export enum SerialAPISetupCommand {
 
 export { SetbackState }
 
-// Warning: (ae-missing-release-tag) "SmartStartProvisioningEntry" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "SmartStartProvisioningEntry" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type SmartStartProvisioningEntry = PlannedProvisioningEntry | IncludedProvisioningEntry;
@@ -961,7 +961,7 @@ export { ValueMetadataString }
 
 export { ValueType }
 
-// Warning: (ae-missing-release-tag) "VirtualEndpoint" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "VirtualEndpoint" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export class VirtualEndpoint implements IVirtualEndpoint {
@@ -984,7 +984,7 @@ export class VirtualEndpoint implements IVirtualEndpoint {
     readonly virtual = true;
 }
 
-// Warning: (ae-missing-release-tag) "VirtualNode" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "VirtualNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class VirtualNode extends VirtualEndpoint implements IVirtualNode {
@@ -1008,7 +1008,7 @@ export class VirtualNode extends VirtualEndpoint implements IVirtualNode {
     setValue(valueId: ValueID_2, value: unknown, options?: SetValueAPIOptions): Promise<boolean>;
 }
 
-// Warning: (ae-missing-release-tag) "VirtualValueID" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "VirtualValueID" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface VirtualValueID extends TranslatedValueID_2 {
@@ -1019,8 +1019,8 @@ export interface VirtualValueID extends TranslatedValueID_2 {
 export { ZWaveApiVersion }
 
 // Warning: (ae-forgotten-export) The symbol "ControllerStatisticsHost" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "ZWaveController" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "ZWaveController" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveController" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveController" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ZWaveController extends ControllerStatisticsHost {
@@ -1228,7 +1228,7 @@ export { ZWaveError }
 
 export { ZWaveErrorCodes }
 
-// Warning: (ae-missing-release-tag) "ZWaveFeature" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveFeature" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export enum ZWaveFeature {
@@ -1236,7 +1236,7 @@ export enum ZWaveFeature {
     SmartStart = 0
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveInterviewFailedCallback" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveInterviewFailedCallback" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ZWaveInterviewFailedCallback = (node: ZWaveNode, args: NodeInterviewFailedEventArgs) => void;
@@ -1245,8 +1245,8 @@ export { ZWaveLibraryTypes }
 
 // Warning: (ae-forgotten-export) The symbol "StatisticsEventCallbacksWithSelf" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "NodeStatisticsHost" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "ZWaveNode" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-// Warning: (ae-missing-release-tag) "ZWaveNode" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ZWaveNode extends TypedEventEmitter<ZWaveNodeEventCallbacks & StatisticsEventCallbacksWithSelf<ZWaveNode, NodeStatistics>>, NodeStatisticsHost {
@@ -1372,7 +1372,7 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner, IZWaveNod
     get zwavePlusVersion(): number | undefined;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveNodeEventCallbacks" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNodeEventCallbacks" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ZWaveNodeEventCallbacks extends ZWaveNodeValueEventCallbacks {
@@ -1402,47 +1402,47 @@ export interface ZWaveNodeEventCallbacks extends ZWaveNodeValueEventCallbacks {
     sleep: ZWaveNodeStatusChangeCallback;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveNodeEvents" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNodeEvents" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ZWaveNodeEvents = Extract<keyof ZWaveNodeEventCallbacks, string>;
 
-// Warning: (ae-missing-release-tag) "ZWaveNodeFirmwareUpdateFinishedCallback" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNodeFirmwareUpdateFinishedCallback" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ZWaveNodeFirmwareUpdateFinishedCallback = (node: ZWaveNode, __DEPRECATED__status: FirmwareUpdateStatus, __DEPRECATED__waitTime: number | undefined, result: FirmwareUpdateResult) => void;
 
-// Warning: (ae-missing-release-tag) "ZWaveNodeFirmwareUpdateProgressCallback" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNodeFirmwareUpdateProgressCallback" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ZWaveNodeFirmwareUpdateProgressCallback = (node: ZWaveNode, __DEPRECATED__sentFragments: number, __DEPRECATED__totalFragments: number, progress: FirmwareUpdateProgress) => void;
 
-// Warning: (ae-missing-release-tag) "ZWaveNodeMetadataUpdatedArgs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNodeMetadataUpdatedArgs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ZWaveNodeMetadataUpdatedArgs = MetadataUpdatedArgs & TranslatedValueID;
 
-// Warning: (ae-missing-release-tag) "ZWaveNodeMetadataUpdatedCallback" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNodeMetadataUpdatedCallback" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ZWaveNodeMetadataUpdatedCallback = (node: ZWaveNode, args: ZWaveNodeMetadataUpdatedArgs) => void;
 
-// Warning: (ae-missing-release-tag) "ZWaveNodeStatusChangeCallback" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNodeStatusChangeCallback" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ZWaveNodeStatusChangeCallback = (node: ZWaveNode, oldStatus: NodeStatus) => void;
 
-// Warning: (ae-missing-release-tag) "ZWaveNodeValueAddedArgs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNodeValueAddedArgs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ZWaveNodeValueAddedArgs = ValueAddedArgs & TranslatedValueID;
 
-// Warning: (ae-missing-release-tag) "ZWaveNodeValueAddedCallback" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNodeValueAddedCallback" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ZWaveNodeValueAddedCallback = (node: ZWaveNode, args: ZWaveNodeValueAddedArgs) => void;
 
-// Warning: (ae-missing-release-tag) "ZWaveNodeValueEventCallbacks" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNodeValueEventCallbacks" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ZWaveNodeValueEventCallbacks {
@@ -1458,42 +1458,42 @@ export interface ZWaveNodeValueEventCallbacks {
     "value updated": ZWaveNodeValueUpdatedCallback;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveNodeValueNotificationArgs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNodeValueNotificationArgs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ZWaveNodeValueNotificationArgs = ValueNotificationArgs & TranslatedValueID;
 
-// Warning: (ae-missing-release-tag) "ZWaveNodeValueNotificationCallback" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNodeValueNotificationCallback" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ZWaveNodeValueNotificationCallback = (node: ZWaveNode, args: ZWaveNodeValueNotificationArgs) => void;
 
-// Warning: (ae-missing-release-tag) "ZWaveNodeValueRemovedArgs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNodeValueRemovedArgs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ZWaveNodeValueRemovedArgs = ValueRemovedArgs & TranslatedValueID;
 
-// Warning: (ae-missing-release-tag) "ZWaveNodeValueRemovedCallback" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNodeValueRemovedCallback" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ZWaveNodeValueRemovedCallback = (node: ZWaveNode, args: ZWaveNodeValueRemovedArgs) => void;
 
-// Warning: (ae-missing-release-tag) "ZWaveNodeValueUpdatedArgs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNodeValueUpdatedArgs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ZWaveNodeValueUpdatedArgs = Omit<ValueUpdatedArgs, "source"> & TranslatedValueID;
 
-// Warning: (ae-missing-release-tag) "ZWaveNodeValueUpdatedCallback" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNodeValueUpdatedCallback" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ZWaveNodeValueUpdatedCallback = (node: ZWaveNode, args: ZWaveNodeValueUpdatedArgs) => void;
 
-// Warning: (ae-missing-release-tag) "ZWaveNotificationCallback" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNotificationCallback" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export type ZWaveNotificationCallback = (...args: ZWaveNotificationCallbackParams_NotificationCC | ZWaveNotificationCallbackParams_EntryControlCC | ZWaveNotificationCallbackParams_PowerlevelCC | ZWaveNotificationCallbackParams_MultilevelSwitchCC) => void;
 
-// Warning: (ae-missing-release-tag) "ZWaveNotificationCallbackArgs_EntryControlCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNotificationCallbackArgs_EntryControlCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ZWaveNotificationCallbackArgs_EntryControlCC {
@@ -1507,7 +1507,7 @@ export interface ZWaveNotificationCallbackArgs_EntryControlCC {
     eventTypeLabel: string;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveNotificationCallbackArgs_MultilevelSwitchCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNotificationCallbackArgs_MultilevelSwitchCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface ZWaveNotificationCallbackArgs_MultilevelSwitchCC {
@@ -1516,7 +1516,7 @@ export interface ZWaveNotificationCallbackArgs_MultilevelSwitchCC {
     eventTypeLabel: string;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveNotificationCallbackArgs_NotificationCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNotificationCallbackArgs_NotificationCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ZWaveNotificationCallbackArgs_NotificationCC {
@@ -1527,7 +1527,7 @@ export interface ZWaveNotificationCallbackArgs_NotificationCC {
     type: number;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveNotificationCallbackArgs_PowerlevelCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNotificationCallbackArgs_PowerlevelCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export interface ZWaveNotificationCallbackArgs_PowerlevelCC {
@@ -1539,7 +1539,7 @@ export interface ZWaveNotificationCallbackArgs_PowerlevelCC {
     testNodeId: number;
 }
 
-// Warning: (ae-missing-release-tag) "ZWaveNotificationCallbackParams_EntryControlCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNotificationCallbackParams_EntryControlCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export type ZWaveNotificationCallbackParams_EntryControlCC = [
@@ -1548,7 +1548,7 @@ ccId: (typeof CommandClasses)["Entry Control"],
 args: ZWaveNotificationCallbackArgs_EntryControlCC
 ];
 
-// Warning: (ae-missing-release-tag) "ZWaveNotificationCallbackParams_MultilevelSwitchCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNotificationCallbackParams_MultilevelSwitchCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export type ZWaveNotificationCallbackParams_MultilevelSwitchCC = [
@@ -1557,7 +1557,7 @@ ccId: (typeof CommandClasses)["Multilevel Switch"],
 args: ZWaveNotificationCallbackArgs_MultilevelSwitchCC
 ];
 
-// Warning: (ae-missing-release-tag) "ZWaveNotificationCallbackParams_NotificationCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNotificationCallbackParams_NotificationCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export type ZWaveNotificationCallbackParams_NotificationCC = [
@@ -1566,7 +1566,7 @@ ccId: CommandClasses.Notification,
 args: ZWaveNotificationCallbackArgs_NotificationCC
 ];
 
-// Warning: (ae-missing-release-tag) "ZWaveNotificationCallbackParams_PowerlevelCC" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveNotificationCallbackParams_PowerlevelCC" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export type ZWaveNotificationCallbackParams_PowerlevelCC = [
@@ -1575,7 +1575,7 @@ ccId: CommandClasses.Powerlevel,
 args: ZWaveNotificationCallbackArgs_PowerlevelCC
 ];
 
-// Warning: (ae-missing-release-tag) "ZWaveOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "ZWaveOptions" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export interface ZWaveOptions extends ZWaveHostOptions {

--- a/packages/zwave-js/package.json
+++ b/packages/zwave-js/package.json
@@ -110,7 +110,7 @@
     "xstate": "4.29.0"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "*",
+    "@microsoft/api-extractor": "^7.35.0",
     "@types/fs-extra": "^9.0.13",
     "@types/node": "^14.18.43",
     "@types/proper-lockfile": "^4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -725,69 +725,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@microsoft/api-extractor-model@npm:7.22.1":
-  version: 7.22.1
-  resolution: "@microsoft/api-extractor-model@npm:7.22.1"
-  dependencies:
-    "@microsoft/tsdoc": 0.14.1
-    "@microsoft/tsdoc-config": ~0.16.1
-    "@rushstack/node-core-library": 3.49.0
-  checksum: f1e583cc95abf383e0650568ec3c8a32810de3f47175308f7f867b5b5fa18a92d6fdb2d1f035f54b77c9346ad8a4070c8c70a18602de80a404b2ff3310d9334d
-  languageName: node
-  linkType: hard
-
-"@microsoft/api-extractor-model@npm:7.26.7":
-  version: 7.26.7
-  resolution: "@microsoft/api-extractor-model@npm:7.26.7"
+"@microsoft/api-extractor-model@npm:7.27.0":
+  version: 7.27.0
+  resolution: "@microsoft/api-extractor-model@npm:7.27.0"
   dependencies:
     "@microsoft/tsdoc": 0.14.2
     "@microsoft/tsdoc-config": ~0.16.1
-    "@rushstack/node-core-library": 3.58.0
-  checksum: eafdbec592cad7bee6010ed83a9a5914729664029bf64013f173688d194b3888c750fbee0364e160ebc2ad8b6374a5d2cce9a65e2d5335a2e8267473d47701a2
+    "@rushstack/node-core-library": 3.59.1
+  checksum: df9818e507fc156acf60dc4bb8759f42506b166b0cf8963a585a38f8f5822169084725472c9196773f0fb77bf5071bfcfacc6d7c698b7ec4a3decdf093375df3
   languageName: node
   linkType: hard
 
-"@microsoft/api-extractor@npm:*":
-  version: 7.28.6
-  resolution: "@microsoft/api-extractor@npm:7.28.6"
+"@microsoft/api-extractor@npm:^7.35.0":
+  version: 7.35.0
+  resolution: "@microsoft/api-extractor@npm:7.35.0"
   dependencies:
-    "@microsoft/api-extractor-model": 7.22.1
-    "@microsoft/tsdoc": 0.14.1
-    "@microsoft/tsdoc-config": ~0.16.1
-    "@rushstack/node-core-library": 3.49.0
-    "@rushstack/rig-package": 0.3.13
-    "@rushstack/ts-command-line": 4.12.1
-    colors: ~1.2.1
-    lodash: ~4.17.15
-    resolve: ~1.17.0
-    semver: ~7.3.0
-    source-map: ~0.6.1
-    typescript: ~4.6.3
-  bin:
-    api-extractor: bin/api-extractor
-  checksum: a287e12c84c8c11690783f1118b7cc2e02f777ef21c72e9e37bd920a4837ab09a05888ce0d25f8d29af0032465b80ab62e9a111b169226c49b17e8b97b21f598
-  languageName: node
-  linkType: hard
-
-"@microsoft/api-extractor@npm:^7.34.7":
-  version: 7.34.7
-  resolution: "@microsoft/api-extractor@npm:7.34.7"
-  dependencies:
-    "@microsoft/api-extractor-model": 7.26.7
+    "@microsoft/api-extractor-model": 7.27.0
     "@microsoft/tsdoc": 0.14.2
     "@microsoft/tsdoc-config": ~0.16.1
-    "@rushstack/node-core-library": 3.58.0
-    "@rushstack/rig-package": 0.3.18
-    "@rushstack/ts-command-line": 4.13.2
+    "@rushstack/node-core-library": 3.59.1
+    "@rushstack/rig-package": 0.3.19
+    "@rushstack/ts-command-line": 4.13.3
     colors: ~1.2.1
     lodash: ~4.17.15
     resolve: ~1.22.1
     semver: ~7.3.0
     source-map: ~0.6.1
-    typescript: ~4.8.4
+    typescript: ~5.0.4
   bin:
     api-extractor: bin/api-extractor
-  checksum: b7253040cf1018de1211858dd19dd436d39c9921a93058776e78bc3f40d32b787ede4231a07d03c061a63542e8d4a959b1d4c7601d25903683640e40d1ca32db
+  checksum: 4ba907a23404a45dfd9c4b78864f6b956748cb0bb03a29cc113b0355791358972f71912fdab35d7dadca7ec6e00f42623a2c9504aefc149ce3f2de66913d21af
   languageName: node
   linkType: hard
 
@@ -1031,26 +998,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rushstack/node-core-library@npm:3.49.0":
-  version: 3.49.0
-  resolution: "@rushstack/node-core-library@npm:3.49.0"
-  dependencies:
-    "@types/node": 12.20.24
-    colors: ~1.2.1
-    fs-extra: ~7.0.1
-    import-lazy: ~4.0.0
-    jju: ~1.4.0
-    resolve: ~1.17.0
-    semver: ~7.3.0
-    timsort: ~0.3.0
-    z-schema: ~5.0.2
-  checksum: 6ac8247a466faebc242cf8ca6a9960d78dee305482358cca15e9a9ba22f775c18d4f857a9dfcad4c03853d4a6fde768d142a794b6af2baa6aecd5f8faee989a2
-  languageName: node
-  linkType: hard
-
-"@rushstack/node-core-library@npm:3.58.0":
-  version: 3.58.0
-  resolution: "@rushstack/node-core-library@npm:3.58.0"
+"@rushstack/node-core-library@npm:3.59.1":
+  version: 3.59.1
+  resolution: "@rushstack/node-core-library@npm:3.59.1"
   dependencies:
     colors: ~1.2.1
     fs-extra: ~7.0.1
@@ -1064,51 +1014,29 @@ __metadata:
   peerDependenciesMeta:
     "@types/node":
       optional: true
-  checksum: b116ae3830e93c7391a65eea88d2b323dbf4ddb9d88363b8a77e85bf8baf67c26fa4bcd9608d07b858910af2cce95b10b68468e5c6d7b1b5fef70474c92de3e5
+  checksum: 2011c4ee736379f977d1b610e404f4a5771159c2b73e29d27b0b028c0141a100795d7263cae19621e5e311c516e9392d0e1aba0153c06e77929dba2776cce4c8
   languageName: node
   linkType: hard
 
-"@rushstack/rig-package@npm:0.3.13":
-  version: 0.3.13
-  resolution: "@rushstack/rig-package@npm:0.3.13"
-  dependencies:
-    resolve: ~1.17.0
-    strip-json-comments: ~3.1.1
-  checksum: 98c0b7dbefe6ae169745d065d696fbef5d07e71bae5146e070a2e37de82c5625752865c54f12bba6b002868fcb27a1d2d098a19b0a5d20a1dfacaa002c81c13d
-  languageName: node
-  linkType: hard
-
-"@rushstack/rig-package@npm:0.3.18":
-  version: 0.3.18
-  resolution: "@rushstack/rig-package@npm:0.3.18"
+"@rushstack/rig-package@npm:0.3.19":
+  version: 0.3.19
+  resolution: "@rushstack/rig-package@npm:0.3.19"
   dependencies:
     resolve: ~1.22.1
     strip-json-comments: ~3.1.1
-  checksum: 41e719fb14d99e0f79093523fede051dba2be5f53d63d5ae45c2ea1b8448e298e0303d8453be3f9ac5e8bb99e3dcf3ddbe4cc59d9be5eddb914286acbdd0a2f3
+  checksum: f7af6a917325d09795b5e1207f5c5ebc92ce0a861252698064f16fa8815b6799cfb7df2b9adad08f07b9a8617211ce522f524edb55a638d30b6b4d4a2135e2d5
   languageName: node
   linkType: hard
 
-"@rushstack/ts-command-line@npm:4.12.1":
-  version: 4.12.1
-  resolution: "@rushstack/ts-command-line@npm:4.12.1"
+"@rushstack/ts-command-line@npm:4.13.3":
+  version: 4.13.3
+  resolution: "@rushstack/ts-command-line@npm:4.13.3"
   dependencies:
     "@types/argparse": 1.0.38
     argparse: ~1.0.9
     colors: ~1.2.1
     string-argv: ~0.3.1
-  checksum: e9479bd001f4f206d207c867ec7b91444727cf8a1c685dac7589c6a33b54f47200deabc450d6831a1cc38501f0322eb7003c1f78f1fa43230541c4b7ddc4718d
-  languageName: node
-  linkType: hard
-
-"@rushstack/ts-command-line@npm:4.13.2":
-  version: 4.13.2
-  resolution: "@rushstack/ts-command-line@npm:4.13.2"
-  dependencies:
-    "@types/argparse": 1.0.38
-    argparse: ~1.0.9
-    colors: ~1.2.1
-    string-argv: ~0.3.1
-  checksum: 3938e533e08d5cf4007a651d1aab658a7a60d6136a56414e2370b64434657a5d5a9eff442da4ddc260d5e6dc90f82428de64dbcfa1285e9ae176629f7fcd821d
+  checksum: bef8088712361d1051ca21027cded5358cdf73440d9ea7a7e517d868524a3e483cdac72f0fe0aa5e2ffd7a1feeddb7cff224b06f91e66c0846fdf3d126ec9248
   languageName: node
   linkType: hard
 
@@ -1508,13 +1436,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:12.20.24":
-  version: 12.20.24
-  resolution: "@types/node@npm:12.20.24"
-  checksum: e7a13460e2f5b0b5a32c0f3af7daf1a05201552a66d542d3cc3b1ea8b52d4730250f9eb1961d755e31cfe5d03c78340911a6242657a0a9a17d6f7e341fc9f366
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:^14.18.43":
   version: 14.18.43
   resolution: "@types/node@npm:14.18.43"
@@ -1797,7 +1718,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@zwave-js/cc@workspace:packages/cc"
   dependencies:
-    "@microsoft/api-extractor": "*"
+    "@microsoft/api-extractor": ^7.35.0
     "@types/fs-extra": ^9.0.13
     "@types/node": ^14.18.43
     "@zwave-js/core": "workspace:*"
@@ -1823,7 +1744,7 @@ __metadata:
   resolution: "@zwave-js/config@workspace:packages/config"
   dependencies:
     "@esm2cjs/got": ^12.5.3
-    "@microsoft/api-extractor": "*"
+    "@microsoft/api-extractor": ^7.35.0
     "@types/fs-extra": ^9.0.13
     "@types/js-levenshtein": ^1.1.1
     "@types/json-logic-js": ^2.0.2
@@ -1864,7 +1785,7 @@ __metadata:
   resolution: "@zwave-js/core@workspace:packages/core"
   dependencies:
     "@alcalzone/jsonl-db": ^3.1.0
-    "@microsoft/api-extractor": "*"
+    "@microsoft/api-extractor": ^7.35.0
     "@types/node": ^14.18.43
     "@types/sinon": ^10.0.14
     "@types/triple-beam": ^1.3.2
@@ -1912,7 +1833,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@zwave-js/host@workspace:packages/host"
   dependencies:
-    "@microsoft/api-extractor": "*"
+    "@microsoft/api-extractor": ^7.35.0
     "@types/node": ^14.18.43
     "@zwave-js/config": "workspace:*"
     "@zwave-js/core": "workspace:*"
@@ -1958,7 +1879,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@zwave-js/nvmedit@workspace:packages/nvmedit"
   dependencies:
-    "@microsoft/api-extractor": "*"
+    "@microsoft/api-extractor": ^7.35.0
     "@types/fs-extra": ^9.0.13
     "@types/node": ^14.18.43
     "@types/semver": ^7.3.13
@@ -1994,7 +1915,7 @@ __metadata:
     "@commitlint/cli": ^17.6.1
     "@commitlint/config-conventional": ^17.6.1
     "@esm2cjs/p-queue": ^7.3.0
-    "@microsoft/api-extractor": ^7.34.7
+    "@microsoft/api-extractor": ^7.35.0
     "@monorepo-utils/workspaces-to-typescript-project-references": ^2.9.0
     "@tsconfig/node14": ^1.0.3
     "@types/fs-extra": ^9.0.13
@@ -2046,7 +1967,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@zwave-js/serial@workspace:packages/serial"
   dependencies:
-    "@microsoft/api-extractor": "*"
+    "@microsoft/api-extractor": ^7.35.0
     "@sentry/node": ^7.12.1
     "@serialport/binding-mock": ^10.2.2
     "@serialport/bindings-interface": "*"
@@ -2074,7 +1995,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@zwave-js/shared@workspace:packages/shared"
   dependencies:
-    "@microsoft/api-extractor": "*"
+    "@microsoft/api-extractor": ^7.35.0
     "@types/fs-extra": ^9.0.13
     "@types/node": ^14.18.43
     "@types/sinon": ^10.0.14
@@ -2094,7 +2015,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@zwave-js/testing@workspace:packages/testing"
   dependencies:
-    "@microsoft/api-extractor": "*"
+    "@microsoft/api-extractor": ^7.35.0
     "@types/node": ^14.18.43
     "@types/triple-beam": ^1.3.2
     "@zwave-js/core": "workspace:*"
@@ -7427,15 +7348,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:~1.17.0":
-  version: 1.17.0
-  resolution: "resolve@npm:1.17.0"
-  dependencies:
-    path-parse: ^1.0.6
-  checksum: 9ceaf83b3429f2d7ff5d0281b8d8f18a1f05b6ca86efea7633e76b8f76547f33800799dfdd24434942dec4fbd9e651ed3aef577d9a6b5ec87ad89c1060e24759
-  languageName: node
-  linkType: hard
-
 "resolve@npm:~1.19.0":
   version: 1.19.0
   resolution: "resolve@npm:1.19.0"
@@ -7492,15 +7404,6 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: 5656f4d0bedcf8eb52685c1abdf8fbe73a1603bb1160a24d716e27a57f6cecbe2432ff9c89c2bd57542c3a7b9d14b1882b73bfe2e9d7849c9a4c0b8b39f02b8b
-  languageName: node
-  linkType: hard
-
-"resolve@patch:resolve@~1.17.0#~builtin<compat/resolve>":
-  version: 1.17.0
-  resolution: "resolve@patch:resolve@npm%3A1.17.0#~builtin<compat/resolve>::version=1.17.0&hash=c3c19d"
-  dependencies:
-    path-parse: ^1.0.6
-  checksum: 6fd799f282ddf078c4bc20ce863e3af01fa8cb218f0658d9162c57161a2dbafe092b13015b9a4c58d0e1e801cf7aa7a4f13115fea9db98c3f9a0c43e429bad6f
   languageName: node
   linkType: hard
 
@@ -8312,13 +8215,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"timsort@npm:~0.3.0":
-  version: 0.3.0
-  resolution: "timsort@npm:0.3.0"
-  checksum: 1a66cb897dacabd7dd7c91b7e2301498ca9e224de2edb9e42d19f5b17c4b6dc62a8d4cbc64f28be82aaf1541cb5a78ab49aa818f42a2989ebe049a64af731e2a
-  languageName: node
-  linkType: hard
-
 "tiny-glob@npm:^0.2.9":
   version: 0.2.9
   resolution: "tiny-glob@npm:0.2.9"
@@ -8646,33 +8542,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.6.4 || ^5.0.0":
+"typescript@npm:^4.6.4 || ^5.0.0, typescript@npm:~5.0.4":
   version: 5.0.4
   resolution: "typescript@npm:5.0.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 82b94da3f4604a8946da585f7d6c3025fff8410779e5bde2855ab130d05e4fd08938b9e593b6ebed165bda6ad9292b230984f10952cf82f0a0ca07bbeaa08172
-  languageName: node
-  linkType: hard
-
-"typescript@npm:~4.6.3":
-  version: 4.6.4
-  resolution: "typescript@npm:4.6.4"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: e7bfcc39cd4571a63a54e5ea21f16b8445268b9900bf55aee0e02ad981be576acc140eba24f1af5e3c1457767c96cea6d12861768fb386cf3ffb34013718631a
-  languageName: node
-  linkType: hard
-
-"typescript@npm:~4.8.4":
-  version: 4.8.4
-  resolution: "typescript@npm:4.8.4"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 3e4f061658e0c8f36c820802fa809e0fd812b85687a9a2f5430bc3d0368e37d1c9605c3ce9b39df9a05af2ece67b1d844f9f6ea8ff42819f13bcb80f85629af0
   languageName: node
   linkType: hard
 
@@ -8686,33 +8562,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.6.4 || ^5.0.0#~builtin<compat/typescript>":
+"typescript@patch:typescript@^4.6.4 || ^5.0.0#~builtin<compat/typescript>, typescript@patch:typescript@~5.0.4#~builtin<compat/typescript>":
   version: 5.0.4
   resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=ad5954"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 6a1fe9a77bb9c5176ead919cc4a1499ee63e46b4e05bf667079f11bf3a8f7887f135aa72460a4c3b016e6e6bb65a822cb8689a6d86cbfe92d22cc9f501f09213
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@~4.6.3#~builtin<compat/typescript>":
-  version: 4.6.4
-  resolution: "typescript@patch:typescript@npm%3A4.6.4#~builtin<compat/typescript>::version=4.6.4&hash=5d3a66"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 1cb434fbc637d347be90e3a0c6cd05e33c38f941713c8786d3031faf1842c2c148ba91d2fac01e7276b0ae3249b8633f1660e32686cc7a8c6a8fd5361dc52c66
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@~4.8.4#~builtin<compat/typescript>":
-  version: 4.8.4
-  resolution: "typescript@patch:typescript@npm%3A4.8.4#~builtin<compat/typescript>::version=4.8.4&hash=0102e9"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 301459fc3eb3b1a38fe91bf96d98eb55da88a9cb17b4ef80b4d105d620f4d547ba776cc27b44cc2ef58b66eda23fe0a74142feb5e79a6fb99f54fc018a696afa
   languageName: node
   linkType: hard
 
@@ -9158,7 +9014,7 @@ __metadata:
     "@alcalzone/pak": ^0.9.0
     "@esm2cjs/got": ^12.5.3
     "@esm2cjs/p-queue": ^7.3.0
-    "@microsoft/api-extractor": "*"
+    "@microsoft/api-extractor": ^7.35.0
     "@sentry/integrations": ^7.12.1
     "@sentry/node": ^7.12.1
     "@types/fs-extra": ^9.0.13


### PR DESCRIPTION
this should solve issues with the `satisfies` syntax