### PR TITLE
fix: bind `SET_VALUE` and `POLL_VALUE` to the correctly proxied API instance

### DIFF
--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -2507,9 +2507,9 @@ export enum BinarySwitchCommand {
 // @public
 export class CCAPI {
     // (undocumented)
-    protected [POLL_VALUE]: PollValueImplementation | undefined;
+    protected get [POLL_VALUE](): PollValueImplementation | undefined;
     // (undocumented)
-    protected [SET_VALUE]: SetValueImplementation | undefined;
+    protected get [SET_VALUE](): SetValueImplementation | undefined;
     // (undocumented)
     protected [SET_VALUE_HOOKS]: SetValueImplementationHooksFactory | undefined;
     constructor(applHost: ZWaveApplicationHost, endpoint: IZWaveEndpoint | IVirtualEndpoint);

--- a/packages/cc/src/cc/BarrierOperatorCC.ts
+++ b/packages/cc/src/cc/BarrierOperatorCC.ts
@@ -219,44 +219,51 @@ export class BarrierOperatorCCAPI extends CCAPI {
 		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
-	protected [SET_VALUE]: SetValueImplementation = async (
-		{ property, propertyKey },
-		value,
-	) => {
-		if (property === "targetState") {
-			if (typeof value !== "number") {
-				throwWrongValueType(
-					this.ccId,
-					property,
-					"number",
-					typeof value,
-				);
-			}
+	protected override get [SET_VALUE](): SetValueImplementation {
+		return async function (
+			this: BarrierOperatorCCAPI,
+			{ property, propertyKey },
+			value,
+		) {
+			if (property === "targetState") {
+				if (typeof value !== "number") {
+					throwWrongValueType(
+						this.ccId,
+						property,
+						"number",
+						typeof value,
+					);
+				}
 
-			const targetValue =
-				value === BarrierState.Closed
-					? BarrierState.Closed
-					: BarrierState.Open;
-			return this.set(targetValue);
-		} else if (property === "signalingState") {
-			if (propertyKey == undefined) {
-				throwMissingPropertyKey(this.ccId, property);
-			} else if (typeof propertyKey !== "number") {
-				throwUnsupportedPropertyKey(this.ccId, property, propertyKey);
+				const targetValue =
+					value === BarrierState.Closed
+						? BarrierState.Closed
+						: BarrierState.Open;
+				return this.set(targetValue);
+			} else if (property === "signalingState") {
+				if (propertyKey == undefined) {
+					throwMissingPropertyKey(this.ccId, property);
+				} else if (typeof propertyKey !== "number") {
+					throwUnsupportedPropertyKey(
+						this.ccId,
+						property,
+						propertyKey,
+					);
+				}
+				if (typeof value !== "number") {
+					throwWrongValueType(
+						this.ccId,
+						property,
+						"number",
+						typeof value,
+					);
+				}
+				return this.setEventSignaling(propertyKey, value);
+			} else {
+				throwUnsupportedProperty(this.ccId, property);
 			}
-			if (typeof value !== "number") {
-				throwWrongValueType(
-					this.ccId,
-					property,
-					"number",
-					typeof value,
-				);
-			}
-			return this.setEventSignaling(propertyKey, value);
-		} else {
-			throwUnsupportedProperty(this.ccId, property);
-		}
-	};
+		};
+	}
 
 	protected [SET_VALUE_HOOKS]: SetValueImplementationHooksFactory = (
 		{ property, propertyKey },
@@ -352,29 +359,31 @@ export class BarrierOperatorCCAPI extends CCAPI {
 		}
 	};
 
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-		propertyKey,
-	}): Promise<unknown> => {
-		switch (property) {
-			case "currentState":
-			case "position":
-				return (await this.get())?.[property];
-			case "signalingState":
-				if (propertyKey == undefined) {
-					throwMissingPropertyKey(this.ccId, property);
-				} else if (typeof propertyKey !== "number") {
-					throwUnsupportedPropertyKey(
-						this.ccId,
-						property,
-						propertyKey,
-					);
-				}
-				return this.getEventSignaling(propertyKey);
-			default:
-				throwUnsupportedProperty(this.ccId, property);
-		}
-	};
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (
+			this: BarrierOperatorCCAPI,
+			{ property, propertyKey },
+		) {
+			switch (property) {
+				case "currentState":
+				case "position":
+					return (await this.get())?.[property];
+				case "signalingState":
+					if (propertyKey == undefined) {
+						throwMissingPropertyKey(this.ccId, property);
+					} else if (typeof propertyKey !== "number") {
+						throwUnsupportedPropertyKey(
+							this.ccId,
+							property,
+							propertyKey,
+						);
+					}
+					return this.getEventSignaling(propertyKey);
+				default:
+					throwUnsupportedProperty(this.ccId, property);
+			}
+		};
+	}
 }
 
 @commandClass(CommandClasses["Barrier Operator"])

--- a/packages/cc/src/cc/BasicCC.ts
+++ b/packages/cc/src/cc/BasicCC.ts
@@ -100,25 +100,29 @@ export class BasicCCAPI extends CCAPI {
 		return super.supportsCommand(cmd);
 	}
 
