### PR TITLE
fix(config): remove unnecessary endpoints for RTC CT32

### DIFF
--- a/packages/config/config/devices/0x0098/ct32.json
+++ b/packages/config/config/devices/0x0098/ct32.json
@@ -223,5 +223,10 @@
 				}
 			]
 		}
-	]
+	],
+	"compat": {
+		// The device has two endpoints, but all reports are received via the root.
+		"preserveRootApplicationCCValueIDs": true,
+		"removeEndpoints": "*"
+	}
 }


### PR DESCRIPTION
This device has 2 endpoints + root. As far as I can tell, root and 1 are mirrors, and 2 is a multilevel sensor device which never reports any unsolicited changes. Refreshing endpoint 2 manually just mirrors the values on the other endpoints. All reports are via root.

Prior to v10.18.0, Z-Wave JS exposed only value IDs for the root endpoint. After updating to v10.18.0+ and re-interviewing the device, endpoint 0 is hidden, which breaks existing use (e.g. HA climate entity keyed off of endpoints), while endpoint 1 and endpoint 2 are added instead.

This fixes #5923 by restoring the v10.17.0 behavior: use compat flags to force the root endpoint values to be exposed and hide the endpoints.
