### PR TITLE
ci: check updates to API report as part of documentation generation

### DIFF
--- a/.github/actions/generateTypedDocs/main.js
+++ b/.github/actions/generateTypedDocs/main.js
@@ -12,17 +12,16 @@ const options = {
 	repo: "node-zwave-js",
 };
 const branchName = "docs/update-typed-docs";
-const reviewers = ["AlCalzone", "robertsLando"];
-const assignees = [
-	// "AlCalzone",
-	// "robertsLando",
-];
+const reviewers = ["AlCalzone"];
+const assignees = [];
+
+const checkPaths = ["docs/", "packages/*/api.md"];
 
 (async function main() {
 	// check if our local working copy has any changes in the docs directory
 	const isChanged = !!(await exec.exec(
 		"git",
-		["diff", "--exit-code", "--", "docs/"],
+		["diff", "--exit-code", "--", ...checkPaths],
 		{
 			ignoreReturnCode: true,
 		},
@@ -61,7 +60,13 @@ const assignees = [
 		// check if our local working copy is different from the remote branch
 		const isChanged = !!(await exec.exec(
 			"git",
-			["diff", "--exit-code", `origin/${branchName}`, "--", "docs/"],
+			[
+				"diff",
+				"--exit-code",
+				`origin/${branchName}`,
+				"--",
+				...checkPaths,
+			],
 			{
 				ignoreReturnCode: true,
 			},
@@ -90,7 +95,7 @@ const assignees = [
 	await exec.exec("git", ["add", "."]);
 	await exec.exec(
 		"git",
-		["commit", "-m", "docs: update typed documentation"],
+		["commit", "-m", "docs: update typed documentation and API report"],
 		// Don't care if this fails due to no changes
 		{
 			ignoreReturnCode: true,
@@ -117,8 +122,8 @@ const assignees = [
 			...options,
 			head: branchName,
 			base: "master",
-			title: "docs: update typed documentation 🤖",
-			body: `The auto-generated documentation has changed. Please review the changes and merge them if desired.`,
+			title: "docs: update typed documentation and API report 🤖",
+			body: `The auto-generated documentation and/or API reports have changed. Please review the changes and merge them if desired.`,
 			maintainer_can_modify: true,
 		});
 		prNumber = pr.data.number;

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -13,7 +13,8 @@ jobs:
   # This job checks if the docs can be generated and produce changes
   # If they do, a PR will be created with the changes
   check-and-update:
-    if: github.repository == 'zwave-js/node-zwave-js' # Don't run in forks
+    # Don't run in forks
+    if: github.repository == 'zwave-js/node-zwave-js'
 
     runs-on: ubuntu-latest
     strategy:
@@ -43,6 +44,9 @@ jobs:
 
     - name: Generate documentation
       run: yarn run docs:generate
+
+    - name: Generate API report
+      run: yarn run accept-api
 
     # Trigger this step only when pushing to master
     - name: Create or update PR

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -227,51 +227,51 @@ jobs:
       env:
         CI: true
 
-  # ===================
-  # This job checks if a PR changes the public API surface
-  api-surface:
-    name: Check public API surface
-    # Only run for PRs
-    if: github.event_name == 'pull_request'
+  # # ===================
+  # # This job checks if a PR changes the public API surface
+  # api-surface:
+  #   name: Check public API surface
+  #   # Only run for PRs
+  #   if: github.event_name == 'pull_request'
 
-    needs: [build]
+  #   needs: [build]
 
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [16.x] # This should be LTS
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       node-version: [16.x] # This should be LTS
 
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
+  #   steps:
+  #   - name: Checkout code
+  #     uses: actions/checkout@v3
 
-    - name: Restore Turbo Cache from previous jobs
-      uses: ./.github/actions/build-cache-download
+  #   - name: Restore Turbo Cache from previous jobs
+  #     uses: ./.github/actions/build-cache-download
 
-    - name: Prepare testing environment
-      uses: ./.github/actions/prepare-env
-      with:
-        node-version: ${{ matrix.node-version }}
-        githubToken: ${{ secrets.GITHUB_TOKEN }}
+  #   - name: Prepare testing environment
+  #     uses: ./.github/actions/prepare-env
+  #     with:
+  #       node-version: ${{ matrix.node-version }}
+  #       githubToken: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Generate API report
-      run: yarn run extract-api $TURBO_FLAGS
+  #   - name: Generate API report
+  #     run: yarn run extract-api $TURBO_FLAGS
 
-    - name: Show changes
-      if: failure()
-      run: |
-        cat packages/*/.tmp/api.md
+  #   - name: Show changes
+  #     if: failure()
+  #     run: |
+  #       cat packages/*/.tmp/api.md
 
-    - name: Comment on PR
-      if: failure()
-      run: |
-        echo "The public API surface has changed!" >> $GITHUB_STEP_SUMMARY
-        echo "Please run" >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-        echo "yarn accept-api" >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-        echo "and review the changes, then commit them if desired." >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
+  #   - name: Comment on PR
+  #     if: failure()
+  #     run: |
+  #       echo "The public API surface has changed!" >> $GITHUB_STEP_SUMMARY
+  #       echo "Please run" >> $GITHUB_STEP_SUMMARY
+  #       echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+  #       echo "yarn accept-api" >> $GITHUB_STEP_SUMMARY
+  #       echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+  #       echo "and review the changes, then commit them if desired." >> $GITHUB_STEP_SUMMARY
+  #       echo "" >> $GITHUB_STEP_SUMMARY
 
   # ===================
 


### PR DESCRIPTION
Requiring this as part of every PR is slowing me down too much, especially since the API generation seems to require two builds locally.