### PR TITLE
feat: change return type of `setValue` to include context on the execution

### DIFF
--- a/docs/getting-started/migrating-to-v11.md
+++ b/docs/getting-started/migrating-to-v11.md
@@ -75,6 +75,32 @@ For config parameters that are defined in configuration files, we have had a bet
 
 However, the type `ConfigValue` has been changed to just `number`, so we treat this as a breaking change.
 
+## Changed `Node.setValue` and `VirtualNode.setValue` to return a `SetValueResult`
+
+Historically, these methods returned a `boolean` indicating whether the value was successfully set or not. While convenient, simply returning `true` or `false` isn't very helpful, especially since Z-Wave JS started using Supervision whereever possible in v10.
+
+For example, it is not possible to know from a simple `true` whether the command was actually executed by the device or whether it just acknowledged an unsupervised command but didn't actually do anything.
+Likewise, returning `false` seems too generic when there are a multitude of possible reasons for this:
+- A value was set on a non-existing endpoint
+- The endpoint does not support the CC
+- The CC is not implemented in Z-Wave JS
+- There is no `setValue` implementation for the CC in Z-Wave JS
+- The command could not be sent
+- The command was sent and received, but the device could not execute it
+- An invalid value was provided
+- ...
+
+To solve this and help applications give better feedback to the user, `Node.setValue` and `VirtualNode.setValue` now return a `SetValueResult` object with the following properties:
+```ts
+type SetValueResult = {
+	status: SetValueStatus;
+	remainingDuration?: Duration;
+	message?: string;
+};
+```
+
+See the [updated documentation](../api/node.md#setValue) for a more detailed explanation on working with `SetValueResult`s.
+
 ## Removed several deprecated method signatures, enums and properties
 
 -   The enum member `NodeType["Routing End Node"]` has been removed. This has been called `"End Node"` since `v9.3.0`

--- a/docs/getting-started/migrating-to-v11.md
+++ b/docs/getting-started/migrating-to-v11.md
@@ -101,6 +101,9 @@ type SetValueResult = {
 
 See the [updated documentation](../api/node.md#setValue) for a more detailed explanation on working with `SetValueResult`s.
 
+Since the result now contains error information, calling `setValue` will no longer emit an `"error"` event in case of a usage error (unimplemented CC, invalid value).
+It will however still throw an error if the communication fails.
+
 ## Removed several deprecated method signatures, enums and properties
 
 -   The enum member `NodeType["Routing End Node"]` has been removed. This has been called `"End Node"` since `v9.3.0`

--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -14592,6 +14592,13 @@ export enum SetbackType {
 // @public
 export type SetValueAPIOptions = Partial<ValueChangeOptions>;
 
+// Warning: (ae-missing-release-tag) "setValueFailed" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function setValueFailed(result: SetValueResult): result is SetValueResult & {
+    status: SetValueStatus.NoDeviceSupport | SetValueStatus.Fail | SetValueStatus.EndpointNotFound | SetValueStatus.NotImplemented | SetValueStatus.InvalidValue;
+};
+
 // Warning: (ae-missing-release-tag) "SetValueImplementation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -14614,6 +14621,55 @@ export type SetValueImplementationHooks = AllOrNone_2<{
 //
 // @public (undocumented)
 export type SetValueImplementationHooksFactory = (property: ValueIDProperties, value: unknown, options?: SetValueAPIOptions) => SetValueImplementationHooks | undefined;
+
+// Warning: (ae-missing-release-tag) "SetValueResult" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export type SetValueResult = {
+    status: SetValueStatus.NoDeviceSupport | SetValueStatus.Fail | SetValueStatus.Success;
+    remainingDuration?: undefined;
+    message?: undefined;
+} | {
+    status: SetValueStatus.Working;
+    remainingDuration: Duration_2;
+    message?: undefined;
+} | {
+    status: SetValueStatus.SuccessUnsupervised;
+    remainingDuration?: undefined;
+    message?: undefined;
+} | {
+    status: SetValueStatus.EndpointNotFound | SetValueStatus.NotImplemented | SetValueStatus.InvalidValue;
+    remainingDuration?: undefined;
+    message: string;
+};
+
+// Warning: (ae-missing-release-tag) "SetValueStatus" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export enum SetValueStatus {
+    EndpointNotFound = 3,
+    Fail = 2,
+    InvalidValue = 5,
+    NoDeviceSupport = 0,
+    NotImplemented = 4,
+    Success = 255,
+    SuccessUnsupervised = 254,
+    Working = 1
+}
+
+// Warning: (ae-missing-release-tag) "setValueSucceeded" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function setValueSucceeded(result: SetValueResult): result is SetValueResult & {
+    status: SetValueStatus.Success | SetValueStatus.Working;
+};
+
+// Warning: (ae-missing-release-tag) "setValueWasUnsupervisedOrSucceeded" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function setValueWasUnsupervisedOrSucceeded(result: SetValueResult): result is SetValueResult & {
+    status: SetValueStatus.SuccessUnsupervised | SetValueStatus.Success | SetValueStatus.Working;
+};
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@publicAPI" is not defined in this configuration
 // Warning: (ae-missing-release-tag) "shouldUseSupervision" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -15043,6 +15099,11 @@ export enum SupervisionCommand {
     // (undocumented)
     Report = 2
 }
