### PR TITLE
feat: include intermediate health check results in progress callback

### DIFF
--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -5353,6 +5353,7 @@ protocol version:      ${this.protocolVersion}`;
 			round: number,
 			totalRounds: number,
 			lastRating: number,
+			lastResult: LifelineHealthCheckResult,
 		) => void,
 	): Promise<LifelineHealthCheckSummary> {
 		if (rounds > 10 || rounds < 1) {
@@ -5551,7 +5552,7 @@ protocol version:      ${this.protocolVersion}`;
 
 			ret.rating = computeRating(ret);
 			results.push(ret);
-			onProgress?.(round, rounds, ret.rating);
+			onProgress?.(round, rounds, ret.rating, { ...ret });
 		}
 
 		const duration = Date.now() - start;
@@ -5577,6 +5578,7 @@ ${formatLifelineHealthCheckSummary(summary)}`,
 			round: number,
 			totalRounds: number,
 			lastRating: number,
+			lastResult: RouteHealthCheckResult,
 		) => void,
 	): Promise<RouteHealthCheckSummary> {
 		if (rounds > 10 || rounds < 1) {
@@ -5776,7 +5778,7 @@ ${formatLifelineHealthCheckSummary(summary)}`,
 			};
 			ret.rating = computeRating(ret);
 			results.push(ret);
-			onProgress?.(round, rounds, ret.rating);
+			onProgress?.(round, rounds, ret.rating, { ...ret });
 		}
 
 		const duration = Date.now() - start;


### PR DESCRIPTION
This PR adds a parameter with the most recent health check result to the `onProgress` callback. This way applications can show some results before the health check is done.

for https://github.com/zwave-js/node-zwave-js/issues/4075