### PR TITLE
fix: handle some commands in a separate "immediate" queue

### DIFF
--- a/packages/cc/src/cc/Security2CC.ts
+++ b/packages/cc/src/cc/Security2CC.ts
@@ -198,7 +198,7 @@ export class Security2CCAPI extends CCAPI {
 				// Only try sending a nonce once
 				maxSendAttempts: 1,
 				// Nonce requests must be handled immediately
-				priority: MessagePriority.Nonce,
+				priority: MessagePriority.Immediate,
 				// We don't want failures causing us to treat the node as asleep or dead
 				changeNodeStatusOnMissingACK: false,
 				// And we need to react to
@@ -243,7 +243,7 @@ export class Security2CCAPI extends CCAPI {
 				// Only try sending a nonce once
 				maxSendAttempts: 1,
 				// Nonce requests must be handled immediately
-				priority: MessagePriority.Nonce,
+				priority: MessagePriority.Immediate,
 				// We don't want failures causing us to treat the node as asleep or dead
 				changeNodeStatusOnMissingACK: false,
 			});
@@ -290,7 +290,7 @@ export class Security2CCAPI extends CCAPI {
 				// Only try sending a nonce once
 				maxSendAttempts: 1,
 				// Nonce requests must be handled immediately
-				priority: MessagePriority.Nonce,
+				priority: MessagePriority.Immediate,
 				// We don't want failures causing us to treat the node as asleep or dead
 				changeNodeStatusOnMissingACK: false,
 			});

--- a/packages/cc/src/cc/SecurityCC.ts
+++ b/packages/cc/src/cc/SecurityCC.ts
@@ -73,7 +73,7 @@ function throwNoNonce(reason?: string): never {
 	throw new ZWaveError(message, ZWaveErrorCodes.SecurityCC_NoNonce);
 }
 
-export const HALF_NONCE_SIZE = 8;
+const HALF_NONCE_SIZE = 8;
 
 // TODO: Ignore commands if received via multicast
 

--- a/packages/cc/src/cc/SecurityCC.ts
+++ b/packages/cc/src/cc/SecurityCC.ts
@@ -127,8 +127,6 @@ export class SecurityCCAPI extends PhysicalCCAPI {
 			cc,
 			{
 				...this.commandOptions,
-				// Nonce requests must be handled immediately
-				priority: MessagePriority.Nonce,
 				// Only try getting a nonce once
 				maxSendAttempts: 1,
 			},
@@ -186,7 +184,7 @@ export class SecurityCCAPI extends PhysicalCCAPI {
 				// Only try sending a nonce once
 				maxSendAttempts: 1,
 				// Nonce requests must be handled immediately
-				priority: MessagePriority.Nonce,
+				priority: MessagePriority.Immediate,
 				// We don't want failures causing us to treat the node as asleep or dead
 				changeNodeStatusOnMissingACK: false,
 			});