+
+// Warning: (ae-missing-release-tag) "supervisionResultToSetValueResult" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function supervisionResultToSetValueResult(result: SupervisionResult_2 | undefined): SetValueResult;
 
 // Warning: (ae-missing-release-tag) "Switchpoint" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/packages/cc/src/lib/API.ts
+++ b/packages/cc/src/lib/API.ts
@@ -76,6 +76,120 @@ export type SetValueImplementationHooksFactory = (
  */
 export type SetValueAPIOptions = Partial<ValueChangeOptions>;
 
+/**
+ * Indicates the status of a `setValue` call. This enum is an extension of `SupervisionStatus`
+ * with additional status codes to indicate errors that are not related to supervision.
+ */
+export enum SetValueStatus {
+	/** The device reports no support for this command */
+	NoDeviceSupport = 0x00,
+	/** The device has accepted the command and is working on it */
+	Working = 0x01,
+	/** The device has rejected the command */
+	Fail = 0x02,
+	/** The endpoint specified in the value ID does not exist */
+	EndpointNotFound = 0x03,
+	/** The given CC or its API is not implemented (yet) or it has no `setValue` implementation */
+	NotImplemented = 0x04,
+	/** The value to set (or a related value) is invalid */
+	InvalidValue = 0x05,
+	/** The command was sent successfully, but it is unknown whether it was executed */
+	SuccessUnsupervised = 0xfe,
+	/** The device has executed the command successfully */
+	Success = 0xff,
+}
+
+/** Indicates the result of a `setValue` call. */
+export type SetValueResult =
+	// Derived from SupervisionResult
+	| {
+			status:
+				| SetValueStatus.NoDeviceSupport
+				| SetValueStatus.Fail
+				| SetValueStatus.Success;
+			remainingDuration?: undefined;
+			message?: undefined;
+	  }
+	| {
+			status: SetValueStatus.Working;
+			remainingDuration: Duration;
+			message?: undefined;
+	  }
+	// Added by setValue
+	| {
+			status: SetValueStatus.SuccessUnsupervised;
+			remainingDuration?: undefined;
+			message?: undefined;
+	  }
+	| {
+			status:
+				| SetValueStatus.EndpointNotFound
+				| SetValueStatus.NotImplemented
+				| SetValueStatus.InvalidValue;
+			remainingDuration?: undefined;
+			message: string;
+	  };
+
+export function supervisionResultToSetValueResult(
+	result: SupervisionResult | undefined,
+): SetValueResult {
+	if (result == undefined) {
+		return {
+			status: SetValueStatus.SuccessUnsupervised,
+		};
+	} else {
+		// @ts-expect-error We only care about the compatible subset of status codes
+		return result;
+	}
+}
+
+/** Tests whether a `SetValueResult` indicates that the device accepted the command. */
+export function setValueSucceeded(
+	result: SetValueResult,
+): result is SetValueResult & {
+	status: SetValueStatus.Success | SetValueStatus.Working;
+} {
+	return (
+		result.status === SetValueStatus.Success ||
+		result.status === SetValueStatus.Working
+	);
+}
+
+/** Tests whether a `SetValueResult` indicates that the command could not be sent or the device did not accept the command. */
+export function setValueFailed(
+	result: SetValueResult,
+): result is SetValueResult & {
+	status:
+		| SetValueStatus.NoDeviceSupport
+		| SetValueStatus.Fail
+		| SetValueStatus.EndpointNotFound
+		| SetValueStatus.NotImplemented
+		| SetValueStatus.InvalidValue;
+} {
+	return (
+		result.status === SetValueStatus.NoDeviceSupport ||
+		result.status === SetValueStatus.Fail ||
+		result.status === SetValueStatus.EndpointNotFound ||
+		result.status === SetValueStatus.NotImplemented ||
+		result.status === SetValueStatus.InvalidValue
+	);
+}
+
+/** Tests whether a `SetValueResult` indicates that the command was sent and that the device maybe accepted the command. */
+export function setValueWasUnsupervisedOrSucceeded(
+	result: SetValueResult,
+): result is SetValueResult & {
+	status:
+		| SetValueStatus.SuccessUnsupervised
+		| SetValueStatus.Success
+		| SetValueStatus.Working;
+} {
+	return (
+		result.status === SetValueStatus.SuccessUnsupervised ||
+		setValueSucceeded(result)
+	);
+}
+
 /** Used to identify the method on the CC API class that handles polling values from nodes */
 export const POLL_VALUE: unique symbol = Symbol.for("CCAPI_POLL_VALUE");
 export type PollValueImplementation<T = unknown> = (

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -128,6 +128,7 @@ import { SensorType } from '@zwave-js/config';
 import type { SerialPort } from 'serialport';
 import { SetbackState } from '@zwave-js/cc';
 import { SetValueAPIOptions } from '@zwave-js/cc';
+import { SetValueResult } from '@zwave-js/cc';
 import { SinglecastCC } from '@zwave-js/core';
 import type { SpecificDeviceClass } from '@zwave-js/config';
 import { Switchpoint } from '@zwave-js/cc';
@@ -1011,7 +1012,7 @@ export class VirtualNode extends VirtualEndpoint implements IVirtualNode {
     readonly nodesBySecurityClass: ReadonlyMap<SecurityClass_2, readonly ZWaveNode[]>;
     // (undocumented)
     readonly physicalNodes: readonly ZWaveNode[];
-    setValue(valueId: ValueID_2, value: unknown, options?: SetValueAPIOptions): Promise<boolean>;
+    setValue(valueId: ValueID_2, value: unknown, options?: SetValueAPIOptions): Promise<SetValueResult>;
 }
 
 // Warning: (ae-missing-release-tag) "VirtualValueID" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1323,7 +1324,7 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner, IZWaveNod
     setDateAndTime(now?: Date): Promise<boolean>;
     // (undocumented)
     setSecurityClass(securityClass: SecurityClass_2, granted: boolean): void;
-    setValue(valueId: ValueID_2, value: unknown, options?: SetValueAPIOptions): Promise<boolean>;
+    setValue(valueId: ValueID_2, value: unknown, options?: SetValueAPIOptions): Promise<SetValueResult>;
     get status(): NodeStatus;
     // (undocumented)
     get supportedDataRates(): MaybeNotKnown<readonly DataRate_2[]>;

--- a/packages/zwave-js/src/lib/node/VirtualNode.ts
+++ b/packages/zwave-js/src/lib/node/VirtualNode.ts
@@ -1,7 +1,10 @@
 import {
 	BasicCCValues,
+	SetValueStatus,
+	supervisionResultToSetValueResult,
 	type CCAPI,
 	type SetValueAPIOptions,
+	type SetValueResult,
 	type ValueIDProperties,
 } from "@zwave-js/cc";
 import {
@@ -10,6 +13,7 @@ import {
 	ZWaveError,
 	ZWaveErrorCodes,
 	actuatorCCs,
+	getCCName,
 	isSupervisionResult,
 	isZWaveError,
 	normalizeValueID,
@@ -97,7 +101,7 @@ export class VirtualNode extends VirtualEndpoint implements IVirtualNode {
 		valueId: ValueID,
 		value: unknown,
 		options?: SetValueAPIOptions,
-	): Promise<boolean> {
+	): Promise<SetValueResult> {
 		// Ensure we're dealing with a valid value ID, with no extra properties
 		valueId = normalizeValueID(valueId);
 
@@ -105,12 +109,26 @@ export class VirtualNode extends VirtualEndpoint implements IVirtualNode {
 		try {
 			// Access the CC API by name
 			const endpointInstance = this.getEndpoint(valueId.endpoint || 0);
-			if (!endpointInstance) return false;
+			if (!endpointInstance) {
+				return {
+					status: SetValueStatus.EndpointNotFound,
+					message: `Endpoint ${
+						valueId.endpoint
+					} does not exist on virtual node ${this.id ?? "??"}`,
+				};
+			}
 			let api = (endpointInstance.commandClasses as any)[
 				valueId.commandClass
 			] as CCAPI;
 			// Check if the setValue method is implemented
-			if (!api.setValue) return false;
+			if (!api.setValue) {
+				return {
+					status: SetValueStatus.NotImplemented,
+					message: `The ${getCCName(
+						valueId.commandClass,
+					)} CC does not support setting values`,
+				};
+			}
 
 			const valueIdProps: ValueIDProperties = {
 				property: valueId.property,
@@ -201,27 +219,30 @@ export class VirtualNode extends VirtualEndpoint implements IVirtualNode {
 				}
 			}
 
-			return true;
+			return supervisionResultToSetValueResult(result);
 		} catch (e) {
-			// Define which errors during setValue are expected and won't crash
-			// the driver:
+			// Define which errors during setValue are expected and won't throw an error
 			if (isZWaveError(e)) {
-				let handled = false;
-				let emitErrorEvent = false;
+				let result: SetValueResult | undefined;
 				switch (e.code) {
 					// This CC or API is not implemented
 					case ZWaveErrorCodes.CC_NotImplemented:
 					case ZWaveErrorCodes.CC_NoAPI:
-						handled = true;
+						result = {
+							status: SetValueStatus.NotImplemented,
+							message: e.message,
+						};
 						break;
 					// A user tried to set an invalid value
 					case ZWaveErrorCodes.Argument_Invalid:
-						handled = true;
-						emitErrorEvent = true;
+						result = {
+							status: SetValueStatus.InvalidValue,
+							message: e.message,
+						};
 						break;
 				}
-				if (emitErrorEvent) this.driver.emit("error", e);
-				if (handled) return false;
+
+				if (result) return result;
 			}
 			throw e;
 		}

--- a/packages/zwave-js/src/lib/test/node/Node.getSetValue.test.ts
+++ b/packages/zwave-js/src/lib/test/node/Node.getSetValue.test.ts
@@ -1,4 +1,4 @@
-import { BasicCommand } from "@zwave-js/cc";
+import { BasicCommand, SetValueStatus } from "@zwave-js/cc";
 import { BasicCC, BasicCCValues } from "@zwave-js/cc/BasicCC";
 import { CommandClasses, ValueMetadata, type ValueID } from "@zwave-js/core";
 import type { ThrowingMap } from "@zwave-js/shared";
@@ -81,7 +81,7 @@ test.serial("setValue() issues the correct xyzCCSet command", async (t) => {
 		5,
 	);
 
-	t.true(result);
+	t.is(result.status, SetValueStatus.SuccessUnsupervised);
 	sinon.assert.called(sendMessage);
 
 	assertCC(t, sendMessage.getCall(0).args[0], {
@@ -102,12 +102,14 @@ test.serial(
 		const node = new ZWaveNode(1, driver);
 		const result = await node.setValue(
 			{
+				// @ts-expect-error
 				commandClass: 0xbada55, // this is guaranteed to not be implemented
 				property: "test",
 			},
 			1,
 		);
-		t.false(result);
+		t.is(result.status, SetValueStatus.NotImplemented);
+		t.regex(result.message!, /Command Class 12245589 is not implemented/);
 		node.destroy();
 	},
 );


### PR DESCRIPTION
This PR changes the return type of `setValue` from `boolean` to `SetValueResult`. While not strictly necessary, this change enables applications to give better feedback to users why a command failed and make better decisions what to do with successful commands.