### PR TITLE
feat: add compat flag to override (almost) arbitrary CC API queries

### DIFF
--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -423,13 +423,14 @@ A frequent reason for device not "working" correctly is that they respond to que
 				"numDailyRepeatingSlots": 1
 			},
 			// Which values should be stored in the value DB when the API method is called (optional).
-			// The keys are the names of statically defined values for the given CC,
-			// see the CC documentation for available values. Dynamic values
-			// which expect an argument are not supported.
+			// The keys are the names of the predefined values of the given CC,
+			// see the CC documentation for available values.
 			"persistValues": {
 				"numWeekDaySlots": 0,
 				"numYearDaySlots": 0,
-				"numDailyRepeatingSlots": 1
+				"numDailyRepeatingSlots": 1,
+				// To pass arguments for dynamic CC values, put them in round brackets (must be parseable by `JSON.parse()`)
+				"userEnabled(1)": true
 			},
 		}
 	]

--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -396,6 +396,46 @@ Some legacy devices emit an NIF when a local event occurs (e.g. a button press) 
 
 Some multi-channel devices incorrectly report state changes for one of their endpoints via the root device, however there is no way to automatically detect for which endpoint these reports are meant. The flag `mapRootReportsToEndpoint` can be used to specify which endpoint these reports are mapped to. Without this flag, reports to the root device are silently ignored, unless `preserveRootApplicationCCValueIDs` is `true`.
 
+### `overrideQueries`
+
+A frequent reason for device not "working" correctly is that they respond to queries incorrectly, e.g. RGB bulbs not reporting support for the blue color channel, or thermostats reporting the wrong supported modes. Using `overrideQueries`, the responses to these queries can be overridden, so they are not queried from the device anymore. Example:
+
+```js
+"overrideQueries": {
+	// For which CC the queries should be overridden. Also accepts the decimal or hexadecimal CC ID.
+	"Schedule Entry Lock": [
+		{
+			// Which endpoint the query should be overridden for (optional).
+			// Defaults to the root endpoint 0
+			"endpoint": 1,
+			// Which API method should be overridden. Available methods depend on the CC.
+			"method": "getNumSlots",
+			// Multiple overrides can optionally be specified for the same method, distinguished
+			// by the method arguments. If `matchArgs` is not specified, the override
+			// is used for all calls to the method.
+			// The arguments must be exactly the same as in the API call and are
+			// compared using equality (===)
+			"matchArgs": [1, 2, 3] 
+			// The result that should be returned by the API method when called.
+			"result": {
+				"numWeekDaySlots": 0,
+				"numYearDaySlots": 0,
+				"numDailyRepeatingSlots": 1
+			},
+			// Which values should be stored in the value DB when the API method is called (optional).
+			// The keys are the names of statically defined values for the given CC,
+			// see the CC documentation for available values. Dynamic values
+			// which expect an argument are not supported.
+			"persistValues": {
+				"numWeekDaySlots": 0,
+				"numYearDaySlots": 0,
+				"numDailyRepeatingSlots": 1
+			},
+		}
+	]
+}
+```
+
 ### `preserveEndpoints`
 
 Many devices unnecessarily use endpoints when they could (or do) provide all functionality via the root device. `zwave-js` tries to detect these cases and ignore all endpoints. To opt out of this behavior or to preserve single endpoints, `preserveEndpoints` can be used. Example:

--- a/maintenance/schemas/device-config.json
+++ b/maintenance/schemas/device-config.json
@@ -614,6 +614,25 @@
 					"minProperties": 1,
 					"additionalProperties": false
 				},
