### PR TITLE
fix: recover from S2 collision when node requests Supervision Report at the same time the controller is sending S2-encapsulated command

### DIFF
--- a/packages/cc/src/cc/SupervisionCC.ts
+++ b/packages/cc/src/cc/SupervisionCC.ts
@@ -71,13 +71,17 @@ export class SupervisionCCAPI extends PhysicalCCAPI {
 	public async sendReport(
 		options: SupervisionCCReportOptions & {
 			encapsulationFlags?: EncapsulationFlags;
+			lowPriority?: boolean;
 		},
 	): Promise<void> {
 		// Here we don't assert support - some devices only half-support Supervision, so we treat them
 		// as if they don't support it. We still need to be able to respond to the Get command though.
 
-		const { encapsulationFlags = EncapsulationFlags.None, ...cmdOptions } =
-			options;
+		const {
+			encapsulationFlags = EncapsulationFlags.None,
+			lowPriority = false,
+			...cmdOptions
+		} = options;
 		const cc = new SupervisionCCReport(this.applHost, {
 			nodeId: this.endpoint.nodeId,
 			endpoint: this.endpoint.index,
@@ -91,7 +95,9 @@ export class SupervisionCCAPI extends PhysicalCCAPI {
 			await this.applHost.sendCommand(cc, {
 				...this.commandOptions,
 				// Supervision Reports must be prioritized over normal messages
-				priority: MessagePriority.Immediate,
+				priority: lowPriority
+					? MessagePriority.ImmediateLow
+					: MessagePriority.Immediate,
 				// But we don't want to wait for an ACK because this can lock up the network for seconds
 				// if the target node is asleep or unreachable
 				transmitOptions: TransmitOptions.DEFAULT_NOACK,

--- a/packages/core/src/consts/Transmission.ts
+++ b/packages/core/src/consts/Transmission.ts
@@ -10,6 +10,9 @@ export enum MessagePriority {
 	// need to be handled before all others. We use this priority to decide which
 	// message goes onto the immediate queue.
 	Immediate = 0,
+	// To avoid S2 collisions, some commands that normally have Immediate priority
+	// have to go onto the normal queue, but still before all other messages
+	ImmediateLow,
 	// Controller commands usually finish quickly and should be preferred over node queries
 	Controller,
 	// Multistep controller commands typically require user interaction but still

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -4279,10 +4279,11 @@ ${handlers.length} left`,
 		}
 
 		// This has potential for a conflict, use low priority
-		this.controllerLog.logNode(
-			targetNode.id,
-			"S2 collision, reducing priority for Supervision report",
-		);
+		this.controllerLog.logNode(targetNode.id, {
+			message:
+				"S2 collision detected, reducing priority for Supervision report",
+			level: "debug",
+		});
 		return true;
 	}
 

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -2843,6 +2843,8 @@ export class Driver
 										node.getEndpoint(
 											msg.command.endpointIndex,
 										) ?? node;
+									const encapsulationFlags =
+										msg.command.encapsulationFlags;
 									await endpoint
 										.createAPI(
 											CommandClasses.Supervision,
@@ -2856,8 +2858,12 @@ export class Driver
 												this.shouldRequestWakeupOnDemand(
 													node,
 												),
-											encapsulationFlags:
-												msg.command.encapsulationFlags,
+											encapsulationFlags,
+											lowPriority:
+												this.shouldUseLowPriorityForSupervisionReport(
+													node,
+													encapsulationFlags,
+												),
 										});
 								}
 								return;
@@ -3951,6 +3957,11 @@ ${handlers.length} left`,
 								requestWakeUpOnDemand:
 									this.shouldRequestWakeupOnDemand(node),
 								encapsulationFlags,
+								lowPriority:
+									this.shouldUseLowPriorityForSupervisionReport(
+										node,
+										encapsulationFlags,
+									),
 							});
 				} else {
 					// Unsupervised, reply is a no-op
@@ -4233,6 +4244,46 @@ ${handlers.length} left`,
 		} else {
 			this._controller?.incrementStatistics("messagesTX");
 		}
+	}
+
+	private shouldUseLowPriorityForSupervisionReport(
+		targetNode: ZWaveNode,
+		encapsulationFlags: EncapsulationFlags,
+	): boolean {
+		// To avoid S2 collisions, we reduce the priority of Supervision reports
+		// when they are S2-encapsulated, and another S2-encapsulated transaction is in
+		// progress for the same node
+
+		// Use Immediate priority if there is no other transaction for this node in progress
+		const currentNormalMsg = this.queue.currentTransaction?.message;
+		if (currentNormalMsg?.getNodeId() !== targetNode.id) {
+			return false;
+		}
+		if (!isCommandClassContainer(currentNormalMsg)) {
+			return false;
+		}
+
+		// Use Immediate priority if the node isn't using Security S2
+		if (!securityClassIsS2(targetNode.getHighestSecurityClass())) {
+			return false;
+		}
+
+		// Use Immediate priority unless both messages are S2-encapsulated
+		const currentMsgIsSecure =
+			currentNormalMsg.command instanceof Security2CCMessageEncapsulation;
+		const reportIsSecure = !!(
+			encapsulationFlags & EncapsulationFlags.Security
+		);
+		if (!currentMsgIsSecure || !reportIsSecure) {
+			return false;
+		}
+
+		// This has potential for a conflict, use low priority
+		this.controllerLog.logNode(
+			targetNode.id,
+			"S2 collision, reducing priority for Supervision report",
+		);
+		return true;
 	}
 
 	private mayStartTransaction(transaction: Transaction): boolean {

--- a/packages/zwave-js/src/lib/test/driver/fixtures/s2CollisionsSupervised/7e570001.jsonl
+++ b/packages/zwave-js/src/lib/test/driver/fixtures/s2CollisionsSupervised/7e570001.jsonl
@@ -24,6 +24,7 @@
 {"k":"node.2.deviceClass","v":{"basic":4,"generic":6,"specific":1}}
 {"k":"node.2.interviewStage","v":"Complete"}
 {"k":"node.2.endpoint.0.commandClass.0x20","v":{"isSupported":true,"isControlled":false,"secure":true,"version":1}}
+{"k":"node.2.endpoint.0.commandClass.0x25","v":{"isSupported":true,"isControlled":false,"secure":true,"version":1}}
 {"k":"node.2.endpoint.0.commandClass.0x6c","v":{"isSupported":true,"isControlled":false,"secure":true,"version":1}}
 {"k":"node.2.endpoint.0.commandClass.0x9f","v":{"isSupported":true,"isControlled":false,"secure":true,"version":1}}
 {"k":"node.2.securityClasses.S2_AccessControl","v":false}

--- a/packages/zwave-js/src/lib/test/driver/s2Collisions.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s2Collisions.test.ts
@@ -1,11 +1,13 @@
 import {
 	BasicCCReport,
 	BasicCCValues,
+	BinarySwitchCCReport,
 	InvalidCC,
 	Security2CC,
 	Security2CCMessageEncapsulation,
 	Security2CCNonceGet,
 	Security2CCNonceReport,
+	SupervisionCC,
 	SupervisionCCGet,
 	SupervisionCCReport,
 	type CommandClass,
@@ -20,6 +22,7 @@ import {
 	MockZWaveFrameType,
 	createMockZWaveRequestFrame,
 	type MockNodeBehavior,
+	type MockZWaveRequestFrame,
 } from "@zwave-js/testing";
 import { wait } from "alcalzone-shared/async";
 import path from "path";
@@ -359,6 +362,235 @@ integrationTest(
 			// If the collision was handled gracefully, we should now have the value reported by the node
 			const currentValue = node.getValue(BasicCCValues.currentValue.id);
 			t.is(currentValue, 99);
+		},
+	},
+);
+
+integrationTest.only(
+	"S2 Collisions: Node sends supervised command at the same time as the controller",
+	{
+		// Repro for #6100
+		debug: true,
+
+		// We need the cache to skip the CC interviews and mark S2 as supported
+		provisioningDirectory: path.join(
+			__dirname,
+			"fixtures/s2CollisionsSupervised",
+		),
+
+		customSetup: async (driver, controller, mockNode) => {
+			// Create a security manager for the node
+			const smNode = new SecurityManager2();
+			// Copy keys from the driver
+			smNode.setKey(
+				SecurityClass.S2_AccessControl,
+				driver.options.securityKeys!.S2_AccessControl!,
+			);
+			smNode.setKey(
+				SecurityClass.S2_Authenticated,
+				driver.options.securityKeys!.S2_Authenticated!,
+			);
+			smNode.setKey(
+				SecurityClass.S2_Unauthenticated,
+				driver.options.securityKeys!.S2_Unauthenticated!,
+			);
+			mockNode.host.securityManager2 = smNode;
+			mockNode.host.getHighestSecurityClass = () =>
+				SecurityClass.S2_Unauthenticated;
+
+			// Create a security manager for the controller
+			const smCtrlr = new SecurityManager2();
+			// Copy keys from the driver
+			smCtrlr.setKey(
+				SecurityClass.S2_AccessControl,
+				driver.options.securityKeys!.S2_AccessControl!,
+			);
+			smCtrlr.setKey(
+				SecurityClass.S2_Authenticated,
+				driver.options.securityKeys!.S2_Authenticated!,
+			);
+			smCtrlr.setKey(
+				SecurityClass.S2_Unauthenticated,
+				driver.options.securityKeys!.S2_Unauthenticated!,
+			);
+			controller.host.securityManager2 = smCtrlr;
+			controller.host.getHighestSecurityClass = () =>
+				SecurityClass.S2_Unauthenticated;
+
+			// Respond to Nonce Get
+			const respondToNonceGet: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof Security2CCNonceGet
+					) {
+						const nonce = smNode.generateNonce(
+							controller.host.ownNodeId,
+						);
+						const cc = new Security2CCNonceReport(self.host, {
+							nodeId: controller.host.ownNodeId,
+							SOS: true,
+							MOS: false,
+							receiverEI: nonce,
+						});
+						await self.sendToController(
+							createMockZWaveRequestFrame(cc, {
+								ackRequested: false,
+							}),
+						);
+						return true;
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(respondToNonceGet);
+
+			// Handle decode errors
+			const handleInvalidCC: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof InvalidCC
+					) {
+						if (
+							frame.payload.reason ===
+								ZWaveErrorCodes.Security2CC_CannotDecode ||
+							frame.payload.reason ===
+								ZWaveErrorCodes.Security2CC_NoSPAN
+						) {
+							const nonce = smNode.generateNonce(
+								controller.host.ownNodeId,
+							);
+							const cc = new Security2CCNonceReport(self.host, {
+								nodeId: controller.host.ownNodeId,
+								SOS: true,
+								MOS: false,
+								receiverEI: nonce,
+							});
+							await self.sendToController(
+								createMockZWaveRequestFrame(cc, {
+									ackRequested: false,
+								}),
+							);
+							return true;
+						}
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(handleInvalidCC);
+
+			// Just have the node respond to all Supervision Get positively
+			const respondToSupervisionGet: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof
+							Security2CCMessageEncapsulation &&
+						frame.payload.encapsulated instanceof SupervisionCCGet
+					) {
+						let cc: CommandClass = new SupervisionCCReport(
+							self.host,
+							{
+								nodeId: controller.host.ownNodeId,
+								sessionId: frame.payload.encapsulated.sessionId,
+								moreUpdatesFollow: false,
+								status: SupervisionStatus.Success,
+							},
+						);
+						cc = Security2CC.encapsulate(self.host, cc);
+						await self.sendToController(
+							createMockZWaveRequestFrame(cc, {
+								ackRequested: false,
+							}),
+						);
+						return true;
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(respondToSupervisionGet);
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			driver.driverLog.print("----------");
+			driver.driverLog.print("START TEST");
+			driver.driverLog.print("----------");
+
+			// Driver sends Binary Switch ON command, supervised with S2
+			await node.commandClasses["Binary Switch"].set(true);
+
+			driver.driverLog.print("---------------");
+			driver.driverLog.print("START COLLISION");
+			driver.driverLog.print("---------------");
+
+			// Driver sends Binary Switch OFF command, supervised with S2
+			const turnOff = node.commandClasses["Binary Switch"].set(false);
+
+			// Node sends supervised Binary Switch report at the same time
+			let nodeToHost: CommandClass = new BinarySwitchCCReport(
+				mockNode.host,
+				{
+					nodeId: mockController.host.ownNodeId,
+					currentValue: true,
+				},
+			);
+			nodeToHost = SupervisionCC.encapsulate(
+				mockNode.host,
+				nodeToHost,
+				false,
+			);
+			nodeToHost = Security2CC.encapsulate(mockNode.host, nodeToHost);
+
+			const report = mockNode.sendToController(
+				createMockZWaveRequestFrame(nodeToHost, {
+					ackRequested: true,
+				}),
+			);
+			const reportConfirmation = mockNode.expectControllerFrame(
+				500,
+				(f): f is MockZWaveRequestFrame =>
+					f.type === MockZWaveFrameType.Request &&
+					f.payload instanceof Security2CCMessageEncapsulation &&
+					f.payload.encapsulated instanceof SupervisionCCReport &&
+					f.payload.encapsulated.status === SupervisionStatus.Success,
+			);
+
+			// We want both transactions to be completed successfully
+			const [turnOffResult, reportResult, confirmationResult] =
+				await Promise.all([turnOff, report, reportConfirmation]);
+
+			t.deepEqual(turnOffResult, { status: SupervisionStatus.Success });
+			t.not(confirmationResult, undefined);
+
+			// // Now create a collision by having both parties send at the same time
+			// const nodeToHost = Security2CC.encapsulate(
+			// 	mockNode.host,
+			// 	new BasicCCReport(mockNode.host, {
+			// 		nodeId: mockController.host.ownNodeId,
+			// 		currentValue: 99,
+			// 	}),
+			// );
+			// const p1 = mockNode.sendToController(
+			// 	createMockZWaveRequestFrame(nodeToHost, {
+			// 		ackRequested: true,
+			// 	}),
+			// );
+			// const p2 = node.commandClasses.Basic.set(0);
+
+			// const [, p2result] = await Promise.all([p1, p2]);
+
+			// // Give the node a chance to respond
+			// await wait(250);
+
+			// // If the collision was handled gracefully, we should now have the value reported by the node
+			// const currentValue = node.getValue(BasicCCValues.currentValue.id);
+			// t.is(currentValue, 99);
+
+			// // Ensure the Basic Set causing a collision eventually gets resolved
+			// t.like(p2result, {
+			// 	status: SupervisionStatus.Success,
+			// });
 		},
 	},
 );


### PR DESCRIPTION
This PR fixes an S2 collision that happens when the node sends an S2-encapsulated and supervised command/report at the same time the controller sends an S2-encapsulated command. This frequently happens when nodes are eager to report status after receiving a command, e.g. if they have a combined status for multiple channels.

Prior to this PR, each outgoing Supervision Report would go onto the immediate queue, meaning they could get transmitted while another S2 transaction was waiting for confirmation. This lead to the S2 encryption state going out of sync and both transactions fighting for re-sync.

We now check if there is an S2 transaction to the same node pending before enqueuing the Supervision report. If it is, the report is instead queued onto the normal queue, but with the highest possible priority, so it can get handled immediately after the pending transaction.

fixes: #6100
fixes: https://github.com/zwave-js/node-zwave-js/issues/6096