### PR TITLE
fix: improve heuristic to refresh legacy nodes when receiving NIF

### DIFF
--- a/packages/cc/src/cc/AssociationCC.ts
+++ b/packages/cc/src/cc/AssociationCC.ts
@@ -1,7 +1,5 @@
-import type { AssociationConfig } from "@zwave-js/config";
 import type {
 	IZWaveEndpoint,
-	IZWaveNode,
 	MaybeNotKnown,
 	MessageRecord,
 	SupervisionResult,
@@ -70,49 +68,6 @@ export const AssociationCCValues = Object.freeze({
 		),
 	}),
 });
-
-export function getLifelineGroupIds(
-	applHost: ZWaveApplicationHost,
-	endpoint: IZWaveEndpoint,
-): number[] {
-	// For now only support this for the root endpoint - i.e. node
-	if (endpoint.index > 0) return [];
-	const node = endpoint as IZWaveNode;
-
-	// Some nodes define multiple lifeline groups, so we need to assign us to
-	// all of them
-	const lifelineGroups: number[] = [];
-
-	// If the target node supports Z-Wave+ info that means the lifeline MUST be group #1
-	if (endpoint.supportsCC(CommandClasses["Z-Wave Plus Info"])) {
-		lifelineGroups.push(1);
-	}
-
-	// We have a device config file that tells us which (additional) association to assign
-	let associations: ReadonlyMap<number, AssociationConfig> | undefined;
-	const deviceConfig = applHost.getDeviceConfig?.(node.id);
-	if (endpoint.index === 0) {
-		// The root endpoint's associations may be configured separately or as part of "endpoints"
-		associations =
-			deviceConfig?.associations ??
-			deviceConfig?.endpoints?.get(0)?.associations;
-	} else {
-		// The other endpoints can only have a configuration as part of "endpoints"
-		associations = deviceConfig?.endpoints?.get(
-			endpoint.index,
-		)?.associations;
-	}
-
-	if (associations?.size) {
-		lifelineGroups.push(
-			...[...associations.values()]
-				.filter((a) => a.isLifeline)
-				.map((a) => a.groupId),
-		);
-	}
-
-	return distinct(lifelineGroups).sort();
-}
 
 // @noSetValueAPI
 

--- a/packages/core/src/capabilities/CommandClasses.ts
+++ b/packages/core/src/capabilities/CommandClasses.ts
@@ -163,6 +163,13 @@ export const actuatorCCs: readonly CommandClasses[] = [
 	CommandClasses["Window Covering"],
 ];
 
+const actuatorCCsAsSet = new Set(actuatorCCs);
+
+/** Returns if the given CC is an Actuator CC */
+export function isActuatorCC(cc: CommandClasses): boolean {
+	return actuatorCCsAsSet.has(cc);
+}
+
 /**
  * Defines which CCs are considered Sensor CCs
  */
@@ -176,6 +183,13 @@ export const sensorCCs: readonly CommandClasses[] = [
 	CommandClasses.Notification, // For pull nodes
 	CommandClasses["Pulse Meter"],
 ];
+
+const sensorCCsAsSet = new Set(sensorCCs);
+
+/** Returns if the given CC is a Sensor CC */
+export function isSensorCC(cc: CommandClasses): boolean {
+	return sensorCCsAsSet.has(cc);
+}
 
 /**
  * Defines which CCs are considered Application CCs
@@ -255,6 +269,13 @@ export const applicationCCs: readonly CommandClasses[] = [
 	CommandClasses["Window Covering"],
 ];
 
+const applicationCCsAsSet = new Set(applicationCCs);
+
+/** Returns if the given CC is an Application CC */
+export function isApplicationCC(cc: CommandClasses): boolean {
+	return applicationCCsAsSet.has(cc);
+}
+
 /**
  * Defines which CCs are considered Encapsulation CCs
  */
@@ -267,6 +288,13 @@ export const encapsulationCCs: readonly CommandClasses[] = [
 	CommandClasses.Supervision,
 	CommandClasses["Transport Service"],
 ];
