### PR TITLE
feat: add methods to read sensor/meter support information from cache for `Alarm/Binary/Multilevel Sensor CC` and `Meter CC`

### DIFF
--- a/packages/cc/src/cc/AlarmSensorCC.ts
+++ b/packages/cc/src/cc/AlarmSensorCC.ts
@@ -6,6 +6,7 @@ import {
 	ZWaveErrorCodes,
 	parseBitMask,
 	validatePayload,
+	type IZWaveEndpoint,
 	type MaybeNotKnown,
 	type MessageOrCCLogEntry,
 	type MessageRecord,
@@ -272,6 +273,23 @@ duration: ${currentValue.duration}`;
 				});
 			}
 		}
+	}
+
+	/**
+	 * Returns which sensor types are supported.
+	 * This only works AFTER the interview process
+	 */
+	public static getSupportedSensorTypesCached(
+		applHost: ZWaveApplicationHost,
+		endpoint: IZWaveEndpoint,
+	): MaybeNotKnown<AlarmSensorType[]> {
+		return applHost
+			.getValueDB(endpoint.nodeId)
+			.getValue(
+				AlarmSensorCCValues.supportedSensorTypes.endpoint(
+					endpoint.index,
+				),
+			);
 	}
 
 	protected createMetadataForSensorType(

--- a/packages/cc/src/cc/BinarySensorCC.ts
+++ b/packages/cc/src/cc/BinarySensorCC.ts
@@ -6,6 +6,7 @@ import {
 	ZWaveErrorCodes,
 	parseBitMask,
 	validatePayload,
+	type IZWaveEndpoint,
 	type MaybeNotKnown,
 	type MessageOrCCLogEntry,
 } from "@zwave-js/core/safe";
@@ -249,6 +250,23 @@ export class BinarySensorCC extends CommandClass {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Returns which sensor types are supported.
+	 * This only works AFTER the interview process
+	 */
+	public static getSupportedSensorTypesCached(
+		applHost: ZWaveApplicationHost,
+		endpoint: IZWaveEndpoint,
+	): MaybeNotKnown<BinarySensorType[]> {
+		return applHost
+			.getValueDB(endpoint.nodeId)
+			.getValue(
+				BinarySensorCCValues.supportedSensorTypes.endpoint(
+					endpoint.index,
+				),
+			);
 	}
 
 	public setMappedBasicValue(

--- a/packages/cc/src/cc/MeterCC.ts
+++ b/packages/cc/src/cc/MeterCC.ts
@@ -3,7 +3,11 @@ import {
 	type ConfigManager,
 	type MeterScale,
 } from "@zwave-js/config";
-import { timespan, type MaybeUnknown } from "@zwave-js/core";
+import {
+	timespan,
+	type IZWaveEndpoint,
+	type MaybeUnknown,
+} from "@zwave-js/core";
 import {
 	CommandClasses,
 	MessagePriority,
@@ -506,6 +510,60 @@ supports reset:       ${suppResp.supportsReset}`;
 				Date.now() - lastUpdated > timespan.hours(6)
 			);
 		});
+	}
+
+	/**
+	 * Returns which type this meter has.
+	 * This only works AFTER the interview process
+	 */
+	public static getMeterTypeCached(
+		applHost: ZWaveApplicationHost,
+		endpoint: IZWaveEndpoint,
+	): MaybeNotKnown<number> {
+		return applHost
+			.getValueDB(endpoint.nodeId)
+			.getValue(MeterCCValues.type.endpoint(endpoint.index));
+	}
+
+	/**
+	 * Returns which scales are supported by this meter.
+	 * This only works AFTER the interview process
+	 */
+	public static getSupportedScalesCached(
+		applHost: ZWaveApplicationHost,
+		endpoint: IZWaveEndpoint,
+	): MaybeNotKnown<number[]> {
+		return applHost
+			.getValueDB(endpoint.nodeId)
+			.getValue(MeterCCValues.supportedScales.endpoint(endpoint.index));
+	}
+
+	/**
+	 * Returns whether reset is supported by this meter.
+	 * This only works AFTER the interview process
+	 */
+	public static supportsResetCached(
+		applHost: ZWaveApplicationHost,
+		endpoint: IZWaveEndpoint,
+	): MaybeNotKnown<boolean> {
+		return applHost
+			.getValueDB(endpoint.nodeId)
+			.getValue(MeterCCValues.supportsReset.endpoint(endpoint.index));
+	}
+
+	/**
+	 * Returns which rate types are supported by this meter.
+	 * This only works AFTER the interview process
+	 */
+	public static getSupportedRateTypesCached(
+		applHost: ZWaveApplicationHost,
+		endpoint: IZWaveEndpoint,
+	): MaybeNotKnown<RateType[]> {
+		return applHost
+			.getValueDB(endpoint.nodeId)
+			.getValue(
+				MeterCCValues.supportedRateTypes.endpoint(endpoint.index),
+			);
 	}
 
 	public translatePropertyKey(

--- a/packages/cc/src/cc/MultilevelSensorCC.ts
+++ b/packages/cc/src/cc/MultilevelSensorCC.ts
@@ -1,6 +1,7 @@
 import { Scale, getDefaultScale } from "@zwave-js/config";
 import { timespan } from "@zwave-js/core";
 import type {
+	IZWaveEndpoint,
 	MessageOrCCLogEntry,
 	MessageRecord,
 	SinglecastCC,
@@ -551,6 +552,41 @@ value:       ${mlsResponse.value} ${sensorScale.unit || ""}`;
 				Date.now() - lastUpdated > timespan.hours(6)
 			);
 		});
+	}
+
+	/**
+	 * Returns which sensor types are supported.
+	 * This only works AFTER the interview process
+	 */
+	public static getSupportedSensorTypesCached(
+		applHost: ZWaveApplicationHost,
+		endpoint: IZWaveEndpoint,
+	): MaybeNotKnown<number[]> {
+		return applHost
+			.getValueDB(endpoint.nodeId)
+			.getValue(
+				MultilevelSensorCCValues.supportedSensorTypes.endpoint(
+					endpoint.index,
+				),
+			);
+	}
+
+	/**
+	 * Returns which scales are supported for a given sensor type.
+	 * This only works AFTER the interview process
+	 */
+	public static getSupportedScalesCached(
+		applHost: ZWaveApplicationHost,
+		endpoint: IZWaveEndpoint,
+		sensorType: number,
+	): MaybeNotKnown<number[]> {
+		return applHost
+			.getValueDB(endpoint.nodeId)
+			.getValue(
+				MultilevelSensorCCValues.supportedScales(sensorType).endpoint(
+					endpoint.index,
+				),
+			);
 	}
 
 	public translatePropertyKey(


### PR DESCRIPTION
fixes: #3326