### PR TITLE
fix: message sequencing between controller and node mocks

### DIFF
--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -44,6 +44,7 @@
     "@zwave-js/host": "workspace:*",
     "@zwave-js/serial": "workspace:*",
     "@zwave-js/shared": "workspace:*",
+    "alcalzone-shared": "^4.0.8",
     "ansi-colors": "^4.1.3"
   },
   "devDependencies": {

--- a/packages/testing/src/MockController.ts
+++ b/packages/testing/src/MockController.ts
@@ -381,16 +381,6 @@ export class MockController {
 			target: node.id,
 			...frame,
 		});
-		// let ret: Promise<MockZWaveAckFrame> | undefined;
-		// if (frame.type === MockZWaveFrameType.Request && frame.ackRequested) {
-		// 	ret = this.expectNodeACK(node, MOCK_FRAME_ACK_TIMEOUT);
-		// }
-		// process.nextTick(() => {
-		// 	void node.onControllerFrame(frame).catch((e) => {
-		// 		console.error(e);
-		// 	});
-		// });
-		// if (ret) return await ret;
 
 		if (frame.type === MockZWaveFrameType.Request && frame.ackRequested) {
 			return await this.expectNodeACK(node, MOCK_FRAME_ACK_TIMEOUT);

--- a/packages/testing/src/MockNode.ts
+++ b/packages/testing/src/MockNode.ts
@@ -262,23 +262,15 @@ export class MockNode {
 	public async sendToController(
 		frame: LazyMockZWaveFrame,
 	): Promise<MockZWaveAckFrame | undefined> {
-		// let ret: Promise<MockZWaveAckFrame> | undefined;
-		// if (frame.type === MockZWaveFrameType.Request && frame.ackRequested) {
-		// 	ret = this.expectControllerACK(MOCK_FRAME_ACK_TIMEOUT);
-		// }
 		this.controller["air"].add({
 			source: this.id,
 			onTransmit: (frame) => this.sentControllerFrames.push(frame),
 			...frame,
 		});
-		// process.nextTick(() => {
-		// 	void this.controller.onNodeFrame(this, frame);
-		// });
+
 		if (frame.type === MockZWaveFrameType.Request && frame.ackRequested) {
 			return await this.expectControllerACK(MOCK_FRAME_ACK_TIMEOUT);
 		}
-
-		// if (ret) return await ret;
 	}
 
 	/** Gets called when a {@link MockZWaveFrame} is received from the {@link MockController} */

--- a/packages/testing/src/MockNode.ts
+++ b/packages/testing/src/MockNode.ts
@@ -22,6 +22,7 @@ import {
 	MOCK_FRAME_ACK_TIMEOUT,
 	MockZWaveFrameType,
 	createMockZWaveAckFrame,
+	type LazyMockZWaveFrame,
 	type MockZWaveAckFrame,
 	type MockZWaveFrame,
 	type MockZWaveRequestFrame,
@@ -259,17 +260,25 @@ export class MockNode {
 	 * Sends a {@link MockZWaveFrame} to the {@link MockController}
 	 */
 	public async sendToController(
-		frame: MockZWaveFrame,
+		frame: LazyMockZWaveFrame,
 	): Promise<MockZWaveAckFrame | undefined> {
-		let ret: Promise<MockZWaveAckFrame> | undefined;
-		if (frame.type === MockZWaveFrameType.Request && frame.ackRequested) {
-			ret = this.expectControllerACK(MOCK_FRAME_ACK_TIMEOUT);
-		}
-		this.sentControllerFrames.push(frame);
-		process.nextTick(() => {
-			void this.controller.onNodeFrame(this, frame);
+		// let ret: Promise<MockZWaveAckFrame> | undefined;
+		// if (frame.type === MockZWaveFrameType.Request && frame.ackRequested) {
+		// 	ret = this.expectControllerACK(MOCK_FRAME_ACK_TIMEOUT);
+		// }
+		this.controller["air"].add({
+			source: this.id,
+			onTransmit: (frame) => this.sentControllerFrames.push(frame),
+			...frame,
 		});
-		if (ret) return await ret;
+		// process.nextTick(() => {
+		// 	void this.controller.onNodeFrame(this, frame);
+		// });
+		if (frame.type === MockZWaveFrameType.Request && frame.ackRequested) {
+			return await this.expectControllerACK(MOCK_FRAME_ACK_TIMEOUT);
+		}
+
+		// if (ret) return await ret;
 	}
 
 	/** Gets called when a {@link MockZWaveFrame} is received from the {@link MockController} */
@@ -281,7 +290,7 @@ export class MockNode {
 			this.autoAckControllerFrames &&
 			frame.type === MockZWaveFrameType.Request
 		) {
-			await this.ackControllerRequestFrame(frame);
+			void this.ackControllerRequestFrame(frame);
 		}
 
 		// Handle message buffer. Check for pending expectations first.

--- a/packages/zwave-js/src/lib/test/driver/targetValueVersionUnknown.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/targetValueVersionUnknown.test.ts
@@ -17,7 +17,7 @@ import { integrationTest } from "../integrationTestSuite";
 integrationTest(
 	`targetValue properties are exposed for CCs where the version could not be queried`,
 	{
-		debug: true,
+		// debug: true,
 
 		nodeCapabilities: {
 			commandClasses: [

--- a/packages/zwave-js/src/lib/test/integrationTestSuite.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuite.ts
@@ -17,9 +17,6 @@ import type { ZWaveOptions } from "../driver/ZWaveOptions";
 import type { ZWaveNode } from "../node/Node";
 import { prepareDriver, prepareMocks } from "./integrationTestSuiteShared";
 
-// Integration tests need to run in serial, or they might block the serial port on CI
-const testSerial = test.serial.bind(test);
-
 interface IntegrationTestOptions {
 	/** Enable debugging for this integration tests. When enabled, a driver logfile will be written and the test directory will not be deleted after each test. Default: false */
 	debug?: boolean;
@@ -143,12 +140,14 @@ function suite(
 		});
 	}
 
-	(modifier === "only"
-		? testSerial.only
-		: modifier === "skip"
-		? testSerial.skip
-		: testSerial
-	).bind(testSerial)(name, async (t) => {
+	// Integration tests need to run in serial, or they might block the serial port on CI
+	const fn =
+		modifier === "only"
+			? test.serial.only
+			: modifier === "skip"
+			? test.serial.skip
+			: test.serial;
+	fn(name, async (t) => {
 		t.timeout(30000);
 		t.teardown(async () => {
 			// Give everything a chance to settle before destroying the driver.

--- a/packages/zwave-js/src/lib/test/integrationTestSuiteMulti.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuiteMulti.ts
@@ -16,9 +16,6 @@ import type { ZWaveOptions } from "../driver/ZWaveOptions";
 import type { ZWaveNode } from "../node/Node";
 import { prepareDriver, prepareMocks } from "./integrationTestSuiteShared";
 
-// Integration tests need to run in serial, or they might block the serial port on CI
-const testSerial = test.serial.bind(test);
-
 interface IntegrationTestOptions {
 	/** Enable debugging for this integration tests. When enabled, a driver logfile will be written and the test directory will not be deleted after each test. Default: false */
 	debug?: boolean;
@@ -152,12 +149,14 @@ function suite(
 		});
 	}
 
-	(modifier === "only"
-		? testSerial.only
-		: modifier === "skip"
-		? testSerial.skip
-		: testSerial
-	).bind(testSerial)(name, async (t) => {
+	// Integration tests need to run in serial, or they might block the serial port on CI
+	const fn =
+		modifier === "only"
+			? test.serial.only
+			: modifier === "skip"
+			? test.serial.skip
+			: test.serial;
+	fn(name, async (t) => {
 		t.timeout(30000);
 		t.teardown(async () => {
 			// Give everything a chance to settle before destroying the driver.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2100,6 +2100,7 @@ __metadata:
     "@zwave-js/host": "workspace:*"
     "@zwave-js/serial": "workspace:*"
     "@zwave-js/shared": "workspace:*"
+    alcalzone-shared: ^4.0.8
     ansi-colors: ^4.1.3
     del-cli: ^5.0.0
     esbuild: 0.15.18


### PR DESCRIPTION
This PR fixes an issue in integration tests and the mock-server that becomes apparent when the `txDelay` of nodes is low. In these cases, due to how the mock communication was previously set up, the node response would often be handled before the ACK.

We now defer the transmission simulation to an async queue (the "air") to better decouple the mock controller from mock nodes.