-	protected [SET_VALUE]: SetValueImplementation = async (
-		{ property },
-		value,
-	) => {
-		// Enable restoring the previous non-zero value
-		if (property === "restorePrevious") {
-			property = "targetValue";
-			value = 255;
-		}
+	protected override get [SET_VALUE](): SetValueImplementation {
+		return async function (this: BasicCCAPI, { property }, value) {
+			// Enable restoring the previous non-zero value
+			if (property === "restorePrevious") {
+				property = "targetValue";
+				value = 255;
+			}
 
-		if (property !== "targetValue") {
-			throwUnsupportedProperty(this.ccId, property);
-		}
-		if (typeof value !== "number") {
-			throwWrongValueType(this.ccId, property, "number", typeof value);
-		}
+			if (property !== "targetValue") {
+				throwUnsupportedProperty(this.ccId, property);
+			}
+			if (typeof value !== "number") {
+				throwWrongValueType(
+					this.ccId,
+					property,
+					"number",
+					typeof value,
+				);
+			}
 
-		return this.set(value);
-	};
+			return this.set(value);
+		};
+	}
 
 	protected [SET_VALUE_HOOKS]: SetValueImplementationHooksFactory = (
 		{ property },
@@ -188,18 +192,18 @@ export class BasicCCAPI extends CCAPI {
 		}
 	};
 
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-	}): Promise<unknown> => {
-		switch (property) {
-			case "currentValue":
-			case "targetValue":
-			case "duration":
-				return (await this.get())?.[property];
-			default:
-				throwUnsupportedProperty(this.ccId, property);
-		}
-	};
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (this: BasicCCAPI, { property }) {
+			switch (property) {
+				case "currentValue":
+				case "targetValue":
+				case "duration":
+					return (await this.get())?.[property];
+				default:
+					throwUnsupportedProperty(this.ccId, property);
+			}
+		};
+	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	public async get() {

--- a/packages/cc/src/cc/BatteryCC.ts
+++ b/packages/cc/src/cc/BatteryCC.ts
@@ -189,30 +189,30 @@ export class BatteryCCAPI extends PhysicalCCAPI {
 		return super.supportsCommand(cmd);
 	}
 
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-	}): Promise<unknown> => {
-		switch (property) {
-			case "level":
-			case "isLow":
-			case "chargingStatus":
-			case "rechargeable":
-			case "backup":
-			case "overheating":
-			case "lowFluid":
-			case "rechargeOrReplace":
-			case "lowTemperatureStatus":
-			case "disconnected":
-				return (await this.get())?.[property];
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (this: BatteryCCAPI, { property }) {
+			switch (property) {
+				case "level":
+				case "isLow":
+				case "chargingStatus":
+				case "rechargeable":
+				case "backup":
+				case "overheating":
+				case "lowFluid":
+				case "rechargeOrReplace":
+				case "lowTemperatureStatus":
+				case "disconnected":
+					return (await this.get())?.[property];
 
-			case "maximumCapacity":
-			case "temperature":
-				return (await this.getHealth())?.[property];
+				case "maximumCapacity":
+				case "temperature":
+					return (await this.getHealth())?.[property];
 
-			default:
-				throwUnsupportedProperty(this.ccId, property);
-		}
-	};
+				default:
+					throwUnsupportedProperty(this.ccId, property);
+			}
+		};
+	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	public async get() {

--- a/packages/cc/src/cc/BinarySensorCC.ts
+++ b/packages/cc/src/cc/BinarySensorCC.ts
@@ -78,17 +78,17 @@ export class BinarySensorCCAPI extends PhysicalCCAPI {
 		return super.supportsCommand(cmd);
 	}
 
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-	}): Promise<unknown> => {
-		if (typeof property === "string") {
-			const sensorType = (BinarySensorType as any)[property] as
-				| BinarySensorType
-				| undefined;
-			if (sensorType) return this.get(sensorType);
-		}
-		throwUnsupportedProperty(this.ccId, property);
-	};
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (this: BinarySensorCCAPI, { property }) {
+			if (typeof property === "string") {
+				const sensorType = (BinarySensorType as any)[property] as
+					| BinarySensorType
+					| undefined;
+				if (sensorType) return this.get(sensorType);
+			}
+			throwUnsupportedProperty(this.ccId, property);
+		};
+	}
 
 	/**
 	 * Retrieves the current value from this sensor

--- a/packages/cc/src/cc/BinarySwitchCC.ts
+++ b/packages/cc/src/cc/BinarySwitchCC.ts
@@ -132,20 +132,28 @@ export class BinarySwitchCCAPI extends CCAPI {
 		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
-	protected [SET_VALUE]: SetValueImplementation = async (
-		{ property },
-		value,
-		options,
-	) => {
-		if (property !== "targetValue") {
-			throwUnsupportedProperty(this.ccId, property);
-		}
-		if (typeof value !== "boolean") {
-			throwWrongValueType(this.ccId, property, "boolean", typeof value);
-		}
-		const duration = Duration.from(options?.transitionDuration);
-		return this.set(value, duration);
-	};
+	protected override get [SET_VALUE](): SetValueImplementation {
+		return async function (
+			this: BinarySwitchCCAPI,
+			{ property },
+			value,
+			options,
+		) {
+			if (property !== "targetValue") {
+				throwUnsupportedProperty(this.ccId, property);
+			}
+			if (typeof value !== "boolean") {
+				throwWrongValueType(
+					this.ccId,
+					property,
+					"boolean",
+					typeof value,
+				);
+			}
+			const duration = Duration.from(options?.transitionDuration);
+			return this.set(value, duration);
+		};
+	}
 
 	protected [SET_VALUE_HOOKS]: SetValueImplementationHooksFactory = (
 		{ property },
@@ -199,18 +207,18 @@ export class BinarySwitchCCAPI extends CCAPI {
 		}
 	};
 
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-	}): Promise<unknown> => {
-		switch (property) {
-			case "currentValue":
-			case "targetValue":
-			case "duration":
-				return (await this.get())?.[property];
-			default:
-				throwUnsupportedProperty(this.ccId, property);
-		}
-	};
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (this: BinarySwitchCCAPI, { property }) {
+			switch (property) {
+				case "currentValue":
+				case "targetValue":
+				case "duration":
+					return (await this.get())?.[property];
+				default:
+					throwUnsupportedProperty(this.ccId, property);
+			}
+		};
+	}
 }
 
 @commandClass(CommandClasses["Binary Switch"])

--- a/packages/cc/src/cc/CentralSceneCC.ts
+++ b/packages/cc/src/cc/CentralSceneCC.ts
@@ -161,27 +161,31 @@ export class CentralSceneCCAPI extends CCAPI {
 		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
-	protected [SET_VALUE]: SetValueImplementation = async (
-		{ property },
-		value,
-	) => {
-		if (property !== "slowRefresh") {
-			throwUnsupportedProperty(this.ccId, property);
-		}
-		if (typeof value !== "boolean") {
-			throwWrongValueType(this.ccId, property, "boolean", typeof value);
-		}
-		return this.setConfiguration(value);
-	};
+	protected override get [SET_VALUE](): SetValueImplementation {
+		return async function (this: CentralSceneCCAPI, { property }, value) {
+			if (property !== "slowRefresh") {
+				throwUnsupportedProperty(this.ccId, property);
+			}
+			if (typeof value !== "boolean") {
+				throwWrongValueType(
+					this.ccId,
+					property,
+					"boolean",
+					typeof value,
+				);
+			}
+			return this.setConfiguration(value);
+		};
+	}
 
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-	}): Promise<unknown> => {
-		if (property === "slowRefresh") {
-			return (await this.getConfiguration())?.[property];
-		}
-		throwUnsupportedProperty(this.ccId, property);
-	};
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (this: CentralSceneCCAPI, { property }) {
+			if (property === "slowRefresh") {
+				return (await this.getConfiguration())?.[property];
+			}
+			throwUnsupportedProperty(this.ccId, property);
+		};
+	}
 }
 
 @commandClass(CommandClasses["Central Scene"])

--- a/packages/cc/src/cc/ColorSwitchCC.ts
+++ b/packages/cc/src/cc/ColorSwitchCC.ts
@@ -368,143 +368,150 @@ export class ColorSwitchCCAPI extends CCAPI {
 		return this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
-	protected [SET_VALUE]: SetValueImplementation = async (
-		{ property, propertyKey },
-		value,
-		options,
-	) => {
-		if (property === "targetColor") {
-			const duration = Duration.from(options?.transitionDuration);
-			if (propertyKey != undefined) {
-				// Single color component, only accepts numbers
-				if (typeof propertyKey !== "number") {
-					throwUnsupportedPropertyKey(
-						this.ccId,
-						property,
-						propertyKey,
-					);
-				} else if (typeof value !== "number") {
+	protected override get [SET_VALUE](): SetValueImplementation {
+		return async function (
+			this: ColorSwitchCCAPI,
+			{ property, propertyKey },
+			value,
+			options,
+		) {
+			if (property === "targetColor") {
+				const duration = Duration.from(options?.transitionDuration);
+				if (propertyKey != undefined) {
+					// Single color component, only accepts numbers
+					if (typeof propertyKey !== "number") {
+						throwUnsupportedPropertyKey(
+							this.ccId,
+							property,
+							propertyKey,
+						);
+					} else if (typeof value !== "number") {
+						throwWrongValueType(
+							this.ccId,
+							property,
+							"number",
+							typeof value,
+						);
+					}
+					const result = await this.set({
+						[propertyKey]: value,
+						duration,
+					});
+
+					if (
+						this.isSinglecast() &&
+						!supervisedCommandSucceeded(result)
+					) {
+						// Verify the current value after a (short) delay, unless the command was supervised and successful
+						this.schedulePoll({ property, propertyKey }, value, {
+							duration,
+							transition: "fast",
+						});
+					}
+
+					return result;
+				} else {
+					// Set the compound color object
+
+					// Ensure the value is an object with only valid keys
+					if (
+						!isObject(value) ||
+						!Object.keys(value).every(
+							(key) => key in ColorComponentMap,
+						)
+					) {
+						throw new ZWaveError(
+							`${
+								CommandClasses[this.ccId]
+							}: "${property}" must be set to an object which specifies each color channel`,
+							ZWaveErrorCodes.Argument_Invalid,
+						);
+					}
+
+					// Ensure that each property is numeric
+					for (const [key, val] of Object.entries(value)) {
+						if (typeof val !== "number") {
+							throwWrongValueType(
+								this.ccId,
+								`${property}.${key}`,
+								"number",
+								typeof val,
+							);
+						}
+					}
+
+					// GH#2527: strip unsupported color components, because some devices don't react otherwise
+					if (this.isSinglecast()) {
+						const supportedColors = this.tryGetValueDB()?.getValue<
+							readonly ColorComponent[]
+						>(
+							ColorSwitchCCValues.supportedColorComponents.endpoint(
+								this.endpoint.index,
+							),
+						);
+						if (supportedColors) {
+							value = pick(
+								value,
+								supportedColors
+									.map((c) => colorComponentToTableKey(c))
+									.filter((c) => !!c) as ColorKey[],
+							);
+						}
+					}
+
+					// Avoid sending empty commands
+					if (Object.keys(value as any).length === 0) return;
+
+					return this.set({ ...(value as ColorTable), duration });
+
+					// We're not going to poll each color component separately
+				}
+			} else if (property === "hexColor") {
+				// No property key, this is the hex color #rrggbb
+				if (typeof value !== "string") {
 					throwWrongValueType(
 						this.ccId,
 						property,
-						"number",
+						"string",
 						typeof value,
 					);
 				}
-				const result = await this.set({
-					[propertyKey]: value,
-					duration,
-				});
 
-				if (
-					this.isSinglecast() &&
-					!supervisedCommandSucceeded(result)
-				) {
-					// Verify the current value after a (short) delay, unless the command was supervised and successful
-					this.schedulePoll({ property, propertyKey }, value, {
-						duration,
-						transition: "fast",
-					});
-				}
-
-				return result;
+				const duration = Duration.from(options?.transitionDuration);
+				return this.set({ hexColor: value, duration });
 			} else {
-				// Set the compound color object
-
-				// Ensure the value is an object with only valid keys
-				if (
-					!isObject(value) ||
-					!Object.keys(value).every((key) => key in ColorComponentMap)
-				) {
-					throw new ZWaveError(
-						`${
-							CommandClasses[this.ccId]
-						}: "${property}" must be set to an object which specifies each color channel`,
-						ZWaveErrorCodes.Argument_Invalid,
-					);
-				}
-
-				// Ensure that each property is numeric
-				for (const [key, val] of Object.entries(value)) {
-					if (typeof val !== "number") {
-						throwWrongValueType(
-							this.ccId,
-							`${property}.${key}`,
-							"number",
-							typeof val,
-						);
-					}
-				}
-
-				// GH#2527: strip unsupported color components, because some devices don't react otherwise
-				if (this.isSinglecast()) {
-					const supportedColors = this.tryGetValueDB()?.getValue<
-						readonly ColorComponent[]
-					>(
-						ColorSwitchCCValues.supportedColorComponents.endpoint(
-							this.endpoint.index,
-						),
-					);
-					if (supportedColors) {
-						value = pick(
-							value,
-							supportedColors
-								.map((c) => colorComponentToTableKey(c))
-								.filter((c) => !!c) as ColorKey[],
-						);
-					}
-				}
-
-				// Avoid sending empty commands
-				if (Object.keys(value as any).length === 0) return;
-
-				return this.set({ ...(value as ColorTable), duration });
-
-				// We're not going to poll each color component separately
+				throwUnsupportedProperty(this.ccId, property);
 			}
-		} else if (property === "hexColor") {
-			// No property key, this is the hex color #rrggbb
-			if (typeof value !== "string") {
-				throwWrongValueType(
-					this.ccId,
-					property,
-					"string",
-					typeof value,
-				);
-			}
-
-			const duration = Duration.from(options?.transitionDuration);
-			return this.set({ hexColor: value, duration });
-		} else {
-			throwUnsupportedProperty(this.ccId, property);
-		}
-	};
+		};
+	}
 
 	public isSetValueOptimistic(_valueId: ValueID): boolean {
 		return false; // Color Switch CC handles updating the value DB itself
 	}
 
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-		propertyKey,
-	}): Promise<unknown> => {
-		if (propertyKey == undefined) {
-			throwMissingPropertyKey(this.ccId, property);
-		} else if (typeof propertyKey !== "number") {
-			throwUnsupportedPropertyKey(this.ccId, property, propertyKey);
-		}
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (
+			this: ColorSwitchCCAPI,
+			{ property, propertyKey },
+		) {
+			if (propertyKey == undefined) {
+				throwMissingPropertyKey(this.ccId, property);
+			} else if (typeof propertyKey !== "number") {
+				throwUnsupportedPropertyKey(this.ccId, property, propertyKey);
+			}
 
-		switch (property) {
-			case "currentColor":
-				return (await this.get(propertyKey))?.currentValue;
-			case "targetColor":
-				return (await this.get(propertyKey))?.targetValue;
-			case "duration":
-				return (await this.get(propertyKey))?.duration;
-			default:
-				throwUnsupportedProperty(this.ccId, property);
-		}
-	};
+			switch (property) {
+				case "currentColor":
+					return (await this.get(propertyKey))?.currentValue;
+				case "targetColor":
+					return (await this.get(propertyKey))?.targetValue;
+				case "duration":
+					return (await this.get(propertyKey))?.duration;
+				default:
+					throwUnsupportedProperty(this.ccId, property);
+			}
+		};
+	}
 }
 
 @commandClass(CommandClasses["Color Switch"])

--- a/packages/cc/src/cc/EnergyProductionCC.ts
+++ b/packages/cc/src/cc/EnergyProductionCC.ts
@@ -74,23 +74,25 @@ export class EnergyProductionCCAPI extends CCAPI {
 		return super.supportsCommand(cmd);
 	}
 
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-		propertyKey,
-	}): Promise<unknown> => {
-		if (
-			EnergyProductionCCValues.value.is({
-				commandClass: this.ccId,
-				property,
-				propertyKey,
-			})
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (
+			this: EnergyProductionCCAPI,
+			{ property, propertyKey },
 		) {
-			return (await this.get(property as EnergyProductionParameter))
-				?.value;
-		} else {
-			throwUnsupportedProperty(this.ccId, property);
-		}
-	};
+			if (
+				EnergyProductionCCValues.value.is({
+					commandClass: this.ccId,
+					property,
+					propertyKey,
+				})
+			) {
+				return (await this.get(property as EnergyProductionParameter))
+					?.value;
+			} else {
+				throwUnsupportedProperty(this.ccId, property);
+			}
+		};
+	}
 
 	@validateArgs({ strictEnums: true })
 	public async get(

--- a/packages/cc/src/cc/HumidityControlModeCC.ts
+++ b/packages/cc/src/cc/HumidityControlModeCC.ts
@@ -68,44 +68,47 @@ export class HumidityControlModeCCAPI extends CCAPI {
 		return super.supportsCommand(cmd);
 	}
 
-	protected [SET_VALUE]: SetValueImplementation = async (
-		{ property },
-		value,
-	) => {
-		if (property === "mode") {
-			if (typeof value !== "number") {
-				throwWrongValueType(
-					this.ccId,
-					property,
-					"number",
-					typeof value,
-				);
-			}
-		} else {
-			throwUnsupportedProperty(this.ccId, property);
-		}
-
-		const result = await this.set(value);
-
-		// Verify the change after a delay, unless the command was supervised and successful
-		if (this.isSinglecast() && !supervisedCommandSucceeded(result)) {
-			this.schedulePoll({ property }, value);
-		}
-
-		return result;
-	};
-
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-	}): Promise<unknown> => {
-		switch (property) {
-			case "mode":
-				return this.get();
-
-			default:
+	protected override get [SET_VALUE](): SetValueImplementation {
+		return async function (
+			this: HumidityControlModeCCAPI,
+			{ property },
+			value,
+		) {
+			if (property === "mode") {
+				if (typeof value !== "number") {
+					throwWrongValueType(
+						this.ccId,
+						property,
+						"number",
+						typeof value,
+					);
+				}
+			} else {
 				throwUnsupportedProperty(this.ccId, property);
-		}
-	};
+			}
+
+			const result = await this.set(value);
+
+			// Verify the change after a delay, unless the command was supervised and successful
+			if (this.isSinglecast() && !supervisedCommandSucceeded(result)) {
+				this.schedulePoll({ property }, value);
+			}
+
+			return result;
+		};
+	}
+
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (this: HumidityControlModeCCAPI, { property }) {
+			switch (property) {
+				case "mode":
+					return this.get();
+
+				default:
+					throwUnsupportedProperty(this.ccId, property);
+			}
+		};
+	}
 
 	public async get(): Promise<HumidityControlMode | undefined> {
 		this.assertSupportsCommand(

--- a/packages/cc/src/cc/HumidityControlOperatingStateCC.ts
+++ b/packages/cc/src/cc/HumidityControlOperatingStateCC.ts
@@ -61,17 +61,20 @@ export class HumidityControlOperatingStateCCAPI extends CCAPI {
 		return super.supportsCommand(cmd);
 	}
 
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-	}): Promise<unknown> => {
-		switch (property) {
-			case "state":
-				return this.get();
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (
+			this: HumidityControlOperatingStateCCAPI,
+			{ property },
+		) {
+			switch (property) {
+				case "state":
+					return this.get();
 
-			default:
-				throwUnsupportedProperty(this.ccId, property);
-		}
-	};
+				default:
+					throwUnsupportedProperty(this.ccId, property);
+			}
+		};
+	}
 
 	public async get(): Promise<HumidityControlOperatingState | undefined> {
 		this.assertSupportsCommand(

--- a/packages/cc/src/cc/HumidityControlSetpointCC.ts
+++ b/packages/cc/src/cc/HumidityControlSetpointCC.ts
@@ -122,61 +122,75 @@ export class HumidityControlSetpointCCAPI extends CCAPI {
 		return super.supportsCommand(cmd);
 	}
 
-	protected [SET_VALUE]: SetValueImplementation = async (
-		{ property, propertyKey },
-		value,
-	) => {
-		if (property !== "setpoint") {
-			throwUnsupportedProperty(this.ccId, property);
-		}
-		if (typeof propertyKey !== "number") {
-			throw new ZWaveError(
-				`${
-					CommandClasses[this.ccId]
-				}: "${property}" must be further specified by a numeric property key`,
-				ZWaveErrorCodes.Argument_Invalid,
-			);
-		}
-		if (typeof value !== "number") {
-			throwWrongValueType(this.ccId, property, "number", typeof value);
-		}
-
-		const scaleValueId = HumidityControlSetpointCCValues.setpointScale(
-			propertyKey,
-		).endpoint(this.endpoint.index);
-		const preferredScale =
-			this.tryGetValueDB()?.getValue<number>(scaleValueId);
-
-		const result = await this.set(propertyKey, value, preferredScale ?? 0);
-
-		// Verify the change after a delay, unless the command was supervised and successful
-		if (this.isSinglecast() && !supervisedCommandSucceeded(result)) {
-			this.schedulePoll({ property, propertyKey }, value);
-		}
-
-		return result;
-	};
-
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-		propertyKey,
-	}): Promise<unknown> => {
-		switch (property) {
-			case "setpoint":
-				if (typeof propertyKey !== "number") {
-					throw new ZWaveError(
-						`${
-							CommandClasses[this.ccId]
-						}: "${property}" must be further specified by a numeric property key`,
-						ZWaveErrorCodes.Argument_Invalid,
-					);
-				}
-
-				return (await this.get(propertyKey))?.value;
-			default:
+	protected override get [SET_VALUE](): SetValueImplementation {
+		return async function (
+			this: HumidityControlSetpointCCAPI,
+			{ property, propertyKey },
+			value,
+		) {
+			if (property !== "setpoint") {
 				throwUnsupportedProperty(this.ccId, property);
-		}
-	};
+			}
+			if (typeof propertyKey !== "number") {
+				throw new ZWaveError(
+					`${
+						CommandClasses[this.ccId]
+					}: "${property}" must be further specified by a numeric property key`,
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
+			if (typeof value !== "number") {
+				throwWrongValueType(
+					this.ccId,
+					property,
+					"number",
+					typeof value,
+				);
+			}
+
+			const scaleValueId = HumidityControlSetpointCCValues.setpointScale(
+				propertyKey,
+			).endpoint(this.endpoint.index);
+			const preferredScale =
+				this.tryGetValueDB()?.getValue<number>(scaleValueId);
+
+			const result = await this.set(
+				propertyKey,
+				value,
+				preferredScale ?? 0,
+			);
+
+			// Verify the change after a delay, unless the command was supervised and successful
+			if (this.isSinglecast() && !supervisedCommandSucceeded(result)) {
+				this.schedulePoll({ property, propertyKey }, value);
+			}
+
+			return result;
+		};
+	}
+
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (
+			this: HumidityControlSetpointCCAPI,
+			{ property, propertyKey },
+		) {
+			switch (property) {
+				case "setpoint":
+					if (typeof propertyKey !== "number") {
+						throw new ZWaveError(
+							`${
+								CommandClasses[this.ccId]
+							}: "${property}" must be further specified by a numeric property key`,
+							ZWaveErrorCodes.Argument_Invalid,
+						);
+					}
+
+					return (await this.get(propertyKey))?.value;
+				default:
+					throwUnsupportedProperty(this.ccId, property);
+			}
+		};
+	}
 
 	@validateArgs()
 	public async get(

--- a/packages/cc/src/cc/IrrigationCC.ts
+++ b/packages/cc/src/cc/IrrigationCC.ts
@@ -839,176 +839,189 @@ export class IrrigationCCAPI extends CCAPI {
 		return this.shutoffSystem(255);
 	}
 
-	protected [SET_VALUE]: SetValueImplementation = async (
-		{ property, propertyKey },
-		value,
-	) => {
-		const valueDB = this.getValueDB();
-
-		if (systemConfigProperties.includes(property as any)) {
-			const options = {} as IrrigationCCSystemConfigSetOptions;
-			for (const prop of systemConfigProperties) {
-				if (prop === property) continue;
-				const valueId: ValueID = {
-					commandClass: this.ccId,
-					endpoint: this.endpoint.index,
-					property: prop as any,
-				};
-				const cachedVal = valueDB.getValue<any>(valueId);
-				if (cachedVal == undefined) {
-					throw new ZWaveError(
-						`The "${property}" property cannot be changed before ${prop} is known!`,
-						ZWaveErrorCodes.Argument_Invalid,
-					);
-				}
-				options[prop] = cachedVal;
-			}
-			options[property as keyof IrrigationCCSystemConfigSetOptions] =
-				value as any;
-
-			return this.setSystemConfig(options);
-		} else if (property === "shutoff") {
-			return this.shutoffSystem(0);
-		} else if (
-			property === "master" ||
-			(typeof property === "number" && property >= 1)
+	protected override get [SET_VALUE](): SetValueImplementation {
+		return async function (
+			this: IrrigationCCAPI,
+			{ property, propertyKey },
+			value,
 		) {
-			// This is a value of a valve
-			if (propertyKey == undefined) {
-				throwMissingPropertyKey(this.ccId, property);
-			}
+			const valueDB = this.getValueDB();
 
-			if (valveConfigPropertyKeys.includes(propertyKey as any)) {
-				const options = {
-					valveId: property,
-				} as IrrigationCCValveConfigSetOptions;
-
-				for (const prop of valveConfigPropertyKeys) {
-					if (prop === propertyKey) continue;
+			if (systemConfigProperties.includes(property as any)) {
+				const options = {} as IrrigationCCSystemConfigSetOptions;
+				for (const prop of systemConfigProperties) {
+					if (prop === property) continue;
 					const valueId: ValueID = {
 						commandClass: this.ccId,
 						endpoint: this.endpoint.index,
-						property,
-						propertyKey: prop as any,
+						property: prop as any,
 					};
 					const cachedVal = valueDB.getValue<any>(valueId);
 					if (cachedVal == undefined) {
 						throw new ZWaveError(
-							`The "${property}_${propertyKey}" property cannot be changed before ${property}_${prop} is known!`,
+							`The "${property}" property cannot be changed before ${prop} is known!`,
 							ZWaveErrorCodes.Argument_Invalid,
 						);
 					}
-					(options as any)[prop] = cachedVal;
+					options[prop] = cachedVal;
 				}
-				(options as any)[propertyKey] = value;
+				options[property as keyof IrrigationCCSystemConfigSetOptions] =
+					value as any;
 
-				return this.setValveConfig(options);
-			} else if (propertyKey === "duration") {
-				// The run duration needs to be set separately from triggering the run
-				// So this is okay
-				return;
-			} else if (propertyKey === "startStop") {
-				// Trigger or stop a valve run, depending on the value
-				if (typeof value !== "boolean") {
-					throwWrongValueType(
-						this.ccId,
-						property,
-						"boolean",
-						typeof value,
-					);
-				}
-
-				if (value) {
-					// Start a valve run
-					const duration = valueDB.getValue<number>(
-						IrrigationCCValues.valveRunDuration(property).endpoint(
-							this.endpoint.index,
-						),
-					);
-					if (duration == undefined) {
-						throw new ZWaveError(
-							`Cannot start a valve run without specifying a duration first!`,
-							ZWaveErrorCodes.Argument_Invalid,
-						);
-					}
-					return this.runValve(property, duration);
-				} else {
-					// Stop a valve run
-					return this.shutoffValve(property);
-				}
-			} else {
-				throwUnsupportedPropertyKey(this.ccId, property, propertyKey);
-			}
-		}
-	};
-
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-		propertyKey,
-	}): Promise<unknown> => {
-		switch (property) {
-			case "systemVoltage":
-			case "flowSensorActive":
-			case "pressureSensorActive":
-			case "rainSensorActive":
-			case "moistureSensorActive":
-			case "flow":
-			case "pressure":
-			case "shutoffDuration":
-			case "errorNotProgrammed":
-			case "errorEmergencyShutdown":
-			case "errorHighPressure":
-			case "errorLowPressure":
-			case "errorValve":
-			case "masterValveOpen":
-			case "firstOpenZoneId":
-				return (await this.getSystemStatus())?.[property];
-
-			case "masterValveDelay":
-			case "highPressureThreshold":
-			case "lowPressureThreshold":
-			case "rainSensorPolarity":
-			case "moistureSensorPolarity":
-				return (await this.getSystemConfig())?.[property];
-		}
-
-		if (
-			property === "master" ||
-			(typeof property === "number" && property >= 1)
-		) {
-			// This is a value of a valve
-			switch (propertyKey) {
-				case "connected":
-				case "nominalCurrent":
-				case "errorShortCircuit":
-				case "errorHighCurrent":
-				case "errorLowCurrent":
-				case "errorMaximumFlow":
-				case "errorHighFlow":
-				case "errorLowFlow":
-					return (await this.getValveInfo(property))?.[propertyKey];
-
-				case "nominalCurrentHighThreshold":
-				case "nominalCurrentLowThreshold":
-				case "maximumFlow":
-				case "highFlowThreshold":
-				case "lowFlowThreshold":
-				case "useRainSensor":
-				case "useMoistureSensor":
-					return (await this.getValveConfig(property))?.[propertyKey];
-
-				case undefined:
+				return this.setSystemConfig(options);
+			} else if (property === "shutoff") {
+				return this.shutoffSystem(0);
+			} else if (
+				property === "master" ||
+				(typeof property === "number" && property >= 1)
+			) {
+				// This is a value of a valve
+				if (propertyKey == undefined) {
 					throwMissingPropertyKey(this.ccId, property);
-				default:
+				}
+
+				if (valveConfigPropertyKeys.includes(propertyKey as any)) {
+					const options = {
+						valveId: property,
+					} as IrrigationCCValveConfigSetOptions;
+
+					for (const prop of valveConfigPropertyKeys) {
+						if (prop === propertyKey) continue;
+						const valueId: ValueID = {
+							commandClass: this.ccId,
+							endpoint: this.endpoint.index,
+							property,
+							propertyKey: prop as any,
+						};
+						const cachedVal = valueDB.getValue<any>(valueId);
+						if (cachedVal == undefined) {
+							throw new ZWaveError(
+								`The "${property}_${propertyKey}" property cannot be changed before ${property}_${prop} is known!`,
+								ZWaveErrorCodes.Argument_Invalid,
+							);
+						}
+						(options as any)[prop] = cachedVal;
+					}
+					(options as any)[propertyKey] = value;
+
+					return this.setValveConfig(options);
+				} else if (propertyKey === "duration") {
+					// The run duration needs to be set separately from triggering the run
+					// So this is okay
+					return;
+				} else if (propertyKey === "startStop") {
+					// Trigger or stop a valve run, depending on the value
+					if (typeof value !== "boolean") {
+						throwWrongValueType(
+							this.ccId,
+							property,
+							"boolean",
+							typeof value,
+						);
+					}
+
+					if (value) {
+						// Start a valve run
+						const duration = valueDB.getValue<number>(
+							IrrigationCCValues.valveRunDuration(
+								property,
+							).endpoint(this.endpoint.index),
+						);
+						if (duration == undefined) {
+							throw new ZWaveError(
+								`Cannot start a valve run without specifying a duration first!`,
+								ZWaveErrorCodes.Argument_Invalid,
+							);
+						}
+						return this.runValve(property, duration);
+					} else {
+						// Stop a valve run
+						return this.shutoffValve(property);
+					}
+				} else {
 					throwUnsupportedPropertyKey(
 						this.ccId,
 						property,
 						propertyKey,
 					);
+				}
 			}
-		}
-		throwUnsupportedProperty(this.ccId, property);
-	};
+		};
+	}
+
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (
+			this: IrrigationCCAPI,
+			{ property, propertyKey },
+		) {
+			switch (property) {
+				case "systemVoltage":
+				case "flowSensorActive":
+				case "pressureSensorActive":
+				case "rainSensorActive":
+				case "moistureSensorActive":
+				case "flow":
+				case "pressure":
+				case "shutoffDuration":
+				case "errorNotProgrammed":
+				case "errorEmergencyShutdown":
+				case "errorHighPressure":
+				case "errorLowPressure":
+				case "errorValve":
+				case "masterValveOpen":
+				case "firstOpenZoneId":
+					return (await this.getSystemStatus())?.[property];
+
+				case "masterValveDelay":
+				case "highPressureThreshold":
+				case "lowPressureThreshold":
+				case "rainSensorPolarity":
+				case "moistureSensorPolarity":
+					return (await this.getSystemConfig())?.[property];
+			}
+
+			if (
+				property === "master" ||
+				(typeof property === "number" && property >= 1)
+			) {
+				// This is a value of a valve
+				switch (propertyKey) {
+					case "connected":
+					case "nominalCurrent":
+					case "errorShortCircuit":
+					case "errorHighCurrent":
+					case "errorLowCurrent":
+					case "errorMaximumFlow":
+					case "errorHighFlow":
+					case "errorLowFlow":
+						return (await this.getValveInfo(property))?.[
+							propertyKey
+						];
+
+					case "nominalCurrentHighThreshold":
+					case "nominalCurrentLowThreshold":
+					case "maximumFlow":
+					case "highFlowThreshold":
+					case "lowFlowThreshold":
+					case "useRainSensor":
+					case "useMoistureSensor":
+						return (await this.getValveConfig(property))?.[
+							propertyKey
+						];
+
+					case undefined:
+						throwMissingPropertyKey(this.ccId, property);
+					default:
+						throwUnsupportedPropertyKey(
+							this.ccId,
+							property,
+							propertyKey,
+						);
+				}
+			}
+			throwUnsupportedProperty(this.ccId, property);
+		};
+	}
 }
 
 @commandClass(CommandClasses.Irrigation)

--- a/packages/cc/src/cc/MultilevelSensorCC.ts
+++ b/packages/cc/src/cc/MultilevelSensorCC.ts
@@ -196,24 +196,24 @@ export class MultilevelSensorCCAPI extends PhysicalCCAPI {
 		return super.supportsCommand(cmd);
 	}
 
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-	}): Promise<unknown> => {
-		// Look up the necessary information
-		const valueId: ValueID = {
-			commandClass: CommandClasses["Multilevel Sensor"],
-			endpoint: this.endpoint.index,
-			property,
-		};
-		const ccSpecific =
-			this.tryGetValueDB()?.getMetadata(valueId)?.ccSpecific;
-		if (!ccSpecific) {
-			throwUnsupportedProperty(this.ccId, property);
-		}
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (this: MultilevelSensorCCAPI, { property }) {
+			// Look up the necessary information
+			const valueId: ValueID = {
+				commandClass: CommandClasses["Multilevel Sensor"],
+				endpoint: this.endpoint.index,
+				property,
+			};
+			const ccSpecific =
+				this.tryGetValueDB()?.getMetadata(valueId)?.ccSpecific;
+			if (!ccSpecific) {
+				throwUnsupportedProperty(this.ccId, property);
+			}
 
-		const { sensorType, scale } = ccSpecific;
-		return this.get(sensorType, scale);
-	};
+			const { sensorType, scale } = ccSpecific;
+			return this.get(sensorType, scale);
+		};
+	}
 
 	/** Query the default sensor value */
 	public async get(): Promise<