+
+const encapsulationCCsAsSet = new Set(encapsulationCCs);
+
+/** Returns if the given CC is an Encapsulation CC */
+export function isEncapsulationCC(cc: CommandClasses): boolean {
+	return encapsulationCCsAsSet.has(cc);
+}
 
 /**
  * Defines which CCs are considered Management CCs
@@ -296,6 +324,13 @@ export const managementCCs: readonly CommandClasses[] = [
 	CommandClasses["Z/IP Naming and Location"],
 	CommandClasses["Z-Wave Plus Info"],
 ];
+
+const managementCCsAsSet = new Set(managementCCs);
+
+/** Returns if the given CC is a Management CC */
+export function isManagementCC(cc: CommandClasses): boolean {
+	return managementCCsAsSet.has(cc);
+}
 
 /**
  * An array of all defined CCs that are not application CCs

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -45,6 +45,7 @@ import {
 	AssociationCCRemove,
 	AssociationCCSet,
 	AssociationCCSupportedGroupingsGet,
+	AssociationCCValues,
 } from "@zwave-js/cc/AssociationCC";
 import {
 	AssociationGroupInfoCCCommandListGet,
@@ -2535,10 +2536,11 @@ protocol version:      ${this.protocolVersion}`;
 		if (
 			this.interviewStage === InterviewStage.Complete &&
 			!this.supportsCC(CommandClasses["Z-Wave Plus Info"]) &&
-			ccUtils.doesAnyLifelineSendActuatorOrSensorReports(
-				this.driver,
-				this,
-			) !== true
+			(!this.valueDB.getValue(AssociationCCValues.hasLifeline.id) ||
+				!ccUtils.doesAnyLifelineSendActuatorOrSensorReports(
+					this.driver,
+					this,
+				))
 		) {
 			const delay =
 				this.deviceConfig?.compat?.manualValueRefreshDelayMs || 0;

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -25,6 +25,7 @@ import {
 	TimeParametersCommand,
 	ZWavePlusNodeType,
 	ZWavePlusRoleType,
+	utils as ccUtils,
 	defaultCCValueOptions,
 	entryControlEventTypeLabels,
 	getCCValues,
@@ -44,7 +45,6 @@ import {
 	AssociationCCRemove,
 	AssociationCCSet,
 	AssociationCCSupportedGroupingsGet,
-	AssociationCCValues,
 } from "@zwave-js/cc/AssociationCC";
 import {
 	AssociationGroupInfoCCCommandListGet,
@@ -2531,10 +2531,14 @@ protocol version:      ${this.protocolVersion}`;
 
 		// This is not the handler for wakeup notifications, but some legacy devices send this
 		// message whenever there's an update and want to be polled.
+		// We do this unless we know for certain that the device sends unsolicited reports for its actuator or sensor CCs
 		if (
 			this.interviewStage === InterviewStage.Complete &&
 			!this.supportsCC(CommandClasses["Z-Wave Plus Info"]) &&
-			!this.valueDB.getValue(AssociationCCValues.hasLifeline.id)
+			ccUtils.doesAnyLifelineSendActuatorOrSensorReports(
+				this.driver,
+				this,
+			) !== true
 		) {
 			const delay =
 				this.deviceConfig?.compat?.manualValueRefreshDelayMs || 0;

--- a/packages/zwave-js/src/lib/test/node/legacyRefreshActuatorSensorCCs.test.ts
+++ b/packages/zwave-js/src/lib/test/node/legacyRefreshActuatorSensorCCs.test.ts
@@ -1,0 +1,111 @@
+import {
+	MultilevelSwitchCCGet,
+	MultilevelSwitchCCReport,
+	MultilevelSwitchCCSet,
+} from "@zwave-js/cc";
+import { CommandClasses } from "@zwave-js/core";
+import {
+	MockZWaveFrameType,
+	createMockZWaveRequestFrame,
+	type MockNodeBehavior,
+} from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import { ApplicationUpdateRequestNodeInfoReceived } from "../../serialapi/application/ApplicationUpdateRequest";
+import { integrationTest } from "../integrationTestSuite";
+
+integrationTest(
+	"When a NIF is received for a node that does not send unsolicited reports, refresh actuator and sensor CCs",
+	{
+		// Repro for #6117
+
+		debug: true,
+		// provisioningDirectory: path.join(__dirname, "fixtures/base_2_nodes"),
+
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				CommandClasses.Association,
+				CommandClasses["Multilevel Switch"],
+			],
+		},
+
+		customSetup: async (driver, mockController, mockNode) => {
+			let lastBrightness = 88;
+			let currentBrightness = 0;
+			const respondToMultilevelSwitchSet: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof MultilevelSwitchCCSet
+					) {
+						const targetValue = frame.payload.targetValue;
+						if (targetValue === 255) {
+							currentBrightness = lastBrightness;
+						} else {
+							currentBrightness = targetValue;
+							if (currentBrightness > 0)
+								lastBrightness = currentBrightness;
+						}
+
+						return true;
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(respondToMultilevelSwitchSet);
+
+			// Report Multilevel Switch status
+			const respondToMultilevelSwitchGet: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof MultilevelSwitchCCGet
+					) {
+						const cc = new MultilevelSwitchCCReport(self.host, {
+							nodeId: controller.host.ownNodeId,
+							targetValue: 88,
+							currentValue: 88,
+						});
+						await self.sendToController(
+							createMockZWaveRequestFrame(cc, {
+								ackRequested: false,
+							}),
+						);
+						return true;
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(respondToMultilevelSwitchGet);
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const nif = new ApplicationUpdateRequestNodeInfoReceived(
+				mockController.host,
+				{
+					nodeInformation: {
+						nodeId: node.id,
+						basicDeviceClass:
+							mockNode.capabilities.basicDeviceClass,
+						genericDeviceClass:
+							mockNode.capabilities.genericDeviceClass,
+						specificDeviceClass:
+							mockNode.capabilities.specificDeviceClass,
+						supportedCCs: [...mockNode.implementedCCs.keys()],
+					},
+				},
+			);
+			await mockController.sendToHost(nif.serialize());
+
+			await wait(100);
+
+			mockNode.assertReceivedControllerFrame(
+				(f) =>
+					f.type === MockZWaveFrameType.Request &&
+					f.payload instanceof MultilevelSwitchCCGet,
+			);
+
+			t.pass();
+		},
+	},
+);

--- a/packages/zwave-js/src/lib/test/node/legacyRefreshActuatorSensorCCs.test.ts
+++ b/packages/zwave-js/src/lib/test/node/legacyRefreshActuatorSensorCCs.test.ts
@@ -18,7 +18,7 @@ integrationTest(
 	{
 		// Repro for #6117
 
-		debug: true,
+		// debug: true,
 		// provisioningDirectory: path.join(__dirname, "fixtures/base_2_nodes"),
 
 		nodeCapabilities: {


### PR DESCRIPTION
As reported in https://github.com/zwave-js/node-zwave-js/discussions/6117, marking an association as a lifeline association in the config file seems to prevent the automatic refresh for legacy devices after them sending a NIF.

With this PR, we now also refresh the values if we don't know for certain that any lifeline group sends actuator or sensor commands.