### PR TITLE
fix(config): override supported color channels for Zipato RGBW Bulb2

### DIFF
--- a/packages/config/config/devices/0x0131/rgbwe2.json
+++ b/packages/config/config/devices/0x0131/rgbwe2.json
@@ -77,5 +77,20 @@
 				}
 			]
 		}
-	]
+	],
+	"compat": {
+		"overrideQueries": {
+			"Color Switch": [
+				// The device supports 5 color channels (Warm/Cold white, RGB)
+				// but does not advertise support for blue
+				{
+					"method": "getSupported",
+					"result": [0, 1, 2, 3, 4],
+					"persistValues": {
+						"supportedColorComponents": [0, 1, 2, 3, 4]
+					}
+				}
+			]
+		}
+	}
 }


### PR DESCRIPTION
fixes: https://github.com/zwave-js/zwave-js-ui/issues/477