--- a/packages/cc/src/cc/SupervisionCC.ts
+++ b/packages/cc/src/cc/SupervisionCC.ts
@@ -91,7 +91,7 @@ export class SupervisionCCAPI extends PhysicalCCAPI {
 			await this.applHost.sendCommand(cc, {
 				...this.commandOptions,
 				// Supervision Reports must be prioritized over normal messages
-				priority: MessagePriority.Supervision,
+				priority: MessagePriority.Immediate,
 				// But we don't want to wait for an ACK because this can lock up the network for seconds
 				// if the target node is asleep or unreachable
 				transmitOptions: TransmitOptions.DEFAULT_NOACK,

--- a/packages/core/src/consts/Transmission.ts
+++ b/packages/core/src/consts/Transmission.ts
@@ -6,18 +6,15 @@ import { Duration } from "../values/Duration";
 
 /** The priority of messages, sorted from high (0) to low (>0) */
 export enum MessagePriority {
-	// Outgoing nonces have the highest priority because they are part of other transactions
-	// which may already be in progress.
-	// Some nodes don't respond to our requests if they are waiting for a nonce, so those need to be handled first.
-	Nonce = 0,
+	// Some messages like nonces, responses to Supervision and Transport Service
+	// need to be handled before all others. We use this priority to decide which
+	// message goes onto the immediate queue.
+	Immediate = 0,
 	// Controller commands usually finish quickly and should be preferred over node queries
 	Controller,
 	// Multistep controller commands typically require user interaction but still
 	// should happen at a higher priority than any node data exchange
 	MultistepController,
-	// Supervision responses must be prioritized over other messages because the nodes requesting them
-	// will get impatient otherwise.
-	Supervision,
 	// Pings (NoOP) are used for device probing at startup and for network diagnostics
 	Ping,
 	// Whenever sleeping devices wake up, their queued messages must be handled quickly

--- a/packages/shared/src/AsyncQueue.test.ts
+++ b/packages/shared/src/AsyncQueue.test.ts
@@ -1,0 +1,77 @@
+import { wait } from "alcalzone-shared/async";
+import test from "ava";
+import { AsyncQueue } from "./AsyncQueue";
+
+test("can be iterated over after adding items", async (t) => {
+	const queue = new AsyncQueue<number>();
+
+	queue.add(1, 2, 3);
+	queue.end();
+
+	const actual = new Promise<number[]>(async (resolve) => {
+		const seen: number[] = [];
+		for await (const item of queue) {
+			seen.push(item);
+		}
+		resolve(seen);
+	});
+
+	t.deepEqual(await actual, [1, 2, 3]);
+});
+
+test("can be iterated over when adding items later", async (t) => {
+	const queue = new AsyncQueue<number>();
+
+	const actual = new Promise<number[]>(async (resolve) => {
+		const seen: number[] = [];
+		for await (const item of queue) {
+			seen.push(item);
+		}
+		resolve(seen);
+	});
+
+	queue.add(1, 2, 3);
+	queue.end();
+
+	t.deepEqual(await actual, [1, 2, 3]);
+});
+
+test("can be iterated over when adding items asynchronously", async (t) => {
+	const queue = new AsyncQueue<number>();
+
+	const actual = new Promise<number[]>(async (resolve) => {
+		const seen: number[] = [];
+		for await (const item of queue) {
+			seen.push(item);
+		}
+		resolve(seen);
+	});
+
+	queue.add(1, 2, 3);
+	await wait(100);
+	queue.add(4, 5);
+	queue.end();
+
+	t.deepEqual(await actual, [1, 2, 3, 4, 5]);
+});
+
+test("aborting clears all pending items", async (t) => {
+	const queue = new AsyncQueue<number>();
+
+	const actual = new Promise<number[]>(async (resolve) => {
+		const seen: number[] = [];
+		for await (const item of queue) {
+			seen.push(item);
+			if (seen.length === 3) {
+				await wait(100);
+			}
+		}
+		resolve(seen);
+	});
+
+	queue.add(1, 2, 3, 4, 5);
+	await wait(75);
+	queue.abort();
+
+	t.deepEqual(await actual, [1, 2, 3]);
+});

--- a/packages/shared/src/AsyncQueue.ts
+++ b/packages/shared/src/AsyncQueue.ts
@@ -1,0 +1,68 @@
+import {
+	createDeferredPromise,
+	type DeferredPromise,
+} from "alcalzone-shared/deferred-promise";
+
+export class AsyncQueue<T> {
+	public add(...items: T[]): void {
+		if (items.length === 0 || this.ended) return;
+
+		// Resolve any pending promises first
+		while (items.length > 0 && this.pending.length > 0) {
+			const promise = this.pending.shift()!;
+			const item = items.shift()!;
+			promise.resolve(item);
+		}
+
+		// Add the remaining items to the backlog
+		this.backlog.push(...items);
+	}
+
+	// A list of items that have been pushed but not pulled
+	private backlog: T[] = [];
+	// A list of Promises that are waiting to be resolved
+	private pending: DeferredPromise<T | undefined>[] = [];
+
+	// Whether the queue was ended
+	private ended = false;
+
+	/** Ends the queue after it has been drained */
+	public end(): void {
+		this.ended = true;
+	}
+
+	/** Ends the queue and discards all pending items */
+	public abort(): void {
+		this.ended = true;
+		this.backlog = [];
+		for (const p of this.pending) {
+			p.resolve(undefined);
+		}
+	}
+
+	public [Symbol.asyncIterator](): AsyncIterator<T> {
+		return {
+			next: async (): Promise<IteratorResult<T>> => {
+				let value: T | undefined;
+
+				if (this.backlog.length > 0) {
+					// If there are items in the backlog, return the first one
+					value = this.backlog.shift();
+				} else if (!this.ended) {
+					// Otherwise create a new promise and add it to the pending list
+					const promise = createDeferredPromise<T | undefined>();
+					this.pending.push(promise);
+					value = await promise;
+				}
+
+				if (value) {
+					// We have a value, return it
+					return { value, done: false };
+				} else {
+					// No value means the queue was ended
+					return { value: undefined, done: true };
+				}
+			},
+		};
+	}
+}

--- a/packages/shared/src/AsyncQueue.ts
+++ b/packages/shared/src/AsyncQueue.ts
@@ -4,6 +4,7 @@ import {
 } from "alcalzone-shared/deferred-promise";
 
 export class AsyncQueue<T> {
+	/** Adds one or more items onto the queue */
 	public add(...items: T[]): void {
 		if (items.length === 0 || this.ended) return;
 
@@ -16,6 +17,23 @@ export class AsyncQueue<T> {
 
 		// Add the remaining items to the backlog
 		this.backlog.push(...items);
+	}
+
+	/**
+	 * Removes an item from the queue if it was not processed yet.
+	 * The return value indicates whether the item was removed.
+	 */
+	public remove(item: T): boolean {
+		if (this.ended) return false;
+
+		// Remove the item from the backlog
+		const index = this.backlog.indexOf(item);
+		if (index !== -1) {
+			this.backlog.splice(index, 1);
+			return true;
+		}
+
+		return false;
 	}
 
 	// A list of items that have been pushed but not pulled

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./AsyncQueue";
 export * from "./EventEmitter";
 export { ObjectKeyMap } from "./ObjectKeyMap";
 export type { ReadonlyObjectKeyMap } from "./ObjectKeyMap";

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -4279,6 +4279,8 @@ ${handlers.length} left`,
 		let prevResult: Message | undefined;
 		let msg: Message | undefined;
 
+		transaction.start();
+
 		// Step through the transaction as long as it gives us a next message
 		while ((msg = await transaction.generateNextMessage(prevResult))) {
 			// TODO: refactor this nested loop or make it part of executeSerialAPICommand

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -489,8 +489,13 @@ export class Driver
 				this._options.storage.deviceConfigPriorityDir,
 		});
 
-		this.immediateQueue = new TransactionQueue();
-		this.queue = new TransactionQueue();
+		this.immediateQueue = new TransactionQueue({
+			// Messages on the immediate queue may always be sent unless the queue is paused
+			mayStartNextTransaction: () => !this.queuePaused,
+		});
+		this.queue = new TransactionQueue({
+			mayStartNextTransaction: (t) => this.mayStartTransaction(t),
+		});
 		this.serialAPIQueue = new AsyncQueue();
 		this._sendThreadIdle = false;
 	}
@@ -960,6 +965,11 @@ export class Driver
 			this.driverLog.print("serial port opened");
 			this._isOpen = true;
 			spOpenPromise.resolve();
+
+			// Start draining the queues
+			for (const queue of this.queues) {
+				void this.drainTransactionQueue(queue);
+			}
 
 			// Start the serial API queue
 			void this.drainSerialAPIQueue();
@@ -1613,7 +1623,7 @@ export class Driver
 
 		// Make sure to handle the pending messages as quickly as possible
 		if (oldStatus === NodeStatus.Asleep) {
-			this.reduceQueue(({ message }) => {
+			this.reduceQueues(({ message }) => {
 				// Ignore messages that are not for this node
 				if (message.getNodeId() !== node.id) return { type: "keep" };
 				// Resolve pings, so we don't need to send them (we know the node is awake)
@@ -2652,8 +2662,11 @@ export class Driver
 
 		this.driverLog.print("destroying driver instance...");
 
-		// First stop the send thread machine and close the serial port, so nothing happens anymore
+		// First stop all queues and close the serial port, so nothing happens anymore
 		this.serialAPIQueue.abort();
+		for (const queue of this.queues) {
+			queue.abort();
+		}
 		if (this.serialAPIInterpreter?.status === InterpreterStatus.Running) {
 			this.serialAPIInterpreter.stop();
 		}
@@ -3492,7 +3505,7 @@ export class Driver
 						});
 						await this.sendCommand(cc, {
 							maxSendAttempts: 1,
-							priority: MessagePriority.Nonce,
+							priority: MessagePriority.Immediate,
 						});
 					},
 					sendSegmentsComplete: async () => {
@@ -3507,7 +3520,7 @@ export class Driver
 						});
 						await this.sendCommand(cc, {
 							maxSendAttempts: 1,
-							priority: MessagePriority.Nonce,
+							priority: MessagePriority.Immediate,
 						});
 					},
 				},
@@ -3554,7 +3567,7 @@ export class Driver
 				});
 				await this.sendCommand(cc, {
 					maxSendAttempts: 1,
-					priority: MessagePriority.Nonce,
+					priority: MessagePriority.Immediate,
 				});
 			}
 		}
@@ -4190,11 +4203,8 @@ ${handlers.length} left`,
 			// Track and potentially update the status of the node when communication succeeds
 			if (success) {
 				if (node.canSleep) {
-					// Do not update the node status when we only responded to a nonce request
-					if (
-						options.priority !== MessagePriority.Nonce &&
-						options.priority !== MessagePriority.Supervision
-					) {
+					// Do not update the node status when we only responded to a nonce/supervision request
+					if (options.priority !== MessagePriority.Immediate) {
 						// If the node is not meant to be kept awake, try to send it back to sleep
 						if (!node.keepAwake) {
 							setImmediate(() =>
@@ -4214,14 +4224,11 @@ ${handlers.length} left`,
 		}
 	}
 
-	private mayStartNextTransaction(queue: TransactionQueue): boolean {
+	private mayStartTransaction(transaction: Transaction): boolean {
 		// We may not send anything if the send thread is paused
 		if (this.queuePaused) return false;
-		const nextTransaction = queue.peek();
-		// We can't send anything if the queue is empty
-		if (!nextTransaction) return false;
 
-		const message = nextTransaction.message;
+		const message = transaction.message;
 		const targetNode = message.getNodeUnsafe(this);
 
 		// The transaction queue is sorted automatically. If the first message is for a sleeping node, all messages in the queue are.
@@ -4232,29 +4239,9 @@ ${handlers.length} left`,
 		// 3. Nodes that can sleep but do not support wakeup: https://github.com/zwave-js/node-zwave-js/discussions/1537
 		//    We need to try and send messages to them even if they are asleep, because we might never hear from them
 
-		// 	// While the queue is busy, we may not start any transaction, except nonce responses to the node we're currently communicating with
-		// 	if (meta.state.matches("busy")) {
-		// 		if (nextTransaction.priority === MessagePriority.Nonce) {
-		// 			for (const active of ctx.activeTransactions.values()) {
-		// 				if (
-		// 					active.transaction.message.getNodeId() ===
-		// 					nextTransaction.message.getNodeId()
-		// 				) {
-		// 					return true;
-		// 				}
-		// 			}
-		// 		}
-		// 		return false;
-		// 	}
+		// 2. is handled by putting the message into the immediate queue
 
-		// 	Replies to nonce requests and Supervision Get requests must always be allowed
-		if (
-			nextTransaction.priority === MessagePriority.Nonce ||
-			nextTransaction.priority === MessagePriority.Supervision
-		) {
-			return true;
-		}
-		// Same for pings
+		// Pings may always be sent
 		if (messageIsPing(message)) return true;
 		// Or messages to the controller
 		if (!targetNode) return true;
@@ -4266,55 +4253,34 @@ ${handlers.length} left`,
 		);
 	}
 
-	private drainQueueBusy = false;
-	private async drainQueue(queue: TransactionQueue): Promise<void> {
-		// Don't execute more than once at a time
-		if (this.drainQueueBusy) return;
-		this.drainQueueBusy = true;
-
-		try {
-			while (this.mayStartNextTransaction(queue)) {
-				const transaction = queue.startNextTransaction();
-				if (!transaction) break;
-
-				// We have something to send, so not idle
-				this.sendThreadIdle = false;
-
-				let error: ZWaveError | undefined;
-				try {
-					await this.drainTransactionGenerator(queue, transaction);
-				} catch (e) {
-					error = e as ZWaveError;
-				} finally {
-					queue.finalizeTransaction();
-				}
-
-				// Handle errors after clearing the current transaction.
-				// Otherwise, it will get considered the active transaction and cause an unnecessary SendDataAbort
-				if (error) {
-					this.rejectTransaction(transaction, error);
-				}
+	private async drainTransactionQueue(
+		queue: TransactionQueue,
+	): Promise<void> {
+		for await (const transaction of queue) {
+			let error: ZWaveError | undefined;
+			try {
+				await this.executeTransaction(transaction);
+			} catch (e) {
+				error = e as ZWaveError;
+			} finally {
+				queue.finalizeTransaction();
 			}
-		} finally {
-			this.drainQueueBusy = false;
-			this.sendThreadIdle = true;
-		}
 
-		// Avoid a deadlock when a transaction was added after the advanceQueue call,
-		// but before setting the busy flag back to false
-		if (this.mayStartNextTransaction(queue)) this.triggerQueue();
+			// Handle errors after clearing the current transaction.
+			// Otherwise, it will get considered the active transaction and cause an unnecessary SendDataAbort
+			if (error) {
+				this.rejectTransaction(transaction, error);
+			}
+		}
 	}
 
 	/** Steps through the message generator of a transaction. Throws an error if the transaction should fail. */
-	private async drainTransactionGenerator(
-		queue: TransactionQueue,
-		transaction: Transaction,
-	): Promise<void> {
+	private async executeTransaction(transaction: Transaction): Promise<void> {
 		let prevResult: Message | undefined;
 		let msg: Message | undefined;
 
 		// Step through the transaction as long as it gives us a next message
-		while ((msg = await queue.tryGenerateNextMessage(prevResult!))) {
+		while ((msg = await transaction.generateNextMessage(prevResult))) {
 			// TODO: refactor this nested loop or make it part of executeSerialAPICommand
 			attemptMessage: for (let attemptNumber = 1; ; attemptNumber++) {
 				try {
@@ -4324,9 +4290,8 @@ ${handlers.length} left`,
 					);
 					if (isTransmitReport(prevResult) && !prevResult.isOK()) {
 						// The node did not acknowledge the command. Convert this into an
-						// error so it can be handled.
-						// First throw into the generator, so it can be reset
-						transaction.parts.self!.throw(prevResult).catch(noop);
+						// error so it can be handled and abort the generator so it can be reset
+						transaction.abort(prevResult);
 
 						throw new ZWaveError(
 							"The node did not acknowledge the command",
@@ -4402,8 +4367,10 @@ ${handlers.length} left`,
 		}
 	}
 
-	private triggerQueue(): void {
-		process.nextTick(() => this.drainQueue());
+	private triggerQueues(): void {
+		for (const queue of this.queues) {
+			queue.trigger();
+		}
 	}
 
 	/** Puts a message on the serial API queue and returns or throws the command result */
@@ -4631,8 +4598,7 @@ ${handlers.length} left`,
 			!(msg instanceof SendDataMulticastRequest) &&
 			!(msg instanceof SendDataMulticastBridgeRequest) &&
 			// Nonces and responses to Supervision Get have to be sent immediately
-			options.priority !== MessagePriority.Nonce &&
-			options.priority !== MessagePriority.Supervision
+			options.priority !== MessagePriority.Immediate
 		) {
 			if (options.priority === MessagePriority.NodeQuery) {
 				// Remember that this transaction was part of an interview
@@ -4668,14 +4634,17 @@ ${handlers.length} left`,
 		transaction.tag = options.tag;
 
 		// And queue it
-		this.queue.add(transaction);
-		this.triggerQueue();
+		if (transaction.priority === MessagePriority.Immediate) {
+			this.immediateQueue.add(transaction);
+		} else {
+			this.queue.add(transaction);
+		}
 
 		// If the transaction should expire, start the timeout
 		let expirationTimeout: NodeJS.Timeout | undefined;
 		if (options.expire) {
 			expirationTimeout = setTimeout(() => {
-				this.reduceQueue((t, _source) => {
+				this.reduceQueues((t, _source) => {
 					if (t === transaction)
 						return {
 							type: "reject",
@@ -4695,8 +4664,7 @@ ${handlers.length} left`,
 			if (isSendData(msg)) {
 				// For SendData messages, make sure the message is not a nonce
 				maybeSendToSleep =
-					options.priority !== MessagePriority.Nonce &&
-					options.priority !== MessagePriority.Supervision &&
+					options.priority !== MessagePriority.Immediate &&
 					// And that the result is either a response from the node
 					// or a transmit report indicating success
 					result &&
@@ -5181,26 +5149,14 @@ ${handlers.length} left`,
 			if (this.handleMissingNodeACK(transaction as any)) return;
 		}
 
-		// If the transaction was already started, we need to throw the error into the message generator
-		// so it correctly gets ended. Otherwise just reject the result promise
-		if (transaction.parts.self) {
-			transaction.parts.self.throw(error).catch(noop);
-		} else {
-			transaction.promise.reject(error);
-		}
+		transaction.abort(error);
 	}
 
 	private resolveTransaction(
 		transaction: Transaction,
 		result?: Message,
 	): void {
-		// If the transaction was already started, we need to end the message generator early by throwing
-		// the result. Otherwise just resolve the result promise
-		if (transaction.parts.self) {
-			transaction.parts.self.throw(result).catch(noop);
-		} else {
-			transaction.promise.resolve(result);
-		}
+		transaction.abort(result);
 	}
 
 	/** Checks if a message is allowed to go into the wakeup queue */
@@ -5209,8 +5165,7 @@ ${handlers.length} left`,
 		switch (true) {
 			// Pings, nonces and Supervision Reports will block the send queue until wakeup, so they must be dropped
 			case messageIsPing(msg):
-			case transaction.priority === MessagePriority.Nonce:
-			case transaction.priority === MessagePriority.Supervision:
+			case transaction.priority === MessagePriority.Immediate:
 			// We also don't want to immediately send the node to sleep when it wakes up
 			case isCommandClassContainer(msg) &&
 				msg.command instanceof WakeUpCCNoMoreInformation:
@@ -5238,7 +5193,7 @@ ${handlers.length} left`,
 			tag: "interview",
 		};
 
-		this.reduceQueue((transaction, _source) => {
+		this.reduceQueues((transaction, _source) => {
 			const msg = transaction.message;
 			if (msg.getNodeId() !== nodeId) return { type: "keep" };
 			// Drop all messages that are not allowed in the wakeup queue
@@ -5260,7 +5215,7 @@ ${handlers.length} left`,
 		errorMsg: string = `The message has been removed from the queue`,
 		errorCode: ZWaveErrorCodes = ZWaveErrorCodes.Controller_MessageDropped,
 	): void {
-		this.reduceQueue((transaction, _source) => {
+		this.reduceQueues((transaction, _source) => {
 			if (predicate(transaction)) {
 				return {
 					type: "reject",
@@ -5301,10 +5256,19 @@ ${handlers.length} left`,
 	 */
 	private unpauseSendQueue(): void {
 		this.queuePaused = false;
-		this.triggerQueue();
+		this.triggerQueues();
 	}
 
-	private reduceQueue(reducer: TransactionReducer): void {
+	private reduceQueues(reducer: TransactionReducer): void {
+		for (const queue of this.queues) {
+			this.reduceQueue(queue, reducer);
+		}
+	}
+
+	private reduceQueue(
+		queue: TransactionQueue,
+		reducer: TransactionReducer,
+	): void {
 		const dropQueued: Transaction[] = [];
 		let stopActive: Transaction | undefined;
 		const requeue: Transaction[] = [];
@@ -5358,35 +5322,35 @@ ${handlers.length} left`,
 			}
 		};
 
-		for (const transaction of this.queue) {
+		for (const transaction of queue.transactions) {
 			reduceTransaction(transaction, "queue");
 		}
 
-		if (this.currentTransaction) {
-			reduceTransaction(this.currentTransaction, "active");
+		if (queue.currentTransaction) {
+			reduceTransaction(queue.currentTransaction, "active");
 		}
 
 		// Now we know what to do with the transactions
-		this.queue.remove(...dropQueued, ...requeue);
-		this.queue.add(...requeue.map((t) => t.clone()));
+		queue.remove(...dropQueued, ...requeue);
+		queue.add(...requeue.map((t) => t.clone()));
 
 		// Abort ongoing SendData messages that should be dropped
 		if (isSendData(stopActive?.message)) {
 			void this.abortSendData();
 		}
-
-		// Continue sending
-		this.triggerQueue();
 	}
 
 	/** @internal */
 	public resolvePendingPings(nodeId: number): void {
 		// When a previously sleeping node sends a NIF after a ping was sent to it, but not acknowledged yet,
 		// the node is awake, but the ping would fail. Resolve pending pings, so communication can continue.
-		const msg = this.currentTransaction?.parts.current;
-		if (!!msg && messageIsPing(msg) && msg.getNodeId() === nodeId) {
-			// The pending transaction is a ping. Short-circuit its message generator by throwing something that's not an error
-			this.currentTransaction?.parts.self!.throw(undefined).catch(noop);
+		for (const { currentTransaction } of this.queues) {
+			if (!currentTransaction) continue;
+			const msg = currentTransaction.parts.current;
+			if (!!msg && messageIsPing(msg) && msg.getNodeId() === nodeId) {
+				// The pending transaction is a ping. Short-circuit its message generator by throwing something that's not an error
+				currentTransaction.abort(undefined);
+			}
 		}
 	}
 

--- a/packages/zwave-js/src/lib/driver/MessageGenerators.ts
+++ b/packages/zwave-js/src/lib/driver/MessageGenerators.ts
@@ -907,7 +907,7 @@ export const secureMessageGeneratorS2Multicast: MessageGeneratorImplementation =
 							// Only try sending a nonce once
 							maxSendAttempts: 1,
 							// Nonce requests must be handled immediately
-							priority: MessagePriority.Nonce,
+							priority: MessagePriority.Immediate,
 							// We don't want failures causing us to treat the node as asleep or dead
 							changeNodeStatusOnMissingACK: false,
 						});

--- a/packages/zwave-js/src/lib/driver/MessageGenerators.ts
+++ b/packages/zwave-js/src/lib/driver/MessageGenerators.ts
@@ -12,10 +12,9 @@ import {
 	type CommandClass,
 } from "@zwave-js/cc";
 import {
-	HALF_NONCE_SIZE,
 	SecurityCCCommandEncapsulation,
 	SecurityCCNonceGet,
-	SecurityCCNonceReport,
+	type SecurityCCNonceReport,
 } from "@zwave-js/cc/SecurityCC";
 import {
 	MAX_SEGMENT_SIZE,
@@ -39,7 +38,6 @@ import {
 	TransmitOptions,
 	ZWaveError,
 	ZWaveErrorCodes,
-	isTransmissionError,
 	mergeSupervisionResults,
 	type SendCommandOptions,
 	type SupervisionResult,
@@ -128,77 +126,6 @@ function getNodeUpdateTimeout(
 	);
 }
 
-function assertFrameSize(driver: Driver, msg: Message) {
-	if (isSendData(msg) && exceedsMaxPayloadLength(msg)) {
-		// We use explorer frames by default, but this reduces the maximum payload length by 2 bytes compared to AUTO_ROUTE
-		// Try disabling explorer frames for this message and see if it fits now.
-		const fail = () => {
-			throw new ZWaveError(
-				"Cannot send this message because it would exceed the maximum payload length!",
-				ZWaveErrorCodes.Controller_MessageTooLarge,
-			);
-		};
-		if (msg.transmitOptions & TransmitOptions.Explore) {
-			msg.transmitOptions &= ~TransmitOptions.Explore;
-			if (exceedsMaxPayloadLength(msg)) {
-				// Still too large
-				throw fail();
-			}
-			driver.controllerLog.logNode(msg.getNodeId()!, {
-				message:
-					"Disabling explorer frames for this message due to its size",
-				level: "warn",
-			});
-		} else {
-			throw fail();
-		}
-	}
-}
-
-/**
- * The most basic message generator that simply sends a message and waits for the
- * Serial API command to finish
- */
-// eslint-disable-next-line @typescript-eslint/require-await
-const baseMessageGenerator: MessageGeneratorImplementation = async function* (
-	driver,
-	msg,
-	onMessageSent,
-) {
-	// Make sure we can send this message
-	assertFrameSize(driver, msg);
-
-	// Pass this message to the send thread and wait for it to be sent
-	let result: Message;
-	// At this point we can't have received a premature update
-	msg.prematureNodeUpdate = undefined;
-
-	try {
-		// The yield can throw and must be handled here
-		result = yield msg;
-
-		// Figure out how long the message took to be handled
-		msg.markAsCompleted();
-
-		onMessageSent(msg, result);
-	} catch (e) {
-		msg.markAsCompleted();
-		throw e;
-	}
-
-	// If the message was sent to a node and came back with a NOK callback,
-	// we want to inspect the callback, for example to look at TX statistics
-	// or update the node status.
-	//
-	// We now need to throw because the callback was passed through so we could inspect it.
-	if (isTransmitReport(result) && !result.isOK()) {
-		// Throw the message in order to short-circuit all possible generators
-		throw result;
-	}
-
-	return result;
-};
-
 /** A simple message generator that simply sends a message, waits for the ACK (and the response if one is expected) */
 export const simpleMessageGenerator: MessageGeneratorImplementation =
 	async function* (
@@ -207,7 +134,59 @@ export const simpleMessageGenerator: MessageGeneratorImplementation =
 		onMessageSent,
 		additionalCommandTimeoutMs = 0,
 	) {
-		const result = yield* baseMessageGenerator(driver, msg, onMessageSent);
+		// Make sure we can send this message
+		if (isSendData(msg) && exceedsMaxPayloadLength(msg)) {
+			// We use explorer frames by default, but this reduces the maximum payload length by 2 bytes compared to AUTO_ROUTE
+			// Try disabling explorer frames for this message and see if it fits now.
+			const fail = () => {
+				throw new ZWaveError(
+					"Cannot send this message because it would exceed the maximum payload length!",
+					ZWaveErrorCodes.Controller_MessageTooLarge,
+				);
+			};
+			if (msg.transmitOptions & TransmitOptions.Explore) {
+				msg.transmitOptions &= ~TransmitOptions.Explore;
+				if (exceedsMaxPayloadLength(msg)) {
+					// Still too large
+					throw fail();
+				}
+				driver.controllerLog.logNode(msg.getNodeId()!, {
+					message:
+						"Disabling explorer frames for this message due to its size",
+					level: "warn",
+				});
+			} else {
+				throw fail();
+			}
+		}
+
+		// Pass this message to the send thread and wait for it to be sent
+		let result: Message;
+		// At this point we can't have received a premature update
+		msg.prematureNodeUpdate = undefined;
+
+		try {
+			// The yield can throw and must be handled here
+			result = yield msg;
+
+			// Figure out how long the message took to be handled
+			msg.markAsCompleted();
+
+			onMessageSent(msg, result);
+		} catch (e) {
+			msg.markAsCompleted();
+			throw e;
+		}
+
+		// If the message was sent to a node and came back with a NOK callback,
+		// we want to inspect the callback, for example to look at TX statistics
+		// or update the node status.
+		//
+		// We now need to throw because the callback was passed through so we could inspect it.
+		if (isTransmitReport(result) && !result.isOK()) {
+			// Throw the message in order to short-circuit all possible generators
+			throw result;
+		}
 
 		// If the sent message expects an update from the node, wait for it
 		if (msg.expectsNodeUpdate()) {
@@ -557,75 +536,12 @@ export const secureMessageGeneratorS0: MessageGeneratorImplementation =
 		msg.command.nonce = nonce;
 
 		// Now send the actual secure command
-		const result = yield* baseMessageGenerator(driver, msg, onMessageSent);
-
-		// If the sent message expects an update from the node, wait for it
-		if (msg.expectsNodeUpdate()) {
-			// The node will request a nonce before it can send the update, which we must wait for and handle
-			const totalTimeout = getNodeUpdateTimeout(
-				driver,
-				msg,
-				additionalTimeoutMs,
-			);
-			const start = Date.now();
-
-			const fail = () => {
-				throw new ZWaveError(
-					`Timed out while waiting for a response from the node`,
-					ZWaveErrorCodes.Controller_NodeTimeout,
-				);
-			};
-
-			try {
-				await driver.waitForCommand<SecurityCCNonceGet>(
-					(cc) =>
-						cc.nodeId === msg.command.nodeId &&
-						cc instanceof SecurityCCNonceGet,
-					totalTimeout,
-				);
-			} catch {
-				throw fail();
-			}
-
-			// FIXME: This is more or less duplicated from SecurityCC.sendNonce()
-			// Find a way to unify this
-
-			const nonce = driver.securityManager!.generateNonce(
-				msg.command.nodeId,
-				HALF_NONCE_SIZE,
-			);
-			const nonceId = driver.securityManager!.getNonceId(nonce);
-
-			const cc = new SecurityCCNonceReport(driver, {
-				nodeId: msg.command.nodeId,
-				nonce,
-			});
-			const nonceMsg = driver.createSendDataMessage(cc, {
-				// Seems we need these options or some nodes won't accept the nonce
-				transmitOptions:
-					TransmitOptions.ACK | TransmitOptions.AutoRoute,
-				// Only try sending a nonce once
-				maxSendAttempts: 1,
-			});
-			try {
-				yield* baseMessageGenerator(driver, nonceMsg, onMessageSent);
-			} catch (e) {
-				if (isTransmissionError(e)) {
-					// The nonce could not be sent, invalidate it
-					driver.securityManager!.deleteNonce(nonceId);
-					throw fail();
-				} else {
-					// Pass other errors through
-					throw e;
-				}
-			}
-
-			// Now the node can send us the response to our query
-			const remainingTimeout = totalTimeout - (Date.now() - start);
-			return waitForNodeUpdate(driver, msg, remainingTimeout);
-		}
-
-		return result;
+		return yield* simpleMessageGenerator(
+			driver,
+			msg,
+			onMessageSent,
+			additionalTimeoutMs,
+		);
 	};
 
 /** A message generator for security encapsulated messages (S2) */

--- a/packages/zwave-js/src/lib/driver/Queue.ts
+++ b/packages/zwave-js/src/lib/driver/Queue.ts
@@ -1,22 +1,39 @@
 import { type Message } from "@zwave-js/serial";
-import { type DeferredPromise } from "alcalzone-shared/deferred-promise";
+import {
+	createDeferredPromise,
+	type DeferredPromise,
+} from "alcalzone-shared/deferred-promise";
 import { SortedList } from "alcalzone-shared/sorted-list";
 import { type Transaction } from "./Transaction";
 
-/**
- * The transaction queue is responsible for sequencing equally-important transactions
- * and starting, stepping through and stopping them.
- */
-export class TransactionQueue {
-	private transactions = new SortedList<Transaction>();
-	public currentTransaction: Transaction | undefined;
+export interface TransactionQueueOptions {
+	mayStartNextTransaction: (transaction: Transaction) => boolean;
+}
 
-	public peek(): Transaction | undefined {
-		return this.transactions.peekStart();
+/**
+ * The transaction queue offers an async-iterable interface to a list of transactions.
+ */
+export class TransactionQueue implements AsyncIterable<Transaction> {
+	public constructor(
+		options: TransactionQueueOptions = {
+			mayStartNextTransaction: () => true,
+		},
+	) {
+		this.mayStartNextTransaction = options.mayStartNextTransaction;
 	}
 
-	public add(...items: Transaction[]): number {
-		return this.transactions.add(...items);
+	private mayStartNextTransaction: (transaction: Transaction) => boolean;
+	public readonly transactions = new SortedList<Transaction>();
+	public currentTransaction: Transaction | undefined;
+
+	public add(...items: Transaction[]): void {
+		this.transactions.add(...items);
+		this.trigger();
+	}
+
+	public remove(...items: Transaction[]): void {
+		this.transactions.remove(...items);
+		this.trigger();
 	}
 
 	public find(
@@ -25,28 +42,75 @@ export class TransactionQueue {
 		return this.transactions.find(predicate);
 	}
 
-	public startNextTransaction(): Transaction | undefined {
-		this.currentTransaction = this.transactions.shift();
-		if (this.currentTransaction) {
-			this.currentTransaction.parts.start();
-		}
-		return this.currentTransaction;
-	}
-
-	public async tryGenerateNextMessage(
-		prevResult: Message,
-	): Promise<Message | undefined> {
-		if (!this.currentTransaction?.parts.self) return;
-		const { done } = await this.currentTransaction.parts.self.next(
-			prevResult,
-		);
-		if (!done) {
-			return this.currentTransaction.getCurrentMessage();
-		}
-	}
-
 	public finalizeTransaction(): void {
 		this.currentTransaction = undefined;
+	}
+
+	public get length(): number {
+		return this.transactions.length;
+	}
+
+	/** Causes the queue to re-evaluate whether the next transaction may be started */
+	public trigger(): void {
+		while (this.transactions.length > 0 && this.listeners.length > 0) {
+			if (this.mayStartNextTransaction(this.transactions.peekStart()!)) {
+				const promise = this.listeners.shift()!;
+				const item = this.transactions.shift()!;
+				promise.resolve(item);
+			}
+		}
+	}
+
+	// A list of Promises that are waiting to be resolved
+	private listeners: DeferredPromise<Transaction | undefined>[] = [];
+
+	// Whether the queue was ended
+	private ended = false;
+
+	/** Ends the queue after it has been drained */
+	public end(): void {
+		this.ended = true;
+	}
+
+	/** Ends the queue and discards all pending items */
+	public abort(): void {
+		this.ended = true;
+		this.transactions.clear();
+		for (const p of this.listeners) {
+			p.resolve(undefined);
+		}
+	}
+
+	// Enable iterating the queue using for-await-of
+	public [Symbol.asyncIterator](): AsyncIterator<Transaction> {
+		return {
+			next: async (): Promise<IteratorResult<Transaction>> => {
+				let value: Transaction | undefined;
+
+				if (
+					this.transactions.length > 0 &&
+					this.mayStartNextTransaction(this.transactions.peekStart()!)
+				) {
+					// If the next transaction may be started, return it
+					value = this.transactions.shift()!;
+				} else if (!this.ended) {
+					// Otherwise create a new promise and add it to the pending list
+					const promise = createDeferredPromise<
+						Transaction | undefined
+					>();
+					this.listeners.push(promise);
+					value = await promise;
+				}
+
+				if (value) {
+					// We have a value, return it
+					return { value, done: false };
+				} else {
+					// No value means the queue was ended
+					return { value: undefined, done: true };
+				}
+			},
+		};
 	}
 }
 

--- a/packages/zwave-js/src/lib/driver/Queue.ts
+++ b/packages/zwave-js/src/lib/driver/Queue.ts
@@ -7,6 +7,7 @@ import { SortedList } from "alcalzone-shared/sorted-list";
 import { type Transaction } from "./Transaction";
 
 export interface TransactionQueueOptions {
+	name: string;
 	mayStartNextTransaction: (transaction: Transaction) => boolean;
 }
 
@@ -14,13 +15,13 @@ export interface TransactionQueueOptions {
  * The transaction queue offers an async-iterable interface to a list of transactions.
  */
 export class TransactionQueue implements AsyncIterable<Transaction> {
-	public constructor(
-		options: TransactionQueueOptions = {
-			mayStartNextTransaction: () => true,
-		},
-	) {
-		this.mayStartNextTransaction = options.mayStartNextTransaction;
+	public constructor(options?: Partial<TransactionQueueOptions>) {
+		this.name = options?.name ?? "unnamed";
+		this.mayStartNextTransaction =
+			options?.mayStartNextTransaction ?? (() => true);
 	}
+
+	public readonly name: string;
 
 	private mayStartNextTransaction: (transaction: Transaction) => boolean;
 	public readonly transactions = new SortedList<Transaction>();

--- a/packages/zwave-js/src/lib/driver/Queue.ts
+++ b/packages/zwave-js/src/lib/driver/Queue.ts
@@ -1,0 +1,57 @@
+import { type Message } from "@zwave-js/serial";
+import { type DeferredPromise } from "alcalzone-shared/deferred-promise";
+import { SortedList } from "alcalzone-shared/sorted-list";
+import { type Transaction } from "./Transaction";
+
+/**
+ * The transaction queue is responsible for sequencing equally-important transactions
+ * and starting, stepping through and stopping them.
+ */
+export class TransactionQueue {
+	private transactions = new SortedList<Transaction>();
+	public currentTransaction: Transaction | undefined;
+
+	public peek(): Transaction | undefined {
+		return this.transactions.peekStart();
+	}
+
+	public add(...items: Transaction[]): number {
+		return this.transactions.add(...items);
+	}
+
+	public find(
+		predicate: (item: Transaction) => boolean,
+	): Transaction | undefined {
+		return this.transactions.find(predicate);
+	}
+
+	public startNextTransaction(): Transaction | undefined {
+		this.currentTransaction = this.transactions.shift();
+		if (this.currentTransaction) {
+			this.currentTransaction.parts.start();
+		}
+		return this.currentTransaction;
+	}
+
+	public async tryGenerateNextMessage(
+		prevResult: Message,
+	): Promise<Message | undefined> {
+		if (!this.currentTransaction?.parts.self) return;
+		const { done } = await this.currentTransaction.parts.self.next(
+			prevResult,
+		);
+		if (!done) {
+			return this.currentTransaction.getCurrentMessage();
+		}
+	}
+
+	public finalizeTransaction(): void {
+		this.currentTransaction = undefined;
+	}
+}
+
+export interface SerialAPIQueueItem {
+	msg: Message;
+	transactionSource?: string;
+	result: DeferredPromise<Message | undefined>;
+}

--- a/packages/zwave-js/src/lib/driver/Queue.ts
+++ b/packages/zwave-js/src/lib/driver/Queue.ts
@@ -56,7 +56,10 @@ export class TransactionQueue implements AsyncIterable<Transaction> {
 			if (this.mayStartNextTransaction(this.transactions.peekStart()!)) {
 				const promise = this.listeners.shift()!;
 				const item = this.transactions.shift()!;
+				this.currentTransaction = item;
 				promise.resolve(item);
+			} else {
+				break;
 			}
 		}
 	}
@@ -101,6 +104,8 @@ export class TransactionQueue implements AsyncIterable<Transaction> {
 					this.listeners.push(promise);
 					value = await promise;
 				}
+
+				this.currentTransaction = value;
 
 				if (value) {
 					// We have a value, return it

--- a/packages/zwave-js/src/lib/driver/Transaction.ts
+++ b/packages/zwave-js/src/lib/driver/Transaction.ts
@@ -88,12 +88,22 @@ export class Transaction implements Comparable<Transaction> {
 		return this.parts.current ?? this.message;
 	}
 
+	/**
+	 * Starts the transaction's message generator if it hasn't been started yet.
+	 * Returns `true` when the generator was started, `false` if it was already started before.
+	 */
+	public start(): boolean {
+		if (!this.parts.self) {
+			this.parts.start();
+			return true;
+		}
+		return false;
+	}
+
 	public async generateNextMessage(
 		prevResult: Message | undefined,
 	): Promise<Message | undefined> {
-		// Start the message generator if it hasn't been started yet
-		if (!this.parts.self) this.parts.start();
-		if (!this.parts.self) return; // This shouldn't happen, but better be sure
+		if (!this.parts.self) return;
 		// Get the next message from the generator
 		const { done, value } = await this.parts.self.next(prevResult!);
 		if (!done) return value;

--- a/packages/zwave-js/src/lib/log/Driver.test.ts
+++ b/packages/zwave-js/src/lib/log/Driver.test.ts
@@ -11,12 +11,12 @@ import {
 } from "@zwave-js/core/test";
 import { FunctionType, Message, MessageType } from "@zwave-js/serial";
 import { createDeferredPromise } from "alcalzone-shared/deferred-promise";
-import { SortedList } from "alcalzone-shared/sorted-list";
 import colors from "ansi-colors";
 import ava, { type TestFn } from "ava";
 import MockDate from "mockdate";
 import type { Driver } from "../driver/Driver";
 import { createAndStartTestingDriver } from "../driver/DriverMock";
+import { TransactionQueue } from "../driver/Queue";
 import { Transaction } from "../driver/Transaction";
 import { DriverLogger } from "./Driver";
 
@@ -299,7 +299,7 @@ test.serial(
 
 test.serial("sendQueue() prints the send queue length", (t) => {
 	const { driver, driverLogger, spyTransport } = t.context;
-	const queue = new SortedList<Transaction>();
+	const queue = new TransactionQueue();
 	driverLogger.sendQueue(queue);
 	assertMessage(t, spyTransport, {
 		predicate: (msg) => msg.includes("(0 messages)"),
@@ -330,7 +330,7 @@ test.serial("sendQueue() prints the send queue length", (t) => {
 
 test.serial("sendQueue() prints the function type for each message", (t) => {
 	const { driver, driverLogger, spyTransport } = t.context;
-	const queue = new SortedList<Transaction>();
+	const queue = new TransactionQueue();
 	queue.add(
 		createTransaction(driver, {
 			functionType: FunctionType.GetSUCNodeId,
@@ -351,7 +351,7 @@ test.serial("sendQueue() prints the function type for each message", (t) => {
 
 test.serial("sendQueue() prints the message type for each message", (t) => {
 	const { driver, driverLogger, spyTransport } = t.context;
-	const queue = new SortedList<Transaction>();
+	const queue = new TransactionQueue();
 	queue.add(
 		createTransaction(driver, {
 			functionType: FunctionType.GetSUCNodeId,

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepNoReject.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepNoReject.test.ts
@@ -63,20 +63,26 @@ integrationTest(
 			const sendQueue = driver["queue"];
 			driver.driverLog.sendQueue(sendQueue);
 			t.is(sendQueue.length, 2);
-			t.is(sendQueue.get(0)?.priority, MessagePriority.WakeUp);
-			t.is(sendQueue.get(1)?.priority, MessagePriority.WakeUp);
+			t.is(
+				sendQueue.transactions.get(0)?.priority,
+				MessagePriority.WakeUp,
+			);
+			t.is(
+				sendQueue.transactions.get(1)?.priority,
+				MessagePriority.WakeUp,
+			);
 			t.is(node2.status, NodeStatus.Asleep);
 
 			// And the order should be correct
 			t.is(
 				(
-					(sendQueue.get(0)?.message as SendDataRequest)
+					(sendQueue.transactions.get(0)?.message as SendDataRequest)
 						.command as BasicCCSet
 				).targetValue,
 				99,
 			);
 			t.true(
-				(sendQueue.get(1)?.message as SendDataRequest)
+				(sendQueue.transactions.get(1)?.message as SendDataRequest)
 					.command instanceof BasicCCGet,
 			);
 		},

--- a/packages/zwave-js/src/lib/test/driver/s0Encapsulation.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s0Encapsulation.test.ts
@@ -17,8 +17,8 @@ import {
 } from "@zwave-js/testing";
 import { integrationTest } from "../integrationTestSuite";
 
-integrationTest("communication via Security S0 works", {
-	debug: true,
+integrationTest("Communication via Security S0 works", {
+	// debug: true,
 
 	nodeCapabilities: {
 		commandClasses: [CommandClasses.Basic, CommandClasses.Security],

--- a/packages/zwave-js/src/lib/test/driver/s0EncapsulationTwoNodes.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s0EncapsulationTwoNodes.test.ts
@@ -1,0 +1,283 @@
+import {
+	BasicCCGet,
+	BasicCCReport,
+	SecurityCC,
+	SecurityCCCommandEncapsulation,
+	SecurityCCCommandsSupportedGet,
+	SecurityCCCommandsSupportedReport,
+	SecurityCCNonceGet,
+	SecurityCCNonceReport,
+} from "@zwave-js/cc";
+import { CommandClasses, SecurityManager } from "@zwave-js/core";
+import {
+	MockZWaveFrameType,
+	createMockZWaveRequestFrame,
+	type MockNodeBehavior,
+	type MockZWaveFrame,
+} from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import { integrationTest } from "../integrationTestSuiteMulti";
+
+integrationTest(
+	"Security S0 Nonce Get is answered while waiting for a reply from another node",
+	{
+		debug: true,
+
+		nodeCapabilities: [
+			{
+				id: 2,
+				capabilities: {
+					commandClasses: [
+						CommandClasses.Basic,
+						CommandClasses.Security,
+					],
+				},
+			},
+			{
+				id: 3,
+				capabilities: {
+					commandClasses: [
+						CommandClasses.Basic,
+						CommandClasses.Security,
+					],
+				},
+			},
+		],
+
+		customSetup: async (driver, controller, mockNodes) => {
+			for (const mockNode of mockNodes) {
+				// Create a security manager for the node
+				const sm0Node = new SecurityManager({
+					ownNodeId: mockNode.id,
+					networkKey: driver.options.securityKeys!.S0_Legacy!,
+					nonceTimeout: 100000,
+				});
+				mockNode.host.securityManager = sm0Node;
+
+				// Create a security manager for the controller
+				const sm0Ctrlr = new SecurityManager({
+					ownNodeId: controller.host.ownNodeId,
+					networkKey: driver.options.securityKeys!.S0_Legacy!,
+					nonceTimeout: 100000,
+				});
+				controller.host.securityManager = sm0Ctrlr;
+
+				// Respond to S0 Nonce Get
+				const respondToS0NonceGet: MockNodeBehavior = {
+					async onControllerFrame(controller, self, frame) {
+						if (
+							frame.type === MockZWaveFrameType.Request &&
+							frame.payload instanceof SecurityCCNonceGet
+						) {
+							const nonce = sm0Node.generateNonce(
+								controller.host.ownNodeId,
+								8,
+							);
+							const cc = new SecurityCCNonceReport(self.host, {
+								nodeId: controller.host.ownNodeId,
+								nonce,
+							});
+							await self.sendToController(
+								createMockZWaveRequestFrame(cc, {
+									ackRequested: false,
+								}),
+							);
+							return true;
+						}
+						return false;
+					},
+				};
+				mockNode.defineBehavior(respondToS0NonceGet);
+
+				// Respond to S0 Commands Supported Get
+				const respondToS0CommandsSupportedGet: MockNodeBehavior = {
+					async onControllerFrame(controller, self, frame) {
+						if (
+							frame.type === MockZWaveFrameType.Request &&
+							frame.payload instanceof
+								SecurityCCCommandEncapsulation &&
+							frame.payload.encapsulated instanceof
+								SecurityCCCommandsSupportedGet
+						) {
+							const nonceGet = new SecurityCCNonceGet(self.host, {
+								nodeId: controller.host.ownNodeId,
+							});
+							await self.sendToController(
+								createMockZWaveRequestFrame(nonceGet, {
+									ackRequested: false,
+								}),
+							);
+
+							const nonceReport =
+								await self.expectControllerFrame(
+									1000,
+									(
+										resp,
+									): resp is MockZWaveFrame & {
+										type: MockZWaveFrameType.Request;
+										payload: SecurityCCNonceReport;
+									} =>
+										resp.type ===
+											MockZWaveFrameType.Request &&
+										resp.payload instanceof
+											SecurityCCNonceReport,
+								);
+							const receiverNonce = nonceReport.payload.nonce;
+
+							const response =
+								new SecurityCCCommandsSupportedReport(
+									self.host,
+									{
+										nodeId: controller.host.ownNodeId,
+										supportedCCs: [CommandClasses.Basic],
+										controlledCCs: [],
+									},
+								);
+							const cc = SecurityCC.encapsulate(
+								self.host,
+								response,
+							);
+							cc.nonce = receiverNonce;
+
+							await self.sendToController(
+								createMockZWaveRequestFrame(cc, {
+									ackRequested: false,
+								}),
+							);
+
+							return true;
+						}
+						return false;
+					},
+				};
+				mockNode.defineBehavior(respondToS0CommandsSupportedGet);
+
+				// Respond to S0-encapsulated Basic Get with a level that increases with each request
+				let queryCount = 0;
+				const respondToS0BasicGet: MockNodeBehavior = {
+					async onControllerFrame(controller, self, frame) {
+						if (
+							frame.type === MockZWaveFrameType.Request &&
+							frame.payload instanceof
+								SecurityCCCommandEncapsulation &&
+							frame.payload.encapsulated instanceof BasicCCGet
+						) {
+							// Introduce a delay in the response for the second query (after interview)
+							// so we can simulate the other node interfering
+							queryCount++;
+							if (queryCount === 2) {
+								await wait(750);
+							}
+
+							const nonceGet = new SecurityCCNonceGet(self.host, {
+								nodeId: controller.host.ownNodeId,
+							});
+							await self.sendToController(
+								createMockZWaveRequestFrame(nonceGet, {
+									ackRequested: false,
+								}),
+							);
+
+							const nonceReport =
+								await self.expectControllerFrame(
+									1000,
+									(
+										resp,
+									): resp is MockZWaveFrame & {
+										type: MockZWaveFrameType.Request;
+										payload: SecurityCCNonceReport;
+									} =>
+										resp.type ===
+											MockZWaveFrameType.Request &&
+										resp.payload instanceof
+											SecurityCCNonceReport,
+								);
+							const receiverNonce = nonceReport.payload.nonce;
+
+							const response = new BasicCCReport(self.host, {
+								nodeId: controller.host.ownNodeId,
+								currentValue: queryCount,
+							});
+							const cc = SecurityCC.encapsulate(
+								self.host,
+								response,
+							);
+							cc.nonce = receiverNonce;
+
+							await self.sendToController(
+								createMockZWaveRequestFrame(cc, {
+									ackRequested: false,
+								}),
+							);
+
+							return true;
+						}
+						return false;
+					},
+				};
+				mockNode.defineBehavior(respondToS0BasicGet);
+
+				// Parse Security CC commands. This MUST be defined last, since defineBehavior will prepend it to the list
+				const parseS0CC: MockNodeBehavior = {
+					async onControllerFrame(controller, self, frame) {
+						// We don't support sequenced commands here
+						if (
+							frame.type === MockZWaveFrameType.Request &&
+							frame.payload instanceof
+								SecurityCCCommandEncapsulation
+						) {
+							frame.payload.mergePartialCCs(undefined as any, []);
+						}
+						// This just decodes - we need to call further handlers
+						return false;
+					},
+				};
+				mockNode.defineBehavior(parseS0CC);
+			}
+		},
+
+		testBody: async (
+			t,
+			driver,
+			[node2, node3],
+			mockController,
+			[mockNode2, mockNode3],
+		) => {
+			const basicGet = node2.commandClasses.Basic.get();
+
+			await wait(150);
+
+			// Now send a Nonce Get from node 3, which must be answered immediately
+			const nonceGet = new SecurityCCNonceGet(mockNode3.host, {
+				nodeId: mockController.host.ownNodeId,
+			});
+			await mockNode3.sendToController(
+				createMockZWaveRequestFrame(nonceGet, {
+					ackRequested: false,
+				}),
+			);
+
+			await mockNode3
+				.expectControllerFrame(
+					250,
+					(
+						resp,
+					): resp is MockZWaveFrame & {
+						type: MockZWaveFrameType.Request;
+						payload: SecurityCCNonceReport;
+					} =>
+						resp.type === MockZWaveFrameType.Request &&
+						resp.payload instanceof SecurityCCNonceReport,
+				)
+				.catch(() => {
+					throw new Error(
+						"The controller did not reply to the Nonce Get ASAP",
+					);
+				});
+
+			t.is((await basicGet)?.currentValue, 2);
+
+			t.pass();
+		},
+	},
+);

--- a/test.ts
+++ b/test.ts
@@ -1,0 +1,40 @@
+import { wait } from "alcalzone-shared/async";
+import stream from "stream";
+
+const queue = new stream.PassThrough({ objectMode: true });
+
+interface Item {
+	id: number;
+}
+
+process.nextTick(async () => {
+	for await (const item of queue as AsyncIterable<Item>) {
+		console.log("processing item", item.id);
+		await wait(250);
+		console.log("finished item", item.id);
+		console.log();
+	}
+	console.log("queue finished");
+});
+
+async function main() {
+	console.log("adding item", 1);
+	queue.write({ id: 1 });
+	await wait(100);
+	console.log("adding item", 2);
+	queue.write({ id: 2 });
+	console.log("adding item", 3);
+	queue.write({ id: 3 });
+
+	await wait(1000);
+	console.log("adding item", 4);
+	queue.write({ id: 4 });
+
+	await wait(2000);
+	console.log("adding item", 5);
+	queue.write({ id: 5 });
+	console.log("closing stream");
+	queue.end();
+}
+
+void main();


### PR DESCRIPTION
With this change, some commands - specifically nonce reports, supervision reports and Transport Service - are handled in a separate immediate queue. Transactions in that queue may always be started, so they can be interlaced with other commands, for example responding to `NonceGet` or `SupervisionGet` from one node while waiting for another node to send a reply.
Messages generated by each queue are going into another queue - the serial API queue, which simply gets drained as fast as possible.

This should fully restore the functionality of the nested state machines we got rid of in #5958 without their complexity.

As an added bonus, looping through the transaction queue(s) is now much easier on the eyes since it is now a simple for-await-of loop.

TODO:

- [x] restore idle detection
- [x] revert #6024 which is now handled by this change too