### PR TITLE
fix: allow other devices to configure a single lifeline, send it reset notifications

### DIFF
--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -421,21 +421,24 @@ export class AssociationCCRemove extends AssociationCC {
 //
 // @public (undocumented)
 export class AssociationCCReport extends AssociationCC {
-    constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
+    // Warning: (ae-forgotten-export) The symbol "AssociationCCReportSpecificOptions" needs to be exported by the entry point index.d.ts
+    constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions | (AssociationCCReportSpecificOptions & CCCommandOptions));
     // (undocumented)
     expectMoreMessages(): boolean;
     // (undocumented)
     getPartialCCSessionId(): Record<string, any> | undefined;
     // (undocumented)
-    get groupId(): number;
+    groupId: number;
     // (undocumented)
-    get maxNodes(): number;
+    maxNodes: number;
     // (undocumented)
     mergePartialCCs(applHost: ZWaveApplicationHost_2, partials: AssociationCCReport[]): void;
     // (undocumented)
-    get nodeIds(): readonly number[];
+    nodeIds: number[];
     // (undocumented)
-    get reportsToFollow(): number;
+    reportsToFollow: number;
+    // (undocumented)
+    serialize(): Buffer;
     // (undocumented)
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
@@ -466,9 +469,12 @@ export class AssociationCCSupportedGroupingsGet extends AssociationCC {
 //
 // @public (undocumented)
 export class AssociationCCSupportedGroupingsReport extends AssociationCC {
-    constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
+    // Warning: (ae-forgotten-export) The symbol "AssociationCCSupportedGroupingsReportOptions" needs to be exported by the entry point index.d.ts
+    constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions | AssociationCCSupportedGroupingsReportOptions);
     // (undocumented)
-    get groupCount(): number;
+    groupCount: number;
+    // (undocumented)
+    serialize(): Buffer;
     // (undocumented)
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
@@ -654,11 +660,14 @@ export class AssociationGroupInfoCCCommandListGet extends AssociationGroupInfoCC
 //
 // @public (undocumented)
 export class AssociationGroupInfoCCCommandListReport extends AssociationGroupInfoCC {
-    constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
+    // Warning: (ae-forgotten-export) The symbol "AssociationGroupInfoCCCommandListReportOptions" needs to be exported by the entry point index.d.ts
+    constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions | AssociationGroupInfoCCCommandListReportOptions);
     // (undocumented)
     readonly commands: ReadonlyMap<CommandClasses, readonly number[]>;
     // (undocumented)
     readonly groupId: number;
+    // (undocumented)
+    serialize(): Buffer;
     // (undocumented)
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
@@ -685,7 +694,8 @@ export class AssociationGroupInfoCCInfoGet extends AssociationGroupInfoCC {
 //
 // @public (undocumented)
 export class AssociationGroupInfoCCInfoReport extends AssociationGroupInfoCC {
-    constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
+    // Warning: (ae-forgotten-export) The symbol "AssociationGroupInfoCCInfoReportSpecificOptions" needs to be exported by the entry point index.d.ts
+    constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions | (AssociationGroupInfoCCInfoReportSpecificOptions & CCCommandOptions));
     // Warning: (ae-forgotten-export) The symbol "AssociationGroupInfo" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -696,6 +706,8 @@ export class AssociationGroupInfoCCInfoReport extends AssociationGroupInfoCC {
     readonly isListMode: boolean;
     // (undocumented)
     persistValues(applHost: ZWaveApplicationHost_2): boolean;
+    // (undocumented)
+    serialize(): Buffer;
     // (undocumented)
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
@@ -718,13 +730,16 @@ export class AssociationGroupInfoCCNameGet extends AssociationGroupInfoCC {
 //
 // @public (undocumented)
 export class AssociationGroupInfoCCNameReport extends AssociationGroupInfoCC {
-    constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions);
+    // Warning: (ae-forgotten-export) The symbol "AssociationGroupInfoCCNameReportOptions" needs to be exported by the entry point index.d.ts
+    constructor(host: ZWaveHost_2, options: CommandClassDeserializationOptions | AssociationGroupInfoCCNameReportOptions);
     // (undocumented)
     readonly groupId: number;
     // (undocumented)
     readonly name: string;
     // (undocumented)
     persistValues(applHost: ZWaveApplicationHost_2): boolean;
+    // (undocumented)
+    serialize(): Buffer;
     // (undocumented)
     toLogEntry(applHost: ZWaveApplicationHost_2): MessageOrCCLogEntry_2;
 }
@@ -2598,6 +2613,10 @@ export interface CCAPIs {
     //
     // (undocumented)
     "CRC-16 Encapsulation": CRC16CCAPI;
+    // Warning: (ae-forgotten-export) The symbol "DeviceResetLocallyCCAPI" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    "Device Reset Locally": DeviceResetLocallyCCAPI;
     // Warning: (ae-forgotten-export) The symbol "DoorLockLoggingCCAPI" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)

--- a/packages/cc/src/cc/AssociationCC.ts
+++ b/packages/cc/src/cc/AssociationCC.ts
@@ -122,8 +122,10 @@ export class AssociationCCAPI extends PhysicalCCAPI {
 		switch (cmd) {
 			case AssociationCommand.Get:
 			case AssociationCommand.Set:
+			case AssociationCommand.Report:
 			case AssociationCommand.Remove:
 			case AssociationCommand.SupportedGroupingsGet:
+			case AssociationCommand.SupportedGroupingsReport:
 				return true; // This is mandatory
 			// Not implemented:
 			// case AssociationCommand.SpecificGroupGet:
@@ -154,6 +156,20 @@ export class AssociationCCAPI extends PhysicalCCAPI {
 		if (response) return response.groupCount;
 	}
 
+	public async reportGroupCount(groupCount: number): Promise<void> {
+		this.assertSupportsCommand(
+			AssociationCommand,
+			AssociationCommand.SupportedGroupingsReport,
+		);
+
+		const cc = new AssociationCCSupportedGroupingsReport(this.applHost, {
+			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
+			groupCount,
+		});
+		await this.applHost.sendCommand(cc, this.commandOptions);
+	}
+
 	/**
 	 * Returns information about an association group.
 	 */
@@ -177,6 +193,20 @@ export class AssociationCCAPI extends PhysicalCCAPI {
 				nodeIds: response.nodeIds,
 			};
 		}
+	}
+
+	public async sendReport(options: AssociationCCReportSpecificOptions): Promise<void> {
+		this.assertSupportsCommand(
+			AssociationCommand,
+			AssociationCommand.Report,
+		);
+
+		const cc = new AssociationCCReport(this.applHost, {
+			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
+			...options
+		});
+		await this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
 	/**
@@ -453,11 +483,9 @@ export class AssociationCCSet extends AssociationCC {
 	) {
 		super(host, options);
 		if (gotDeserializationOptions(options)) {
-			// TODO: Deserialize payload
-			throw new ZWaveError(
-				`${this.constructor.name}: deserialization not implemented`,
-				ZWaveErrorCodes.Deserialization_NotImplemented,
-			);
+			validatePayload(this.payload.length >= 2);
+			this.groupId = this.payload[0];
+			this.nodeIds = [...this.payload.slice(1)];
 		} else {
 			if (options.groupId < 1) {
 				throw new ZWaveError(
@@ -516,11 +544,11 @@ export class AssociationCCRemove extends AssociationCC {
 	) {
 		super(host, options);
 		if (gotDeserializationOptions(options)) {
-			// TODO: Deserialize payload
-			throw new ZWaveError(
-				`${this.constructor.name}: deserialization not implemented`,
-				ZWaveErrorCodes.Deserialization_NotImplemented,
-			);
+			validatePayload(this.payload.length >= 1);
+			if (this.payload[0] !== 0) {
+				this.groupId = this.payload[0];
+			}
+			this.nodeIds = [...this.payload.slice(1)];
 		} else {
 			// Validate options
 			if (!options.groupId) {
@@ -572,56 +600,60 @@ export class AssociationCCRemove extends AssociationCC {
 	}
 }
 
+export interface AssociationCCReportSpecificOptions {
+	groupId: number;
+	maxNodes: number;
+	nodeIds: number[];
+	reportsToFollow: number;
+}
+
 @CCCommand(AssociationCommand.Report)
 export class AssociationCCReport extends AssociationCC {
 	public constructor(
 		host: ZWaveHost,
-		options: CommandClassDeserializationOptions,
+		options:
+			| CommandClassDeserializationOptions
+			| (AssociationCCReportSpecificOptions & CCCommandOptions),
 	) {
 		super(host, options);
 
-		validatePayload(this.payload.length >= 3);
-		this._groupId = this.payload[0];
-		this._maxNodes = this.payload[1];
-		this._reportsToFollow = this.payload[2];
-		this._nodeIds = [...this.payload.slice(3)];
+		if (gotDeserializationOptions(options)) {
+			validatePayload(this.payload.length >= 3);
+			this.groupId = this.payload[0];
+			this.maxNodes = this.payload[1];
+			this.reportsToFollow = this.payload[2];
+			this.nodeIds = [...this.payload.slice(3)];
+		} else {
+			this.groupId = options.groupId;
+			this.maxNodes = options.maxNodes;
+			this.nodeIds = options.nodeIds;
+			this.reportsToFollow = options.reportsToFollow;
+		}
 	}
 
-	private _groupId: number;
-	public get groupId(): number {
-		return this._groupId;
-	}
+	public groupId: number;
 
-	private _maxNodes: number;
 	@ccValue(
 		AssociationCCValues.maxNodes,
 		(self: AssociationCCReport) => [self.groupId] as const,
 	)
-	public get maxNodes(): number {
-		return this._maxNodes;
-	}
+	public maxNodes: number;
 
-	private _nodeIds: number[];
 	@ccValue(
 		AssociationCCValues.nodeIds,
 		(self: AssociationCCReport) => [self.groupId] as const,
 	)
-	public get nodeIds(): readonly number[] {
-		return this._nodeIds;
-	}
+	public nodeIds: number[];
 
-	private _reportsToFollow: number;
-	public get reportsToFollow(): number {
-		return this._reportsToFollow;
-	}
+	public reportsToFollow: number;
 
 	public getPartialCCSessionId(): Record<string, any> | undefined {
 		// Distinguish sessions by the association group ID
-		return { groupId: this._groupId };
+		return { groupId: this.groupId };
 	}
 
 	public expectMoreMessages(): boolean {
-		return this._reportsToFollow > 0;
+		return this.reportsToFollow > 0;
 	}
 
 	public mergePartialCCs(
@@ -629,9 +661,19 @@ export class AssociationCCReport extends AssociationCC {
 		partials: AssociationCCReport[],
 	): void {
 		// Concat the list of nodes
-		this._nodeIds = [...partials, this]
-			.map((report) => report._nodeIds)
+		this.nodeIds = [...partials, this]
+			.map((report) => report.nodeIds)
 			.reduce((prev, cur) => prev.concat(...cur), []);
+	}
+
+	public serialize(): Buffer {
+		this.payload = Buffer.from([
+			this.groupId,
+			this.maxNodes,
+			this.reportsToFollow,
+			...this.nodeIds,
+		]);
+		return super.serialize();
 	}
 
 	public toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry {
@@ -660,11 +702,8 @@ export class AssociationCCGet extends AssociationCC {
 	) {
 		super(host, options);
 		if (gotDeserializationOptions(options)) {
-			// TODO: Deserialize payload
-			throw new ZWaveError(
-				`${this.constructor.name}: deserialization not implemented`,
-				ZWaveErrorCodes.Deserialization_NotImplemented,
-			);
+			validatePayload(this.payload.length >= 1);
+			this.groupId = this.payload[0];
 		} else {
 			if (options.groupId < 1) {
 				throw new ZWaveError(
@@ -691,22 +730,35 @@ export class AssociationCCGet extends AssociationCC {
 	}
 }
 
+export interface AssociationCCSupportedGroupingsReportOptions
+	extends CCCommandOptions {
+	groupCount: number;
+}
+
 @CCCommand(AssociationCommand.SupportedGroupingsReport)
 export class AssociationCCSupportedGroupingsReport extends AssociationCC {
 	public constructor(
 		host: ZWaveHost,
-		options: CommandClassDeserializationOptions,
+		options:
+			| CommandClassDeserializationOptions
+			| AssociationCCSupportedGroupingsReportOptions,
 	) {
 		super(host, options);
 
-		validatePayload(this.payload.length >= 1);
-		this._groupCount = this.payload[0];
+		if (gotDeserializationOptions(options)) {
+			validatePayload(this.payload.length >= 1);
+			this.groupCount = this.payload[0];
+		} else {
+			this.groupCount = options.groupCount;
+		}
 	}
 
-	private _groupCount: number;
 	@ccValue(AssociationCCValues.groupCount)
-	public get groupCount(): number {
-		return this._groupCount;
+	public groupCount: number;
+
+	public serialize(): Buffer {
+		this.payload = Buffer.from([this.groupCount]);
+		return super.serialize();
 	}
 
 	public toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry {

--- a/packages/cc/src/cc/AssociationCC.ts
+++ b/packages/cc/src/cc/AssociationCC.ts
@@ -195,7 +195,9 @@ export class AssociationCCAPI extends PhysicalCCAPI {
 		}
 	}
 
-	public async sendReport(options: AssociationCCReportSpecificOptions): Promise<void> {
+	public async sendReport(
+		options: AssociationCCReportSpecificOptions,
+	): Promise<void> {
 		this.assertSupportsCommand(
 			AssociationCommand,
 			AssociationCommand.Report,
@@ -204,7 +206,7 @@ export class AssociationCCAPI extends PhysicalCCAPI {
 		const cc = new AssociationCCReport(this.applHost, {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
-			...options
+			...options,
 		});
 		await this.applHost.sendCommand(cc, this.commandOptions);
 	}

--- a/packages/cc/src/cc/AssociationGroupInfoCC.ts
+++ b/packages/cc/src/cc/AssociationGroupInfoCC.ts
@@ -1,8 +1,7 @@
 import {
 	CommandClasses,
 	MessagePriority,
-	ZWaveError,
-	ZWaveErrorCodes,
+	encodeCCId,
 	getCCName,
 	parseCCId,
 	validatePayload,
@@ -89,8 +88,11 @@ export class AssociationGroupInfoCCAPI extends PhysicalCCAPI {
 	): MaybeNotKnown<boolean> {
 		switch (cmd) {
 			case AssociationGroupInfoCommand.NameGet:
+			case AssociationGroupInfoCommand.NameReport:
 			case AssociationGroupInfoCommand.InfoGet:
+			case AssociationGroupInfoCommand.InfoReport:
 			case AssociationGroupInfoCommand.CommandListGet:
+			case AssociationGroupInfoCommand.CommandListReport:
 				return true; // This is mandatory
 		}
 		return super.supportsCommand(cmd);
@@ -114,6 +116,23 @@ export class AssociationGroupInfoCCAPI extends PhysicalCCAPI {
 				this.commandOptions,
 			);
 		if (response) return response.name;
+	}
+
+	@validateArgs()
+	public async reportGroupName(groupId: number, name: string): Promise<void> {
+		this.assertSupportsCommand(
+			AssociationGroupInfoCommand,
+			AssociationGroupInfoCommand.NameReport,
+		);
+
+		const cc = new AssociationGroupInfoCCNameReport(this.applHost, {
+			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
+			groupId,
+			name,
+		});
+
+		await this.applHost.sendCommand(cc, this.commandOptions);
 	}
 
 	@validateArgs()
@@ -147,6 +166,23 @@ export class AssociationGroupInfoCCAPI extends PhysicalCCAPI {
 		}
 	}
 
+	public async reportGroupInfo(
+		options: AssociationGroupInfoCCInfoReportSpecificOptions,
+	): Promise<void> {
+		this.assertSupportsCommand(
+			AssociationGroupInfoCommand,
+			AssociationGroupInfoCommand.InfoReport,
+		);
+
+		const cc = new AssociationGroupInfoCCInfoReport(this.applHost, {
+			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
+			...options,
+		});
+
+		await this.applHost.sendCommand(cc, this.commandOptions);
+	}
+
 	@validateArgs()
 	public async getCommands(
 		groupId: number,
@@ -171,6 +207,26 @@ export class AssociationGroupInfoCCAPI extends PhysicalCCAPI {
 				this.commandOptions,
 			);
 		if (response) return response.commands;
+	}
+
+	@validateArgs()
+	public async reportCommands(
+		groupId: number,
+		commands: ReadonlyMap<CommandClasses, readonly number[]>,
+	): Promise<void> {
+		this.assertSupportsCommand(
+			AssociationGroupInfoCommand,
+			AssociationGroupInfoCommand.CommandListReport,
+		);
+
+		const cc = new AssociationGroupInfoCCCommandListReport(this.applHost, {
+			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
+			groupId,
+			commands,
+		});
+
+		await this.applHost.sendCommand(cc, this.commandOptions);
 	}
 }
 
@@ -382,23 +438,41 @@ profile:         ${getEnumMemberName(
 		}
 	}
 }
+
+export interface AssociationGroupInfoCCNameReportOptions
+	extends CCCommandOptions {
+	groupId: number;
+	name: string;
+}
+
 @CCCommand(AssociationGroupInfoCommand.NameReport)
 export class AssociationGroupInfoCCNameReport extends AssociationGroupInfoCC {
 	public constructor(
 		host: ZWaveHost,
-		options: CommandClassDeserializationOptions,
+		options:
+			| CommandClassDeserializationOptions
+			| AssociationGroupInfoCCNameReportOptions,
 	) {
 		super(host, options);
-		validatePayload(this.payload.length >= 2);
-		this.groupId = this.payload[0];
-		const nameLength = this.payload[1];
-		validatePayload(this.payload.length >= 2 + nameLength);
-		// The specs don't allow 0-terminated string, but some devices use them
-		// So we need to cut them off
-		this.name = cpp2js(
-			this.payload.slice(2, 2 + nameLength).toString("utf8"),
-		);
+
+		if (gotDeserializationOptions(options)) {
+			validatePayload(this.payload.length >= 2);
+			this.groupId = this.payload[0];
+			const nameLength = this.payload[1];
+			validatePayload(this.payload.length >= 2 + nameLength);
+			// The specs don't allow 0-terminated string, but some devices use them
+			// So we need to cut them off
+			this.name = cpp2js(
+				this.payload.slice(2, 2 + nameLength).toString("utf8"),
+			);
+		} else {
+			this.groupId = options.groupId;
+			this.name = options.name;
+		}
 	}
+
+	public readonly groupId: number;
+	public readonly name: string;
 
 	public persistValues(applHost: ZWaveApplicationHost): boolean {
 		if (!super.persistValues(applHost)) return false;
@@ -414,8 +488,13 @@ export class AssociationGroupInfoCCNameReport extends AssociationGroupInfoCC {
 		return true;
 	}
 
-	public readonly groupId: number;
-	public readonly name: string;
+	public serialize(): Buffer {
+		this.payload = Buffer.concat([
+			Buffer.from([this.groupId, this.name.length]),
+			Buffer.from(this.name, "utf8"),
+		]);
+		return super.serialize();
+	}
 
 	public toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry {
 		return {
@@ -443,11 +522,8 @@ export class AssociationGroupInfoCCNameGet extends AssociationGroupInfoCC {
 	) {
 		super(host, options);
 		if (gotDeserializationOptions(options)) {
-			// TODO: Deserialize payload
-			throw new ZWaveError(
-				`${this.constructor.name}: deserialization not implemented`,
-				ZWaveErrorCodes.Deserialization_NotImplemented,
-			);
+			validatePayload(this.payload.length >= 1);
+			this.groupId = this.payload[0];
 		} else {
 			this.groupId = options.groupId;
 		}
@@ -475,33 +551,56 @@ export interface AssociationGroupInfo {
 	eventCode: number;
 }
 
+export interface AssociationGroupInfoCCInfoReportSpecificOptions {
+	isListMode: boolean;
+	hasDynamicInfo: boolean;
+	groups: AssociationGroupInfo[];
+}
+
 @CCCommand(AssociationGroupInfoCommand.InfoReport)
 export class AssociationGroupInfoCCInfoReport extends AssociationGroupInfoCC {
 	public constructor(
 		host: ZWaveHost,
-		options: CommandClassDeserializationOptions,
+		options:
+			| CommandClassDeserializationOptions
+			| (AssociationGroupInfoCCInfoReportSpecificOptions &
+					CCCommandOptions),
 	) {
 		super(host, options);
-		validatePayload(this.payload.length >= 1);
-		this.isListMode = !!(this.payload[0] & 0b1000_0000);
-		this.hasDynamicInfo = !!(this.payload[0] & 0b0100_0000);
 
-		const groupCount = this.payload[0] & 0b0011_1111;
-		// each group requires 7 bytes of payload
-		validatePayload(this.payload.length >= 1 + groupCount * 7);
-		const _groups: AssociationGroupInfo[] = [];
-		for (let i = 0; i < groupCount; i++) {
-			const offset = 1 + i * 7;
-			// Parse the payload
-			const groupBytes = this.payload.slice(offset, offset + 7);
-			const groupId = groupBytes[0];
-			const mode = 0; //groupBytes[1];
-			const profile = groupBytes.readUInt16BE(2);
-			const eventCode = 0; // groupBytes.readUInt16BE(5);
-			_groups.push({ groupId, mode, profile, eventCode });
+		if (gotDeserializationOptions(options)) {
+			validatePayload(this.payload.length >= 1);
+			this.isListMode = !!(this.payload[0] & 0b1000_0000);
+			this.hasDynamicInfo = !!(this.payload[0] & 0b0100_0000);
+
+			const groupCount = this.payload[0] & 0b0011_1111;
+			// each group requires 7 bytes of payload
+			validatePayload(this.payload.length >= 1 + groupCount * 7);
+			const _groups: AssociationGroupInfo[] = [];
+			for (let i = 0; i < groupCount; i++) {
+				const offset = 1 + i * 7;
+				// Parse the payload
+				const groupBytes = this.payload.slice(offset, offset + 7);
+				const groupId = groupBytes[0];
+				const mode = 0; //groupBytes[1];
+				const profile = groupBytes.readUInt16BE(2);
+				const eventCode = 0; // groupBytes.readUInt16BE(5);
+				_groups.push({ groupId, mode, profile, eventCode });
+			}
+			this.groups = _groups;
+		} else {
+			this.isListMode = options.isListMode;
+			this.hasDynamicInfo = options.hasDynamicInfo;
+			this.groups = options.groups;
 		}
-		this.groups = _groups;
 	}
+
+	public readonly isListMode: boolean;
+
+	@ccValue(AssociationGroupInfoCCValues.hasDynamicInfo)
+	public readonly hasDynamicInfo: boolean;
+
+	public readonly groups: readonly AssociationGroupInfo[];
 
 	public persistValues(applHost: ZWaveApplicationHost): boolean {
 		if (!super.persistValues(applHost)) return false;
@@ -521,12 +620,23 @@ export class AssociationGroupInfoCCInfoReport extends AssociationGroupInfoCC {
 		return true;
 	}
 
-	public readonly isListMode: boolean;
+	public serialize(): Buffer {
+		this.payload = Buffer.alloc(1 + this.groups.length * 7, 0);
 
-	@ccValue(AssociationGroupInfoCCValues.hasDynamicInfo)
-	public readonly hasDynamicInfo: boolean;
+		this.payload[0] =
+			(this.isListMode ? 0b1000_0000 : 0) |
+			(this.hasDynamicInfo ? 0b0100_0000 : 0) |
+			(this.groups.length & 0b0011_1111);
 
-	public readonly groups: readonly AssociationGroupInfo[];
+		for (let i = 0; i < this.groups.length; i++) {
+			const offset = 1 + i * 7;
+			this.payload[offset] = this.groups[i].groupId;
+			this.payload.writeUint16BE(this.groups[i].profile, offset + 2);
+			// The remaining bytes are zero
+		}
+
+		return super.serialize();
+	}
 
 	public toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry {
 		return {
@@ -570,11 +680,13 @@ export class AssociationGroupInfoCCInfoGet extends AssociationGroupInfoCC {
 	) {
 		super(host, options);
 		if (gotDeserializationOptions(options)) {
-			// TODO: Deserialize payload
-			throw new ZWaveError(
-				`${this.constructor.name}: deserialization not implemented`,
-				ZWaveErrorCodes.Deserialization_NotImplemented,
-			);
+			validatePayload(this.payload.length >= 2);
+			const optionByte = this.payload[0];
+			this.refreshCache = !!(optionByte & 0b1000_0000);
+			this.listMode = !!(optionByte & 0b0100_0000);
+			if (!this.listMode) {
+				this.groupId = this.payload[1];
+			}
 		} else {
 			this.refreshCache = options.refreshCache;
 			if ("listMode" in options) this.listMode = options.listMode;
@@ -614,30 +726,44 @@ export class AssociationGroupInfoCCInfoGet extends AssociationGroupInfoCC {
 	}
 }
 
+export interface AssociationGroupInfoCCCommandListReportOptions
+	extends CCCommandOptions {
+	groupId: number;
+	commands: ReadonlyMap<CommandClasses, readonly number[]>;
+}
+
 @CCCommand(AssociationGroupInfoCommand.CommandListReport)
 export class AssociationGroupInfoCCCommandListReport extends AssociationGroupInfoCC {
 	public constructor(
 		host: ZWaveHost,
-		options: CommandClassDeserializationOptions,
+		options:
+			| CommandClassDeserializationOptions
+			| AssociationGroupInfoCCCommandListReportOptions,
 	) {
 		super(host, options);
-		validatePayload(this.payload.length >= 2);
-		this.groupId = this.payload[0];
-		const listLength = this.payload[1];
-		validatePayload(this.payload.length >= 2 + listLength);
-		const listBytes = this.payload.slice(2, 2 + listLength);
-		// Parse all CC ids and commands
-		let offset = 0;
-		const commands = new Map<CommandClasses, number[]>();
-		while (offset < listLength) {
-			const { ccId, bytesRead } = parseCCId(listBytes, offset);
-			const command = listBytes[offset + bytesRead];
-			if (!commands.has(ccId)) commands.set(ccId, []);
-			commands.get(ccId)!.push(command);
-			offset += bytesRead + 1;
-		}
 
-		this.commands = commands;
+		if (gotDeserializationOptions(options)) {
+			validatePayload(this.payload.length >= 2);
+			this.groupId = this.payload[0];
+			const listLength = this.payload[1];
+			validatePayload(this.payload.length >= 2 + listLength);
+			const listBytes = this.payload.slice(2, 2 + listLength);
+			// Parse all CC ids and commands
+			let offset = 0;
+			const commands = new Map<CommandClasses, number[]>();
+			while (offset < listLength) {
+				const { ccId, bytesRead } = parseCCId(listBytes, offset);
+				const command = listBytes[offset + bytesRead];
+				if (!commands.has(ccId)) commands.set(ccId, []);
+				commands.get(ccId)!.push(command);
+				offset += bytesRead + 1;
+			}
+
+			this.commands = commands;
+		} else {
+			this.groupId = options.groupId;
+			this.commands = options.commands;
+		}
 	}
 
 	public readonly groupId: number;
@@ -648,6 +774,24 @@ export class AssociationGroupInfoCCCommandListReport extends AssociationGroupInf
 			[self.groupId] as const,
 	)
 	public readonly commands: ReadonlyMap<CommandClasses, readonly number[]>;
+
+	public serialize(): Buffer {
+		// To make it easier to encode possible extended CCs, we first
+		// allocate as much space as we may need, then trim it again
+		this.payload = Buffer.allocUnsafe(2 + this.commands.size * 3);
+		this.payload[0] = this.groupId;
+		let offset = 2;
+		for (const [ccId, commands] of this.commands) {
+			for (const command of commands) {
+				offset += encodeCCId(ccId, this.payload, offset);
+				this.payload[offset] = command;
+				offset++;
+			}
+		}
+		this.payload[1] = offset - 2; // list length
+
+		return super.serialize();
+	}
 
 	public toLogEntry(applHost: ZWaveApplicationHost): MessageOrCCLogEntry {
 		return {
@@ -682,11 +826,9 @@ export class AssociationGroupInfoCCCommandListGet extends AssociationGroupInfoCC
 	) {
 		super(host, options);
 		if (gotDeserializationOptions(options)) {
-			// TODO: Deserialize payload
-			throw new ZWaveError(
-				`${this.constructor.name}: deserialization not implemented`,
-				ZWaveErrorCodes.Deserialization_NotImplemented,
-			);
+			validatePayload(this.payload.length >= 2);
+			this.allowCache = !!(this.payload[0] & 0b1000_0000);
+			this.groupId = this.payload[1];
 		} else {
 			this.allowCache = options.allowCache;
 			this.groupId = options.groupId;

--- a/packages/cc/src/cc/DeviceResetLocallyCC.ts
+++ b/packages/cc/src/cc/DeviceResetLocallyCC.ts
@@ -1,4 +1,4 @@
-import { CommandClasses, validatePayload } from "@zwave-js/core/safe";
+import { CommandClasses, MaybeNotKnown, TransmitOptions, validatePayload } from "@zwave-js/core/safe";
 import type { ZWaveHost } from "@zwave-js/host/safe";
 import {
 	CommandClass,
@@ -6,14 +6,53 @@ import {
 	type CommandClassOptions,
 } from "../lib/CommandClass";
 import {
+	API,
 	CCCommand,
 	commandClass,
 	implementedVersion,
 } from "../lib/CommandClassDecorators";
 import { DeviceResetLocallyCommand } from "../lib/_Types";
+import { CCAPI } from "../lib/API";
 
-// @noAPI: We can only receive this command
-// @noInterview: We can only receive this command
+// @noInterview: There is no interview procedure
+
+@API(CommandClasses["Device Reset Locally"])
+export class DeviceResetLocallyCCAPI extends CCAPI {
+	public supportsCommand(cmd: DeviceResetLocallyCommand): MaybeNotKnown<boolean> {
+		switch (cmd) {
+			case DeviceResetLocallyCommand.Notification:
+				return true; // This is mandatory
+		}
+		return super.supportsCommand(cmd);
+	}
+	
+	public async sendNotification(): Promise<void> {
+		this.assertSupportsCommand(
+			DeviceResetLocallyCommand,
+			DeviceResetLocallyCommand.Notification,
+		);
+
+		const cc = new DeviceResetLocallyCCNotification(this.applHost, {
+			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
+		});
+
+		try {
+			await this.applHost.sendCommand(cc, {
+				...this.commandOptions,
+				// Seems we need these options or some nodes won't accept the nonce
+				transmitOptions: TransmitOptions.DEFAULT_NOACK,
+				// Only try sending once
+				maxSendAttempts: 1,
+				// We don't want failures causing us to treat the node as asleep or dead
+				changeNodeStatusOnMissingACK: false,
+			});
+		} catch (e) {
+			// Don't care
+		}
+	}
+
+}
 
 @commandClass(CommandClasses["Device Reset Locally"])
 @implementedVersion(1)

--- a/packages/cc/src/cc/DeviceResetLocallyCC.ts
+++ b/packages/cc/src/cc/DeviceResetLocallyCC.ts
@@ -1,8 +1,8 @@
 import {
 	CommandClasses,
-	MaybeNotKnown,
 	TransmitOptions,
 	validatePayload,
+	type MaybeNotKnown,
 } from "@zwave-js/core/safe";
 import type { ZWaveHost } from "@zwave-js/host/safe";
 import { CCAPI } from "../lib/API";

--- a/packages/cc/src/cc/DeviceResetLocallyCC.ts
+++ b/packages/cc/src/cc/DeviceResetLocallyCC.ts
@@ -1,5 +1,11 @@
-import { CommandClasses, MaybeNotKnown, TransmitOptions, validatePayload } from "@zwave-js/core/safe";
+import {
+	CommandClasses,
+	MaybeNotKnown,
+	TransmitOptions,
+	validatePayload,
+} from "@zwave-js/core/safe";
 import type { ZWaveHost } from "@zwave-js/host/safe";
+import { CCAPI } from "../lib/API";
 import {
 	CommandClass,
 	gotDeserializationOptions,
@@ -12,20 +18,21 @@ import {
 	implementedVersion,
 } from "../lib/CommandClassDecorators";
 import { DeviceResetLocallyCommand } from "../lib/_Types";
-import { CCAPI } from "../lib/API";
 
 // @noInterview: There is no interview procedure
 
 @API(CommandClasses["Device Reset Locally"])
 export class DeviceResetLocallyCCAPI extends CCAPI {
-	public supportsCommand(cmd: DeviceResetLocallyCommand): MaybeNotKnown<boolean> {
+	public supportsCommand(
+		cmd: DeviceResetLocallyCommand,
+	): MaybeNotKnown<boolean> {
 		switch (cmd) {
 			case DeviceResetLocallyCommand.Notification:
 				return true; // This is mandatory
 		}
 		return super.supportsCommand(cmd);
 	}
-	
+
 	public async sendNotification(): Promise<void> {
 		this.assertSupportsCommand(
 			DeviceResetLocallyCommand,
@@ -51,7 +58,6 @@ export class DeviceResetLocallyCCAPI extends CCAPI {
 			// Don't care
 		}
 	}
-
 }
 
 @commandClass(CommandClasses["Device Reset Locally"])

--- a/packages/cc/src/lib/API.ts
+++ b/packages/cc/src/lib/API.ts
@@ -584,6 +584,7 @@ type CCNameMap = {
 	Clock: (typeof CommandClasses)["Clock"];
 	"Color Switch": (typeof CommandClasses)["Color Switch"];
 	Configuration: (typeof CommandClasses)["Configuration"];
+	"Device Reset Locally": (typeof CommandClasses)["Device Reset Locally"];
 	"Door Lock": (typeof CommandClasses)["Door Lock"];
 	"Door Lock Logging": (typeof CommandClasses)["Door Lock Logging"];
 	"Energy Production": (typeof CommandClasses)["Energy Production"];
@@ -723,6 +724,7 @@ export interface CCAPIs {
 	Clock: import("../cc/ClockCC").ClockCCAPI;
 	"Color Switch": import("../cc/ColorSwitchCC").ColorSwitchCCAPI;
 	Configuration: import("../cc/ConfigurationCC").ConfigurationCCAPI;
+	"Device Reset Locally": import("../cc/DeviceResetLocallyCC").DeviceResetLocallyCCAPI;
 	"Door Lock": import("../cc/DoorLockCC").DoorLockCCAPI;
 	"Door Lock Logging": import("../cc/DoorLockLoggingCC").DoorLockLoggingCCAPI;
 	"Energy Production": import("../cc/EnergyProductionCC").EnergyProductionCCAPI;

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -1335,6 +1335,8 @@ export class ZWaveNode extends Endpoint implements SecurityClassOwner, IZWaveNod
     requestNodeInfo(): Promise<NodeUpdatePayload>;
     // (undocumented)
     get sdkVersion(): MaybeNotKnown<string>;
+    // (undocumented)
+    sendResetLocallyNotification(): Promise<void>;
     setDateAndTime(now?: Date): Promise<boolean>;
     // (undocumented)
     setSecurityClass(securityClass: SecurityClass_2, granted: boolean): void;

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -1273,7 +1273,9 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 					const node = this.nodes.get(nodeId);
 					if (!node) continue;
 
-					void node.sendResetLocallyNotification().catch(() => {});
+					void node.sendResetLocallyNotification().catch(() => {
+						// ignore
+					});
 				}
 			}
 

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -1264,6 +1264,19 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 	public async hardReset(): Promise<void> {
 		// begin the reset process
 		try {
+			const associations = this.nodes.get(this._ownNodeId!)?.associations;
+			if (associations?.length) {
+				this.driver.controllerLog.print(
+					"Notifying associated nodes about reset...",
+				);
+				for (const nodeId of associations) {
+					const node = this.nodes.get(nodeId);
+					if (!node) continue;
+
+					void node.sendResetLocallyNotification().catch(() => {});
+				}
+			}
+
 			this.driver.controllerLog.print("performing hard reset...");
 			await this.driver.sendMessage(new HardResetRequest(this.driver), {
 				supportCheck: false,

--- a/packages/zwave-js/src/lib/controller/NodeInformationFrame.ts
+++ b/packages/zwave-js/src/lib/controller/NodeInformationFrame.ts
@@ -32,6 +32,10 @@ export function determineNIF(): {
 		// Gateway device type MUST support Inclusion Controller and Time CC
 		CommandClasses["Inclusion Controller"],
 		CommandClasses.Time,
+		// Supporting lifeline associations is also mandatory
+		CommandClasses.Association,
+		// And apparently we must advertise that we're able to send Device Reset Locally notifications
+		CommandClasses["Device Reset Locally"],
 		...implementedEncapsulationCCs,
 	]);
 

--- a/packages/zwave-js/src/lib/driver/NetworkCache.ts
+++ b/packages/zwave-js/src/lib/driver/NetworkCache.ts
@@ -64,6 +64,8 @@ export const cacheKeys = {
 				};
 			},
 			hasSUCReturnRoute: `${nodeBaseKey}hasSUCReturnRoute`,
+			associations: (groupId: number) =>
+				`${nodeBaseKey}associations.${groupId}`,
 		};
 	},
 } as const;

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3685,9 +3685,7 @@ protocol version:      ${this.protocolVersion}`;
 		});
 	}
 
-	private async handleAssociationSet(
-		command: AssociationCCSet,
-	): Promise<void> {
+	private handleAssociationSet(command: AssociationCCSet): void {
 		if (command.groupId !== 1) {
 			// We only "support" the lifeline group
 			return;
@@ -3704,9 +3702,7 @@ protocol version:      ${this.protocolVersion}`;
 		].slice(0, MAX_ASSOCIATIONS);
 	}
 
-	private async handleAssociationRemove(
-		command: AssociationCCRemove,
-	): Promise<void> {
+	private handleAssociationRemove(command: AssociationCCRemove): void {
 		// Allow accessing the lifeline group or all groups (which is the same)
 		if (!!command.groupId && command.groupId !== 1) {
 			// We only "support" the lifeline group

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1,7 +1,9 @@
 import {
+	AssociationGroupInfoProfile,
 	CentralSceneKeys,
 	ClockCommand,
 	CommandClass,
+	DeviceResetLocallyCommand,
 	DoorLockMode,
 	EntryControlDataTypes,
 	FirmwareUpdateRequestStatus,
@@ -35,7 +37,18 @@ import {
 	type SetValueAPIOptions,
 	type ValueIDProperties,
 } from "@zwave-js/cc";
-import { AssociationCCValues } from "@zwave-js/cc/AssociationCC";
+import {
+	AssociationCCGet,
+	AssociationCCRemove,
+	AssociationCCSet,
+	AssociationCCSupportedGroupingsGet,
+	AssociationCCValues,
+} from "@zwave-js/cc/AssociationCC";
+import {
+	AssociationGroupInfoCCCommandListGet,
+	AssociationGroupInfoCCInfoGet,
+	AssociationGroupInfoCCNameGet,
+} from "@zwave-js/cc/AssociationGroupInfoCC";
 import {
 	BasicCC,
 	BasicCCReport,
@@ -852,6 +865,17 @@ export class ZWaveNode
 	}
 	public set hasSUCReturnRoute(value: boolean) {
 		this.driver.cacheSet(cacheKeys.node(this.id).hasSUCReturnRoute, value);
+	}
+
+	/** @internal Which associations are currently configured */
+	public get associations(): readonly number[] {
+		return (
+			this.driver.cacheGet(cacheKeys.node(this.id).associations(1)) ?? []
+		);
+	}
+
+	private set associations(value: readonly number[]) {
+		this.driver.cacheSet(cacheKeys.node(this.id).associations(1), value);
 	}
 
 	private _deviceConfig: DeviceConfig | undefined;
@@ -2806,6 +2830,20 @@ protocol version:      ${this.protocolVersion}`;
 			return this.handleVersionGet(command);
 		} else if (command instanceof VersionCCCommandClassGet) {
 			return this.handleVersionCommandClassGet(command);
+		} else if (command instanceof AssociationGroupInfoCCNameGet) {
+			return this.handleAGINameGet(command);
+		} else if (command instanceof AssociationGroupInfoCCInfoGet) {
+			return this.handleAGIInfoGet(command);
+		} else if (command instanceof AssociationGroupInfoCCCommandListGet) {
+			return this.handleAGICommandListGet(command);
+		} else if (command instanceof AssociationCCSupportedGroupingsGet) {
+			return this.handleAssociationSupportedGroupingsGet(command);
+		} else if (command instanceof AssociationCCGet) {
+			return this.handleAssociationGet(command);
+		} else if (command instanceof AssociationCCSet) {
+			return this.handleAssociationSet(command);
+		} else if (command instanceof AssociationCCRemove) {
+			return this.handleAssociationRemove(command);
 		} else if (command instanceof InclusionControllerCCInitiate) {
 			// Inclusion controller commands are handled by the controller class
 			if (
@@ -3510,6 +3548,179 @@ protocol version:      ${this.protocolVersion}`;
 			});
 
 		await api.reportCCVersion(command.requestedCC);
+	}
+
+	private async handleAGINameGet(
+		command: AssociationGroupInfoCCNameGet,
+	): Promise<void> {
+		if (command.groupId !== 1) {
+			// We only "support" the lifeline group
+			return;
+		}
+
+		const endpoint = this.getEndpoint(command.endpointIndex) ?? this;
+
+		// We are being queried, so the device may actually not support the CC, just control it.
+		// Using the commandClasses property would throw in that case
+		const api = endpoint
+			.createAPI(CommandClasses["Association Group Information"], false)
+			.withOptions({
+				// Answer with the same encapsulation as asked
+				encapsulationFlags: command.encapsulationFlags,
+			});
+
+		await api.reportGroupName(1, "Lifeline");
+	}
+
+	private async handleAGIInfoGet(
+		command: AssociationGroupInfoCCInfoGet,
+	): Promise<void> {
+		if (!command.listMode && command.groupId !== 1) {
+			// We only "support" the lifeline group
+			return;
+		}
+
+		const endpoint = this.getEndpoint(command.endpointIndex) ?? this;
+
+		// We are being queried, so the device may actually not support the CC, just control it.
+		// Using the commandClasses property would throw in that case
+		const api = endpoint
+			.createAPI(CommandClasses["Association Group Information"], false)
+			.withOptions({
+				// Answer with the same encapsulation as asked
+				encapsulationFlags: command.encapsulationFlags,
+			});
+
+		await api.reportGroupInfo({
+			isListMode: command.listMode ?? false,
+			hasDynamicInfo: false,
+			groups: [
+				{
+					groupId: 1,
+					eventCode: 0, // ignored anyways
+					profile: AssociationGroupInfoProfile["General: Lifeline"],
+					mode: 0, // ignored anyways
+				},
+			],
+		});
+	}
+
+	private async handleAGICommandListGet(
+		command: AssociationGroupInfoCCCommandListGet,
+	): Promise<void> {
+		if (command.groupId !== 1) {
+			// We only "support" the lifeline group
+			return;
+		}
+
+		const endpoint = this.getEndpoint(command.endpointIndex) ?? this;
+
+		// We are being queried, so the device may actually not support the CC, just control it.
+		// Using the commandClasses property would throw in that case
+		const api = endpoint
+			.createAPI(CommandClasses["Association Group Information"], false)
+			.withOptions({
+				// Answer with the same encapsulation as asked
+				encapsulationFlags: command.encapsulationFlags,
+			});
+
+		await api.reportCommands(
+			command.groupId,
+			new Map([
+				[
+					CommandClasses["Device Reset Locally"],
+					[DeviceResetLocallyCommand.Notification],
+				],
+			]),
+		);
+	}
+
+	private async handleAssociationSupportedGroupingsGet(
+		command: AssociationCCSupportedGroupingsGet,
+	): Promise<void> {
+		const endpoint = this.getEndpoint(command.endpointIndex) ?? this;
+
+		// We are being queried, so the device may actually not support the CC, just control it.
+		// Using the commandClasses property would throw in that case
+		const api = endpoint
+			.createAPI(CommandClasses.Association, false)
+			.withOptions({
+				// Answer with the same encapsulation as asked
+				encapsulationFlags: command.encapsulationFlags,
+			});
+
+		// We only "support" the lifeline group
+		await api.reportGroupCount(1);
+	}
+
+	private async handleAssociationGet(
+		command: AssociationCCGet,
+	): Promise<void> {
+		if (command.groupId !== 1) {
+			// We only "support" the lifeline group
+			return;
+		}
+		const endpoint = this.getEndpoint(command.endpointIndex) ?? this;
+
+		const controllerNode = this.driver.controller.nodes.get(
+			this.driver.controller.ownNodeId!,
+		)!;
+
+		// We are being queried, so the device may actually not support the CC, just control it.
+		// Using the commandClasses property would throw in that case
+		const api = endpoint
+			.createAPI(CommandClasses.Association, false)
+			.withOptions({
+				// Answer with the same encapsulation as asked
+				encapsulationFlags: command.encapsulationFlags,
+			});
+
+		await api.sendReport({
+			groupId: command.groupId,
+			maxNodes: 1,
+			nodeIds: [...(controllerNode?.associations ?? [])],
+			reportsToFollow: 0,
+		});
+	}
+
+	private async handleAssociationSet(
+		command: AssociationCCSet,
+	): Promise<void> {
+		if (command.groupId !== 1) {
+			// We only "support" the lifeline group
+			return;
+		}
+
+		const controllerNode = this.driver.controller.nodes.get(
+			this.driver.controller.ownNodeId!,
+		);
+		if (!controllerNode) return;
+
+		controllerNode.associations = [...controllerNode.associations, ...command.nodeIds];
+	}
+
+	private async handleAssociationRemove(
+		command: AssociationCCRemove,
+	): Promise<void> {
+		// Allow accessing the lifeline group or all groups (which is the same)
+		if (!!command.groupId && command.groupId !== 1) {
+			// We only "support" the lifeline group
+			return;
+		}
+
+		const controllerNode = this.driver.controller.nodes.get(
+			this.driver.controller.ownNodeId!,
+		);
+		if (!controllerNode) return;
+
+		if (!command.nodeIds) {
+			// clear
+			controllerNode.associations = [];
+		} else {
+			controllerNode.associations = controllerNode.associations.filter(
+				(nodeId) => !command.nodeIds!.includes(nodeId),
+			);
+		}
 	}
 
 	private async handleSecurityCommandsSupportedGet(
@@ -5604,5 +5815,15 @@ ${formatRouteHealthCheckSummary(this.id, otherNode.id, summary)}`,
 		}
 
 		return true;
+	}
+
+	public async sendResetLocallyNotification(): Promise<void> {
+		// We don't care if the CC is supported by the receiving node
+		const api = this.createAPI(
+			CommandClasses["Device Reset Locally"],
+			false,
+		);
+
+		await api.sendNotification();
 	}
 }

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -265,6 +265,8 @@ interface AbortFirmwareUpdateContext {
 	abortPromise: DeferredPromise<boolean>;
 }
 
+const MAX_ASSOCIATIONS = 1;
+
 export interface ZWaveNode
 	extends TypedEventEmitter<
 			ZWaveNodeEventCallbacks &
@@ -3677,7 +3679,7 @@ protocol version:      ${this.protocolVersion}`;
 
 		await api.sendReport({
 			groupId: command.groupId,
-			maxNodes: 1,
+			maxNodes: MAX_ASSOCIATIONS,
 			nodeIds: [...(controllerNode?.associations ?? [])],
 			reportsToFollow: 0,
 		});
@@ -3696,7 +3698,10 @@ protocol version:      ${this.protocolVersion}`;
 		);
 		if (!controllerNode) return;
 
-		controllerNode.associations = [...controllerNode.associations, ...command.nodeIds];
+		controllerNode.associations = [
+			...controllerNode.associations,
+			...command.nodeIds,
+		].slice(0, MAX_ASSOCIATIONS);
 	}
 
 	private async handleAssociationRemove(


### PR DESCRIPTION
Certification expects us to send a `Device Reset Locally Notification` via the lifeline on a factory reset. Although this doesn't seem to make a lot of sense when we're the primary controller, we now implement the bare minimum for supporting this.