--- a/packages/cc/src/cc/NodeNamingCC.ts
+++ b/packages/cc/src/cc/NodeNamingCC.ts
@@ -79,39 +79,47 @@ export class NodeNamingAndLocationCCAPI extends PhysicalCCAPI {
 		return super.supportsCommand(cmd);
 	}
 
-	protected [SET_VALUE]: SetValueImplementation = async (
-		{ property },
-		value,
-	) => {
-		if (property !== "name" && property !== "location") {
-			throwUnsupportedProperty(this.ccId, property);
-		}
-		if (typeof value !== "string") {
-			throwWrongValueType(this.ccId, property, "string", typeof value);
-		}
-
-		switch (property) {
-			case "name":
-				return this.setName(value);
-			case "location":
-				return this.setLocation(value);
-		}
-
-		return undefined;
-	};
-
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-	}): Promise<unknown> => {
-		switch (property) {
-			case "name":
-				return this.getName();
-			case "location":
-				return this.getLocation();
-			default:
+	protected override get [SET_VALUE](): SetValueImplementation {
+		return async function (
+			this: NodeNamingAndLocationCCAPI,
+			{ property },
+			value,
+		) {
+			if (property !== "name" && property !== "location") {
 				throwUnsupportedProperty(this.ccId, property);
-		}
-	};
+			}
+			if (typeof value !== "string") {
+				throwWrongValueType(
+					this.ccId,
+					property,
+					"string",
+					typeof value,
+				);
+			}
+
+			switch (property) {
+				case "name":
+					return this.setName(value);
+				case "location":
+					return this.setLocation(value);
+			}
+
+			return undefined;
+		};
+	}
+
+	protected override get [POLL_VALUE](): PollValueImplementation {
+		return async function (this: NodeNamingAndLocationCCAPI, { property }) {
+			switch (property) {
+				case "name":
+					return this.getName();
+				case "location":
+					return this.getLocation();
+				default:
+					throwUnsupportedProperty(this.ccId, property);
+			}
+		};
+	}
 
 	public async getName(): Promise<string | undefined> {
 		this.assertSupportsCommand(

--- a/packages/cc/src/cc/NotificationCC.ts
+++ b/packages/cc/src/cc/NotificationCC.ts
@@ -234,27 +234,29 @@ export class NotificationCCAPI extends PhysicalCCAPI {
 		return super.supportsCommand(cmd);
 	}
 
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-		propertyKey,
-	}): Promise<unknown> => {
-		const valueId: ValueID = {
-			commandClass: this.ccId,
-			endpoint: this.endpoint.index,
-			property,
-			propertyKey,
-		};
-		if (NotificationCCValues.notificationVariable.is(valueId)) {
-			const notificationType: number | undefined =
-				this.tryGetValueDB()?.getMetadata(valueId)?.ccSpecific
-					?.notificationType;
-			if (notificationType != undefined) {
-				return this.getInternal({ notificationType });
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (
+			this: NotificationCCAPI,
+			{ property, propertyKey },
+		) {
+			const valueId: ValueID = {
+				commandClass: this.ccId,
+				endpoint: this.endpoint.index,
+				property,
+				propertyKey,
+			};
+			if (NotificationCCValues.notificationVariable.is(valueId)) {
+				const notificationType: number | undefined =
+					this.tryGetValueDB()?.getMetadata(valueId)?.ccSpecific
+						?.notificationType;
+				if (notificationType != undefined) {
+					return this.getInternal({ notificationType });
+				}
 			}
-		}
 
-		throwUnsupportedProperty(this.ccId, property);
-	};
+			throwUnsupportedProperty(this.ccId, property);
+		};
+	}
 
 	/**
 	 * @internal

--- a/packages/cc/src/cc/ProtectionCC.ts
+++ b/packages/cc/src/cc/ProtectionCC.ts
@@ -143,71 +143,73 @@ export class ProtectionCCAPI extends CCAPI {
 		return super.supportsCommand(cmd);
 	}
 
-	protected [SET_VALUE]: SetValueImplementation = async (
-		{ property },
-		value,
-	) => {
-		const valueDB = this.tryGetValueDB();
-		if (property === "local") {
-			if (typeof value !== "number") {
-				throwWrongValueType(
-					this.ccId,
-					property,
-					"number",
-					typeof value,
+	protected override get [SET_VALUE](): SetValueImplementation {
+		return async function (this: ProtectionCCAPI, { property }, value) {
+			const valueDB = this.tryGetValueDB();
+			if (property === "local") {
+				if (typeof value !== "number") {
+					throwWrongValueType(
+						this.ccId,
+						property,
+						"number",
+						typeof value,
+					);
+				}
+				// We need to set both values together, so retrieve the other one from the value DB
+				const rf = valueDB?.getValue<RFProtectionState>(
+					ProtectionCCValues.rfProtectionState.endpoint(
+						this.endpoint.index,
+					),
 				);
-			}
-			// We need to set both values together, so retrieve the other one from the value DB
-			const rf = valueDB?.getValue<RFProtectionState>(
-				ProtectionCCValues.rfProtectionState.endpoint(
-					this.endpoint.index,
-				),
-			);
-			return this.set(value, rf);
-		} else if (property === "rf") {
-			if (typeof value !== "number") {
-				throwWrongValueType(
-					this.ccId,
-					property,
-					"number",
-					typeof value,
+				return this.set(value, rf);
+			} else if (property === "rf") {
+				if (typeof value !== "number") {
+					throwWrongValueType(
+						this.ccId,
+						property,
+						"number",
+						typeof value,
+					);
+				}
+				// We need to set both values together, so retrieve the other one from the value DB
+				const local = valueDB?.getValue<LocalProtectionState>(
+					ProtectionCCValues.localProtectionState.endpoint(
+						this.endpoint.index,
+					),
 				);
-			}
-			// We need to set both values together, so retrieve the other one from the value DB
-			const local = valueDB?.getValue<LocalProtectionState>(
-				ProtectionCCValues.localProtectionState.endpoint(
-					this.endpoint.index,
-				),
-			);
-			return this.set(local ?? LocalProtectionState.Unprotected, value);
-		} else if (property === "exclusiveControlNodeId") {
-			if (typeof value !== "number") {
-				throwWrongValueType(
-					this.ccId,
-					property,
-					"number",
-					typeof value,
+				return this.set(
+					local ?? LocalProtectionState.Unprotected,
+					value,
 				);
-			}
-			return this.setExclusiveControl(value);
-		} else {
-			throwUnsupportedProperty(this.ccId, property);
-		}
-	};
-
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-	}): Promise<unknown> => {
-		switch (property) {
-			case "local":
-			case "rf":
-				return (await this.get())?.[property];
-			case "exclusiveControlNodeId":
-				return this.getExclusiveControl();
-			default:
+			} else if (property === "exclusiveControlNodeId") {
+				if (typeof value !== "number") {
+					throwWrongValueType(
+						this.ccId,
+						property,
+						"number",
+						typeof value,
+					);
+				}
+				return this.setExclusiveControl(value);
+			} else {
 				throwUnsupportedProperty(this.ccId, property);
-		}
-	};
+			}
+		};
+	}
+
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (this: ProtectionCCAPI, { property }) {
+			switch (property) {
+				case "local":
+				case "rf":
+					return (await this.get())?.[property];
+				case "exclusiveControlNodeId":
+					return this.getExclusiveControl();
+				default:
+					throwUnsupportedProperty(this.ccId, property);
+			}
+		};
+	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	public async get() {

--- a/packages/cc/src/cc/SceneActivationCC.ts
+++ b/packages/cc/src/cc/SceneActivationCC.ts
@@ -66,20 +66,28 @@ export class SceneActivationCCAPI extends CCAPI {
 		return true;
 	}
 
-	protected [SET_VALUE]: SetValueImplementation = async (
-		{ property },
-		value,
-		options,
-	) => {
-		if (property !== "sceneId") {
-			throwUnsupportedProperty(this.ccId, property);
-		}
-		if (typeof value !== "number") {
-			throwWrongValueType(this.ccId, property, "number", typeof value);
-		}
-		const duration = Duration.from(options?.transitionDuration);
-		return this.set(value, duration);
-	};
+	protected override get [SET_VALUE](): SetValueImplementation {
+		return async function (
+			this: SceneActivationCCAPI,
+			{ property },
+			value,
+			options,
+		) {
+			if (property !== "sceneId") {
+				throwUnsupportedProperty(this.ccId, property);
+			}
+			if (typeof value !== "number") {
+				throwWrongValueType(
+					this.ccId,
+					property,
+					"number",
+					typeof value,
+				);
+			}
+			const duration = Duration.from(options?.transitionDuration);
+			return this.set(value, duration);
+		};
+	}
 
 	/**
 	 * Activates the Scene with the given ID

--- a/packages/cc/src/cc/SceneControllerConfigurationCC.ts
+++ b/packages/cc/src/cc/SceneControllerConfigurationCC.ts
@@ -94,114 +94,122 @@ export class SceneControllerConfigurationCCAPI extends CCAPI {
 		return super.supportsCommand(cmd);
 	}
 
-	protected [SET_VALUE]: SetValueImplementation = async (
-		{ property, propertyKey },
-		value,
-		options,
-	) => {
-		if (propertyKey == undefined) {
-			throwMissingPropertyKey(this.ccId, property);
-		} else if (typeof propertyKey !== "number") {
-			throwUnsupportedPropertyKey(this.ccId, property, propertyKey);
-		}
-		if (property === "sceneId") {
-			if (typeof value !== "number") {
-				throwWrongValueType(
-					this.ccId,
-					property,
-					"number",
-					typeof value,
-				);
+	protected override get [SET_VALUE](): SetValueImplementation {
+		return async function (
+			this: SceneControllerConfigurationCCAPI,
+			{ property, propertyKey },
+			value,
+			options,
+		) {
+			if (propertyKey == undefined) {
+				throwMissingPropertyKey(this.ccId, property);
+			} else if (typeof propertyKey !== "number") {
+				throwUnsupportedPropertyKey(this.ccId, property, propertyKey);
 			}
-
-			if (value === 0) {
-				// Disable Group ID / Scene ID
-				return this.disable(propertyKey);
-			} else {
-				// We need to set the dimming duration along with the scene ID
-				// Dimming duration is chosen with the following precedence:
-				// 1. options.transitionDuration
-				// 2. current stored value
-				// 3. default value
-				const dimmingDuration =
-					Duration.from(options?.transitionDuration) ??
-					this.tryGetValueDB()?.getValue<Duration>(
-						SceneControllerConfigurationCCValues.dimmingDuration(
-							propertyKey,
-						).endpoint(this.endpoint.index),
-					) ??
-					Duration.default();
-				return this.set(propertyKey, value, dimmingDuration);
-			}
-		} else if (property === "dimmingDuration") {
-			if (typeof value !== "string" && !(value instanceof Duration)) {
-				throwWrongValueType(
-					this.ccId,
-					property,
-					"duration",
-					typeof value,
-				);
-			}
-
-			const dimmingDuration = Duration.from(value);
-			if (dimmingDuration == undefined) {
-				throw new ZWaveError(
-					`${getCCName(
-						this.ccId,
-					)}: "${property}" could not be set. ${JSON.stringify(
-						value,
-					)} is not a valid duration.`,
-					ZWaveErrorCodes.Argument_Invalid,
-				);
-			}
-
-			const valueDB = this.tryGetValueDB();
-			const sceneId = valueDB?.getValue<number>(
-				SceneControllerConfigurationCCValues.sceneId(
-					propertyKey,
-				).endpoint(this.endpoint.index),
-			);
-			if (sceneId == undefined || sceneId === 0) {
-				if (valueDB) {
-					// Can't actually send dimmingDuration without valid sceneId
-					// So we save it in the valueDB without sending it to the node
-					const dimmingDurationValueId =
-						SceneControllerConfigurationCCValues.dimmingDuration(
-							propertyKey,
-						).endpoint(this.endpoint.index);
-					valueDB.setValue(dimmingDurationValueId, dimmingDuration);
-				}
-				return;
-			}
-
-			return this.set(propertyKey, sceneId, dimmingDuration);
-		} else {
-			throwUnsupportedProperty(this.ccId, property);
-		}
-	};
-
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-		propertyKey,
-	}): Promise<unknown> => {
-		switch (property) {
-			case "sceneId":
-			case "dimmingDuration": {
-				if (propertyKey == undefined) {
-					throwMissingPropertyKey(this.ccId, property);
-				} else if (typeof propertyKey !== "number") {
-					throwUnsupportedPropertyKey(
+			if (property === "sceneId") {
+				if (typeof value !== "number") {
+					throwWrongValueType(
 						this.ccId,
 						property,
-						propertyKey,
+						"number",
+						typeof value,
 					);
 				}
-				return (await this.get(propertyKey))?.[property];
-			}
-			default:
+
+				if (value === 0) {
+					// Disable Group ID / Scene ID
+					return this.disable(propertyKey);
+				} else {
+					// We need to set the dimming duration along with the scene ID
+					// Dimming duration is chosen with the following precedence:
+					// 1. options.transitionDuration
+					// 2. current stored value
+					// 3. default value
+					const dimmingDuration =
+						Duration.from(options?.transitionDuration) ??
+						this.tryGetValueDB()?.getValue<Duration>(
+							SceneControllerConfigurationCCValues.dimmingDuration(
+								propertyKey,
+							).endpoint(this.endpoint.index),
+						) ??
+						Duration.default();
+					return this.set(propertyKey, value, dimmingDuration);
+				}
+			} else if (property === "dimmingDuration") {
+				if (typeof value !== "string" && !(value instanceof Duration)) {
+					throwWrongValueType(
+						this.ccId,
+						property,
+						"duration",
+						typeof value,
+					);
+				}
+
+				const dimmingDuration = Duration.from(value);
+				if (dimmingDuration == undefined) {
+					throw new ZWaveError(
+						`${getCCName(
+							this.ccId,
+						)}: "${property}" could not be set. ${JSON.stringify(
+							value,
+						)} is not a valid duration.`,
+						ZWaveErrorCodes.Argument_Invalid,
+					);
+				}
+
+				const valueDB = this.tryGetValueDB();
+				const sceneId = valueDB?.getValue<number>(
+					SceneControllerConfigurationCCValues.sceneId(
+						propertyKey,
+					).endpoint(this.endpoint.index),
+				);
+				if (sceneId == undefined || sceneId === 0) {
+					if (valueDB) {
+						// Can't actually send dimmingDuration without valid sceneId
+						// So we save it in the valueDB without sending it to the node
+						const dimmingDurationValueId =
+							SceneControllerConfigurationCCValues.dimmingDuration(
+								propertyKey,
+							).endpoint(this.endpoint.index);
+						valueDB.setValue(
+							dimmingDurationValueId,
+							dimmingDuration,
+						);
+					}
+					return;
+				}
+
+				return this.set(propertyKey, sceneId, dimmingDuration);
+			} else {
 				throwUnsupportedProperty(this.ccId, property);
-		}
-	};
+			}
+		};
+	}
+
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (
+			this: SceneControllerConfigurationCCAPI,
+			{ property, propertyKey },
+		) {
+			switch (property) {
+				case "sceneId":
+				case "dimmingDuration": {
+					if (propertyKey == undefined) {
+						throwMissingPropertyKey(this.ccId, property);
+					} else if (typeof propertyKey !== "number") {
+						throwUnsupportedPropertyKey(
+							this.ccId,
+							property,
+							propertyKey,
+						);
+					}
+					return (await this.get(propertyKey))?.[property];
+				}
+				default:
+					throwUnsupportedProperty(this.ccId, property);
+			}
+		};
+	}
 
 	@validateArgs()
 	public async disable(

--- a/packages/cc/src/cc/ThermostatFanModeCC.ts
+++ b/packages/cc/src/cc/ThermostatFanModeCC.ts
@@ -84,74 +84,79 @@ export class ThermostatFanModeCCAPI extends CCAPI {
 		return super.supportsCommand(cmd);
 	}
 
-	protected [SET_VALUE]: SetValueImplementation = async (
-		{ property },
-		value,
-	) => {
-		const valueDB = this.getValueDB();
-		let result: SupervisionResult | undefined;
+	protected override get [SET_VALUE](): SetValueImplementation {
+		return async function (
+			this: ThermostatFanModeCCAPI,
+			{ property },
+			value,
+		) {
+			const valueDB = this.getValueDB();
+			let result: SupervisionResult | undefined;
 
-		if (property === "mode") {
-			if (typeof value !== "number") {
-				throwWrongValueType(
-					this.ccId,
-					property,
-					"number",
-					typeof value,
+			if (property === "mode") {
+				if (typeof value !== "number") {
+					throwWrongValueType(
+						this.ccId,
+						property,
+						"number",
+						typeof value,
+					);
+				}
+				// Preserve the value of the "off" flag
+				const off = valueDB.getValue<boolean>(
+					ThermostatFanModeCCValues.turnedOff.endpoint(
+						this.endpoint.index,
+					),
 				);
-			}
-			// Preserve the value of the "off" flag
-			const off = valueDB.getValue<boolean>(
-				ThermostatFanModeCCValues.turnedOff.endpoint(
-					this.endpoint.index,
-				),
-			);
-			result = await this.set(value, off);
-		} else if (property === "off") {
-			if (typeof value !== "boolean") {
-				throwWrongValueType(
-					this.ccId,
-					property,
-					"boolean",
-					typeof value,
+				result = await this.set(value, off);
+			} else if (property === "off") {
+				if (typeof value !== "boolean") {
+					throwWrongValueType(
+						this.ccId,
+						property,
+						"boolean",
+						typeof value,
+					);
+				}
+				const mode = valueDB.getValue<ThermostatFanMode>(
+					ThermostatFanModeCCValues.fanMode.endpoint(
+						this.endpoint.index,
+					),
 				);
-			}
-			const mode = valueDB.getValue<ThermostatFanMode>(
-				ThermostatFanModeCCValues.fanMode.endpoint(this.endpoint.index),
-			);
-			if (mode == undefined) {
-				throw new ZWaveError(
-					`The "off" property cannot be changed before the fan mode is known!`,
-					ZWaveErrorCodes.Argument_Invalid,
-				);
-			}
-			result = await this.set(mode, value);
-		} else {
-			throwUnsupportedProperty(this.ccId, property);
-		}
-
-		// Verify the current value after a delay, unless the command was supervised and successful
-		if (this.isSinglecast() && !supervisedCommandSucceeded(result)) {
-			// TODO: Ideally this would be a short delay, but some thermostats like Remotec ZXT-600
-			// aren't able to handle the GET this quickly.
-			this.schedulePoll({ property }, value);
-		}
-
-		return result;
-	};
-
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-	}): Promise<unknown> => {
-		switch (property) {
-			case "mode":
-			case "off":
-				return (await this.get())?.[property];
-
-			default:
+				if (mode == undefined) {
+					throw new ZWaveError(
+						`The "off" property cannot be changed before the fan mode is known!`,
+						ZWaveErrorCodes.Argument_Invalid,
+					);
+				}
+				result = await this.set(mode, value);
+			} else {
 				throwUnsupportedProperty(this.ccId, property);
-		}
-	};
+			}
+
+			// Verify the current value after a delay, unless the command was supervised and successful
+			if (this.isSinglecast() && !supervisedCommandSucceeded(result)) {
+				// TODO: Ideally this would be a short delay, but some thermostats like Remotec ZXT-600
+				// aren't able to handle the GET this quickly.
+				this.schedulePoll({ property }, value);
+			}
+
+			return result;
+		};
+	}
+
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (this: ThermostatFanModeCCAPI, { property }) {
+			switch (property) {
+				case "mode":
+				case "off":
+					return (await this.get())?.[property];
+
+				default:
+					throwUnsupportedProperty(this.ccId, property);
+			}
+		};
+	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	public async get() {

--- a/packages/cc/src/cc/ThermostatFanStateCC.ts
+++ b/packages/cc/src/cc/ThermostatFanStateCC.ts
@@ -52,17 +52,17 @@ export class ThermostatFanStateCCAPI extends CCAPI {
 		return super.supportsCommand(cmd);
 	}
 
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-	}): Promise<unknown> => {
-		switch (property) {
-			case "state":
-				return this.get();
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (this: ThermostatFanStateCCAPI, { property }) {
+			switch (property) {
+				case "state":
+					return this.get();
 
-			default:
-				throwUnsupportedProperty(this.ccId, property);
-		}
-	};
+				default:
+					throwUnsupportedProperty(this.ccId, property);
+			}
+		};
+	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	public async get() {

--- a/packages/cc/src/cc/ThermostatOperatingStateCC.ts
+++ b/packages/cc/src/cc/ThermostatOperatingStateCC.ts
@@ -58,16 +58,19 @@ export class ThermostatOperatingStateCCAPI extends PhysicalCCAPI {
 		return super.supportsCommand(cmd);
 	}
 
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-	}): Promise<unknown> => {
-		switch (property) {
-			case "state":
-				return this.get();
-			default:
-				throwUnsupportedProperty(this.ccId, property);
-		}
-	};
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (
+			this: ThermostatOperatingStateCCAPI,
+			{ property },
+		) {
+			switch (property) {
+				case "state":
+					return this.get();
+				default:
+					throwUnsupportedProperty(this.ccId, property);
+			}
+		};
+	}
 
 	public async get(): Promise<ThermostatOperatingState | undefined> {
 		this.assertSupportsCommand(

--- a/packages/cc/src/cc/ThermostatSetbackCC.ts
+++ b/packages/cc/src/cc/ThermostatSetbackCC.ts
@@ -76,18 +76,18 @@ export class ThermostatSetbackCCAPI extends CCAPI {
 		return super.supportsCommand(cmd);
 	}
 
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-	}): Promise<unknown> => {
-		switch (property) {
-			case "setbackType":
-			case "setbackState":
-				return (await this.get())?.[property];
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (this: ThermostatSetbackCCAPI, { property }) {
+			switch (property) {
+				case "setbackType":
+				case "setbackState":
+					return (await this.get())?.[property];
 
-			default:
-				throwUnsupportedProperty(this.ccId, property);
-		}
-	};
+				default:
+					throwUnsupportedProperty(this.ccId, property);
+			}
+		};
+	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	public async get() {

--- a/packages/cc/src/cc/ThermostatSetpointCC.ts
+++ b/packages/cc/src/cc/ThermostatSetpointCC.ts
@@ -119,64 +119,78 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 		return super.supportsCommand(cmd);
 	}
 
-	protected [SET_VALUE]: SetValueImplementation = async (
-		{ property, propertyKey },
-		value,
-	) => {
-		if (property !== "setpoint") {
-			throwUnsupportedProperty(this.ccId, property);
-		}
-		if (typeof propertyKey !== "number") {
-			throw new ZWaveError(
-				`${
-					CommandClasses[this.ccId]
-				}: "${property}" must be further specified by a numeric property key`,
-				ZWaveErrorCodes.Argument_Invalid,
-			);
-		}
-		if (typeof value !== "number") {
-			throwWrongValueType(this.ccId, property, "number", typeof value);
-		}
-
-		// SDS14223: The Scale field value MUST be identical to the value received in the Thermostat Setpoint Report for the
-		// actual Setpoint Type during the node interview. Fall back to the first scale if none is known
-		const preferredScale = this.tryGetValueDB()?.getValue<number>(
-			ThermostatSetpointCCValues.setpointScale(propertyKey).endpoint(
-				this.endpoint.index,
-			),
-		);
-		const result = await this.set(propertyKey, value, preferredScale ?? 0);
-
-		// Verify the current value after a delay, unless the command was supervised and successful
-		if (this.isSinglecast() && !supervisedCommandSucceeded(result)) {
-			// TODO: Ideally this would be a short delay, but some thermostats like Remotec ZXT-600
-			// aren't able to handle the GET this quickly.
-			this.schedulePoll({ property, propertyKey }, value);
-		}
-
-		return result;
-	};
-
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-		propertyKey,
-	}): Promise<unknown> => {
-		switch (property) {
-			case "setpoint":
-				if (typeof propertyKey !== "number") {
-					throw new ZWaveError(
-						`${
-							CommandClasses[this.ccId]
-						}: "${property}" must be further specified by a numeric property key`,
-						ZWaveErrorCodes.Argument_Invalid,
-					);
-				}
-
-				return (await this.get(propertyKey))?.value;
-			default:
+	protected override get [SET_VALUE](): SetValueImplementation {
+		return async function (
+			this: ThermostatSetpointCCAPI,
+			{ property, propertyKey },
+			value,
+		) {
+			if (property !== "setpoint") {
 				throwUnsupportedProperty(this.ccId, property);
-		}
-	};
+			}
+			if (typeof propertyKey !== "number") {
+				throw new ZWaveError(
+					`${
+						CommandClasses[this.ccId]
+					}: "${property}" must be further specified by a numeric property key`,
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
+			if (typeof value !== "number") {
+				throwWrongValueType(
+					this.ccId,
+					property,
+					"number",
+					typeof value,
+				);
+			}
+
+			// SDS14223: The Scale field value MUST be identical to the value received in the Thermostat Setpoint Report for the
+			// actual Setpoint Type during the node interview. Fall back to the first scale if none is known
+			const preferredScale = this.tryGetValueDB()?.getValue<number>(
+				ThermostatSetpointCCValues.setpointScale(propertyKey).endpoint(
+					this.endpoint.index,
+				),
+			);
+			const result = await this.set(
+				propertyKey,
+				value,
+				preferredScale ?? 0,
+			);
+
+			// Verify the current value after a delay, unless the command was supervised and successful
+			if (this.isSinglecast() && !supervisedCommandSucceeded(result)) {
+				// TODO: Ideally this would be a short delay, but some thermostats like Remotec ZXT-600
+				// aren't able to handle the GET this quickly.
+				this.schedulePoll({ property, propertyKey }, value);
+			}
+
+			return result;
+		};
+	}
+
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (
+			this: ThermostatSetpointCCAPI,
+			{ property, propertyKey },
+		) {
+			switch (property) {
+				case "setpoint":
+					if (typeof propertyKey !== "number") {
+						throw new ZWaveError(
+							`${
+								CommandClasses[this.ccId]
+							}: "${property}" must be further specified by a numeric property key`,
+							ZWaveErrorCodes.Argument_Invalid,
+						);
+					}
+
+					return (await this.get(propertyKey))?.value;
+				default:
+					throwUnsupportedProperty(this.ccId, property);
+			}
+		};
+	}
 
 	@validateArgs()
 	public async get(

--- a/packages/cc/src/cc/TimeParametersCC.ts
+++ b/packages/cc/src/cc/TimeParametersCC.ts
@@ -124,29 +124,28 @@ export class TimeParametersCCAPI extends CCAPI {
 		return super.supportsCommand(cmd);
 	}
 
-	protected [SET_VALUE]: SetValueImplementation = async (
-		{ property },
-		value,
-	) => {
-		if (property !== "dateAndTime") {
-			throwUnsupportedProperty(this.ccId, property);
-		}
-		if (!(value instanceof Date)) {
-			throwWrongValueType(this.ccId, property, "date", typeof value);
-		}
-		return this.set(value);
-	};
-
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-	}): Promise<unknown> => {
-		switch (property) {
-			case "dateAndTime":
-				return this.get();
-			default:
+	protected override get [SET_VALUE](): SetValueImplementation {
+		return async function (this: TimeParametersCCAPI, { property }, value) {
+			if (property !== "dateAndTime") {
 				throwUnsupportedProperty(this.ccId, property);
-		}
-	};
+			}
+			if (!(value instanceof Date)) {
+				throwWrongValueType(this.ccId, property, "date", typeof value);
+			}
+			return this.set(value);
+		};
+	}
+
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (this: TimeParametersCCAPI, { property }) {
+			switch (property) {
+				case "dateAndTime":
+					return this.get();
+				default:
+					throwUnsupportedProperty(this.ccId, property);
+			}
+		};
+	}
 
 	public async get(): Promise<Date | undefined> {
 		this.assertSupportsCommand(

--- a/packages/cc/src/cc/UserCodeCC.ts
+++ b/packages/cc/src/cc/UserCodeCC.ts
@@ -282,111 +282,34 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 		return super.supportsCommand(cmd);
 	}
 
-	protected [SET_VALUE]: SetValueImplementation = async (
-		{ property, propertyKey },
-		value,
-	) => {
-		let result: SupervisionResult | undefined;
-		if (property === "keypadMode") {
-			if (typeof value !== "number") {
-				throwWrongValueType(
-					this.ccId,
-					property,
-					"number",
-					typeof value,
-				);
-			}
-			result = await this.setKeypadMode(value);
-		} else if (property === "masterCode") {
-			if (typeof value !== "string") {
-				throwWrongValueType(
-					this.ccId,
-					property,
-					"string",
-					typeof value,
-				);
-			}
-			result = await this.setMasterCode(value);
-		} else if (property === "userIdStatus") {
-			if (propertyKey == undefined) {
-				throwMissingPropertyKey(this.ccId, property);
-			} else if (typeof propertyKey !== "number") {
-				throwUnsupportedPropertyKey(this.ccId, property, propertyKey);
-			}
-			if (typeof value !== "number") {
-				throwWrongValueType(
-					this.ccId,
-					property,
-					"number",
-					typeof value,
-				);
-			}
-
-			if (value === UserIDStatus.Available) {
-				// Clear Code
-				result = await this.clear(propertyKey);
-			} else {
-				// We need to set the user code along with the status
-				const userCode = this.getValueDB().getValue<string>(
-					UserCodeCCValues.userCode(propertyKey).endpoint(
-						this.endpoint.index,
-					),
-				);
-				result = await this.set(propertyKey, value, userCode!);
-			}
-		} else if (property === "userCode") {
-			if (propertyKey == undefined) {
-				throwMissingPropertyKey(this.ccId, property);
-			} else if (typeof propertyKey !== "number") {
-				throwUnsupportedPropertyKey(this.ccId, property, propertyKey);
-			}
-			if (typeof value !== "string" && !Buffer.isBuffer(value)) {
-				throwWrongValueType(
-					this.ccId,
-					property,
-					"string or Buffer",
-					typeof value,
-				);
-			}
-
-			// We need to set the user id status along with the code
-			let userIdStatus = this.getValueDB().getValue<UserIDStatus>(
-				UserCodeCCValues.userIdStatus(propertyKey).endpoint(
-					this.endpoint.index,
-				),
-			);
-			if (
-				userIdStatus === UserIDStatus.Available ||
-				userIdStatus == undefined
-			) {
-				userIdStatus = UserIDStatus.Enabled;
-			}
-			result = await this.set(propertyKey, userIdStatus as any, value);
-		} else {
-			throwUnsupportedProperty(this.ccId, property);
-		}
-
-		// Verify the change after a short delay, unless the command was supervised and successful
-		if (this.isSinglecast() && !supervisedCommandSucceeded(result)) {
-			this.schedulePoll({ property, propertyKey }, value, {
-				transition: "fast",
-			});
-		}
-
-		return result;
-	};
-
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-		propertyKey,
-	}): Promise<unknown> => {
-		switch (property) {
-			case "keypadMode":
-				return this.getKeypadMode();
-			case "masterCode":
-				return this.getMasterCode();
-			case "userIdStatus":
-			case "userCode": {
+	protected override get [SET_VALUE](): SetValueImplementation {
+		return async function (
+			this: UserCodeCCAPI,
+			{ property, propertyKey },
+			value,
+		) {
+			let result: SupervisionResult | undefined;
+			if (property === "keypadMode") {
+				if (typeof value !== "number") {
+					throwWrongValueType(
+						this.ccId,
+						property,
+						"number",
+						typeof value,
+					);
+				}
+				result = await this.setKeypadMode(value);
+			} else if (property === "masterCode") {
+				if (typeof value !== "string") {
+					throwWrongValueType(
+						this.ccId,
+						property,
+						"string",
+						typeof value,
+					);
+				}
+				result = await this.setMasterCode(value);
+			} else if (property === "userIdStatus") {
 				if (propertyKey == undefined) {
 					throwMissingPropertyKey(this.ccId, property);
 				} else if (typeof propertyKey !== "number") {
@@ -396,12 +319,103 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 						propertyKey,
 					);
 				}
-				return (await this.get(propertyKey))?.[property];
-			}
-			default:
+				if (typeof value !== "number") {
+					throwWrongValueType(
+						this.ccId,
+						property,
+						"number",
+						typeof value,
+					);
+				}
+
+				if (value === UserIDStatus.Available) {
+					// Clear Code
+					result = await this.clear(propertyKey);
+				} else {
+					// We need to set the user code along with the status
+					const userCode = this.getValueDB().getValue<string>(
+						UserCodeCCValues.userCode(propertyKey).endpoint(
+							this.endpoint.index,
+						),
+					);
+					result = await this.set(propertyKey, value, userCode!);
+				}
+			} else if (property === "userCode") {
+				if (propertyKey == undefined) {
+					throwMissingPropertyKey(this.ccId, property);
+				} else if (typeof propertyKey !== "number") {
+					throwUnsupportedPropertyKey(
+						this.ccId,
+						property,
+						propertyKey,
+					);
+				}
+				if (typeof value !== "string" && !Buffer.isBuffer(value)) {
+					throwWrongValueType(
+						this.ccId,
+						property,
+						"string or Buffer",
+						typeof value,
+					);
+				}
+
+				// We need to set the user id status along with the code
+				let userIdStatus = this.getValueDB().getValue<UserIDStatus>(
+					UserCodeCCValues.userIdStatus(propertyKey).endpoint(
+						this.endpoint.index,
+					),
+				);
+				if (
+					userIdStatus === UserIDStatus.Available ||
+					userIdStatus == undefined
+				) {
+					userIdStatus = UserIDStatus.Enabled;
+				}
+				result = await this.set(
+					propertyKey,
+					userIdStatus as any,
+					value,
+				);
+			} else {
 				throwUnsupportedProperty(this.ccId, property);
-		}
-	};
+			}
+
+			// Verify the change after a short delay, unless the command was supervised and successful
+			if (this.isSinglecast() && !supervisedCommandSucceeded(result)) {
+				this.schedulePoll({ property, propertyKey }, value, {
+					transition: "fast",
+				});
+			}
+
+			return result;
+		};
+	}
+
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (this: UserCodeCCAPI, { property, propertyKey }) {
+			switch (property) {
+				case "keypadMode":
+					return this.getKeypadMode();
+				case "masterCode":
+					return this.getMasterCode();
+				case "userIdStatus":
+				case "userCode": {
+					if (propertyKey == undefined) {
+						throwMissingPropertyKey(this.ccId, property);
+					} else if (typeof propertyKey !== "number") {
+						throwUnsupportedPropertyKey(
+							this.ccId,
+							property,
+							propertyKey,
+						);
+					}
+					return (await this.get(propertyKey))?.[property];
+				}
+				default:
+					throwUnsupportedProperty(this.ccId, property);
+			}
+		};
+	}
 
 	public async getUsersCount(): Promise<number | undefined> {
 		this.assertSupportsCommand(

--- a/packages/cc/src/cc/WakeUpCC.ts
+++ b/packages/cc/src/cc/WakeUpCC.ts
@@ -89,39 +89,43 @@ export class WakeUpCCAPI extends CCAPI {
 		return super.supportsCommand(cmd);
 	}
 
-	protected [SET_VALUE]: SetValueImplementation = async (
-		{ property },
-		value,
-	) => {
-		if (property !== "wakeUpInterval") {
-			throwUnsupportedProperty(this.ccId, property);
-		}
-		if (typeof value !== "number") {
-			throwWrongValueType(this.ccId, property, "number", typeof value);
-		}
-		const result = await this.setInterval(
-			value,
-			this.applHost.ownNodeId ?? 1,
-		);
-
-		// Verify the change after a short delay, unless the command was supervised and successful
-		if (this.isSinglecast() && !supervisedCommandSucceeded(result)) {
-			this.schedulePoll({ property }, value, { transition: "fast" });
-		}
-
-		return result;
-	};
-
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-	}): Promise<unknown> => {
-		switch (property) {
-			case "wakeUpInterval":
-				return (await this.getInterval())?.[property];
-			default:
+	protected override get [SET_VALUE](): SetValueImplementation {
+		return async function (this: WakeUpCCAPI, { property }, value) {
+			if (property !== "wakeUpInterval") {
 				throwUnsupportedProperty(this.ccId, property);
-		}
-	};
+			}
+			if (typeof value !== "number") {
+				throwWrongValueType(
+					this.ccId,
+					property,
+					"number",
+					typeof value,
+				);
+			}
+			const result = await this.setInterval(
+				value,
+				this.applHost.ownNodeId ?? 1,
+			);
+
+			// Verify the change after a short delay, unless the command was supervised and successful
+			if (this.isSinglecast() && !supervisedCommandSucceeded(result)) {
+				this.schedulePoll({ property }, value, { transition: "fast" });
+			}
+
+			return result;
+		};
+	}
+
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (this: WakeUpCCAPI, { property }) {
+			switch (property) {
+				case "wakeUpInterval":
+					return (await this.getInterval())?.[property];
+				default:
+					throwUnsupportedProperty(this.ccId, property);
+			}
+		};
+	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	public async getInterval() {

--- a/packages/cc/src/cc/manufacturerProprietary/FibaroCC.ts
+++ b/packages/cc/src/cc/manufacturerProprietary/FibaroCC.ts
@@ -128,64 +128,70 @@ export class FibaroCCAPI extends ManufacturerProprietaryCCAPI {
 		await this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
-	protected [SET_VALUE]: SetValueImplementation = async (
-		{ property, propertyKey },
-		value,
-	) => {
-		if (property !== "fibaro") {
-			throwUnsupportedProperty(this.ccId, property);
-		}
-
-		if (propertyKey === "venetianBlindsPosition") {
-			if (typeof value !== "number") {
-				throwWrongValueType(
-					this.ccId,
-					property,
-					"number",
-					typeof value,
-				);
+	protected override get [SET_VALUE](): SetValueImplementation {
+		return async function (
+			this: FibaroCCAPI,
+			{ property, propertyKey },
+			value,
+		) {
+			if (property !== "fibaro") {
+				throwUnsupportedProperty(this.ccId, property);
 			}
-			await this.fibaroVenetianBlindsSetPosition(value);
-		} else if (propertyKey === "venetianBlindsTilt") {
-			if (typeof value !== "number") {
-				throwWrongValueType(
-					this.ccId,
-					property,
-					"number",
-					typeof value,
-				);
+
+			if (propertyKey === "venetianBlindsPosition") {
+				if (typeof value !== "number") {
+					throwWrongValueType(
+						this.ccId,
+						property,
+						"number",
+						typeof value,
+					);
+				}
+				await this.fibaroVenetianBlindsSetPosition(value);
+			} else if (propertyKey === "venetianBlindsTilt") {
+				if (typeof value !== "number") {
+					throwWrongValueType(
+						this.ccId,
+						property,
+						"number",
+						typeof value,
+					);
+				}
+				await this.fibaroVenetianBlindsSetTilt(value);
+			} else {
+				// unsupported property key, ignore...
+				return;
 			}
-			await this.fibaroVenetianBlindsSetTilt(value);
-		} else {
-			// unsupported property key, ignore...
-			return;
-		}
 
-		// Verify the current value after a delay
-		this.schedulePoll({ property, propertyKey }, value);
+			// Verify the current value after a delay
+			this.schedulePoll({ property, propertyKey }, value);
 
-		return undefined;
-	};
+			return undefined;
+		};
+	}
 
-	protected [POLL_VALUE]: PollValueImplementation = async ({
-		property,
-		propertyKey,
-	}): Promise<unknown> => {
-		if (property !== "fibaro") {
-			throwUnsupportedProperty(this.ccId, property);
-		} else if (propertyKey == undefined) {
-			throwMissingPropertyKey(this.ccId, property);
-		}
+	protected get [POLL_VALUE](): PollValueImplementation {
+		return async function (this: FibaroCCAPI, { property, propertyKey }) {
+			if (property !== "fibaro") {
+				throwUnsupportedProperty(this.ccId, property);
+			} else if (propertyKey == undefined) {
+				throwMissingPropertyKey(this.ccId, property);
+			}
 
-		switch (propertyKey) {
-			case "venetianBlindsPosition":
-				return (await this.fibaroVenetianBlindsGet())?.position;
-			case "venetianBlindsTilt":
-				return (await this.fibaroVenetianBlindsGet())?.tilt;
-			default:
-				throwUnsupportedPropertyKey(this.ccId, property, propertyKey);
-		}
-	};
+			switch (propertyKey) {
+				case "venetianBlindsPosition":
+					return (await this.fibaroVenetianBlindsGet())?.position;
+				case "venetianBlindsTilt":
+					return (await this.fibaroVenetianBlindsGet())?.tilt;
+				default:
+					throwUnsupportedPropertyKey(
+						this.ccId,
+						property,
+						propertyKey,
+					);
+			}
+		};
+	}
 }
 
 @manufacturerId(MANUFACTURERID_FIBARO)

--- a/packages/cc/src/lib/API.ts
+++ b/packages/cc/src/lib/API.ts
@@ -36,6 +36,7 @@ export type ValueIDProperties = Pick<ValueID, "property" | "propertyKey">;
 
 /** Used to identify the method on the CC API class that handles setting values on nodes directly */
 export const SET_VALUE: unique symbol = Symbol.for("CCAPI_SET_VALUE");
