### PR TITLE
feat: add node to controller `identify` event callback

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -1490,10 +1490,10 @@ enum ControllerFirmwareUpdateStatus {
 
 ### `"identify"`
 
-This is emitted when another node instructs Z-Wave JS to identify itself using the `Indicator CC`, indicator ID `0x50`. The callback has no arguments:
+This is emitted when another node instructs Z-Wave JS to identify itself using the `Indicator CC`, indicator ID `0x50`.
 
 ```ts
-() => void
+(node: ZWaveNode) => void
 ```
 
 > [!NOTE] Although support for this seems to be a certification requirement, it is currently unclear how this requirement must be fulfilled for controllers. The specification only refers to nodes:

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -376,7 +376,7 @@ interface ControllerEventCallbacks
 	"firmware update finished": (
 		result: ControllerFirmwareUpdateResult,
 	) => void;
-	identify: () => void;
+	"identify": (node: ZWaveNode) => void;
 }
 
 export type ControllerEvents = Extract<keyof ControllerEventCallbacks, string>;

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -376,7 +376,7 @@ interface ControllerEventCallbacks
 	"firmware update finished": (
 		result: ControllerFirmwareUpdateResult,
 	) => void;
-	"identify": (node: ZWaveNode) => void;
+	identify: (node: ZWaveNode) => void;
 }
 
 export type ControllerEvents = Extract<keyof ControllerEventCallbacks, string>;

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3860,7 +3860,7 @@ protocol version:      ${this.protocolVersion}`;
 			direction: "inbound",
 		});
 
-		this.driver.controller.emit("identify");
+		this.driver.controller.emit("identify", this);
 	}
 
 	private async handleSecurityCommandsSupportedGet(


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

Adds the node that triggered the identify event to the event callback
