### PR TITLE
fix: evaluate `setValue` hooks on virtual nodes

### DIFF
--- a/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
+++ b/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
@@ -70,6 +70,9 @@ import {
 	RequestNodeInfoResponse,
 } from "../serialapi/network-mgmt/RequestNodeInfoMessages";
 import {
+	SendDataMulticastRequest,
+	SendDataMulticastRequestTransmitReport,
+	SendDataMulticastResponse,
 	SendDataRequest,
 	SendDataRequestTransmitReport,
 	SendDataResponse,
@@ -342,6 +345,142 @@ const handleSendData: MockControllerBehavior = {
 	},
 };
 
+const handleSendDataMulticast: MockControllerBehavior = {
+	async onHostMessage(host, controller, msg) {
+		if (msg instanceof SendDataMulticastRequest) {
+			// Check if this command is legal right now
+			const state = controller.state.get(
+				MockControllerStateKeys.CommunicationState,
+			) as MockControllerCommunicationState | undefined;
+			if (
+				state != undefined &&
+				state !== MockControllerCommunicationState.Idle
+			) {
+				throw new Error(
+					"Received SendDataMulticastRequest while not idle",
+				);
+			}
+
+			// Put the controller into sending state
+			controller.state.set(
+				MockControllerStateKeys.CommunicationState,
+				MockControllerCommunicationState.Sending,
+			);
+
+			// We deferred parsing of the CC because it requires the node's host to do so.
+			// Now we can do that. Also set the CC node ID to the controller's own node ID,
+			// so CC knows it came from the controller's node ID.
+			const nodeIds = msg["_nodeIds"]!;
+
+			const ackPromises = nodeIds.map((nodeId) => {
+				const node = controller.nodes.get(nodeId)!;
+				// Simulate the frame being transmitted via radio
+				const ackPromise = wait(node.capabilities.txDelay).then(() => {
+					// Deserialize on the node after a short delay
+					try {
+						msg.command = CommandClass.from(node.host, {
+							nodeId: controller.host.ownNodeId,
+							data: msg.payload,
+							origin: MessageOrigin.Host,
+						});
+					} catch (e) {
+						let handled = false;
+						if (isZWaveError(e)) {
+							// We want to know when we're using a command in tests that cannot be decoded yet
+							if (
+								e.code ===
+								ZWaveErrorCodes.Deserialization_NotImplemented
+							) {
+								console.error(e.message);
+							} else if (
+								e.code === ZWaveErrorCodes.CC_NotImplemented
+							) {
+								// The whole CC is not implemented yet. If this happens in tests, it is because we sent a raw CC.
+								try {
+									msg.command = new CommandClass(host, {
+										nodeId: controller.host.ownNodeId,
+										ccId: msg.payload[0],
+										ccCommand: msg.payload[1],
+										payload: msg.payload.slice(2),
+									});
+									handled = true;
+								} catch (e: any) {
+									console.error(e.message);
+								}
+							}
+						}
+
+						if (!handled) throw e;
+					}
+
+					// Send the data to the node
+					const frame = createMockZWaveRequestFrame(msg.command, {
+						ackRequested: !!(
+							msg.transmitOptions & TransmitOptions.ACK
+						),
+					});
+
+					return controller.sendToNode(node, frame);
+				});
+				return ackPromise;
+			});
+
+			// Notify the host that the message was sent
+			const res = new SendDataMulticastResponse(host, {
+				wasSent: true,
+			});
+			await controller.sendToHost(res.serialize());
+
+			if (msg.callbackId !== 0) {
+				// Put the controller into waiting state
+				controller.state.set(
+					MockControllerStateKeys.CommunicationState,
+					MockControllerCommunicationState.WaitingForNode,
+				);
+
+				// Wait for the ACKs and notify the host
+				let ack = false;
+				try {
+					const ackResults = await Promise.all(ackPromises);
+					ack = ackResults.every((result) => !!result?.ack);
+				} catch (e) {
+					// We want to know when we're using a command in tests that cannot be decoded yet
+					if (
+						isZWaveError(e) &&
+						e.code ===
+							ZWaveErrorCodes.Deserialization_NotImplemented
+					) {
+						console.error(e.message);
+						throw e;
+					}
+
+					// Treat all other errors as no response
+				}
+				controller.state.set(
+					MockControllerStateKeys.CommunicationState,
+					MockControllerCommunicationState.Idle,
+				);
+
+				const cb = new SendDataMulticastRequestTransmitReport(host, {
+					callbackId: msg.callbackId,
+					transmitStatus: ack
+						? TransmitStatus.OK
+						: TransmitStatus.NoAck,
+				});
+
+				await controller.sendToHost(cb.serialize());
+			} else {
+				// No callback was requested, we're done
+				controller.state.set(
+					MockControllerStateKeys.CommunicationState,
+					MockControllerCommunicationState.Idle,
+				);
+			}
+			return true;
+		}
+	},
+};
+
 const handleRequestNodeInfo: MockControllerBehavior = {
 	async onHostMessage(host, controller, msg) {
 		if (msg instanceof RequestNodeInfoRequest) {
@@ -532,6 +671,7 @@ export function createDefaultBehaviors(): MockControllerBehavior[] {
 		respondToSoftReset,
 		respondToGetNodeProtocolInfo,
 		handleSendData,
+		handleSendDataMulticast,
 		handleRequestNodeInfo,
 		handleAssignSUCReturnRoute,
 		forwardCommandClassesToHost,

--- a/packages/zwave-js/src/lib/test/driver/multicastOptimisticValueUpdate.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/multicastOptimisticValueUpdate.test.ts
@@ -1,0 +1,59 @@
+import { BinarySwitchCCSet, BinarySwitchCCValues } from "@zwave-js/cc";
+import { CommandClasses } from "@zwave-js/core";
+import { MockZWaveFrameType } from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import { integrationTest } from "../integrationTestSuiteMulti";
+
+// Regression test for #5844
+
+integrationTest("multicast setValue: do optimistic value update after ACK", {
+	debug: true,
+	// provisioningDirectory: path.join(
+	// 	__dirname,
+	// 	"__fixtures/supervision_binary_switch",
+	// ),
+
+	nodeCapabilities: [
+		{
+			id: 2,
+			capabilities: {
+				commandClasses: [CommandClasses["Binary Switch"]],
+			},
+		},
+		{
+			id: 3,
+			capabilities: {
+				commandClasses: [CommandClasses["Binary Switch"]],
+			},
+		},
+	],
+
+	testBody: async (t, driver, nodes, mockController, mockNodes) => {
+		const [node2, node3] = nodes;
+
+		t.is(node2.getValue(BinarySwitchCCValues.targetValue.id), undefined);
+		t.is(node3.getValue(BinarySwitchCCValues.targetValue.id), undefined);
+		t.is(node2.getValue(BinarySwitchCCValues.currentValue.id), undefined);
+		t.is(node3.getValue(BinarySwitchCCValues.currentValue.id), undefined);
+
+		const mcGroup = driver.controller.getMulticastGroup([2, 3]);
+
+		await mcGroup.setValue(BinarySwitchCCValues.targetValue.id, true);
+
+		for (const mockNode of mockNodes) {
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request &&
+					frame.payload instanceof BinarySwitchCCSet,
+				{
+					errorMessage: `Node ${mockNode.id} should have received a BinarySwitchCCSet`,
+				},
+			);
+		}
+
+		await wait(100);
+
+		t.is(node2.getValue(BinarySwitchCCValues.currentValue.id), true);
+		t.is(node3.getValue(BinarySwitchCCValues.currentValue.id), true);
+	},
+});

--- a/packages/zwave-js/src/lib/test/integrationTestSuiteMulti.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuiteMulti.ts
@@ -134,8 +134,6 @@ function suite(
 				}
 
 				await Promise.all(promises);
-				console.error(`all nodes ready`);
-
 				process.nextTick(resolve);
 			});
 

--- a/packages/zwave-js/src/lib/test/integrationTestSuiteShared.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuiteShared.ts
@@ -1,0 +1,97 @@
+import { type MockPortBinding } from "@zwave-js/serial/mock";
+import {
+	MockController,
+	MockNode,
+	type MockControllerOptions,
+	type MockNodeOptions,
+} from "@zwave-js/testing";
+import path from "path";
+import {
+	createDefaultMockControllerBehaviors,
+	createDefaultMockNodeBehaviors,
+} from "../../Utils";
+import {
+	createAndStartDriverWithMockPort,
+	type CreateAndStartDriverWithMockPortResult,
+} from "../driver/DriverMock";
+import { type ZWaveOptions } from "../driver/ZWaveOptions";
+
+export function prepareDriver(
+	cacheDir: string = path.join(__dirname, "cache"),
+	logToFile: boolean = false,
+	additionalOptions: Partial<ZWaveOptions> = {},
+): Promise<CreateAndStartDriverWithMockPortResult> {
+	return createAndStartDriverWithMockPort({
+		...additionalOptions,
+		portAddress: "/tty/FAKE",
+		...(logToFile
+			? {
+					logConfig: {
+						filename: path.join(
+							cacheDir,
+							"logs",
+							"zwavejs_%DATE%.log",
+						),
+						logToFile: true,
+						enabled: true,
+						level: "debug",
+					},
+			  }
+			: {}),
+		securityKeys: {
+			S0_Legacy: Buffer.from("0102030405060708090a0b0c0d0e0f10", "hex"),
+			S2_Unauthenticated: Buffer.from(
+				"11111111111111111111111111111111",
+				"hex",
+			),
+			S2_Authenticated: Buffer.from(
+				"22222222222222222222222222222222",
+				"hex",
+			),
+			S2_AccessControl: Buffer.from(
+				"33333333333333333333333333333333",
+				"hex",
+			),
+		},
+		storage: {
+			cacheDir: cacheDir,
+			lockDir: path.join(cacheDir, "locks"),
+		},
+	});
+}
+
+export function prepareMocks(
+	mockPort: MockPortBinding,
+	controller: Pick<
+		MockControllerOptions,
+		"ownNodeId" | "homeId" | "capabilities"
+	> = {},
+	nodes: Pick<MockNodeOptions, "id" | "capabilities">[] = [],
+): {
+	mockController: MockController;
+	mockNodes: MockNode[];
+} {
+	const mockController = new MockController({
+		homeId: 0x7e570001,
+		ownNodeId: 1,
+		...controller,
+		serial: mockPort,
+	});
+	// Apply default behaviors that are required for interacting with the driver correctly
+	mockController.defineBehavior(...createDefaultMockControllerBehaviors());
+
+	const mockNodes: MockNode[] = [];
+	for (const node of nodes) {
+		const mockNode = new MockNode({
+			...node,
+			controller: mockController,
+		});
+		mockController.addNode(mockNode);
+		mockNodes.push(mockNode);
+
+		// Apply default behaviors that are required for interacting with the driver correctly
+		mockNode.defineBehavior(...createDefaultMockNodeBehaviors());
+	}
+
+	return { mockController, mockNodes };
+}


### PR DESCRIPTION
Ok, this was a dumb one. I simply forgot to give the `VirtualNode.setValue` method the same treatment as the `ZWaveNode.setValue` method.

At least the testing framework gained multicast support in the process.

fixes: #5844