### PR TITLE
fix: remove default preference for Celsius scale

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -250,9 +250,7 @@ const defaultOptions: ZWaveOptions = {
 		throttle: "normal",
 	},
 	preferences: {
-		scales: {
-			temperature: "Celsius",
-		},
+		scales: {},
 	},
 };
 


### PR DESCRIPTION
fixes: https://github.com/zwave-js/node-zwave-js/issues/5755