### PR TITLE
feat: enable 16 bit node IDs in Serial API communication

### DIFF
--- a/packages/core/src/consts/index.ts
+++ b/packages/core/src/consts/index.ts
@@ -10,6 +10,11 @@ export const NODE_ID_MAX = MAX_NODES;
 /** The number of bytes in a node bit mask */
 export const NUM_NODEMASK_BYTES = MAX_NODES / 8;
 
+export enum NodeIDType {
+	Short = 0x01,
+	Long = 0x02,
+}
+
 /** The size of a Home ID */
 export const HOMEID_BYTES = 4;
 

--- a/packages/host/src/ZWaveHost.ts
+++ b/packages/host/src/ZWaveHost.ts
@@ -5,6 +5,7 @@ import type {
 	ICommandClass,
 	IZWaveNode,
 	MaybeNotKnown,
+	NodeIDType,
 	SecurityClass,
 	SecurityManager,
 	SecurityManager2,
@@ -22,6 +23,9 @@ export interface ZWaveHost {
 	ownNodeId: number;
 	/** The Home ID of the current network */
 	homeId: number;
+
+	/** How many bytes a node ID occupies in serial API commands */
+	readonly nodeIdType?: NodeIDType;
 
 	/** Management of Security S0 keys and nonces */
 	securityManager: SecurityManager | undefined;

--- a/packages/host/src/mocks.ts
+++ b/packages/host/src/mocks.ts
@@ -2,6 +2,7 @@
 import { ConfigManager } from "@zwave-js/config";
 import {
 	MAX_SUPERVISION_SESSION_ID,
+	NodeIDType,
 	ValueDB,
 	ZWaveError,
 	ZWaveErrorCodes,
@@ -38,6 +39,7 @@ export function createTestingHost(
 	const ret: TestingHost = {
 		homeId: options.homeId ?? 0x7e570001,
 		ownNodeId: options.ownNodeId ?? 1,
+		nodeIdType: NodeIDType.Short,
 		isControllerNode: (nodeId) => nodeId === ret.ownNodeId,
 		securityManager: undefined,
 		securityManager2: undefined,

--- a/packages/serial/src/message/Constants.ts
+++ b/packages/serial/src/message/Constants.ts
@@ -183,8 +183,3 @@ export enum FunctionType {
 	UNKNOWN_FUNC_ZMECapabilities = 0xf5,
 	UNKNOWN_FUNC_ZMESerialAPIOptions = 0xf8,
 }
-
-export enum NodeIDType {
-	Short = 0x01,
-	Long = 0x02,
-}

--- a/packages/serial/src/message/Constants.ts
+++ b/packages/serial/src/message/Constants.ts
@@ -183,3 +183,8 @@ export enum FunctionType {
 	UNKNOWN_FUNC_ZMECapabilities = 0xf5,
 	UNKNOWN_FUNC_ZMESerialAPIOptions = 0xf8,
 }
+
+export enum NodeIDType {
+	Short = 0x01,
+	Long = 0x02,
+}

--- a/packages/serial/src/message/Message.ts
+++ b/packages/serial/src/message/Message.ts
@@ -12,7 +12,7 @@ import type { ZWaveApplicationHost, ZWaveHost } from "@zwave-js/host";
 import type { JSONObject, TypedClassDecorator } from "@zwave-js/shared/safe";
 import { num2hex, staticExtends } from "@zwave-js/shared/safe";
 import { MessageHeaders } from "../MessageHeaders";
-import { FunctionType, MessageType, type NodeIDType } from "./Constants";
+import { FunctionType, MessageType } from "./Constants";
 import { isNodeQuery } from "./INodeQuery";
 
 export type MessageConstructor<T extends Message> = new (
@@ -38,8 +38,6 @@ export interface MessageDeserializationOptions {
 	parseCCs?: boolean;
 	/** If known already, this contains the SDK version of the stick which can be used to interpret payloads differently */
 	sdkVersion?: string;
-	/** How many bytes a node ID occupies in Serial API commands */
-	nodeIdType?: NodeIDType;
 }
 
 /**

--- a/packages/serial/src/message/Message.ts
+++ b/packages/serial/src/message/Message.ts
@@ -12,7 +12,7 @@ import type { ZWaveApplicationHost, ZWaveHost } from "@zwave-js/host";
 import type { JSONObject, TypedClassDecorator } from "@zwave-js/shared/safe";
 import { num2hex, staticExtends } from "@zwave-js/shared/safe";
 import { MessageHeaders } from "../MessageHeaders";
-import { FunctionType, MessageType } from "./Constants";
+import { FunctionType, MessageType, type NodeIDType } from "./Constants";
 import { isNodeQuery } from "./INodeQuery";
 
 export type MessageConstructor<T extends Message> = new (
@@ -38,6 +38,8 @@ export interface MessageDeserializationOptions {
 	parseCCs?: boolean;
 	/** If known already, this contains the SDK version of the stick which can be used to interpret payloads differently */
 	sdkVersion?: string;
+	/** How many bytes a node ID occupies in Serial API commands */
+	nodeIdType?: NodeIDType;
 }
 
 /**

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -33,6 +33,7 @@ import {
 	EMPTY_ROUTE,
 	MAX_NODES,
 	NODE_ID_BROADCAST,
+	NodeIDType,
 	NodeType,
 	ProtocolType,
 	RFRegion,
@@ -71,7 +72,6 @@ import { migrateNVM } from "@zwave-js/nvmedit";
 import {
 	BootloaderChunkType,
 	FunctionType,
-	NodeIDType,
 	XModemMessageHeaders,
 	type BootloaderChunk,
 	type Message,

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -54,6 +54,7 @@ import {
 	MAX_TRANSPORT_SERVICE_SESSION_ID,
 	MPANState,
 	MessagePriority,
+	NodeIDType,
 	SPANState,
 	SecurityClass,
 	SecurityManager,
@@ -95,7 +96,6 @@ import {
 	Message,
 	MessageHeaders,
 	MessageType,
-	NodeIDType,
 	XModemMessageHeaders,
 	ZWaveSerialMode,
 	ZWaveSerialPort,
@@ -678,6 +678,10 @@ export class Driver
 	public get ownNodeId(): number {
 		// This is needed for the ZWaveHost interface
 		return this.controller.ownNodeId!;
+	}
+
+	public get nodeIdType(): NodeIDType {
+		return this._controller?.nodeIdType ?? NodeIDType.Short;
 	}
 
 	/**
@@ -2793,7 +2797,6 @@ export class Driver
 			msg = Message.from(this, {
 				data,
 				sdkVersion: this._controller?.sdkVersion,
-				nodeIdType: this._controller?.nodeIdType ?? NodeIDType.Short,
 			});
 			if (isCommandClassContainer(msg)) {
 				// Whether successful or not, a message from a node should update last seen

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -95,6 +95,7 @@ import {
 	Message,
 	MessageHeaders,
 	MessageType,
+	NodeIDType,
 	XModemMessageHeaders,
 	ZWaveSerialMode,
 	ZWaveSerialPort,
@@ -2792,6 +2793,7 @@ export class Driver
 			msg = Message.from(this, {
 				data,
 				sdkVersion: this._controller?.sdkVersion,
+				nodeIdType: this._controller?.nodeIdType ?? NodeIDType.Short,
 			});
 			if (isCommandClassContainer(msg)) {
 				// Whether successful or not, a message from a node should update last seen

--- a/packages/zwave-js/src/lib/serialapi/_Types.ts
+++ b/packages/zwave-js/src/lib/serialapi/_Types.ts
@@ -1,7 +1,2 @@
 export { ZWaveLibraryTypes } from "@zwave-js/core/safe";
 export type { ZWaveApiVersion } from "@zwave-js/core/safe";
-
-export enum NodeIDType {
-	Short = 0x01,
-	Long = 0x02,
-}

--- a/packages/zwave-js/src/lib/serialapi/capability/SerialAPISetupMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/capability/SerialAPISetupMessages.ts
@@ -1,5 +1,6 @@
 import {
 	MessagePriority,
+	NodeIDType,
 	RFRegion,
 	ZWaveError,
 	ZWaveErrorCodes,
@@ -18,7 +19,6 @@ import {
 	FunctionType,
 	Message,
 	MessageType,
-	NodeIDType,
 	expectedResponse,
 	gotDeserializationOptions,
 	messageTypes,

--- a/packages/zwave-js/src/lib/serialapi/capability/SerialAPISetupMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/capability/SerialAPISetupMessages.ts
@@ -18,6 +18,7 @@ import {
 	FunctionType,
 	Message,
 	MessageType,
+	NodeIDType,
 	expectedResponse,
 	gotDeserializationOptions,
 	messageTypes,
@@ -28,7 +29,6 @@ import {
 } from "@zwave-js/serial";
 import { getEnumMemberName } from "@zwave-js/shared";
 import { sdkVersionLt } from "../../controller/utils";
-import { NodeIDType } from "../_Types";
 
 export enum SerialAPISetupCommand {
 	Unsupported = 0x00,

--- a/packages/zwave-js/src/lib/serialapi/memory/GetControllerIdMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/memory/GetControllerIdMessages.ts
@@ -1,5 +1,5 @@
 import type { MessageOrCCLogEntry } from "@zwave-js/core";
-import { MessagePriority } from "@zwave-js/core";
+import { MessagePriority, encodeNodeID, parseNodeID } from "@zwave-js/core";
 import type { ZWaveHost } from "@zwave-js/host";
 import {
 	FunctionType,
@@ -34,7 +34,8 @@ export class GetControllerIdResponse extends Message {
 		if (gotDeserializationOptions(options)) {
 			// The payload is 4 bytes home id, followed by the controller node id
 			this.homeId = this.payload.readUInt32BE(0);
-			this.ownNodeId = this.payload.readUInt8(4);
+			const { nodeId } = parseNodeID(this.payload, host.nodeIdType, 4);
+			this.ownNodeId = nodeId;
 		} else {
 			this.homeId = options.homeId;
 			this.ownNodeId = options.ownNodeId;
@@ -45,9 +46,11 @@ export class GetControllerIdResponse extends Message {
 	public ownNodeId: number;
 
 	public serialize(): Buffer {
-		this.payload = Buffer.allocUnsafe(5);
-		this.payload.writeUInt32BE(this.homeId, 0);
-		this.payload.writeUInt8(this.ownNodeId, 4);
+		const nodeId = encodeNodeID(this.ownNodeId, this.host.nodeIdType);
+		const homeId = Buffer.allocUnsafe(4);
+		homeId.writeUInt32BE(this.homeId, 0);
+
+		this.payload = Buffer.concat([homeId, nodeId]);
 
 		return super.serialize();
 	}

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/AddNodeToNetworkRequest.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/AddNodeToNetworkRequest.ts
@@ -1,6 +1,7 @@
 import {
 	MessagePriority,
 	NodeType,
+	parseNodeID,
 	parseNodeUpdatePayload,
 	type CommandClasses,
 	type MessageOrCCLogEntry,
@@ -270,15 +271,22 @@ export class AddNodeToNetworkRequestStatusReport
 				// no context for the status to parse
 				break;
 
-			case AddNodeStatus.Done:
-				this.statusContext = { nodeId: this.payload[2] };
+			case AddNodeStatus.Done: {
+				const { nodeId } = parseNodeID(
+					this.payload,
+					host.nodeIdType,
+					2,
+				);
+				this.statusContext = { nodeId };
 				break;
+			}
 
 			case AddNodeStatus.AddingController:
 			case AddNodeStatus.AddingSlave: {
 				// the payload contains a node information frame
 				this.statusContext = parseNodeUpdatePayload(
 					this.payload.slice(2),
+					host.nodeIdType,
 				);
 				break;
 			}

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/AssignPriorityReturnRouteMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/AssignPriorityReturnRouteMessages.ts
@@ -6,6 +6,7 @@ import {
 	ZWaveDataRate,
 	ZWaveError,
 	ZWaveErrorCodes,
+	encodeNodeID,
 	type MessageOrCCLogEntry,
 } from "@zwave-js/core";
 import type { ZWaveHost } from "@zwave-js/host";
@@ -96,15 +97,22 @@ export class AssignPriorityReturnRouteRequest extends AssignPriorityReturnRouteR
 	public routeSpeed: ZWaveDataRate;
 
 	public serialize(): Buffer {
-		this.payload = Buffer.from([
-			this.nodeId,
+		const nodeId = encodeNodeID(this.nodeId, this.host.nodeIdType);
+		const destinationNodeId = encodeNodeID(
 			this.destinationNodeId,
-			this.repeaters[0] ?? 0,
-			this.repeaters[1] ?? 0,
-			this.repeaters[2] ?? 0,
-			this.repeaters[3] ?? 0,
-			this.routeSpeed,
-			this.callbackId,
+			this.host.nodeIdType,
+		);
+		this.payload = Buffer.concat([
+			nodeId,
+			destinationNodeId,
+			Buffer.from([
+				this.repeaters[0] ?? 0,
+				this.repeaters[1] ?? 0,
+				this.repeaters[2] ?? 0,
+				this.repeaters[3] ?? 0,
+				this.routeSpeed,
+				this.callbackId,
+			]),
 		]);
 
 		return super.serialize();

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/AssignPrioritySUCReturnRouteMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/AssignPrioritySUCReturnRouteMessages.ts
@@ -6,6 +6,7 @@ import {
 	ZWaveDataRate,
 	ZWaveError,
 	ZWaveErrorCodes,
+	encodeNodeID,
 	type MessageOrCCLogEntry,
 } from "@zwave-js/core";
 import type { ZWaveHost } from "@zwave-js/host";
@@ -87,14 +88,17 @@ export class AssignPrioritySUCReturnRouteRequest extends AssignPrioritySUCReturn
 	public routeSpeed: ZWaveDataRate;
 
 	public serialize(): Buffer {
-		this.payload = Buffer.from([
-			this.nodeId,
-			this.repeaters[0] ?? 0,
-			this.repeaters[1] ?? 0,
-			this.repeaters[2] ?? 0,
-			this.repeaters[3] ?? 0,
-			this.routeSpeed,
-			this.callbackId,
+		const nodeId = encodeNodeID(this.nodeId, this.host.nodeIdType);
+		this.payload = Buffer.concat([
+			nodeId,
+			Buffer.from([
+				this.repeaters[0] ?? 0,
+				this.repeaters[1] ?? 0,
+				this.repeaters[2] ?? 0,
+				this.repeaters[3] ?? 0,
+				this.routeSpeed,
+				this.callbackId,
+			]),
 		]);
 
 		return super.serialize();

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/AssignReturnRouteMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/AssignReturnRouteMessages.ts
@@ -3,6 +3,7 @@ import {
 	TransmitStatus,
 	ZWaveError,
 	ZWaveErrorCodes,
+	encodeNodeID,
 	type MessageOrCCLogEntry,
 } from "@zwave-js/core";
 import type { ZWaveHost } from "@zwave-js/host";
@@ -75,10 +76,16 @@ export class AssignReturnRouteRequest
 	public destinationNodeId: number;
 
 	public serialize(): Buffer {
-		this.payload = Buffer.from([
-			this.nodeId,
+		const nodeId = encodeNodeID(this.nodeId, this.host.nodeIdType);
+		const destinationNodeId = encodeNodeID(
 			this.destinationNodeId,
-			this.callbackId,
+			this.host.nodeIdType,
+		);
+
+		this.payload = Buffer.concat([
+			nodeId,
+			destinationNodeId,
+			Buffer.from([this.callbackId]),
 		]);
 
 		return super.serialize();

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/AssignSUCReturnRouteMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/AssignSUCReturnRouteMessages.ts
@@ -1,6 +1,7 @@
 import {
 	MessagePriority,
 	TransmitStatus,
+	encodeNodeID,
 	type MessageOrCCLogEntry,
 } from "@zwave-js/core";
 import type { ZWaveHost } from "@zwave-js/host";
@@ -76,7 +77,8 @@ export class AssignSUCReturnRouteRequest
 	public nodeId: number;
 
 	public serialize(): Buffer {
-		this.payload = Buffer.from([this.nodeId, this.callbackId]);
+		const nodeId = encodeNodeID(this.nodeId, this.host.nodeIdType);
+		this.payload = Buffer.concat([nodeId, Buffer.from([this.callbackId])]);
 
 		return super.serialize();
 	}

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/DeleteReturnRouteMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/DeleteReturnRouteMessages.ts
@@ -3,6 +3,7 @@ import {
 	TransmitStatus,
 	ZWaveError,
 	ZWaveErrorCodes,
+	encodeNodeID,
 	type MessageOrCCLogEntry,
 } from "@zwave-js/core";
 import type { ZWaveHost } from "@zwave-js/host";
@@ -66,7 +67,8 @@ export class DeleteReturnRouteRequest
 	public nodeId: number;
 
 	public serialize(): Buffer {
-		this.payload = Buffer.from([this.nodeId, this.callbackId]);
+		const nodeId = encodeNodeID(this.nodeId, this.host.nodeIdType);
+		this.payload = Buffer.concat([nodeId, Buffer.from([this.callbackId])]);
 
 		return super.serialize();
 	}

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/DeleteSUCReturnRouteMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/DeleteSUCReturnRouteMessages.ts
@@ -3,6 +3,7 @@ import {
 	TransmitStatus,
 	ZWaveError,
 	ZWaveErrorCodes,
+	encodeNodeID,
 	type MessageOrCCLogEntry,
 } from "@zwave-js/core";
 import type { ZWaveHost } from "@zwave-js/host";
@@ -66,7 +67,8 @@ export class DeleteSUCReturnRouteRequest
 	public nodeId: number;
 
 	public serialize(): Buffer {
-		this.payload = Buffer.from([this.nodeId, this.callbackId]);
+		const nodeId = encodeNodeID(this.nodeId, this.host.nodeIdType);
+		this.payload = Buffer.concat([nodeId, Buffer.from([this.callbackId])]);
 
 		return super.serialize();
 	}

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/GetNodeProtocolInfoMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/GetNodeProtocolInfoMessages.ts
@@ -1,5 +1,6 @@
 import {
 	MessagePriority,
+	encodeNodeID,
 	encodeNodeProtocolInfo,
 	parseNodeProtocolInfo,
 	type DataRate,
@@ -48,7 +49,7 @@ export class GetNodeProtocolInfoRequest extends Message {
 	public requestedNodeId: number;
 
 	public serialize(): Buffer {
-		this.payload = Buffer.from([this.requestedNodeId]);
+		this.payload = encodeNodeID(this.requestedNodeId, this.host.nodeIdType);
 		return super.serialize();
 	}
 }

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/GetRoutingInfoMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/GetRoutingInfoMessages.ts
@@ -1,6 +1,7 @@
 import {
 	MessagePriority,
 	NUM_NODEMASK_BYTES,
+	encodeNodeID,
 	parseNodeBitMask,
 	type MessageOrCCLogEntry,
 } from "@zwave-js/core";
@@ -38,11 +39,16 @@ export class GetRoutingInfoRequest extends Message {
 	public removeBadLinks: boolean;
 
 	public serialize(): Buffer {
-		this.payload = Buffer.from([
-			this.sourceNodeId,
-			this.removeNonRepeaters ? 1 : 0,
-			this.removeBadLinks ? 1 : 0,
-			0, // callbackId - this must be 0 as per the docs
+		const nodeId = encodeNodeID(this.sourceNodeId, this.host.nodeIdType);
+		const optionsByte =
+			(this.removeBadLinks ? 0b1000_0000 : 0) |
+			(this.removeNonRepeaters ? 0b0100_0000 : 0);
+		this.payload = Buffer.concat([
+			nodeId,
+			Buffer.from([
+				optionsByte,
+				0, // callbackId - this must be 0 as per the docs
+			]),
 		]);
 		return super.serialize();
 	}

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/GetSUCNodeIdMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/GetSUCNodeIdMessages.ts
@@ -1,4 +1,4 @@
-import { MessagePriority } from "@zwave-js/core";
+import { MessagePriority, encodeNodeID, parseNodeID } from "@zwave-js/core";
 import type { ZWaveHost } from "@zwave-js/host";
 import {
 	FunctionType,
@@ -30,7 +30,11 @@ export class GetSUCNodeIdResponse extends Message {
 		super(host, options);
 
 		if (gotDeserializationOptions(options)) {
-			this.sucNodeId = this.payload[0];
+			this.sucNodeId = parseNodeID(
+				this.payload,
+				this.host.nodeIdType,
+				0,
+			).nodeId;
 		} else {
 			this.sucNodeId = options.sucNodeId;
 		}
@@ -40,7 +44,7 @@ export class GetSUCNodeIdResponse extends Message {
 	public sucNodeId: number;
 
 	public serialize(): Buffer {
-		this.payload = Buffer.from([this.sucNodeId]);
+		this.payload = encodeNodeID(this.sucNodeId, this.host.nodeIdType);
 		return super.serialize();
 	}
 }

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/IsFailedNodeMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/IsFailedNodeMessages.ts
@@ -1,4 +1,4 @@
-import { MessagePriority } from "@zwave-js/core";
+import { MessagePriority, encodeNodeID } from "@zwave-js/core";
 import type { ZWaveHost } from "@zwave-js/host";
 import {
 	FunctionType,
@@ -29,7 +29,7 @@ export class IsFailedNodeRequest extends Message {
 	public failedNodeId: number;
 
 	public serialize(): Buffer {
-		this.payload = Buffer.from([this.failedNodeId]);
+		this.payload = encodeNodeID(this.failedNodeId, this.host.nodeIdType);
 		return super.serialize();
 	}
 }

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/RemoveFailedNodeMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/RemoveFailedNodeMessages.ts
@@ -1,4 +1,4 @@
-import { MessagePriority } from "@zwave-js/core";
+import { MessagePriority, encodeNodeID } from "@zwave-js/core";
 import type { ZWaveHost } from "@zwave-js/host";
 import type { SuccessIndicator } from "@zwave-js/serial";
 import {
@@ -76,7 +76,8 @@ export class RemoveFailedNodeRequest extends RemoveFailedNodeRequestBase {
 	public failedNodeId: number;
 
 	public serialize(): Buffer {
-		this.payload = Buffer.from([this.failedNodeId, this.callbackId]);
+		const nodeId = encodeNodeID(this.failedNodeId, this.host.nodeIdType);
+		this.payload = Buffer.concat([nodeId, Buffer.from([this.callbackId])]);
 		return super.serialize();
 	}
 }

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/RemoveNodeFromNetworkRequest.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/RemoveNodeFromNetworkRequest.ts
@@ -148,6 +148,7 @@ export class RemoveNodeFromNetworkRequestStatusReport
 				// the payload contains a node information frame
 				this.statusContext = parseNodeUpdatePayload(
 					this.payload.slice(2),
+					this.host.nodeIdType,
 				);
 				break;
 		}

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/ReplaceFailedNodeRequest.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/ReplaceFailedNodeRequest.ts
@@ -1,4 +1,4 @@
-import { MessagePriority } from "@zwave-js/core";
+import { MessagePriority, encodeNodeID } from "@zwave-js/core";
 import type { ZWaveHost } from "@zwave-js/host";
 import type { SuccessIndicator } from "@zwave-js/serial";
 import {
@@ -74,7 +74,8 @@ export class ReplaceFailedNodeRequest extends ReplaceFailedNodeRequestBase {
 	public failedNodeId: number;
 
 	public serialize(): Buffer {
-		this.payload = Buffer.from([this.failedNodeId, this.callbackId]);
+		const nodeId = encodeNodeID(this.failedNodeId, this.host.nodeIdType);
+		this.payload = Buffer.concat([nodeId, Buffer.from([this.callbackId])]);
 		return super.serialize();
 	}
 }

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/RequestNodeInfoMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/RequestNodeInfoMessages.ts
@@ -1,4 +1,9 @@
-import { MessagePriority, type MessageOrCCLogEntry } from "@zwave-js/core";
+import {
+	MessagePriority,
+	encodeNodeID,
+	parseNodeID,
+	type MessageOrCCLogEntry,
+} from "@zwave-js/core";
 import type { ZWaveHost } from "@zwave-js/host";
 import {
 	FunctionType,
@@ -85,7 +90,11 @@ export class RequestNodeInfoRequest extends Message implements INodeQuery {
 	) {
 		super(host, options);
 		if (gotDeserializationOptions(options)) {
-			this.nodeId = this.payload[0];
+			this.nodeId = parseNodeID(
+				this.payload,
+				this.host.nodeIdType,
+				0,
+			).nodeId;
 		} else {
 			this.nodeId = options.nodeId;
 		}
@@ -99,7 +108,7 @@ export class RequestNodeInfoRequest extends Message implements INodeQuery {
 	}
 
 	public serialize(): Buffer {
-		this.payload = Buffer.from([this.nodeId]);
+		this.payload = encodeNodeID(this.nodeId, this.host.nodeIdType);
 		return super.serialize();
 	}
 

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/RequestNodeNeighborUpdateMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/RequestNodeNeighborUpdateMessages.ts
@@ -1,5 +1,5 @@
 import type { MessageOrCCLogEntry } from "@zwave-js/core";
-import { MessagePriority } from "@zwave-js/core";
+import { MessagePriority, encodeNodeID } from "@zwave-js/core";
 import type { ZWaveHost } from "@zwave-js/host";
 import type { MultiStageCallback, SuccessIndicator } from "@zwave-js/serial";
 import {
@@ -58,7 +58,8 @@ export class RequestNodeNeighborUpdateRequest extends RequestNodeNeighborUpdateR
 	public discoveryTimeout: number;
 
 	public serialize(): Buffer {
-		this.payload = Buffer.from([this.nodeId, this.callbackId]);
+		const nodeId = encodeNodeID(this.nodeId, this.host.nodeIdType);
+		this.payload = Buffer.concat([nodeId, Buffer.from([this.callbackId])]);
 		return super.serialize();
 	}
 

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/SetPriorityRouteMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/SetPriorityRouteMessages.ts
@@ -5,6 +5,7 @@ import {
 	ZWaveDataRate,
 	ZWaveError,
 	ZWaveErrorCodes,
+	encodeNodeID,
 	type MessageOrCCLogEntry,
 	type MessageRecord,
 } from "@zwave-js/core";
@@ -76,18 +77,24 @@ export class SetPriorityRouteRequest extends Message {
 	public routeSpeed: ZWaveDataRate | undefined;
 
 	public serialize(): Buffer {
+		const nodeId = encodeNodeID(
+			this.destinationNodeId,
+			this.host.nodeIdType,
+		);
 		if (this.repeaters == undefined || this.routeSpeed == undefined) {
 			// Remove the priority route
-			this.payload = Buffer.from([this.destinationNodeId]);
+			this.payload = nodeId;
 		} else {
 			// Set the priority route
-			this.payload = Buffer.from([
-				this.destinationNodeId,
-				this.repeaters[0] ?? 0,
-				this.repeaters[1] ?? 0,
-				this.repeaters[2] ?? 0,
-				this.repeaters[3] ?? 0,
-				this.routeSpeed,
+			this.payload = Buffer.concat([
+				nodeId,
+				Buffer.from([
+					this.repeaters[0] ?? 0,
+					this.repeaters[1] ?? 0,
+					this.repeaters[2] ?? 0,
+					this.repeaters[3] ?? 0,
+					this.routeSpeed,
+				]),
 			]);
 		}
 

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/SetPriorityRouteMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/SetPriorityRouteMessages.ts
@@ -6,6 +6,7 @@ import {
 	ZWaveError,
 	ZWaveErrorCodes,
 	encodeNodeID,
+	parseNodeID,
 	type MessageOrCCLogEntry,
 	type MessageRecord,
 } from "@zwave-js/core";
@@ -135,7 +136,14 @@ export class SetPriorityRouteResponse
 		options: MessageDeserializationOptions,
 	) {
 		super(host, options);
-		this.success = this.payload[0] !== 0;
+		// Byte(s) 0/1 are the node ID - this is missing from the Host API specs
+		const { /* nodeId, */ bytesRead } = parseNodeID(
+			this.payload,
+			this.host.nodeIdType,
+			0,
+		);
+
+		this.success = this.payload[bytesRead] !== 0;
 	}
 
 	isOK(): boolean {

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/SetSUCNodeIDMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/SetSUCNodeIDMessages.ts
@@ -3,6 +3,7 @@ import {
 	TransmitOptions,
 	ZWaveError,
 	ZWaveErrorCodes,
+	encodeNodeID,
 	type MessageOrCCLogEntry,
 } from "@zwave-js/core";
 import type { ZWaveHost } from "@zwave-js/host";
@@ -75,12 +76,15 @@ export class SetSUCNodeIdRequest extends SetSUCNodeIdRequestBase {
 	public transmitOptions: TransmitOptions;
 
 	public serialize(): Buffer {
-		this.payload = Buffer.from([
-			this.sucNodeId,
-			this.enableSUC ? 0x01 : 0x00,
-			this.transmitOptions,
-			this.enableSIS ? 0x01 : 0x00,
-			this.callbackId,
+		const nodeId = encodeNodeID(this.sucNodeId, this.host.nodeIdType);
+		this.payload = Buffer.concat([
+			nodeId,
+			Buffer.from([
+				this.enableSUC ? 0x01 : 0x00,
+				this.transmitOptions,
+				this.enableSIS ? 0x01 : 0x00,
+				this.callbackId,
+			]),
 		]);
 
 		return super.serialize();


### PR DESCRIPTION
This PR switches the encoding of node IDs in serial API commands to 16 bits which lays the foundation for Z-Wave Long Range support.

Coincidentally it uncovered a bug in the controller firmware:
https://community.silabs.com/s/question/0D58Y0000AcPqWrSQK/7x-firmware-setpriorityroute-behaves-erratically-when-used-with-16bit-node-ids-host-api-specification-missing-node-id