### PR TITLE
fix(config): add parameters 9-13 to Minoston MP21ZP / MP31ZP

### DIFF
--- a/packages/config/config/devices/0x0312/mp21zp_mp31zp.json
+++ b/packages/config/config/devices/0x0312/mp21zp_mp31zp.json
@@ -20,6 +20,11 @@
 			"$import": "templates/minoston_template.json#led_indicator_four_options_inverted"
 		},
 		{
+			"#": "9",
+			"$if": "firmwareVersion >= 1.10.1",
+			"$import": "templates/minoston_template.json#led_indicator_brightness"
+		},
+		{
 			"#": "2",
 			"$import": "templates/minoston_template.json#auto_off_timer"
 		},
@@ -32,6 +37,11 @@
 			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off_on"
 		},
 		{
+			"#": "10",
+			"$if": "firmwareVersion >= 1.11.1",
+			"$import": "templates/minoston_template.json#power_reporting"
+		},
+		{
 			"#": "5",
 			"$import": "templates/minoston_template.json#power_reporting_threshold"
 		},
@@ -40,14 +50,29 @@
 			"$import": "templates/minoston_template.json#power_reporting_interval"
 		},
 		{
+			"#": "11",
+			"$if": "firmwareVersion >= 1.11.1",
+			"$import": "templates/minoston_template.json#current_reporting"
+		},
+		{
 			"#": "7",
 			"$import": "templates/minoston_template.json#current_reporting_threshold"
 		},
 		{
+			"#": "12",
+			"$if": "firmwareVersion >= 1.11.1",
+			"$import": "templates/minoston_template.json#current_reporting_interval"
+		},
+		{
 			"#": "8",
 			"$import": "templates/minoston_template.json#energy_reporting_threshold"
+		},
+		{
+			"#": "13",
+			"$if": "firmwareVersion >= 1.11.1",
+			"$import": "templates/minoston_template.json#voltage_reporting_interval"
 		}
-	],
+    ],
 	"metadata": {
 		"inclusion": "ADD or Remove the MP21ZP from the existing Z-Wave home control network with your primary controller.\n---Refer to your primary controller instructions to process the inclusion / exclusion setup procedure.\n---When prompted by your primary controller, click the PROG button Three times in one second.\nInclude MP21ZP to/from a Z-Wave Gateway with supporting Security.The MP21ZP can support the Primary Controller that implemented the\nNotice: Including a node ID allocated by Z-WaveTM Controller means “Add” or “Inclusion”. Excluding a node ID allocated by\nZ-WaveTM Controller means “Remove” or “Exclusion”",
 		"exclusion": "ADD or Remove the MP21ZP from the existing Z-Wave home control network with your primary controller.\n---Refer to your primary controller instructions to process the inclusion / exclusion setup procedure.\n---When prompted by your primary controller, click the PROG button Three times in one second.\nInclude MP21ZP to/from a Z-Wave Gateway with supporting Security.The MP21ZP can support the Primary Controller that implemented the\nNotice: Including a node ID allocated by Z-WaveTM Controller means “Add” or “Inclusion”. Excluding a node ID allocated by\nZ-WaveTM Controller means “Remove” or “Exclusion”",

--- a/packages/config/config/devices/0x0312/mp21zp_mp31zp.json
+++ b/packages/config/config/devices/0x0312/mp21zp_mp31zp.json
@@ -72,7 +72,7 @@
 			"$if": "firmwareVersion >= 1.11.1",
 			"$import": "templates/minoston_template.json#voltage_reporting_interval"
 		}
-    ],
+	],
 	"metadata": {
 		"inclusion": "ADD or Remove the MP21ZP from the existing Z-Wave home control network with your primary controller.\n---Refer to your primary controller instructions to process the inclusion / exclusion setup procedure.\n---When prompted by your primary controller, click the PROG button Three times in one second.\nInclude MP21ZP to/from a Z-Wave Gateway with supporting Security.The MP21ZP can support the Primary Controller that implemented the\nNotice: Including a node ID allocated by Z-WaveTM Controller means “Add” or “Inclusion”. Excluding a node ID allocated by\nZ-WaveTM Controller means “Remove” or “Exclusion”",
 		"exclusion": "ADD or Remove the MP21ZP from the existing Z-Wave home control network with your primary controller.\n---Refer to your primary controller instructions to process the inclusion / exclusion setup procedure.\n---When prompted by your primary controller, click the PROG button Three times in one second.\nInclude MP21ZP to/from a Z-Wave Gateway with supporting Security.The MP21ZP can support the Primary Controller that implemented the\nNotice: Including a node ID allocated by Z-WaveTM Controller means “Add” or “Inclusion”. Excluding a node ID allocated by\nZ-WaveTM Controller means “Remove” or “Exclusion”",

--- a/packages/config/config/devices/0x0312/templates/minoston_template.json
+++ b/packages/config/config/devices/0x0312/templates/minoston_template.json
@@ -500,44 +500,16 @@
 		"defaultValue": 5,
 		"unsigned": true
 	},
