### PR TITLE
fix: remove force-adding of CC support for Z-Wave+ v2

### DIFF
--- a/packages/cc/src/cc/ZWavePlusCC.ts
+++ b/packages/cc/src/cc/ZWavePlusCC.ts
@@ -1,9 +1,7 @@
 import {
 	CommandClasses,
 	MessagePriority,
-	getCCName,
 	validatePayload,
-	type IZWaveEndpoint,
 	type Maybe,
 	type MessageOrCCLogEntry,
 } from "@zwave-js/core/safe";
@@ -156,119 +154,119 @@ user icon:       ${num2hex(zwavePlusResponse.userIcon)}`;
 				direction: "inbound",
 			});
 
-			if (zwavePlusResponse.zwavePlusVersion >= 2) {
-				// A Z-Wave Plus v2 node MUST support:
-				// - Association, version 2
-				// - Association Group Information
-				// - Device Reset Locally
-				// - Firmware Update Meta Data, version 5
-				// - Indicator, version 3
-				// - Manufacturer Specific
-				// - Multi Channel Association, version 3
-				// - Powerlevel
-				// - Security 2
-				// - Supervision
-				// - Transport Service, version 2
-				// - Version, version 2
-				// - Z-Wave Plus Info, version 2
-				//
-				// All Multi Channel End Points MUST support:
-				// - Association, version 2
-				// - Association Group Information
-				// - Multi Channel Association, version 3
-				// - Supervision
-				// - Z-Wave Plus Info, version 2
+			// if (zwavePlusResponse.zwavePlusVersion >= 2) {
+			// 	// A Z-Wave Plus v2 node MUST support:
+			// 	// - Association, version 2
+			// 	// - Association Group Information
+			// 	// - Device Reset Locally
+			// 	// - Firmware Update Meta Data, version 5
+			// 	// - Indicator, version 3
+			// 	// - Manufacturer Specific
+			// 	// - Multi Channel Association, version 3
+			// 	// - Powerlevel
+			// 	// - Security 2
+			// 	// - Supervision
+			// 	// - Transport Service, version 2
+			// 	// - Version, version 2
+			// 	// - Z-Wave Plus Info, version 2
+			// 	//
+			// 	// All Multi Channel End Points MUST support:
+			// 	// - Association, version 2
+			// 	// - Association Group Information
+			// 	// - Multi Channel Association, version 3
+			// 	// - Supervision
+			// 	// - Z-Wave Plus Info, version 2
 
-				// It has been found that some devices are not advertising all of these (looking at you CTT!),
-				// so we force-add support here:
-				const maybeAddCC = (
-					endpoint: IZWaveEndpoint,
-					cc: CommandClasses,
-					version: number,
-				) => {
-					if (
-						!endpoint.supportsCC(cc) ||
-						endpoint.getCCVersion(cc) < version
-					) {
-						applHost.controllerLog.logNode(node.id, {
-							endpoint: this.endpointIndex,
-							message: `force-adding support for mandatory CC ${getCCName(
-								cc,
-							)}${version > 1 ? ` v${version}` : ""}`,
-							level: "warn",
-						});
+			// 	// It has been found that some devices are not advertising all of these (looking at you CTT!),
+			// 	// so we force-add support here:
+			// 	const maybeAddCC = (
+			// 		endpoint: IZWaveEndpoint,
+			// 		cc: CommandClasses,
+			// 		version: number,
+			// 	) => {
+			// 		if (
+			// 			!endpoint.supportsCC(cc) ||
+			// 			endpoint.getCCVersion(cc) < version
+			// 		) {
+			// 			applHost.controllerLog.logNode(node.id, {
+			// 				endpoint: this.endpointIndex,
+			// 				message: `force-adding support for mandatory CC ${getCCName(
+			// 					cc,
+			// 				)}${version > 1 ? ` v${version}` : ""}`,
+			// 				level: "warn",
+			// 			});
 
-						endpoint.addCC(cc, {
-							isSupported: true,
-							version: Math.max(
-								endpoint.getCCVersion(cc),
-								version,
-							),
-						});
-					}
-				};
+			// 			endpoint.addCC(cc, {
+			// 				isSupported: true,
+			// 				version: Math.max(
+			// 					endpoint.getCCVersion(cc),
+			// 					version,
+			// 				),
+			// 			});
+			// 		}
+			// 	};
 
