### PR TITLE
fix(config): Add Product Type to zwa018

### DIFF
--- a/packages/config/config/devices/0x0371/zwa018.json
+++ b/packages/config/config/devices/0x0371/zwa018.json
@@ -7,6 +7,10 @@
 		{
 			"productType": "0x0002",
 			"productId": "0x0012"
+		},
+		{
+			"productType": "0x0102",
+			"productId": "0x0012"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
Have "Aeotec Ltd. / Water Sensor 7 Basic" (ZWA018) in hand that reports product ID "0x0102". Current config only contains ID "0x0002", causing "unknown" type and device in ZWave JS. The "Plus" variant of this device (ZWA019) already contains this alternate "0x0102" product type apparently currently in use by aeotec for these devices.