+
 export type SetValueImplementation = (
 	property: ValueIDProperties,
 	value: unknown,
@@ -211,9 +212,13 @@ export class CCAPI {
 	 */
 	public readonly ccId: CommandClasses;
 
-	protected [SET_VALUE]: SetValueImplementation | undefined;
+	protected get [SET_VALUE](): SetValueImplementation | undefined {
+		return undefined;
+	}
+
 	/**
-	 * Can be used on supported CC APIs to set a CC value by property name (and optionally the property key)
+	 * Can be used on supported CC APIs to set a CC value by property name (and optionally the property key).
+	 * **WARNING:** This function is NOT bound to an API instance. It must be called with the correct `this` context!
 	 */
 	public get setValue(): SetValueImplementation | undefined {
 		return this[SET_VALUE];
@@ -233,9 +238,12 @@ export class CCAPI {
 		return true;
 	}
 
-	protected [POLL_VALUE]: PollValueImplementation | undefined;
+	protected get [POLL_VALUE](): PollValueImplementation | undefined {
+		return undefined;
+	}
 	/**
 	 * Can be used on supported CC APIs to poll a CC value by property name (and optionally the property key)
+	 * **WARNING:** This function is NOT bound to an API instance. It must be called with the correct `this` context!
 	 */
 	public get pollValue(): PollValueImplementation | undefined {
 		return this[POLL_VALUE]?.bind(this);

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -993,7 +993,12 @@ export class ZWaveNode
 			}
 
 			// And call it
-			const result = await api.setValue!(valueIdProps, value, options);
+			const result = await api.setValue!.call(
+				api,
+				valueIdProps,
+				value,
+				options,
+			);
 
 			if (loglevel === "silly") {
 				let message = `[setValue] result of SET_VALUE API call for ${api.constructor.name}:`;
@@ -1172,7 +1177,7 @@ export class ZWaveNode
 		}
 
 		// And call it
-		return (api.pollValue as PollValueImplementation<T>)({
+		return (api.pollValue as PollValueImplementation<T>).call(api, {
 			property: valueId.property,
 			propertyKey: valueId.propertyKey,
 		});
@@ -1225,7 +1230,7 @@ export class ZWaveNode
 			// clean up after the timeout
 			this.cancelScheduledPoll(valueId);
 			try {
-				await api.pollValue!(valueId);
+				await api.pollValue!.call(api, valueId);
 			} catch {
 				/* ignore */
 			}

--- a/packages/zwave-js/src/lib/node/VirtualNode.ts
+++ b/packages/zwave-js/src/lib/node/VirtualNode.ts
@@ -104,7 +104,8 @@ export class VirtualNode extends VirtualEndpoint implements IVirtualNode {
 			// Check if the setValue method is implemented
 			if (!api.setValue) return false;
 			// And call it
-			await api.setValue(
+			await api.setValue.call(
+				api,
 				{
 					property: valueId.property,
 					propertyKey: valueId.propertyKey,

--- a/packages/zwave-js/src/lib/test/driver/setValueSupervisionWorking.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/setValueSupervisionWorking.test.ts
@@ -1,0 +1,96 @@
+import {
+	MultilevelSwitchCCValues,
+	SupervisionCCGet,
+	SupervisionCCReport,
+} from "@zwave-js/cc";
+import { CommandClasses, Duration, SupervisionStatus } from "@zwave-js/core";
+import {
+	createMockZWaveRequestFrame,
+	MockNodeBehavior,
+	MockZWaveFrameType,
+} from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import { integrationTest } from "../integrationTestSuite";
+
+integrationTest(
+	`Regression test for #5825: Update values when "Success" is received after an initial "Working" result`,
+	{
+		debug: true,
+		// provisioningDirectory: path.join(
+		// 	__dirname,
+		// 	"__fixtures/supervision_binary_switch",
+		// ),
+
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses["Multilevel Switch"],
+				CommandClasses.Supervision,
+			],
+		},
+
+		customSetup: async (_driver, _controller, mockNode) => {
+			// When receiving a Supervision Get, first respond with "Working" and after a delay with "Success"
+			const respondToSupervisionGet: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof SupervisionCCGet
+					) {
+						let cc = new SupervisionCCReport(self.host, {
+							nodeId: controller.host.ownNodeId,
+							sessionId: frame.payload.sessionId,
+							moreUpdatesFollow: true,
+							status: SupervisionStatus.Working,
+							duration: new Duration(10, "seconds"),
+						});
+						await self.sendToController(
+							createMockZWaveRequestFrame(cc, {
+								ackRequested: false,
+							}),
+						);
+
+						await wait(2000);
+
+						cc = new SupervisionCCReport(self.host, {
+							nodeId: controller.host.ownNodeId,
+							sessionId: frame.payload.sessionId,
+							moreUpdatesFollow: false,
+							status: SupervisionStatus.Success,
+						});
+						await self.sendToController(
+							createMockZWaveRequestFrame(cc, {
+								ackRequested: false,
+							}),
+						);
+
+						return true;
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(respondToSupervisionGet);
+		},
+		testBody: async (t, driver, node, _mockController, _mockNode) => {
+			const targetValueId = MultilevelSwitchCCValues.targetValue.id;
+			const currentValueId = MultilevelSwitchCCValues.currentValue.id;
+
+			t.is(node.getValue(targetValueId), undefined);
+			t.is(node.getValue(currentValueId), undefined);
+
+			await node.setValue(targetValueId, 55);
+
+			t.is(node.getValue(targetValueId), 55);
+			t.is(node.getValue(currentValueId), undefined);
+
+			// Unchanged after 0.5s
+			await wait(500);
+			t.is(node.getValue(targetValueId), 55);
+			t.is(node.getValue(currentValueId), undefined);
+
+			// Updated after 2.5s
+			await wait(2000);
+			t.is(node.getValue(targetValueId), 55);
+			t.is(node.getValue(currentValueId), 55);
+		},
+	},
+);

--- a/packages/zwave-js/src/lib/test/driver/setValueSupervisionWorking.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/setValueSupervisionWorking.test.ts
@@ -15,7 +15,7 @@ import { integrationTest } from "../integrationTestSuite";
 integrationTest(
 	`Regression test for #5825: Update values when "Success" is received after an initial "Working" result`,
 	{
-		debug: true,
+		// debug: true,
 		// provisioningDirectory: path.join(
 		// 	__dirname,
 		// 	"__fixtures/supervision_binary_switch",


### PR DESCRIPTION
Well, this was fun. As it turns out, the arrow functions we used for the API-specific SET_VALUE and POLL_VALUE implementations made it impossible to pass in `commandOptions`.

A huge refactor later, this is now possible.

fixes: #5825