+				"overrideQueries": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "array",
+						"minItems": 1,
+						"items": {
+							"type": "object",
+							"properties": {
+								"endpoint": { "type": "integer", "minimum": 0 },
+								"method": { "type": "string" },
+								"matchArgs": { "type": "array" },
+								"result": true,
+								"persistValues": { "type": "object" }
+							},
+							"required": ["method", "result"],
+							"additionalProperties": false
+						}
+					}
+				},
 				"preserveEndpoints": {
 					"oneOf": [
 						{

--- a/packages/cc/src/lib/API.ts
+++ b/packages/cc/src/lib/API.ts
@@ -5,6 +5,7 @@ import {
 	NOT_KNOWN,
 	ZWaveError,
 	ZWaveErrorCodes,
+	getCCName,
 	isZWaveError,
 	stripUndefined,
 	type Duration,
@@ -591,6 +592,14 @@ function overrideQueriesWrapper(
 	return (...args: any[]) => {
 		const match = overrides.matchQuery(ccId, endpoint.index, method, args);
 		if (!match) return fallback(...args);
+
+		applHost.controllerLog.logNode(endpoint.nodeId, {
+			message: `API call ${method} for ${getCCName(
+				ccId,
+			)} CC overridden by a compat flag.`,
+			level: "debug",
+			direction: "none",
+		});
 
 		// Persist values if necessary
 		if (match.persistValues) {

--- a/packages/config/src/devices/CompatConfig.ts
+++ b/packages/config/src/devices/CompatConfig.ts
@@ -837,7 +837,10 @@ Property "method" in compat option overrideQueries, CC ${getCCName(
 						cc,
 					)} must be a string!`,
 				);
-			} else if (!isArray(info.matchArgs)) {
+			} else if (
+				info.matchArgs != undefined &&
+				!isArray(info.matchArgs)
+			) {
 				throwInvalidConfig(
 					"devices",
 					`config/devices/${filename}:
@@ -922,7 +925,11 @@ Property "${key}" in compat option overrideQueries must be a single override obj
 		CompatOverrideQuery[]
 	>;
 
-	public matchQuery(
+	public hasOverride(ccId: CommandClasses): boolean {
+		return this.overrides.has(ccId);
+	}
+
+	public matchOverride(
 		cc: CommandClasses,
 		endpointIndex: number,
 		method: string,
@@ -952,7 +959,7 @@ export interface CompatOverrideQuery {
 	 * An array of method arguments that needs to match for this override to apply.
 	 * If `undefined`, no matching is performed.
 	 */
-	matchArgs: any[];
+	matchArgs?: any[];
 	/** The result to return from the API call */
 	result: any;
 	/**

--- a/packages/config/src/devices/CompatConfig.ts
+++ b/packages/config/src/devices/CompatConfig.ts
@@ -1,11 +1,16 @@
-import type {
-	CommandClasses,
-	CommandClassInfo,
-	ValueID,
+import {
+	getCCName,
+	type CommandClassInfo,
+	type CommandClasses,
+	type ValueID,
 } from "@zwave-js/core/safe";
 import { pick, type JSONObject } from "@zwave-js/shared/safe";
 import { isArray, isObject } from "alcalzone-shared/typeguards";
-import { hexKeyRegex2Digits, throwInvalidConfig } from "../utils_safe";
+import {
+	hexKeyRegex2Digits,
+	throwInvalidConfig,
+	tryParseCCId,
+} from "../utils_safe";
 import { conditionApplies, type ConditionalItem } from "./ConditionalItem";
 import type { DeviceID } from "./shared";
 
@@ -540,6 +545,20 @@ compat option alarmMapping must be an array where all items are objects!`,
 				(m, i) => new CompatMapAlarm(filename, m, i + 1),
 			);
 		}
+
+		if (definition.overrideQueries != undefined) {
+			if (!isObject(definition.overrideQueries)) {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+compat option overrideQueries must be an object!`,
+				);
+			}
+			this.overrideQueries = new CompatOverrideQueries(
+				filename,
+				definition.overrideQueries,
+			);
+		}
 	}
 
 	public readonly alarmMapping?: readonly CompatMapAlarm[];
@@ -561,6 +580,7 @@ compat option alarmMapping must be an array where all items are objects!`,
 		size?: number;
 		precision?: number;
 	};
+	public readonly overrideQueries?: CompatOverrideQueries;
 	public readonly preserveRootApplicationCCValueIDs?: boolean;
 	public readonly preserveEndpoints?: "*" | readonly number[];
 	public readonly removeEndpoints?: "*" | readonly number[];
@@ -599,6 +619,7 @@ compat option alarmMapping must be an array where all items are objects!`,
 			"manualValueRefreshDelayMs",
 			"mapRootReportsToEndpoint",
 			"overrideFloatEncoding",
+			"overrideQueries",
 			"reportTimeout",
 			"preserveRootApplicationCCValueIDs",
 			"preserveEndpoints",
@@ -798,4 +819,145 @@ error in compat option alarmMapping, mapping #${index}: property "to.eventParame
 
 	public readonly from: CompatMapAlarmFrom;
 	public readonly to: CompatMapAlarmTo;
+}
+
+export class CompatOverrideQueries {
+	public constructor(filename: string, definition: JSONObject) {
+		const overrides = new Map();
+
+		const parseOverride = (
+			cc: CommandClasses,
+			info: JSONObject,
+		): CompatOverrideQuery => {
+			if (typeof info.method !== "string") {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+Property "method" in compat option overrideQueries, CC ${getCCName(
+						cc,
+					)} must be a string!`,
+				);
+			} else if (!isArray(info.matchArgs)) {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+Property "matchArgs" in compat option overrideQueries, CC ${getCCName(
+						cc,
+					)} must be an array!`,
+				);
+			} else if (!("result" in info)) {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+Property "result" is missing in in compat option overrideQueries, CC ${getCCName(
+						cc,
+					)}!`,
+				);
+			} else if (
+				info.endpoint != undefined &&
+				typeof info.endpoint !== "number"
+			) {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+Property "endpoint" in compat option overrideQueries, CC ${getCCName(
+						cc,
+					)} must be a number!`,
+				);
+			} else if (info.persistValues && !isObject(info.persistValues)) {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+Property "persistValues" in compat option overrideQueries, CC ${getCCName(
+						cc,
+					)} must be an object!`,
+				);
+			}
+
+			return {
+				endpoint: info.endpoint,
+				method: info.method,
+				matchArgs: info.matchArgs,
+				result: info.result,
+				persistValues: info.persistValues,
+			};
+		};
+
+		for (const [key, value] of Object.entries(definition)) {
+			// Parse the key into a CC ID
+			const cc = tryParseCCId(key);
+			if (cc == undefined) {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+Invalid Command Class "${key}" specified in compat option overrideQueries!`,
+				);
+			}
+
+			let overrideDefinitions: any;
+			if (isObject(value)) {
+				overrideDefinitions = [value];
+			} else if (!isArray(value)) {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+Property "${key}" in compat option overrideQueries must be a single override object or an array thereof!`,
+				);
+			} else {
+				overrideDefinitions = value;
+			}
+
+			overrides.set(
+				cc,
+				overrideDefinitions.map((info: any) => parseOverride(cc, info)),
+			);
+		}
+
+		this.overrides = overrides;
+	}
+
+	// CC -> endpoint -> queries
+	private readonly overrides: ReadonlyMap<
+		CommandClasses,
+		CompatOverrideQuery[]
+	>;
+
+	public matchQuery(
+		cc: CommandClasses,
+		endpointIndex: number,
+		method: string,
+		args: any[],
+	): Pick<CompatOverrideQuery, "result" | "persistValues"> | undefined {
+		const queries = this.overrides.get(cc);
+		if (!queries) return undefined;
+		for (const query of queries) {
+			if ((query.endpoint ?? 0) !== endpointIndex) continue;
+			if (query.method !== method) continue;
+			if (query.matchArgs) {
+				if (query.matchArgs.length !== args.length) continue;
+				if (!query.matchArgs.every((arg, i) => arg === args[i]))
+					continue;
+			}
+			return pick(query, ["result", "persistValues"]);
+		}
+	}
+}
+
+export interface CompatOverrideQuery {
+	/** Which endpoint this override is for */
+	endpoint?: number;
+	/** For which API method this override is defined */
+	method: string;
+	/**
+	 * An array of method arguments that needs to match for this override to apply.
+	 * If `undefined`, no matching is performed.
+	 */
+	matchArgs: any[];
+	/** The result to return from the API call */
+	result: any;
+	/**
+	 * Optionally a dictionary of values that will be persisted in the cache.
+	 * The keys are properties of the `...CCValues` objects that belong to this CC.
+	 */
+	persistValues?: Record<string, any>;
 }

--- a/packages/config/src/utils_safe.ts
+++ b/packages/config/src/utils_safe.ts
@@ -1,4 +1,8 @@
-import { ZWaveError, ZWaveErrorCodes } from "@zwave-js/core/safe";
+import {
+	CommandClasses,
+	ZWaveError,
+	ZWaveErrorCodes,
+} from "@zwave-js/core/safe";
 
 export const hexKeyRegexNDigits = /^0x[a-f0-9]+$/;
 export const hexKeyRegex4Digits = /^0x[a-f0-9]{4}$/;
@@ -10,4 +14,23 @@ export function throwInvalidConfig(which: string, reason?: string): never {
 			(reason ? `\n${reason}` : ""),
 		ZWaveErrorCodes.Config_Invalid,
 	);
+}
+
+export function tryParseCCId(from: string): CommandClasses | undefined {
+	let ccId: number | undefined;
+	if (/^\d+$/.test(from)) {
+		// Decimal CC ID
+		ccId = parseInt(from, 10);
+	} else if (hexKeyRegexNDigits.test(from)) {
+		// Hexadecimal CC ID
+		ccId = parseInt(from.slice(2), 16);
+	} else if (from in CommandClasses) {
+		// CC name
+		return (CommandClasses as any)[from];
+	}
+
+	if (ccId != undefined && ccId in CommandClasses) {
+		// This is a valid CC ID
+		return ccId;
+	}
 }


### PR DESCRIPTION
A lot of device issues are caused by incorrect responses to certain queries. This PR attempts to solve this issue by declaratively overriding what a CC API call returns and which values need to be stored in the value DB. It is set up this way, because device interviews internally use the CC API methods.
By hooking into this process, we simply skip the original API call and simulate the result.

This allows us to avoid interview-specific implementations and provides a framework to solve this issue for most problematic devices.

closes: https://github.com/zwave-js/node-zwave-js/pull/4609
fixes: #1625