### PR TITLE
fix: hide configuration values for `Door Lock CC v4` functionality that is not supported by a lock

### DIFF
--- a/packages/cc/src/cc/DoorLockCC.ts
+++ b/packages/cc/src/cc/DoorLockCC.ts
@@ -127,7 +127,10 @@ export const DoorLockCCValues = Object.freeze({
 				...ValueMetadata.UInt16,
 				label: "Duration in seconds until lock returns to secure state",
 			} as const,
-			{ minVersion: 4 } as const,
+			{
+				minVersion: 4,
+				autoCreate: shouldAutoCreateAutoRelockConfigValue,
+			} as const,
 		),
 
 		...V.staticProperty("holdAndReleaseSupported", undefined, {
@@ -140,7 +143,10 @@ export const DoorLockCCValues = Object.freeze({
 				...ValueMetadata.UInt16,
 				label: "Duration in seconds the latch stays retracted",
 			} as const,
-			{ minVersion: 4 } as const,
+			{
+				minVersion: 4,
+				autoCreate: shouldAutoCreateHoldAndReleaseConfigValue,
+			} as const,
 		),
 
 		...V.staticProperty("twistAssistSupported", undefined, {
@@ -153,7 +159,10 @@ export const DoorLockCCValues = Object.freeze({
 				...ValueMetadata.Boolean,
 				label: "Twist Assist enabled",
 			} as const,
-			{ minVersion: 4 } as const,
+			{
+				minVersion: 4,
+				autoCreate: shouldAutoCreateTwistAssistConfigValue,
+			} as const,
 		),
 
 		...V.staticProperty("blockToBlockSupported", undefined, {
@@ -166,7 +175,10 @@ export const DoorLockCCValues = Object.freeze({
 				...ValueMetadata.Boolean,
 				label: "Block-to-block functionality enabled",
 			} as const,
-			{ minVersion: 4 } as const,
+			{
+				minVersion: 4,
+				autoCreate: shouldAutoCreateBlockToBlockConfigValue,
+			} as const,
 		),
 
 		...V.staticProperty("latchSupported", undefined, { internal: true }),
@@ -237,6 +249,50 @@ function shouldAutoCreateDoorStatusValue(
 	if (!valueDB) return false;
 	return !!valueDB.getValue(
 		DoorLockCCValues.doorSupported.endpoint(endpoint.index),
+	);
+}
+
+function shouldAutoCreateTwistAssistConfigValue(
+	applHost: ZWaveApplicationHost,
+	endpoint: IZWaveEndpoint,
+): boolean {
+	const valueDB = applHost.tryGetValueDB(endpoint.nodeId);
+	if (!valueDB) return false;
+	return !!valueDB.getValue(
+		DoorLockCCValues.twistAssistSupported.endpoint(endpoint.index),
+	);
+}
+
+function shouldAutoCreateBlockToBlockConfigValue(
+	applHost: ZWaveApplicationHost,
+	endpoint: IZWaveEndpoint,
+): boolean {
+	const valueDB = applHost.tryGetValueDB(endpoint.nodeId);
+	if (!valueDB) return false;
+	return !!valueDB.getValue(
+		DoorLockCCValues.blockToBlockSupported.endpoint(endpoint.index),
+	);
+}
+
+function shouldAutoCreateAutoRelockConfigValue(
+	applHost: ZWaveApplicationHost,
+	endpoint: IZWaveEndpoint,
+): boolean {
+	const valueDB = applHost.tryGetValueDB(endpoint.nodeId);
+	if (!valueDB) return false;
+	return !!valueDB.getValue(
+		DoorLockCCValues.autoRelockSupported.endpoint(endpoint.index),
+	);
+}
+
+function shouldAutoCreateHoldAndReleaseConfigValue(
+	applHost: ZWaveApplicationHost,
+	endpoint: IZWaveEndpoint,
+): boolean {
+	const valueDB = applHost.tryGetValueDB(endpoint.nodeId);
+	if (!valueDB) return false;
+	return !!valueDB.getValue(
+		DoorLockCCValues.autoRelockSupported.endpoint(endpoint.index),
 	);
 }
 
@@ -1233,6 +1289,8 @@ export class DoorLockCCCapabilitiesReport extends DoorLockCC {
 	@ccValue(DoorLockCCValues.supportedInsideHandles)
 	public readonly supportedInsideHandles: DoorHandleStatus;
 
+	// These 3 are not automatically persisted because in CC version 3
+	// we have to assume them to be supported. In v4 we can query this.
 	public readonly latchSupported: boolean;
 	public readonly boltSupported: boolean;
 	public readonly doorSupported: boolean;


### PR DESCRIPTION
fixes: #6074