### PR TITLE
feat: extract neighbor discovery into separate method, cleanup healing process, assign routes to all association destinations

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ node_modules/
 
 **/ava.config.cjs
 maintenance/esbuild-register.js
+.eslintrc.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,7 +27,7 @@ module.exports = {
 		// Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
 		"plugin:prettier/recommended",
 	],
-	plugins: [],
+	plugins: ["deprecation"],
 	reportUnusedDisableDirectives: true,
 	rules: {
 		// Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
@@ -122,6 +122,7 @@ module.exports = {
 			},
 		],
 		"quote-props": ["error", "as-needed"],
+		"deprecation/deprecation": "error",
 	},
 	overrides: [
 		{

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "esbuild-register": "^3.4.2",
     "eslint": "^8.41.0",
     "eslint-config-prettier": "^8.8.0",
+    "eslint-plugin-deprecation": "^1.4.1",
     "eslint-plugin-prettier": "^4.2.1",
     "execa": "^5.1.1",
     "fs-extra": "^10.1.0",

--- a/packages/config/src/SensorTypes.ts
+++ b/packages/config/src/SensorTypes.ts
@@ -28,9 +28,7 @@ export class SensorType {
 			definition.scales.startsWith(namedScalesMarker)
 		) {
 			// This is referencing a named scale
-			const scaleName = definition.scales.substr(
-				namedScalesMarker.length,
-			);
+			const scaleName = definition.scales.slice(namedScalesMarker.length);
 			const scales = manager.lookupNamedScaleGroup(scaleName);
 			if (!scales) {
 				throw new ZWaveError(

--- a/packages/config/src/devices/CompatConfig.ts
+++ b/packages/config/src/devices/CompatConfig.ts
@@ -50,7 +50,7 @@ error in compat option queryOnWakeup`,
 							this.valueIdRegex.test(arg)
 						) {
 							const tuple = JSON.parse(
-								arg.substr("$value$".length),
+								arg.slice("$value$".length),
 							);
 							return {
 								property: tuple[0],

--- a/packages/core/src/log/shared.ts
+++ b/packages/core/src/log/shared.ts
@@ -392,8 +392,8 @@ export const logMessageFormatter: Format = {
 							: LOG_WIDTH - CONTROL_CHAR_WIDTH,
 					);
 					isFirstLine = false;
-					lines.push(message.substr(0, cut));
-					message = message.substr(cut);
+					lines.push(message.slice(0, cut));
+					message = message.slice(cut);
 				}
 			}
 			info.message = lines.join("\n");

--- a/packages/core/src/security/QR.ts
+++ b/packages/core/src/security/QR.ts
@@ -6,7 +6,7 @@ import { dskToString } from "./DSK";
 import { SecurityClass } from "./SecurityClass";
 
 function readNumber(qr: string, offset: number, length: number): number {
-	return parseInt(qr.substr(offset, length), 10);
+	return parseInt(qr.slice(offset, offset + length), 10);
 }
 
 function fail(reason: string): never {
@@ -191,7 +191,7 @@ function parseTLV(qr: string): {
 	offset += 4;
 	if (qr.length - offset < length) fail("incomplete TLV block");
 
-	const data = qr.substr(offset, length);
+	const data = qr.slice(offset, offset + length);
 	offset += length;
 
 	// Try to parse the raw data and fail if a critical block is not understood

--- a/packages/maintenance/src/generateTypedDocs.ts
+++ b/packages/maintenance/src/generateTypedDocs.ts
@@ -319,7 +319,7 @@ function printMethodDeclaration(method: MethodDeclaration): string {
 	const end = method.getBody()!.getStart();
 	let ret = method
 		.getText()
-		.substr(0, end - start)
+		.slice(0, end - start)
 		.trim();
 	if (!method.getReturnTypeNode()) {
 		ret += ": " + method.getSignature().getReturnType().getText(method);

--- a/packages/maintenance/src/prettier.ts
+++ b/packages/maintenance/src/prettier.ts
@@ -7,7 +7,7 @@ export function formatWithPrettier(
 	sourceText: string,
 ): string {
 	let rootPath = __dirname.replace(/\\/g, "/");
-	rootPath = rootPath.substr(0, rootPath.lastIndexOf("/packages/"));
+	rootPath = rootPath.slice(0, rootPath.lastIndexOf("/packages/"));
 
 	const prettierOptions = {
 		...require(path.join(rootPath, ".prettierrc")),

--- a/packages/shared/src/strings.ts
+++ b/packages/shared/src/strings.ts
@@ -4,7 +4,7 @@ import { padStart } from "alcalzone-shared/strings";
 export function cpp2js(str: string): string {
 	const nullIndex = str.indexOf("\0");
 	if (nullIndex === -1) return str;
-	return str.substr(0, nullIndex);
+	return str.slice(0, nullIndex);
 }
 
 /**

--- a/packages/zwave-js/api.md
+++ b/packages/zwave-js/api.md
@@ -1059,10 +1059,16 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     assignPrioritySUCReturnRoute(nodeId: number, repeaters: number[], routeSpeed: ZWaveDataRate): Promise<boolean>;
-    // (undocumented)
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "zwave-js" does not have an export "assignReturnRoutes"
+    //
+    // @deprecated (undocumented)
     assignReturnRoute(nodeId: number, destinationNodeId: number): Promise<boolean>;
-    // (undocumented)
+    assignReturnRoutes(nodeId: number, destinationNodeId: number): Promise<boolean>;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "zwave-js" does not have an export "assignSUCReturnRoutes"
+    //
+    // @deprecated (undocumented)
     assignSUCReturnRoute(nodeId: number): Promise<boolean>;
+    assignSUCReturnRoutes(nodeId: number): Promise<boolean>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
     backupNVMRaw(onProgress?: (bytesRead: number, total: number) => void): Promise<Buffer>;
     // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
@@ -1073,10 +1079,18 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
     // (undocumented)
     cancelSecureBootstrapS2(reason: KEXFailType): void;
     configureSUC(nodeId: number, enableSUC: boolean, enableSIS: boolean): Promise<boolean>;
-    // (undocumented)
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "zwave-js" does not have an export "deleteReturnRoutes"
+    //
+    // @deprecated (undocumented)
     deleteReturnRoute(nodeId: number): Promise<boolean>;
-    // (undocumented)
+    deleteReturnRoutes(nodeId: number): Promise<boolean>;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "zwave-js" does not have an export "deleteSUCReturnRoutes"
+    //
+    // @deprecated (undocumented)
     deleteSUCReturnRoute(nodeId: number): Promise<boolean>;
+    deleteSUCReturnRoutes(nodeId: number): Promise<boolean>;
+    // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "zwave-js" does not have an export "getKnownNodeNeighbors"
+    discoverNodeNeighbors(nodeId: number): Promise<boolean>;
     externalNVMClose(): Promise<void>;
     externalNVMOpen(): Promise<number>;
     externalNVMReadBuffer(offset: number, length: number): Promise<Buffer>;

--- a/packages/zwave-js/src/lib/controller/ZWaveSDKVersions.ts
+++ b/packages/zwave-js/src/lib/controller/ZWaveSDKVersions.ts
@@ -347,7 +347,7 @@ function semverToLegacy(version: string): string {
  */
 export function protocolVersionToSDKVersion(protocolVersion: string): string {
 	if (protocolVersion.startsWith("Z-Wave ")) {
-		protocolVersion = protocolVersion.substr(7);
+		protocolVersion = protocolVersion.slice(7);
 	}
 
 	const normalizedVersion = semverToLegacy(protocolVersion);

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1539,7 +1539,9 @@ export class Driver
 						node.status !== NodeStatus.Dead
 					) {
 						node.hasSUCReturnRoute =
-							await this.controller.assignSUCReturnRoute(node.id);
+							await this.controller.assignSUCReturnRoutes(
+								node.id,
+							);
 					}
 				})();
 			}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1630,6 +1630,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:5.60.0":
+  version: 5.60.0
+  resolution: "@typescript-eslint/scope-manager@npm:5.60.0"
+  dependencies:
+    "@typescript-eslint/types": 5.60.0
+    "@typescript-eslint/visitor-keys": 5.60.0
+  checksum: b21ee1ef57be948a806aa31fd65a9186766b3e1a727030dc47025edcadc54bd1aa6133a439acd5f44a93e2b983dd55bc5571bb01cb834461dab733682d66256a
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/type-utils@npm:5.59.7":
   version: 5.59.7
   resolution: "@typescript-eslint/type-utils@npm:5.59.7"
@@ -1654,6 +1664,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/types@npm:5.60.0":
+  version: 5.60.0
+  resolution: "@typescript-eslint/types@npm:5.60.0"
+  checksum: 48f29e5c084c5663cfed1a6c4458799a6690a213e7861a24501f9b96698ae59e89a1df1c77e481777e4da78f1b0a5573a549f7b8880e3f4071a7a8b686254db8
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/typescript-estree@npm:5.59.7":
   version: 5.59.7
   resolution: "@typescript-eslint/typescript-estree@npm:5.59.7"
@@ -1669,6 +1686,24 @@ __metadata:
     typescript:
       optional: true
   checksum: eefe82eedf9ee2e14463c3f2b5b18df084c1328a859b245ee897a9a7075acce7cca0216a21fd7968b75aa64189daa008bfde1e2f9afbcc336f3dfe856e7f342e
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@npm:5.60.0":
+  version: 5.60.0
+  resolution: "@typescript-eslint/typescript-estree@npm:5.60.0"
+  dependencies:
+    "@typescript-eslint/types": 5.60.0
+    "@typescript-eslint/visitor-keys": 5.60.0
+    debug: ^4.3.4
+    globby: ^11.1.0
+    is-glob: ^4.0.3
+    semver: ^7.3.7
+    tsutils: ^3.21.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 0f4f342730ead42ba60b5fca4bf1950abebd83030010c38b5df98ff9fd95d0ce1cfc3974a44c90c65f381f4f172adcf1a540e018d7968cc845d937bf6c734dae
   languageName: node
   linkType: hard
 
@@ -1690,6 +1725,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/utils@npm:^5.57.0":
+  version: 5.60.0
+  resolution: "@typescript-eslint/utils@npm:5.60.0"
+  dependencies:
+    "@eslint-community/eslint-utils": ^4.2.0
+    "@types/json-schema": ^7.0.9
+    "@types/semver": ^7.3.12
+    "@typescript-eslint/scope-manager": 5.60.0
+    "@typescript-eslint/types": 5.60.0
+    "@typescript-eslint/typescript-estree": 5.60.0
+    eslint-scope: ^5.1.1
+    semver: ^7.3.7
+  peerDependencies:
+    eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+  checksum: cbe56567f0b53e24ad7ef7d2fb4cdc8596e2559c21ee639aa0560879b6216208550e51e9d8ae4b388ff21286809c6dc985cec66738294871051396a8ae5bccbc
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/visitor-keys@npm:5.59.7":
   version: 5.59.7
   resolution: "@typescript-eslint/visitor-keys@npm:5.59.7"
@@ -1697,6 +1750,16 @@ __metadata:
     "@typescript-eslint/types": 5.59.7
     eslint-visitor-keys: ^3.3.0
   checksum: 4367f2ea68dd96a0520485434ad11e1bd26239eeeb3a2150bee7478a0f1df3c2099a39f96486722932be0456bcb7a47a483b452876d1d30bdeb9b81d354eef3d
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:5.60.0":
+  version: 5.60.0
+  resolution: "@typescript-eslint/visitor-keys@npm:5.60.0"
+  dependencies:
+    "@typescript-eslint/types": 5.60.0
+    eslint-visitor-keys: ^3.3.0
+  checksum: d39b2485d030f9755820d0f6f3748a8ec44e1ca23cb36ddcba67a9eb1f258c8ec83c61fc015c50e8f4a00d05df62d719dbda445625e3e71a64a659f1d248157e
   languageName: node
   linkType: hard
 
@@ -1953,6 +2016,7 @@ __metadata:
     esbuild-register: ^3.4.2
     eslint: ^8.41.0
     eslint-config-prettier: ^8.8.0
+    eslint-plugin-deprecation: ^1.4.1
     eslint-plugin-prettier: ^4.2.1
     execa: ^5.1.1
     fs-extra: ^10.1.0
@@ -3990,6 +4054,20 @@ __metadata:
   bin:
     eslint-config-prettier: bin/cli.js
   checksum: 1e94c3882c4d5e41e1dcfa2c368dbccbfe3134f6ac7d40101644d3bfbe3eb2f2ffac757f3145910b5eacf20c0e85e02b91293d3126d770cbf3dc390b3564681c
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-deprecation@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "eslint-plugin-deprecation@npm:1.4.1"
+  dependencies:
+    "@typescript-eslint/utils": ^5.57.0
+    tslib: ^2.3.1
+    tsutils: ^3.21.0
+  peerDependencies:
+    eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    typescript: ^3.7.5 || ^4.0.0 || ^5.0.0
+  checksum: 75c7535d820d1749664705724cc979d706da126a2277f2937467f70156a2c220b10c66670f18226801c9555e4cd02312d353936f14d5752c2d2c648455fe5769
   languageName: node
   linkType: hard
 
@@ -8383,6 +8461,13 @@ __metadata:
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
   checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.3.1":
+  version: 2.5.3
+  resolution: "tslib@npm:2.5.3"
+  checksum: 88902b309afaf83259131c1e13da1dceb0ad1682a213143a1346a649143924d78cf3760c448b84d796938fd76127183894f8d85cbb3bf9c4fddbfcc140c0003c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
With this PR, neighbor discovery is now available outside of a healing process. This also gave a chance to clarify the assign/delete return route methods.

If a node has more than 4 association targets, healing now assigns routes to all of them. Previously, only 4 were assigned due to a misunderstanding.