### PR TITLE
fix: reference the endpoint in `"notification"` events

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -1348,7 +1348,7 @@ The base callback signature has the following shape:
 
 ```ts
 type ZWaveNotificationCallback = (
-	node: ZWaveNode,
+	endpoint: Endpoint,
 	ccId: CommandClasses,
 	args: Record<string, unknown>,
 ): void;
@@ -1370,7 +1370,7 @@ uses the following signature
 
 ```ts
 type ZWaveNotificationCallbackParams_EntryControlCC = [
-	node: ZWaveNode,
+	endpoint: Endpoint,
 	ccId: (typeof CommandClasses)["Entry Control"],
 	args: ZWaveNotificationCallbackArgs_EntryControlCC,
 ];
@@ -1400,7 +1400,7 @@ uses the following signature
 
 ```ts
 type ZWaveNotificationCallbackParams_MultilevelSwitchCC = [
-	node: ZWaveNode,
+	endpoint: Endpoint,
 	ccId: (typeof CommandClasses)["Multilevel Switch"],
 	args: ZWaveNotificationCallbackArgs_MultilevelSwitchCC,
 ];
@@ -1431,7 +1431,7 @@ uses the following signature
 
 ```ts
 type ZWaveNotificationCallbackParams_NotificationCC = [
-	node: ZWaveNode,
+	endpoint: Endpoint,
 	ccId: CommandClasses.Notification,
 	args: ZWaveNotificationCallbackArgs_NotificationCC,
 ];
@@ -1465,7 +1465,7 @@ It uses the following signature
 
 ```ts
 type ZWaveNotificationCallbackParams_PowerlevelCC = [
-	node: ZWaveNode,
+	endpoint: Endpoint,
 	ccId: CommandClasses.Powerlevel,
 	args: ZWaveNotificationCallbackArgs_PowerlevelCC,
 ];
@@ -1494,6 +1494,8 @@ enum PowerlevelTestStatus {
 	"In Progress" = 2,
 }
 ```
+
+> [!NOTE] Here the endpoint is always the root endpoint (the node itself). The argument type is `Endpoint` though to be compatible with the other notification events.
 
 ### `"statistics updated"`
 

--- a/docs/getting-started/migrating-to-v12.md
+++ b/docs/getting-started/migrating-to-v12.md
@@ -2,4 +2,16 @@
 
 A bit earlier than expected, but there were some necessary breaking changes queueing up. And with the upcoming end-of-life of Node.js 16, it's now time to get them out of the way.
 
-## TODO
+## Reference the endpoint in `"notification"` events
+
+Endpoints can send notifications, but when those were translated to `"notification"` events, the endpoint was not included in the event, only the node. To solve this, the first parameter of the event callback is now the endpoint that sent the notification. This can still be the node itself (which inherits from `Endpoint`), but this is no longer guaranteed.
+
+```diff
+type ZWaveNotificationCallback = (
+-	node: ZWaveNode,
++	endpoint: Endpoint,
+	ccId: CommandClasses,
+	args: Record<string, unknown>,
+): void;
+```
+

