### PR TITLE
fix: only use `ExtendedUserCodeSet` command for user IDs above 255

### DIFF
--- a/packages/cc/src/cc/UserCodeCC.ts
+++ b/packages/cc/src/cc/UserCodeCC.ts
@@ -502,7 +502,7 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 		>,
 		userCode: string | Buffer,
 	): Promise<SupervisionResult | undefined> {
-		if (this.version > 1 || userId > 255) {
+		if (userId > 255) {
 			return this.setMany([{ userId, userIdStatus, userCode }]);
 		}
 


### PR DESCRIPTION
for https://github.com/zwave-js/zwave-js-ui/discussions/3124