### PR TITLE
fix: support decoding certain commands with other security classes than the highest one

### DIFF
--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -51,6 +51,7 @@ import { OnlyMethods } from '@zwave-js/shared';
 import type { ParamInfoMap } from '@zwave-js/config';
 import { ProtocolVersion } from '@zwave-js/core';
 import { ReadonlyObjectKeyMap } from '@zwave-js/shared/safe';
+import { S2SecurityClass } from '@zwave-js/core';
 import { Scale } from '@zwave-js/config';
 import type { Scale as Scale_2 } from '@zwave-js/config/safe';
 import { SecurityClass } from '@zwave-js/core';
@@ -14108,7 +14109,7 @@ export class Security2CC extends CommandClass {
     // (undocumented)
     ccCommand: Security2Command;
     static encapsulate(host: ZWaveHost_2, cc: CommandClass, options?: {
-        securityClass?: SecurityClass;
+        securityClass?: S2SecurityClass;
         multicastOutOfSync?: boolean;
         multicastGroupId?: number;
         verifyDelivery?: boolean;
@@ -14226,6 +14227,8 @@ export class Security2CCMessageEncapsulation extends Security2CC {
     };
     // (undocumented)
     prepareRetransmission(): void;
+    // (undocumented)
+    readonly securityClass?: SecurityClass;
     get sequenceNumber(): number;
     // (undocumented)
     serialize(): Buffer;

--- a/packages/cc/src/cc/Security2CC.ts
+++ b/packages/cc/src/cc/Security2CC.ts
@@ -1541,6 +1541,15 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 				  );
 
 			for (const secClass of possibleSecurityClasses) {
+				// Skip security classes we don't have keys for
+				if (
+					!this.host.securityManager2.hasKeysForSecurityClass(
+						secClass,
+					)
+				) {
+					continue;
+				}
+
 				// Initialize an SPAN with that security class
 				this.host.securityManager2.initializeSPAN(
 					sendingNodeId,

--- a/packages/core/api.md
+++ b/packages/core/api.md
@@ -2169,6 +2169,7 @@ export type SendCommandReturnType<TResponse extends ICommandClass | undefined> =
 //
 // @public (undocumented)
 export type SendCommandSecurityS2Options = {
+    s2OverrideSecurityClass?: S2SecurityClass;
     s2VerifyDelivery?: boolean;
     s2MulticastOutOfSync?: boolean;
     s2MulticastGroupId?: number;

--- a/packages/core/src/consts/Transmission.ts
+++ b/packages/core/src/consts/Transmission.ts
@@ -1,6 +1,7 @@
 import { isObject } from "alcalzone-shared/typeguards";
 import type { ICommandClass } from "../abstractions/ICommandClass";
 import type { ProtocolDataRate } from "../capabilities/Protocols";
+import { type S2SecurityClass } from "../security/SecurityClass";
 import { Duration } from "../values/Duration";
 
 /** The priority of messages, sorted from high (0) to low (>0) */
@@ -216,6 +217,8 @@ export type SupervisionOptions =
 	  };
 
 export type SendCommandSecurityS2Options = {
+	/** Send the command using a different (lower) security class */
+	s2OverrideSecurityClass?: S2SecurityClass;
 	/** Whether delivery of non-supervised SET-type commands is verified by waiting for potential Nonce Reports. Default: true */
 	s2VerifyDelivery?: boolean;
 	/** Whether the MOS extension should be included in S2 message encapsulation. */

--- a/packages/testing/src/MockController.ts
+++ b/packages/testing/src/MockController.ts
@@ -371,7 +371,9 @@ export class MockController {
 			ret = this.expectNodeACK(node, MOCK_FRAME_ACK_TIMEOUT);
 		}
 		process.nextTick(() => {
-			void node.onControllerFrame(frame);
+			void node.onControllerFrame(frame).catch((e) => {
+				console.error(e);
+			});
 		});
 		if (ret) return await ret;
 	}

--- a/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
+++ b/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
@@ -278,7 +278,10 @@ const handleSendData: MockControllerBehavior = {
 						}
 					}
 
-					if (!handled) throw e;
+					if (!handled) {
+						console.error(e);
+						throw e;
+					}
 				}
 
 				// Send the data to the node

--- a/packages/zwave-js/src/lib/driver/MessageGenerators.ts
+++ b/packages/zwave-js/src/lib/driver/MessageGenerators.ts
@@ -569,9 +569,16 @@ export const secureMessageGeneratorS2: MessageGeneratorImplementation =
 		const spanState = secMan.getSPANState(nodeId);
 		let additionalTimeoutMs: number | undefined;
 
+		// We need a new nonce when there is no shared SPAN state, or the SPAN state is for a lower security class
+		// than the command we want to send
+		const expectedSecurityClass =
+			msg.command.securityClass ?? driver.getHighestSecurityClass(nodeId);
+
 		if (
 			spanState.type === SPANState.None ||
-			spanState.type === SPANState.LocalEI
+			spanState.type === SPANState.LocalEI ||
+			(spanState.type === SPANState.SPAN &&
+				spanState.securityClass !== expectedSecurityClass)
 		) {
 			// Request a new nonce
 

--- a/packages/zwave-js/src/lib/driver/MessageGenerators.ts
+++ b/packages/zwave-js/src/lib/driver/MessageGenerators.ts
@@ -33,6 +33,7 @@ import {
 	MessagePriority,
 	NODE_ID_BROADCAST,
 	SPANState,
+	SecurityClass,
 	SupervisionStatus,
 	TransmitOptions,
 	ZWaveError,
@@ -578,6 +579,7 @@ export const secureMessageGeneratorS2: MessageGeneratorImplementation =
 			spanState.type === SPANState.None ||
 			spanState.type === SPANState.LocalEI ||
 			(spanState.type === SPANState.SPAN &&
+				spanState.securityClass !== SecurityClass.Temporary &&
 				spanState.securityClass !== expectedSecurityClass)
 		) {
 			// Request a new nonce

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -13,6 +13,7 @@ import {
 	Powerlevel,
 	PowerlevelTestStatus,
 	ScheduleEntryLockCommand,
+	Security2Command,
 	TimeCCDateGet,
 	TimeCCTimeGet,
 	TimeCCTimeOffsetGet,
@@ -79,6 +80,7 @@ import {
 	Security2CCCommandsSupportedGet,
 	Security2CCNonceGet,
 	Security2CCNonceReport,
+	type Security2CCMessageEncapsulation,
 } from "@zwave-js/cc/Security2CC";
 import {
 	SecurityCCCommandsSupportedGet,
@@ -3471,9 +3473,7 @@ protocol version:      ${this.protocolVersion}`;
 			const { supportedCCs } = determineNIF();
 			await endpoint.commandClasses.Security.reportSupportedCommands(
 				supportedCCs,
-				// The list of controlled CCs is long. We would need to split this
-				// into multiple reports.
-				// FIXME: Do that
+				// We don't report controlled CCs
 				[],
 			);
 		} else {
@@ -3490,9 +3490,32 @@ protocol version:      ${this.protocolVersion}`;
 	): Promise<void> {
 		const endpoint = this.getEndpoint(command.endpointIndex) ?? this;
 
-		await endpoint.commandClasses["Security 2"].reportSupportedCommands(
-			determineNIF().supportedCCs,
-		);
+		const highestSecurityClass = this.getHighestSecurityClass();
+		const actualSecurityClass = (
+			command.getEncapsulatingCC(
+				CommandClasses["Security 2"],
+				Security2Command.MessageEncapsulation,
+			) as Security2CCMessageEncapsulation | undefined
+		)?.securityClass;
+
+		if (
+			highestSecurityClass !== undefined &&
+			highestSecurityClass === actualSecurityClass
+		) {
+			// The command was received using the highest security class. Return the list of supported CCs
+			await endpoint.commandClasses["Security 2"].reportSupportedCommands(
+				determineNIF().supportedCCs,
+			);
+		} else if (securityClassIsS2(actualSecurityClass)) {
+			// The command was received using a lower security class. Return an empty list
+			await endpoint.commandClasses["Security 2"]
+				.withOptions({
+					s2OverrideSecurityClass: actualSecurityClass,
+				})
+				.reportSupportedCommands([]);
+		} else {
+			// Do not respond
+		}
 	}
 
 	/**

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3504,7 +3504,15 @@ protocol version:      ${this.protocolVersion}`;
 		) {
 			// The command was received using the highest security class. Return the list of supported CCs
 			await endpoint.commandClasses["Security 2"].reportSupportedCommands(
-				determineNIF().supportedCCs,
+				determineNIF().supportedCCs.filter(
+					(cc) =>
+						// CC:009F.01.0E.11.00F
+						// The Security 0 and Security 2 Command Class MUST NOT be advertised in this command
+						// The Transport Service Command Class MUST NOT be advertised in this command.
+						cc !== CommandClasses.Security &&
+						cc !== CommandClasses["Security 2"] &&
+						cc !== CommandClasses["Transport Service"],
+				),
 			);
 		} else if (securityClassIsS2(actualSecurityClass)) {
 			// The command was received using a lower security class. Return an empty list

--- a/packages/zwave-js/src/lib/test/compliance/decodeLowerS2Keys.test.ts
+++ b/packages/zwave-js/src/lib/test/compliance/decodeLowerS2Keys.test.ts
@@ -1,12 +1,19 @@
 import {
 	BasicCCSet,
+	Security2CCCommandsSupportedGet,
+	Security2CCCommandsSupportedReport,
 	Security2CCMessageEncapsulation,
+	Security2CCNonceGet,
 	Security2CCNonceReport,
+	TimeCCTimeGet,
+	TimeCCTimeReport,
+	type CommandClass,
 } from "@zwave-js/cc";
 import { SPANState, SecurityClass, SecurityManager2 } from "@zwave-js/core";
 import {
 	MockZWaveFrameType,
 	createMockZWaveRequestFrame,
+	type MockNodeBehavior,
 } from "@zwave-js/testing";
 import { wait } from "alcalzone-shared/async";
 import { randomBytes } from "crypto";
@@ -16,7 +23,7 @@ import { integrationTest } from "../integrationTestSuite";
 integrationTest(
 	"S2 encapsulated commands using a lower security class can be decoded",
 	{
-		debug: true,
+		// debug: true,
 
 		// We need the cache to skip the CC interviews and mark S2 as supported
 		provisioningDirectory: path.join(
@@ -27,43 +34,51 @@ integrationTest(
 		customSetup: async (driver, controller, mockNode) => {
 			// Create a security manager for the node
 			const sm2Node = new SecurityManager2();
-			// The fixtures define Access Control as granted, but we want the node to send the command using Unauthenticated
 			// Copy keys from the driver
+			sm2Node.setKey(
+				SecurityClass.S2_AccessControl,
+				driver.options.securityKeys!.S2_AccessControl!,
+			);
+			sm2Node.setKey(
+				SecurityClass.S2_Authenticated,
+				driver.options.securityKeys!.S2_Authenticated!,
+			);
 			sm2Node.setKey(
 				SecurityClass.S2_Unauthenticated,
 				driver.options.securityKeys!.S2_Unauthenticated!,
 			);
 			mockNode.host.securityManager2 = sm2Node;
-			// The node thinks it must send the command using S2 Unauthenticated
+			// The fixtures define Access Control as granted, but we want the node to send commands using Unauthenticated
 			mockNode.host.getHighestSecurityClass = () =>
 				SecurityClass.S2_Unauthenticated;
 
-			// // Create a security manager for the controller
-			// const smCtrlr = new SecurityManager2();
-			// // Copy keys from the driver
-			// smCtrlr.setKey(
-			// 	SecurityClass.S2_AccessControl,
-			// 	driver.options.securityKeys!.S2_AccessControl!,
-			// );
-			// smCtrlr.setKey(
-			// 	SecurityClass.S2_Authenticated,
-			// 	driver.options.securityKeys!.S2_Authenticated!,
-			// );
-			// smCtrlr.setKey(
-			// 	SecurityClass.S2_Unauthenticated,
-			// 	driver.options.securityKeys!.S2_Unauthenticated!,
-			// );
-			// controller.host.securityManager2 = smCtrlr;
-			// // The controller thinks that the node has the Access Control class
-			// controller.host.getHighestSecurityClass = () =>
-			// 	SecurityClass.S2_AccessControl;
-
-			// const sm0Ctrlr = new SecurityManager({
-			// 	ownNodeId: controller.host.ownNodeId,
-			// 	networkKey: driver.options.securityKeys!.S0_Legacy!,
-			// 	nonceTimeout: 100000,
-			// });
-			// controller.host.securityManager = sm0Ctrlr;
+			// Respond to S2 Nonce Get
+			const respondToS2NonceGet: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof Security2CCNonceGet
+					) {
+						const nonce = sm2Node.generateNonce(
+							controller.host.ownNodeId,
+						);
+						const cc = new Security2CCNonceReport(self.host, {
+							nodeId: controller.host.ownNodeId,
+							SOS: true,
+							MOS: false,
+							receiverEI: nonce,
+						});
+						await self.sendToController(
+							createMockZWaveRequestFrame(cc, {
+								ackRequested: false,
+							}),
+						);
+						return true;
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(respondToS2NonceGet);
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
@@ -82,11 +97,10 @@ integrationTest(
 			);
 
 			// The node sends an S2-encapsulated command, but with a lower security class than expected
-			const innerCC = new BasicCCSet(mockNode.host, {
+			let innerCC: CommandClass = new TimeCCTimeGet(mockNode.host, {
 				nodeId: mockController.host.ownNodeId,
-				targetValue: 0,
 			});
-			const cc = new Security2CCMessageEncapsulation(mockNode.host, {
+			let cc = new Security2CCMessageEncapsulation(mockNode.host, {
 				nodeId: mockController.host.ownNodeId,
 				encapsulated: innerCC,
 			});
@@ -106,6 +120,80 @@ integrationTest(
 				{
 					noMatch: true,
 				},
+			);
+
+			// And the controller should also NOT have answered it
+			mockNode.assertReceivedControllerFrame(
+				(f) =>
+					f.type === MockZWaveFrameType.Request &&
+					f.payload instanceof Security2CCMessageEncapsulation &&
+					f.payload.encapsulated instanceof TimeCCTimeReport,
+				{
+					noMatch: true,
+				},
+			);
+
+			await wait(200);
+
+			mockNode.clearReceivedControllerFrames();
+
+			// Now the node queries our securely supported commands
+			innerCC = new Security2CCCommandsSupportedGet(mockNode.host, {
+				nodeId: mockController.host.ownNodeId,
+			});
+
+			cc = new Security2CCMessageEncapsulation(mockNode.host, {
+				nodeId: mockController.host.ownNodeId,
+				encapsulated: innerCC,
+			});
+
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			await wait(200);
+
+			// The controller should NOT have sent a NonceReport in response
+			mockNode.assertReceivedControllerFrame(
+				(f) =>
+					f.type === MockZWaveFrameType.Request &&
+					f.payload instanceof Security2CCNonceReport,
+				{
+					noMatch: true,
+				},
+			);
+
+			// It should have answered though
+			mockNode.assertReceivedControllerFrame(
+				(f) =>
+					f.type === MockZWaveFrameType.Request &&
+					f.payload instanceof Security2CCMessageEncapsulation &&
+					f.payload.encapsulated instanceof
+						Security2CCCommandsSupportedReport &&
+					f.payload.encapsulated.supportedCCs.length === 0,
+			);
+
+			await wait(200);
+
+			// Sending a new command to the node MUST use the highest shared security class, even if there was a shared SPAN for a lower class
+			mockNode.clearReceivedControllerFrames();
+			await node.commandClasses.Basic.set(0xff);
+
+			await wait(200);
+
+			// The controller MUST have sent a NonceGet
+			mockNode.assertReceivedControllerFrame(
+				(f) =>
+					f.type === MockZWaveFrameType.Request &&
+					f.payload instanceof Security2CCNonceGet,
+			);
+			// And the Basic Set with the sender EI
+			mockNode.assertReceivedControllerFrame(
+				(f) =>
+					f.type === MockZWaveFrameType.Request &&
+					f.payload instanceof Security2CCMessageEncapsulation &&
+					f.payload.encapsulated instanceof BasicCCSet,
 			);
 
 			t.pass();

--- a/packages/zwave-js/src/lib/test/compliance/decodeLowerS2Keys.test.ts
+++ b/packages/zwave-js/src/lib/test/compliance/decodeLowerS2Keys.test.ts
@@ -1,0 +1,114 @@
+import {
+	BasicCCSet,
+	Security2CCMessageEncapsulation,
+	Security2CCNonceReport,
+} from "@zwave-js/cc";
+import { SPANState, SecurityClass, SecurityManager2 } from "@zwave-js/core";
+import {
+	MockZWaveFrameType,
+	createMockZWaveRequestFrame,
+} from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import { randomBytes } from "crypto";
+import path from "path";
+import { integrationTest } from "../integrationTestSuite";
+
+integrationTest(
+	"S2 encapsulated commands using a lower security class can be decoded",
+	{
+		debug: true,
+
+		// We need the cache to skip the CC interviews and mark S2 as supported
+		provisioningDirectory: path.join(
+			__dirname,
+			"fixtures/decodeLowerS2Keys",
+		),
+
+		customSetup: async (driver, controller, mockNode) => {
+			// Create a security manager for the node
+			const sm2Node = new SecurityManager2();
+			// The fixtures define Access Control as granted, but we want the node to send the command using Unauthenticated
+			// Copy keys from the driver
+			sm2Node.setKey(
+				SecurityClass.S2_Unauthenticated,
+				driver.options.securityKeys!.S2_Unauthenticated!,
+			);
+			mockNode.host.securityManager2 = sm2Node;
+			// The node thinks it must send the command using S2 Unauthenticated
+			mockNode.host.getHighestSecurityClass = () =>
+				SecurityClass.S2_Unauthenticated;
+
+			// // Create a security manager for the controller
+			// const smCtrlr = new SecurityManager2();
+			// // Copy keys from the driver
+			// smCtrlr.setKey(
+			// 	SecurityClass.S2_AccessControl,
+			// 	driver.options.securityKeys!.S2_AccessControl!,
+			// );
+			// smCtrlr.setKey(
+			// 	SecurityClass.S2_Authenticated,
+			// 	driver.options.securityKeys!.S2_Authenticated!,
+			// );
+			// smCtrlr.setKey(
+			// 	SecurityClass.S2_Unauthenticated,
+			// 	driver.options.securityKeys!.S2_Unauthenticated!,
+			// );
+			// controller.host.securityManager2 = smCtrlr;
+			// // The controller thinks that the node has the Access Control class
+			// controller.host.getHighestSecurityClass = () =>
+			// 	SecurityClass.S2_AccessControl;
+
+			// const sm0Ctrlr = new SecurityManager({
+			// 	ownNodeId: controller.host.ownNodeId,
+			// 	networkKey: driver.options.securityKeys!.S0_Legacy!,
+			// 	nonceTimeout: 100000,
+			// });
+			// controller.host.securityManager = sm0Ctrlr;
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// Simulate a situation where the node has requested the controller's nonce
+			const controllerEI = randomBytes(16);
+			driver.securityManager2!.setSPANState(mockNode.id, {
+				type: SPANState.LocalEI,
+				receiverEI: controllerEI,
+			});
+			mockNode.host.securityManager2!.setSPANState(
+				mockController.host.ownNodeId,
+				{
+					type: SPANState.RemoteEI,
+					receiverEI: controllerEI,
+				},
+			);
+
+			// The node sends an S2-encapsulated command, but with a lower security class than expected
+			const innerCC = new BasicCCSet(mockNode.host, {
+				nodeId: mockController.host.ownNodeId,
+				targetValue: 0,
+			});
+			const cc = new Security2CCMessageEncapsulation(mockNode.host, {
+				nodeId: mockController.host.ownNodeId,
+				encapsulated: innerCC,
+			});
+
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			await wait(200);
+
+			// The controller should NOT have sent a NonceReport in response
+			mockNode.assertReceivedControllerFrame(
+				(f) =>
+					f.type === MockZWaveFrameType.Request &&
+					f.payload instanceof Security2CCNonceReport,
+				{
+					noMatch: true,
+				},
+			);
+
+			t.pass();
+		},
+	},
+);

--- a/packages/zwave-js/src/lib/test/compliance/fixtures/decodeLowerS2Keys/7e570001.jsonl
+++ b/packages/zwave-js/src/lib/test/compliance/fixtures/decodeLowerS2Keys/7e570001.jsonl
@@ -1,0 +1,35 @@
+{"k":"cacheFormat","v":1}
+{"k":"node.1.isListening","v":true}
+{"k":"node.1.isFrequentListening","v":false}
+{"k":"node.1.isRouting","v":true}
+{"k":"node.1.supportedDataRates","v":[40000,9600,100000]}
+{"k":"node.1.protocolVersion","v":3}
+{"k":"node.1.nodeType","v":"Controller"}
+{"k":"node.1.supportsSecurity","v":false}
+{"k":"node.1.supportsBeaming","v":true}
+{"k":"node.1.deviceClass","v":{"basic":2,"generic":2,"specific":7}}
+{"k":"node.1.endpoint.0.commandClass.0x72","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x86","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x20","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x60","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.interviewStage","v":"Complete"}
+{"k":"node.2.isListening","v":true}
+{"k":"node.2.isFrequentListening","v":false}
+{"k":"node.2.isRouting","v":true}
+{"k":"node.2.supportedDataRates","v":[40000,9600,100000]}
+{"k":"node.2.protocolVersion","v":3}
+{"k":"node.2.nodeType","v":"End Node"}
+{"k":"node.2.supportsSecurity","v":false}
+{"k":"node.2.supportsBeaming","v":true}
+{"k":"node.2.deviceClass","v":{"basic":4,"generic":6,"specific":1}}
+{"k":"node.2.interviewStage","v":"Complete"}
+{"k":"node.2.endpoint.0.commandClass.0x20","v":{"isSupported":true,"isControlled":false,"secure":true,"version":1}}
+{"k":"node.2.endpoint.0.commandClass.0x9f","v":{"isSupported":true,"isControlled":false,"secure":true,"version":1}}
+
+# S2 is supported and Access Control granted (at least we think that)
+{"k":"node.2.securityClasses.S2_AccessControl","v":true}
+{"k":"node.2.securityClasses.S2_Authenticated","v":false}
+{"k":"node.2.securityClasses.S2_Unauthenticated","v":false}
+
+{"k":"node.2.interviewStage","v":"Complete"}
+{"k":"node.2.hasSUCReturnRoute","v":true}

--- a/packages/zwave-js/src/lib/test/compliance/fixtures/decodeLowerS2Keys/7e570001.jsonl
+++ b/packages/zwave-js/src/lib/test/compliance/fixtures/decodeLowerS2Keys/7e570001.jsonl
@@ -26,10 +26,10 @@
 {"k":"node.2.endpoint.0.commandClass.0x20","v":{"isSupported":true,"isControlled":false,"secure":true,"version":1}}
 {"k":"node.2.endpoint.0.commandClass.0x9f","v":{"isSupported":true,"isControlled":false,"secure":true,"version":1}}
 
-# S2 is supported and Access Control granted (at least we think that)
+# S2 is supported and all S2 keys granted (at least we think so)
 {"k":"node.2.securityClasses.S2_AccessControl","v":true}
-{"k":"node.2.securityClasses.S2_Authenticated","v":false}
-{"k":"node.2.securityClasses.S2_Unauthenticated","v":false}
+{"k":"node.2.securityClasses.S2_Authenticated","v":true}
+{"k":"node.2.securityClasses.S2_Unauthenticated","v":true}
 
 {"k":"node.2.interviewStage","v":"Complete"}
 {"k":"node.2.hasSUCReturnRoute","v":true}

--- a/packages/zwave-js/src/lib/test/compliance/secureNodeSecureEndpoint.test.ts
+++ b/packages/zwave-js/src/lib/test/compliance/secureNodeSecureEndpoint.test.ts
@@ -195,11 +195,9 @@ integrationTest(
 						frame.payload.encapsulated instanceof
 							Security2CCCommandsSupportedGet
 					) {
-						const isHighestGranted = frame.payload["key"]?.equals(
-							smNode.getKeysForSecurityClass(
-								self.host.getHighestSecurityClass(self.id)!,
-							).keyCCM,
-						);
+						const isHighestGranted =
+							frame.payload.securityClass ===
+							self.host.getHighestSecurityClass(self.id);
 
 						const cc = Security2CC.encapsulate(
 							self.host,


### PR DESCRIPTION
With this PR, we attempt decoding S2-encapsulated commands with lower granted keys if using the highest one fails. This allows us to answer the secure command queries which are used by other controllers to learn our security classes.

fixes: #5700