### PR TITLE
fix(config): Added four items to the template to support new parameters

### DIFF
--- a/packages/config/config/devices/0x0312/templates/minoston_template.json
+++ b/packages/config/config/devices/0x0312/templates/minoston_template.json
@@ -499,5 +499,67 @@
 		"maxValue": 20,
 		"defaultValue": 5,
 		"unsigned": true
-	}
+	},
+    "power_reporting": {
+		"label": "Power Reporting",
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 1,
+		"defaultValue": 0,
+		"unsigned": true,
+        "allowManualEntry": false,
+		"options": [
+			{
+				"label": "Enabled",
+				"value": 0
+			},
+			{
+				"label": "Disabled",
+				"value": 1
+			}
+		]
+    },
+    "current_reporting": {
+        "label": "Current Reporting",
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 1,
+		"defaultValue": 0,
+		"unsigned": true,
+        "allowManualEntry": false,
+		"options": [
+			{
+				"label": "Enabled",
+				"value": 0
+			},
+			{
+				"label": "Disabled",
+				"value": 1
+			}
+		]
+    },
+	"current_reporting_interval": {
+		"label": "Current Reporting Interval",
+		"valueSize": 4,
+		"unit": "minutes",
+		"minValue": 1,
+		"maxValue": 65535,
+		"defaultValue": 60,
+		"unsigned": true
+     },
+	"voltage_reporting_interval": {
+		"label": "Voltage Reporting Interval",
+		"valueSize": 4,
+		"unit": "minutes",
+		"minValue": 1,
+		"maxValue": 65535,
+		"defaultValue": 60,
+		"unsigned": true,
+		"options": [
+			{
+				"label": "Disabled",
+				"value": 0
+			}
+		]
+   }
 }


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

Added:
power_reporting
current_reporting
current_reporting_interval
voltage_reporting_interval
