### PR TITLE
feat: assign custom return routes, cache priority return routes

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -602,14 +602,16 @@ assignPrioritySUCReturnRoute(
 -   `assignPriorityReturnRoute` sets the priority route from node `nodeId` to the destination node.
 -   `assignPrioritySUCReturnRoute` does the same, but with the SUC (controller) as the destination node.
 
+> [!WARNING] It has been found that assigning return routes to nodes that already have a priority route can cause the priority route to be changed unexpectedly. To avoid this, assigning priority routes should be done last. Otherwise, call `deleteReturnRoutes` or `deleteSUCReturnRoutes` (for routes to the controller) before assigning new routes. Unfortunately, `deleteReturnRoutes` deletes **all** return routes to all destination nodes, so they all have to be set up again afterwards.
+
 As mentioned before, there is unfortunately no way to query return routes from a node. To remedy this, Z-Wave JS caches the routes it has assigned. To read them, use the following methods:
 
 ```ts
-getPriorityReturnRouteCached(nodeId: number, destinationNodeId: number): Route | undefined;
-getPrioritySUCReturnRouteCached(nodeId: number): Route | undefined;
+getPriorityReturnRouteCached(nodeId: number, destinationNodeId: number): MaybeUnknown<Route> | undefined;
+getPrioritySUCReturnRouteCached(nodeId: number): MaybeUnknown<Route> | undefined;
 ```
 
--   `getPriorityReturnRouteCached` returns a priority return route that was set using `assignPriorityReturnRoute`.
+-   `getPriorityReturnRouteCached` returns a priority return route that was set using `assignPriorityReturnRoute`. If a non-priority return route has been set since assigning the priority route, this will return `UNKNOWN_STATE` (`null`).
 -   `getPrioritySUCReturnRouteCached` does the same for a route set through `assignPrioritySUCReturnRoute`.
 
 The return type `Route` has the following shape:

--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -495,20 +495,26 @@ type ReplaceNodeOptions =
 
 ### Managing routes
 
-The methods shown here can be used to manage routes between nodes. For the most part, these are not particularly relevant for applications or even end users, since they are used automatically by Z-Wave JS when necessary.
+#### Automatic assignment
+
+The methods shown here can be used to manage routes between nodes. For the most part, these are not particularly relevant for applications or even end users, since they are used automatically by Z-Wave JS when necessary. Routes assigned by these methods are determined by the controller, which should be preferred usually.
 
 ```ts
-assignReturnRoute(nodeId: number, destinationNodeId: number): Promise<boolean>;
-deleteReturnRoute(nodeId: number): Promise<boolean>;
+assignReturnRoutes(nodeId: number, destinationNodeId: number): Promise<boolean>;
+deleteReturnRoutes(nodeId: number): Promise<boolean>;
 
-assignSUCReturnRoute(nodeId: number): Promise<boolean>;
-deleteSUCReturnRoute(nodeId: number): Promise<boolean>;
+assignSUCReturnRoutes(nodeId: number): Promise<boolean>;
+deleteSUCReturnRoutes(nodeId: number): Promise<boolean>;
 ```
 
--   `assignReturnRoute` instructs the controller to assign node `nodeId` a set of routes to node `destinationNodeId`. These routes are determined by the controller.
--   `deleteReturnRoute` instructs node `nodeId` to delete all previously assigned routes.
--   `assignSUCReturnRoute` works like `assignReturnRoute`, but the routes have the SUC as the destination.
--   `deleteSUCReturnRoute` works like `deleteReturnRoute`, but for routes that have the SUC as the destination.
+-   `assignReturnRoutes` instructs the controller to assign node `nodeId` a set of routes to node `destinationNodeId`.
+-   `deleteReturnRoutes` instructs node `nodeId` to delete all previously assigned routes.
+-   `assignSUCReturnRoutes` works like `assignReturnRoutes`, but the routes have the SUC as the destination.
+-   `deleteSUCReturnRoutes` works like `deleteReturnRoutes`, but for routes that have the SUC as the destination.
+
+> [!NOTE] These routes cannot be read back, since they are managed internally by the controller and no API exists to query them.
+
+#### Priority routes
 
 In certain scenarios, the routing algorithm of Z-Wave can break down and produce subpar results. It is possible to manually assign priority routes which will always be attempted first instead of the automatically determined routes.
 
@@ -595,6 +601,56 @@ assignPrioritySUCReturnRoute(
 
 -   `assignPriorityReturnRoute` sets the priority route from node `nodeId` to the destination node.
 -   `assignPrioritySUCReturnRoute` does the same, but with the SUC (controller) as the destination node.
+
+As mentioned before, there is unfortunately no way to query return routes from a node. To remedy this, Z-Wave JS caches the routes it has assigned. To read them, use the following methods:
+
+```ts
+getPriorityReturnRouteCached(nodeId: number, destinationNodeId: number): Route | undefined;
+getPrioritySUCReturnRouteCached(nodeId: number): Route | undefined;
+```
+
+-   `getPriorityReturnRouteCached` returns a priority return route that was set using `assignPriorityReturnRoute`.
+-   `getPrioritySUCReturnRouteCached` does the same for a route set through `assignPrioritySUCReturnRoute`.
+
+The return type `Route` has the following shape:
+
+<!-- #import Route from "@zwave-js/core" -->
+
+```ts
+interface Route {
+	repeaters: number[];
+	routeSpeed: ZWaveDataRate;
+}
+```
+
+> [!NOTE] When another controller also manages routes in a network, the cached information is not guaranteed to be up to date. In this case, use the methods above to set the routes again or clear them.
+
+#### Custom non-priority return routes
+
+A middle ground between the two approaches above is to set custom return routes manually. Unlike priority routes, these are not set in stone like priority return routes, so they can change if they fail. This uses the `Z-Wave Protocol` command class, which is used internally by the controller and Z-Wave protocol, so this should at least be considered an inofficial way to set return routes.
+
+Routes set by these methods have to be provided manually, up to 4 for each combination of source and destination node. If less routes are given, the remaining ones will be cleared:
+```ts
+assignCustomReturnRoutes(nodeId: number, destinationNodeId: number, routes: Route[]): Promise<boolean>;
+assignCustomSUCReturnRoutes(nodeId: number, routes: Route[]): Promise<boolean>;
+```
+
+-   `assignCustomReturnRoutes` assigns node `nodeId` a set of routes to node `destinationNodeId`.
+-   `assignCustomSUCReturnRoutes` does the same, but with the SUC as the destination.
+
+To remove these routes, use `deleteReturnRoutes` and `deleteSUCReturnRoutes` as described above.
+
+Like with priority return routes, Z-Wave JS caches the assigned routes, so they can be read back:
+
+```ts
+getCustomReturnRoutesCached(nodeId: number, destinationNodeId: number): Route[] | undefined;
+getCustomSUCReturnRoutesCached(nodeId: number, destinationNodeId: number): Route[] | undefined;
+```
+
+-   `getCustomReturnRoutesCached` returns routes that were was set using `assignCustomReturnRoutes`.
+-   `getCustomSUCReturnRoutesCached` returns routes that were was set using `assignCustomSUCReturnRoutes`.
+
+> [!NOTE] When another controller also manages routes in a network, the cached information is not guaranteed to be up to date. In this case, use the methods above to set the routes again or clear them.
 
 ### Managing associations
 

--- a/packages/cc/src/cc/ZWaveProtocolCC.ts
+++ b/packages/cc/src/cc/ZWaveProtocolCC.ts
@@ -112,7 +112,7 @@ export class ZWaveProtocolCCNodeInformationFrame
 export class ZWaveProtocolCCRequestNodeInformationFrame extends ZWaveProtocolCC {}
 
 interface ZWaveProtocolCCAssignIDsOptions extends CCCommandOptions {
-	nodeId: number;
+	assignedNodeId: number;
 	homeId: number;
 }
 
@@ -127,20 +127,20 @@ export class ZWaveProtocolCCAssignIDs extends ZWaveProtocolCC {
 		super(host, options);
 		if (gotDeserializationOptions(options)) {
 			validatePayload(this.payload.length >= 5);
-			this.nodeId = this.payload[0];
+			this.assignedNodeId = this.payload[0];
 			this.homeId = this.payload.readUInt32BE(1);
 		} else {
-			this.nodeId = options.nodeId;
+			this.assignedNodeId = options.assignedNodeId;
 			this.homeId = options.homeId;
 		}
 	}
 
-	public nodeId: number;
+	public assignedNodeId: number;
 	public homeId: number;
 
 	public serialize(): Buffer {
 		this.payload = Buffer.allocUnsafe(5);
-		this.payload[0] = this.nodeId;
+		this.payload[0] = this.assignedNodeId;
 		this.payload.writeUInt32BE(this.homeId, 1);
 		return super.serialize();
 	}
@@ -347,7 +347,7 @@ interface ZWaveProtocolCCTransferNodeInformationOptions
 	extends CCCommandOptions,
 		NodeProtocolInfoAndDeviceClass {
 	sequenceNumber: number;
-	nodeId: number;
+	sourceNodeId: number;
 }
 
 @CCCommand(ZWaveProtocolCommand.TransferNodeInformation)
@@ -367,13 +367,13 @@ export class ZWaveProtocolCCTransferNodeInformation
 		if (gotDeserializationOptions(options)) {
 			validatePayload(this.payload.length >= 2);
 			this.sequenceNumber = this.payload[0];
-			this.nodeId = this.payload[1];
+			this.sourceNodeId = this.payload[1];
 			info = parseNodeProtocolInfoAndDeviceClass(
 				this.payload.slice(2),
 			).info;
 		} else {
 			this.sequenceNumber = options.sequenceNumber;
-			this.nodeId = options.nodeId;
+			this.sourceNodeId = options.sourceNodeId;
 			info = options;
 		}
 
@@ -392,7 +392,7 @@ export class ZWaveProtocolCCTransferNodeInformation
 	}
 
 	public sequenceNumber: number;
-	public nodeId: number;
+	public sourceNodeId: number;
 	public basicDeviceClass: number;
 	public genericDeviceClass: number;
 	public specificDeviceClass: number;
@@ -408,7 +408,7 @@ export class ZWaveProtocolCCTransferNodeInformation
 
 	public serialize(): Buffer {
 		this.payload = Buffer.concat([
-			Buffer.from([this.sequenceNumber, this.nodeId]),
+			Buffer.from([this.sequenceNumber, this.sourceNodeId]),
 			encodeNodeProtocolInfoAndDeviceClass(this),
 		]);
 		return super.serialize();
@@ -418,7 +418,7 @@ export class ZWaveProtocolCCTransferNodeInformation
 interface ZWaveProtocolCCTransferRangeInformationOptions
 	extends CCCommandOptions {
 	sequenceNumber: number;
-	nodeId: number;
+	testedNodeId: number;
 	neighborNodeIds: number[];
 }
 
@@ -434,7 +434,7 @@ export class ZWaveProtocolCCTransferRangeInformation extends ZWaveProtocolCC {
 		if (gotDeserializationOptions(options)) {
 			validatePayload(this.payload.length >= 3);
 			this.sequenceNumber = this.payload[0];
-			this.nodeId = this.payload[1];
+			this.testedNodeId = this.payload[1];
 			const bitmaskLength = this.payload[2];
 			validatePayload(this.payload.length >= 3 + bitmaskLength);
 			this.neighborNodeIds = parseBitMask(
@@ -442,13 +442,13 @@ export class ZWaveProtocolCCTransferRangeInformation extends ZWaveProtocolCC {
 			);
 		} else {
 			this.sequenceNumber = options.sequenceNumber;
-			this.nodeId = options.nodeId;
+			this.testedNodeId = options.testedNodeId;
 			this.neighborNodeIds = options.neighborNodeIds;
 		}
 	}
 
 	public sequenceNumber: number;
-	public nodeId: number;
+	public testedNodeId: number;
 	public neighborNodeIds: number[];
 
 	public serialize(): Buffer {
@@ -456,7 +456,7 @@ export class ZWaveProtocolCCTransferRangeInformation extends ZWaveProtocolCC {
 		this.payload = Buffer.concat([
 			Buffer.from([
 				this.sequenceNumber,
-				this.nodeId,
+				this.testedNodeId,
 				nodesBitmask.length,
 			]),
 			nodesBitmask,
@@ -495,7 +495,7 @@ export class ZWaveProtocolCCTransferEnd extends ZWaveProtocolCC {
 }
 
 interface ZWaveProtocolCCAssignReturnRouteOptions extends CCCommandOptions {
-	nodeId: number;
+	destinationNodeId: number;
 	routeIndex: number;
 	repeaters: number[];
 	destinationWakeUp: WakeUpTime;
@@ -513,7 +513,7 @@ export class ZWaveProtocolCCAssignReturnRoute extends ZWaveProtocolCC {
 		super(host, options);
 		if (gotDeserializationOptions(options)) {
 			validatePayload(this.payload.length >= 7);
-			this.nodeId = this.payload[0];
+			this.destinationNodeId = this.payload[0];
 			this.routeIndex = this.payload[1] >>> 4;
 			const numRepeaters = this.payload[1] & 0b1111;
 			this.repeaters = [...this.payload.slice(2, 2 + numRepeaters)];
@@ -528,7 +528,7 @@ export class ZWaveProtocolCCAssignReturnRoute extends ZWaveProtocolCC {
 				);
 			}
 
-			this.nodeId = options.nodeId;
+			this.destinationNodeId = options.destinationNodeId;
 			this.routeIndex = options.routeIndex;
 			this.repeaters = options.repeaters;
 			this.destinationWakeUp = options.destinationWakeUp;
@@ -536,7 +536,7 @@ export class ZWaveProtocolCCAssignReturnRoute extends ZWaveProtocolCC {
 		}
 	}
 
-	public nodeId: number;
+	public destinationNodeId: number;
 	public routeIndex: number;
 	public repeaters: number[];
 	public destinationWakeUp: WakeUpTime;
@@ -544,7 +544,7 @@ export class ZWaveProtocolCCAssignReturnRoute extends ZWaveProtocolCC {
 
 	public serialize(): Buffer {
 		this.payload = Buffer.from([
-			this.nodeId,
+			this.destinationNodeId,
 			(this.routeIndex << 4) | this.repeaters.length,
 			this.repeaters[0] ?? 0,
 			this.repeaters[1] ?? 0,
@@ -559,7 +559,7 @@ export class ZWaveProtocolCCAssignReturnRoute extends ZWaveProtocolCC {
 interface ZWaveProtocolCCNewNodeRegisteredOptions
 	extends CCCommandOptions,
 		NodeInformationFrame {
-	nodeId: number;
+	newNodeId: number;
 }
 
 @CCCommand(ZWaveProtocolCommand.NewNodeRegistered)
@@ -578,10 +578,10 @@ export class ZWaveProtocolCCNewNodeRegistered
 		let nif: NodeInformationFrame;
 		if (gotDeserializationOptions(options)) {
 			validatePayload(this.payload.length >= 1);
-			this.nodeId = this.payload[0];
+			this.newNodeId = this.payload[0];
 			nif = parseNodeInformationFrame(this.payload.slice(1));
 		} else {
-			this.nodeId = options.nodeId;
+			this.newNodeId = options.newNodeId;
 			nif = options;
 		}
 
@@ -600,7 +600,7 @@ export class ZWaveProtocolCCNewNodeRegistered
 		this.supportedCCs = nif.supportedCCs;
 	}
 
-	public nodeId: number;
+	public newNodeId: number;
 	public basicDeviceClass: number;
 	public genericDeviceClass: number;
 	public specificDeviceClass: number;
@@ -617,7 +617,7 @@ export class ZWaveProtocolCCNewNodeRegistered
 
 	public serialize(): Buffer {
 		this.payload = Buffer.concat([
-			Buffer.from([this.nodeId]),
+			Buffer.from([this.newNodeId]),
 			encodeNodeInformationFrame(this),
 		]);
 		return super.serialize();
@@ -625,7 +625,7 @@ export class ZWaveProtocolCCNewNodeRegistered
 }
 
 interface ZWaveProtocolCCNewRangeRegisteredOptions extends CCCommandOptions {
-	nodeId: number;
+	testedNodeId: number;
 	neighborNodeIds: number[];
 }
 
@@ -640,22 +640,22 @@ export class ZWaveProtocolCCNewRangeRegistered extends ZWaveProtocolCC {
 		super(host, options);
 		if (gotDeserializationOptions(options)) {
 			validatePayload(this.payload.length >= 2);
-			this.nodeId = this.payload[0];
+			this.testedNodeId = this.payload[0];
 			const numNeighbors = this.payload[1];
 			this.neighborNodeIds = [...this.payload.slice(2, 2 + numNeighbors)];
 		} else {
-			this.nodeId = options.nodeId;
+			this.testedNodeId = options.testedNodeId;
 			this.neighborNodeIds = options.neighborNodeIds;
 		}
 	}
 
-	public nodeId: number;
+	public testedNodeId: number;
 	public neighborNodeIds: number[];
 
 	public serialize(): Buffer {
 		const nodesBitmask = encodeBitMask(this.neighborNodeIds, MAX_NODES);
 		this.payload = Buffer.concat([
-			Buffer.from([this.nodeId, nodesBitmask.length]),
+			Buffer.from([this.testedNodeId, nodesBitmask.length]),
 			nodesBitmask,
 		]);
 		return super.serialize();
@@ -841,7 +841,7 @@ export class ZWaveProtocolCCStaticRouteRequest extends ZWaveProtocolCC {
 }
 
 interface ZWaveProtocolCCLostOptions extends CCCommandOptions {
-	nodeId: number;
+	lostNodeId: number;
 }
 
 @CCCommand(ZWaveProtocolCommand.Lost)
@@ -855,16 +855,16 @@ export class ZWaveProtocolCCLost extends ZWaveProtocolCC {
 		super(host, options);
 		if (gotDeserializationOptions(options)) {
 			validatePayload(this.payload.length >= 1);
-			this.nodeId = this.payload[0];
+			this.lostNodeId = this.payload[0];
 		} else {
-			this.nodeId = options.nodeId;
+			this.lostNodeId = options.lostNodeId;
 		}
 	}
 
-	public nodeId: number;
+	public lostNodeId: number;
 
 	public serialize(): Buffer {
-		this.payload = Buffer.from([this.nodeId]);
+		this.payload = Buffer.from([this.lostNodeId]);
 		return super.serialize();
 	}
 }

--- a/packages/core/src/capabilities/Protocols.ts
+++ b/packages/core/src/capabilities/Protocols.ts
@@ -58,3 +58,8 @@ export enum RouteKind {
 	/** Application-defined priority route */
 	Application = 0x10,
 }
+
+export interface Route {
+	repeaters: number[];
+	routeSpeed: ZWaveDataRate;
+}

--- a/packages/core/src/capabilities/Protocols.ts
+++ b/packages/core/src/capabilities/Protocols.ts
@@ -63,3 +63,15 @@ export interface Route {
 	repeaters: number[];
 	routeSpeed: ZWaveDataRate;
 }
+
+export const EMPTY_ROUTE: Route = {
+	repeaters: [],
+	routeSpeed: ZWaveDataRate["9k6"],
+};
+
+export function isEmptyRoute(route: Route): boolean {
+	return (
+		route.repeaters.length === 0 &&
+		route.routeSpeed === ZWaveDataRate["9k6"]
+	);
+}

--- a/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
+++ b/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
@@ -585,8 +585,9 @@ const handleAssignSUCReturnRoute: MockControllerBehavior = {
 
 			// Send the command to the node
 			const node = controller.nodes.get(msg.getNodeId()!)!;
-			const command = new ZWaveProtocolCCAssignSUCReturnRoute(node.host, {
-				nodeId: controller.host.ownNodeId,
+			const command = new ZWaveProtocolCCAssignSUCReturnRoute(host, {
+				nodeId: node.id,
+				destinationNodeId: controller.host.ownNodeId,
 				repeaters: [], // don't care
 				routeIndex: 0, // don't care
 				destinationSpeed: ZWaveDataRate["100k"],

--- a/packages/zwave-js/src/lib/driver/NetworkCache.ts
+++ b/packages/zwave-js/src/lib/driver/NetworkCache.ts
@@ -66,6 +66,9 @@ export const cacheKeys = {
 			hasSUCReturnRoute: `${nodeBaseKey}hasSUCReturnRoute`,
 			associations: (groupId: number) =>
 				`${nodeBaseKey}associations.${groupId}`,
+			customReturnRoutes: (destinationNodeId: number) =>
+				`${nodeBaseKey}customReturnRoutes.${destinationNodeId}`,
+			customSUCReturnRoutes: `${nodeBaseKey}customReturnRoutes.SUC`,
 		};
 	},
 } as const;

--- a/packages/zwave-js/src/lib/driver/NetworkCache.ts
+++ b/packages/zwave-js/src/lib/driver/NetworkCache.ts
@@ -66,6 +66,9 @@ export const cacheKeys = {
 			hasSUCReturnRoute: `${nodeBaseKey}hasSUCReturnRoute`,
 			associations: (groupId: number) =>
 				`${nodeBaseKey}associations.${groupId}`,
+			priorityReturnRoute: (destinationNodeId: number) =>
+				`${nodeBaseKey}priorityReturnRoute.${destinationNodeId}`,
+			prioritySUCReturnRoute: `${nodeBaseKey}priorityReturnRoute.SUC`,
 			customReturnRoutes: (destinationNodeId: number) =>
 				`${nodeBaseKey}customReturnRoutes.${destinationNodeId}`,
 			customSUCReturnRoutes: `${nodeBaseKey}customReturnRoutes.SUC`,


### PR DESCRIPTION
This PR adds a missing piece of functionality for managing return routes. Previously, there were two ways to do this:
- Let the controller assign them, which usually works fine, but can produce subpar results
- Assign priority routes, which are always used first and can introduce permanent latency if they fail

With this PR, applications are now able to assign custom return routes without going through the corresponding serial API. This uses the internal `Z-Wave Protocol CC`, which is normally only used by the controller as part of serial API calls, so it should at least be considered an inofficial way.

Routes set this way are cached, so they can be read back from cache, since there's no Z-Wave API to query routes from a node. In addition, priority return routes are now also cached, so they can also be read back.
It should be noted that all this caching is done on a best-effort basis. There might be some edge cases where the controller assigns new routes without Z-Wave JS knowing.

---

Also, this PR introduces a consistent naming scheme for the route assignment methods. Methods that deal with multiple routes have been renamed to plural:
- `assignReturnRoute` -> `assignReturnRoutes` 
- `assignSUCReturnRoute` -> `assignSUCReturnRoutes`
- `deleteReturnRoute` -> `deleteReturnRoutes` 
- `deleteSUCReturnRoute` -> `deleteSUCReturnRoutes`

The original methods still exist, but are now deprecated.