### PR TITLE
fix: update of `currentValue` after successful supervised turn-on `setValue` call

### DIFF
--- a/packages/cc/src/cc/MultilevelSwitchCC.ts
+++ b/packages/cc/src/cc/MultilevelSwitchCC.ts
@@ -398,8 +398,25 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 				// Therefore we try to supervise the command execution and delay the
 				// optimistic update until the final result is received.
 				supervisionDelayedUpdates: true,
-				supervisionOnSuccess: () => {
-					this.tryGetValueDB()?.setValue(currentValueValueId, value);
+				supervisionOnSuccess: async () => {
+					// Only update currentValue for valid target values
+					if (
+						typeof value === "number" &&
+						value >= 0 &&
+						value <= 99
+					) {
+						this.tryGetValueDB()?.setValue(
+							currentValueValueId,
+							value,
+						);
+					} else if (value === 255) {
+						// We don't know the status now, so refresh the current value
+						try {
+							await this.get();
+						} catch {
+							// ignore
+						}
+					}
 				},
 				supervisionOnFailure: async () => {
 					// The transition failed, so now we don't know the status - refresh the current value

--- a/packages/cc/src/cc/WindowCoveringCC.ts
+++ b/packages/cc/src/cc/WindowCoveringCC.ts
@@ -349,8 +349,25 @@ export class WindowCoveringCCAPI extends CCAPI {
 				// Therefore we try to supervise the command execution and delay the
 				// optimistic update until the final result is received.
 				supervisionDelayedUpdates: true,
-				supervisionOnSuccess: () => {
-					this.tryGetValueDB()?.setValue(currentValueValueId, value);
+				supervisionOnSuccess: async () => {
+					// Only update currentValue for valid target values
+					if (
+						typeof value === "number" &&
+						value >= 0 &&
+						value <= 99
+					) {
+						this.tryGetValueDB()?.setValue(
+							currentValueValueId,
+							value,
+						);
+					} else if (value === 255) {
+						// We don't know the status now, so refresh the current value
+						try {
+							await this.get(parameter);
+						} catch {
+							// ignore
+						}
+					}
 				},
 				supervisionOnFailure: async () => {
 					// The transition failed, so now we don't know the status - refresh the current value

--- a/packages/zwave-js/src/lib/test/driver/setValueSupervision255Get.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/setValueSupervision255Get.test.ts
@@ -172,7 +172,7 @@ integrationTest(
 				},
 			);
 
-			await wait(2000);
+			await wait(1000);
 
 			mockNode.assertReceivedControllerFrame(
 				(frame) =>

--- a/packages/zwave-js/src/lib/test/driver/setValueSupervision255Get.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/setValueSupervision255Get.test.ts
@@ -1,0 +1,194 @@
+import {
+	MultilevelSwitchCCGet,
+	MultilevelSwitchCCReport,
+	MultilevelSwitchCCSet,
+	MultilevelSwitchCCValues,
+	SupervisionCCGet,
+	SupervisionCCReport,
+} from "@zwave-js/cc";
+import { CommandClasses, SupervisionStatus } from "@zwave-js/core";
+import {
+	MockZWaveFrameType,
+	createMockZWaveRequestFrame,
+	type MockNodeBehavior,
+} from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import { integrationTest } from "../integrationTestSuite";
+
+integrationTest(
+	"successful supervised setValue(255) with duration: expect validation GET",
+	{
+		debug: true,
+
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses["Multilevel Switch"],
+				CommandClasses.Supervision,
+			],
+		},
+
+		customSetup: async (driver, controller, mockNode) => {
+			// Just have the node respond to all Supervision Get positively
+			const respondToSupervisionGet: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof SupervisionCCGet
+					) {
+						const cc = new SupervisionCCReport(self.host, {
+							nodeId: controller.host.ownNodeId,
+							sessionId: frame.payload.sessionId,
+							moreUpdatesFollow: false,
+							status: SupervisionStatus.Success,
+						});
+						await self.sendToController(
+							createMockZWaveRequestFrame(cc, {
+								ackRequested: false,
+							}),
+						);
+						return true;
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(respondToSupervisionGet);
+
+			// Except the ones with a duration in the command, those need special handling
+			const respondToSupervisionGetWithDuration: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof SupervisionCCGet &&
+						frame.payload.encapsulated instanceof
+							MultilevelSwitchCCSet &&
+						!!frame.payload.encapsulated.duration?.toMilliseconds()
+					) {
+						const cc1 = new SupervisionCCReport(self.host, {
+							nodeId: controller.host.ownNodeId,
+							sessionId: frame.payload.sessionId,
+							moreUpdatesFollow: true,
+							status: SupervisionStatus.Working,
+							duration: frame.payload.encapsulated.duration,
+						});
+
+						const cc2 = new SupervisionCCReport(self.host, {
+							nodeId: controller.host.ownNodeId,
+							sessionId: frame.payload.sessionId,
+							moreUpdatesFollow: false,
+							status: SupervisionStatus.Success,
+						});
+
+						void self.sendToController(
+							createMockZWaveRequestFrame(cc1, {
+								ackRequested: false,
+							}),
+						);
+
+						setTimeout(() => {
+							void self.sendToController(
+								createMockZWaveRequestFrame(cc2, {
+									ackRequested: false,
+								}),
+							);
+						}, frame.payload.encapsulated.duration.toMilliseconds());
+
+						return true;
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(respondToSupervisionGetWithDuration);
+
+			let lastBrightness = 88;
+			let currentBrightness = 0;
+			const respondToMultilevelSwitchSet: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof MultilevelSwitchCCSet
+					) {
+						const targetValue = frame.payload.targetValue;
+						if (targetValue === 255) {
+							currentBrightness = lastBrightness;
+						} else {
+							currentBrightness = targetValue;
+							if (currentBrightness > 0)
+								lastBrightness = currentBrightness;
+						}
+
+						return true;
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(respondToMultilevelSwitchSet);
+
+			// Report Multilevel Switch status
+			const respondToMultilevelSwitchGet: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof MultilevelSwitchCCGet
+					) {
+						const cc = new MultilevelSwitchCCReport(self.host, {
+							nodeId: controller.host.ownNodeId,
+							targetValue: 88,
+							currentValue: 88,
+						});
+						await self.sendToController(
+							createMockZWaveRequestFrame(cc, {
+								ackRequested: false,
+							}),
+						);
+						return true;
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(respondToMultilevelSwitchGet);
+		},
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// await node.setValue(MultilevelSwitchCCValues.targetValue.id, 55);
+			// await node.setValue(MultilevelSwitchCCValues.targetValue.id, 0);
+
+			// await wait(500);
+
+			// mockNode.clearReceivedControllerFrames();
+
+			await node.setValue(MultilevelSwitchCCValues.targetValue.id, 255, {
+				transitionDuration: "1s",
+			});
+
+			await wait(500);
+
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request &&
+					frame.payload instanceof SupervisionCCGet &&
+					frame.payload.encapsulated instanceof MultilevelSwitchCCSet,
+				{
+					errorMessage:
+						"Node should have received a supervised MultilevelSwitchCCSet",
+				},
+			);
+
+			await wait(2000);
+
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request &&
+					frame.payload instanceof MultilevelSwitchCCGet,
+				{
+					errorMessage:
+						"Node should have received a MultilevelSwitchCCGet",
+				},
+			);
+
+			// The current value should NOT be updated to 255
+			const currentValue = node.getValue(
+				MultilevelSwitchCCValues.currentValue.id,
+			);
+			t.is(currentValue, 88);
+		},
+	},
+);


### PR DESCRIPTION
This fixes an edge case for supervised `setValue` calls where the `targetValue` is 255 and a duration is specified. In this case we'd always set `currentValue` equal to `targetValue` after the command execution was successful, regardless what `targetValue` actually is.
We now use the same check as for immediately successful supervised commands, and query the current value if targetValue is 255.

fixes: https://github.com/zwave-js/node-zwave-js/issues/6110
fixes: https://github.com/home-assistant/core/issues/97595