### PR TITLE
fix(config): fix Zooz ZSE40 parameters 7 and 8

### DIFF
--- a/packages/config/config/devices/0x027a/zse40.json
+++ b/packages/config/config/devices/0x027a/zse40.json
@@ -201,11 +201,11 @@
 					"value": 1
 				},
 				{
-					"label": "Pulsing Temperature, Flashing Motion",
+					"label": "Flashing with Temperature and Motion",
 					"value": 2
 				},
 				{
-					"label": "Flashing Temperature and Motion",
+					"label": "Flashing with Motion (Default)",
 					"value": 3
 				}
 			]
@@ -240,7 +240,7 @@
 			"#": "8",
 			// Added in firmware version 32.2, still present in HW 3.0
 			"$if": "firmwareVersion >= 32.2 || firmwareVersion >= 1.10 && firmwareVersion < 16.9",
-			"$import": "~/templates/master_template.json#base_enable_disable",
+			"$import": "~/templates/master_template.json#base_enable_disable_255",
 			"label": "Basic Set Reports",
 			"defaultValue": 1
 		},

--- a/packages/config/config/devices/0x027a/zse40.json
+++ b/packages/config/config/devices/0x027a/zse40.json
@@ -205,7 +205,7 @@
 					"value": 2
 				},
 				{
-					"label": "Flashing with Motion (Default)",
+					"label": "Flashing with Motion",
 					"value": 3
 				}
 			]


### PR DESCRIPTION
Fix parameters 7 and 8

Although settings (https://www.support.getzooz.com/kb/article/1005-zse40-4-in-1-sensor-advanced-settings/) say:
Basic Set Reports
Parameter 8: Disable Basic Set reports sent to the hub when motion is detected to reduce Z-Wave activity from the sensor.
Values:
0 – Basic Set reports disabled.
1 – Basic Set reports enabled (default).
Size: 1 byte dec

It only can be set as:
0 – Basic Set reports disabled.
255 – Basic Set reports enabled (default).

Also, LED Indicator mode has different meanings
LED Indicator Mode
Parameter 7: Select the LED indicator mode that best fits your needs. NOTE: Mode 2 will increase activity and reduce battery life.
Values:
1 – LED indicator is turned off (no visual notifications).
2 – temperature and motion indicated with flashing light. Flashes every 3 minutes for temperature.
3 – no indication for temperature, motion indicated with red flashing light (default).
Size: 1 byte dec

fixes: #6018