### PR TITLE
fix: do not mark a node as awake when it sends a `NonceGet`

### DIFF
--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -2703,7 +2703,12 @@ protocol version:      ${this.protocolVersion}`;
 		}
 
 		// If we're being queried by another node, treat this as a sign that the other node is awake
-		if (command.constructor.name.endsWith("Get")) {
+		if (
+			command.constructor.name.endsWith("Get") &&
+			// Nonces can be sent while asleep though
+			!(command instanceof SecurityCCNonceGet) &&
+			!(command instanceof Security2CCNonceGet)
+		) {
 			this.markAsAwake();
 		}
 


### PR DESCRIPTION
fixes: https://github.com/zwave-js/node-zwave-js/issues/5854