-    "power_reporting": {
+	"power_reporting": {
+		"$import": "~/templates/master_template.json#base_enable_disable_inverted",
 		"label": "Power Reporting",
-		"valueSize": 1,
-		"minValue": 0,
-		"maxValue": 1,
-		"defaultValue": 0,
-		"unsigned": true,
-        "allowManualEntry": false,
-		"options": [
-			{
-				"label": "Enabled",
-				"value": 0
-			},
-			{
-				"label": "Disabled",
-				"value": 1
-			}
-		]
-    },
-    "current_reporting": {
-        "label": "Current Reporting",
-		"valueSize": 1,
-		"minValue": 0,
-		"maxValue": 1,
-		"defaultValue": 0,
-		"unsigned": true,
-        "allowManualEntry": false,
-		"options": [
-			{
-				"label": "Enabled",
-				"value": 0
-			},
-			{
-				"label": "Disabled",
-				"value": 1
-			}
-		]
-    },
+		"defaultValue": 0
+	},
+	"current_reporting": {
+		"$import": "~/templates/master_template.json#base_enable_disable_inverted",
+		"label": "Current Reporting",
+		"defaultValue": 0
+	},
 	"current_reporting_interval": {
 		"label": "Current Reporting Interval",
 		"valueSize": 4,
@@ -546,20 +518,20 @@
 		"maxValue": 65535,
 		"defaultValue": 60,
 		"unsigned": true
-     },
+	},
 	"voltage_reporting_interval": {
 		"label": "Voltage Reporting Interval",
 		"valueSize": 4,
 		"unit": "minutes",
-		"minValue": 1,
+		"minValue": 0,
 		"maxValue": 65535,
 		"defaultValue": 60,
 		"unsigned": true,
 		"options": [
 			{
-				"label": "Disabled",
+				"label": "Disable",
 				"value": 0
 			}
 		]
-   }
+	}
 }

--- a/packages/config/config/devices/0x0312/templates/minoston_template.json
+++ b/packages/config/config/devices/0x0312/templates/minoston_template.json
@@ -499,5 +499,67 @@
 		"maxValue": 20,
 		"defaultValue": 5,
 		"unsigned": true
-	}
+	},
+    "power_reporting": {
+		"label": "Power Reporting",
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 1,
+		"defaultValue": 0,
+		"unsigned": true,
+        "allowManualEntry": false,
+		"options": [
+			{
+				"label": "Enabled",
+				"value": 0
+			},
+			{
+				"label": "Disabled",
+				"value": 1
+			}
+		]
+    },
+    "current_reporting": {
+        "label": "Current Reporting",
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 1,
+		"defaultValue": 0,
+		"unsigned": true,
+        "allowManualEntry": false,
+		"options": [
+			{
+				"label": "Enabled",
+				"value": 0
+			},
+			{
+				"label": "Disabled",
+				"value": 1
+			}
+		]
+    },
+	"current_reporting_interval": {
+		"label": "Current Reporting Interval",
+		"valueSize": 4,
+		"unit": "minutes",
+		"minValue": 1,
+		"maxValue": 65535,
+		"defaultValue": 60,
+		"unsigned": true
+     },
+	"voltage_reporting_interval": {
+		"label": "Voltage Reporting Interval",
+		"valueSize": 4,
+		"unit": "minutes",
+		"minValue": 1,
+		"maxValue": 65535,
+		"defaultValue": 60,
+		"unsigned": true,
+		"options": [
+			{
+				"label": "Disabled",
+				"value": 0
+			}
+		]
+   }
 }


### PR DESCRIPTION
fixes: #6097

1. Added to minoston_template.json:
power_reporting
current_reporting
current_reporting_interval
voltage_reporting_interval
2. Added to mp21zp_mp31zp.json:
parameters 9 - 13
3. Reordered parameters in mp21zp_mp31zp.json to group like parameters together