--- a/docs/getting-started/migrating-to-v12.md
+++ b/docs/getting-started/migrating-to-v12.md
@@ -14,4 +14,3 @@ type ZWaveNotificationCallback = (
 	args: Record<string, unknown>,
 ): void;
 ```
-

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -2206,7 +2206,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks>
 
 	/** This is called when a node emits a `"notification"` event */
 	private onNodeNotification: ZWaveNotificationCallback = (
-		node,
+		endpoint,
 		ccId,
 		ccArgs,
 	) => {
@@ -2247,7 +2247,8 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks>
 			return;
 		}
 
-		this.controllerLog.logNode(node.id, {
+		this.controllerLog.logNode(endpoint.nodeId, {
+			endpoint: endpoint.index,
 			message: [prefix, ...details.map((d) => `  ${d}`)].join("\n"),
 		});
 	};

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3682,6 +3682,8 @@ protocol version:      ${this.protocolVersion}`;
 
 	/** Handles the receipt of a MultilevelCC Set or Report */
 	private handleMultilevelSwitchCommand(command: MultilevelSwitchCC): void {
+		const endpoint = this.getEndpoint(command.endpointIndex ?? 0) ?? this;
+
 		if (command instanceof MultilevelSwitchCCSet) {
 			this.driver.controllerLog.logNode(this.id, {
 				endpoint: command.endpointIndex,
@@ -3704,7 +3706,7 @@ protocol version:      ${this.protocolVersion}`;
 			});
 			this.emit(
 				"notification",
-				this,
+				endpoint,
 				CommandClasses["Multilevel Switch"],
 				{
 					eventType: MultilevelSwitchCommand.StartLevelChange,
@@ -3720,7 +3722,7 @@ protocol version:      ${this.protocolVersion}`;
 			});
 			this.emit(
 				"notification",
-				this,
+				endpoint,
 				CommandClasses["Multilevel Switch"],
 				{
 					eventType: MultilevelSwitchCommand.StopLevelChange,
@@ -4315,13 +4317,20 @@ protocol version:      ${this.protocolVersion}`;
 				allowIdleReset = valueConfig.idle;
 			} else {
 				// This is an event
-				this.emit("notification", this, CommandClasses.Notification, {
-					type: command.notificationType,
-					event: value,
-					label: notificationConfig.name,
-					eventLabel: valueConfig.label,
-					parameters: command.eventParameters,
-				});
+				const endpoint = this.getEndpoint(command.endpointIndex)
+					?? this;
+				this.emit(
+					"notification",
+					endpoint,
+					CommandClasses.Notification,
+					{
+						type: command.notificationType,
+						event: value,
+						label: notificationConfig.name,
+						eventLabel: valueConfig.label,
+						parameters: command.eventParameters,
+					},
+				);
 
 				// We may need to reset some linked states to idle
 				if (valueConfig.idleVariables?.length) {
@@ -5365,7 +5374,8 @@ protocol version:      ${this.protocolVersion}`;
 		}
 
 		// Notify listeners
-		this.emit("notification", this, CommandClasses["Entry Control"], {
+		const endpoint = this.getEndpoint(command.endpointIndex) ?? this;
+		this.emit("notification", endpoint, CommandClasses["Entry Control"], {
 			...pick(command, ["eventType", "dataType", "eventData"]),
 			eventTypeLabel: entryControlEventTypeLabels[command.eventType],
 			dataTypeLabel: getEnumMemberName(

--- a/packages/zwave-js/src/lib/node/_Types.ts
+++ b/packages/zwave-js/src/lib/node/_Types.ts
@@ -20,6 +20,7 @@ import type {
 	ValueUpdatedArgs,
 } from "@zwave-js/core/safe";
 import { type AllOrNone } from "@zwave-js/shared";
+import { type Endpoint } from "./Endpoint";
 import type { ZWaveNode } from "./Node";
 import type { RouteStatistics } from "./NodeStatistics";
 
@@ -119,7 +120,7 @@ export interface ZWaveNotificationCallbackArgs_MultilevelSwitchCC {
  * Parameter types for the MultilevelSwitch CC specific version of ZWaveNotificationCallback
  */
 export type ZWaveNotificationCallbackParams_MultilevelSwitchCC = [
-	node: ZWaveNode,
+	endpoint: Endpoint,
 	ccId: (typeof CommandClasses)["Multilevel Switch"],
 	args: ZWaveNotificationCallbackArgs_MultilevelSwitchCC,
 ];
@@ -141,7 +142,7 @@ export interface ZWaveNotificationCallbackArgs_NotificationCC {
  * Parameter types for the Notification CC specific version of ZWaveNotificationCallback
  */
 export type ZWaveNotificationCallbackParams_NotificationCC = [
-	node: ZWaveNode,
+	endpoint: Endpoint,
 	ccId: CommandClasses.Notification,
 	args: ZWaveNotificationCallbackArgs_NotificationCC,
 ];
@@ -159,7 +160,7 @@ export interface ZWaveNotificationCallbackArgs_PowerlevelCC {
  * Parameter types for the Powerlevel CC specific version of ZWaveNotificationCallback
  */
 export type ZWaveNotificationCallbackParams_PowerlevelCC = [
-	node: ZWaveNode,
+	endpoint: Endpoint,
 	ccId: CommandClasses.Powerlevel,
 	args: ZWaveNotificationCallbackArgs_PowerlevelCC,
 ];
@@ -178,7 +179,7 @@ export interface ZWaveNotificationCallbackArgs_EntryControlCC {
  * Parameter types for the Entry Control CC specific version of ZWaveNotificationCallback
  */
 export type ZWaveNotificationCallbackParams_EntryControlCC = [
-	node: ZWaveNode,
+	endpoint: Endpoint,
 	ccId: (typeof CommandClasses)["Entry Control"],
 	args: ZWaveNotificationCallbackArgs_EntryControlCC,
 ];


### PR DESCRIPTION
This PR changes the first argument in node `"notification"` events from the node to the endpoint emitting the event. Previously the endpoint information was not included in these events, making it impossible to distinguish multiple endpoints sending the same notifications.

fixes: https://github.com/zwave-js/node-zwave-js/issues/5399