### PR TITLE
fix: make guessing the firmware file format case-insensitive

### DIFF
--- a/packages/core/src/util/firmware.ts
+++ b/packages/core/src/util/firmware.ts
@@ -25,6 +25,8 @@ export function guessFirmwareFileFormat(
 	filename: string,
 	rawData: Buffer,
 ): FirmwareFileFormat {
+	filename = filename.toLowerCase();
+
 	if (filename.endsWith(".bin")) {
 		return "bin";
 	} else if (


### PR DESCRIPTION
Apparently some manufacturers distribute files with uppercase extensions.