### PR TITLE
fix(config): remove duplicated battery info on endpoint 0 for Fibaro FGT001

### DIFF
--- a/packages/config/config/devices/0x010f/fgt001.json
+++ b/packages/config/config/devices/0x010f/fgt001.json
@@ -140,6 +140,13 @@
 		// The device has two endpoints with different device classes, but both need to exist
 		"preserveEndpoints": [1, 2],
 		// Not sure if necessary, but this can prevent missing updates on endpoint 1
-		"mapRootReportsToEndpoint": 1
+		"mapRootReportsToEndpoint": 1,
+		"commandClasses": {
+			"remove": {
+				"0x80": {
+					"endpoints": [0]
+				}
+			}
+		}
 	}
 }

--- a/packages/config/config/devices/0x010f/fgt001.json
+++ b/packages/config/config/devices/0x010f/fgt001.json
@@ -141,6 +141,7 @@
 		"preserveEndpoints": [1, 2],
 		// Not sure if necessary, but this can prevent missing updates on endpoint 1
 		"mapRootReportsToEndpoint": 1,
+		// Hide CCs from root endpoint that are duplicated on the manually preserved endpoint 1
 		"commandClasses": {
 			"remove": {
 				"0x80": {


### PR DESCRIPTION
Fix regression. On fibaro thermostat we have 3 endpoints. 0 and 1 are duplicated - main, 2 - is an endpoint for external sensor. With this fix we remove reporting battery on endpoint 0, cause we have same reports on endpoint 1.