-				const mandatoryCCs: { cc: CommandClasses; version: number }[] =
-					endpoint.index === 0
-						? [
-								{ cc: CommandClasses.Association, version: 2 },
-								{
-									cc: CommandClasses[
-										"Association Group Information"
-									],
-									version: 1,
-								},
-								{
-									cc: CommandClasses["Device Reset Locally"],
-									version: 1,
-								},
-								{
-									cc: CommandClasses[
-										"Firmware Update Meta Data"
-									],
-									version: 5,
-								},
-								{ cc: CommandClasses.Indicator, version: 3 },
-								{
-									cc: CommandClasses["Manufacturer Specific"],
-									version: 1,
-								},
-								{
-									cc: CommandClasses[
-										"Multi Channel Association"
-									],
-									version: 3,
-								},
-								{ cc: CommandClasses.Powerlevel, version: 1 },
-								{ cc: CommandClasses.Security, version: 1 },
-								{ cc: CommandClasses.Supervision, version: 1 },
-								{
-									cc: CommandClasses["Transport Service"],
-									version: 2,
-								},
-								{ cc: CommandClasses.Version, version: 2 },
-						  ]
-						: [
-								{ cc: CommandClasses.Association, version: 2 },
-								{
-									cc: CommandClasses[
-										"Association Group Information"
-									],
-									version: 1,
-								},
-								{
-									cc: CommandClasses[
-										"Multi Channel Association"
-									],
-									version: 3,
-								},
-								{ cc: CommandClasses.Supervision, version: 1 },
-						  ];
+			// 	const mandatoryCCs: { cc: CommandClasses; version: number }[] =
+			// 		endpoint.index === 0
+			// 			? [
+			// 					{ cc: CommandClasses.Association, version: 2 },
+			// 					{
+			// 						cc: CommandClasses[
+			// 							"Association Group Information"
+			// 						],
+			// 						version: 1,
+			// 					},
+			// 					{
+			// 						cc: CommandClasses["Device Reset Locally"],
+			// 						version: 1,
+			// 					},
+			// 					{
+			// 						cc: CommandClasses[
+			// 							"Firmware Update Meta Data"
+			// 						],
+			// 						version: 5,
+			// 					},
+			// 					{ cc: CommandClasses.Indicator, version: 3 },
+			// 					{
+			// 						cc: CommandClasses["Manufacturer Specific"],
+			// 						version: 1,
+			// 					},
+			// 					{
+			// 						cc: CommandClasses[
+			// 							"Multi Channel Association"
+			// 						],
+			// 						version: 3,
+			// 					},
+			// 					{ cc: CommandClasses.Powerlevel, version: 1 },
+			// 					{ cc: CommandClasses.Security, version: 1 },
+			// 					{ cc: CommandClasses.Supervision, version: 1 },
+			// 					{
+			// 						cc: CommandClasses["Transport Service"],
+			// 						version: 2,
+			// 					},
+			// 					{ cc: CommandClasses.Version, version: 2 },
+			// 			  ]
+			// 			: [
+			// 					{ cc: CommandClasses.Association, version: 2 },
+			// 					{
+			// 						cc: CommandClasses[
+			// 							"Association Group Information"
+			// 						],
+			// 						version: 1,
+			// 					},
+			// 					{
+			// 						cc: CommandClasses[
+			// 							"Multi Channel Association"
+			// 						],
+			// 						version: 3,
+			// 					},
+			// 					{ cc: CommandClasses.Supervision, version: 1 },
+			// 			  ];
 
-				for (const { cc, version } of mandatoryCCs) {
-					maybeAddCC(endpoint, cc, version);
-				}
-			}
+			// 	for (const { cc, version } of mandatoryCCs) {
+			// 		maybeAddCC(endpoint, cc, version);
+			// 	}
+			// }
 		}
 
 		// Remember that the interview is complete


### PR DESCRIPTION
This PR removes a hack we added to force-add support for certain mandatory CCs after a node was determined to be Z-Wave+ v2. It is not worth the headaches and https://github.com/zwave-js/node-zwave-js/pull/5905 is a better solution.