### PR TITLE
fix: change order of startup commands to consider 16-bit node IDs

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -156,7 +156,6 @@ import { ApplicationUpdateRequest } from "../serialapi/application/ApplicationUp
 import { BridgeApplicationCommandRequest } from "../serialapi/application/BridgeApplicationCommandRequest";
 import type { SerialAPIStartedRequest } from "../serialapi/application/SerialAPIStartedRequest";
 import { GetControllerVersionRequest } from "../serialapi/capability/GetControllerVersionMessages";
-import { SerialAPISetupCommand } from "../serialapi/capability/SerialAPISetupMessages";
 import { SoftResetRequest } from "../serialapi/misc/SoftResetRequest";
 import {
 	SendDataBridgeRequest,
@@ -2444,15 +2443,7 @@ export class Driver
 		// This is a bit hacky, but what the heck...
 		if (!this._enteringBootloader) {
 			// If desired, re-configure the controller to use 16 bit node IDs
-			if (
-				this._controller?.isSerialAPISetupCommandSupported(
-					SerialAPISetupCommand.SetNodeIDType,
-				)
-			) {
-				void this._controller
-					.setNodeIDType(NodeIDType.Long)
-					.catch(noop);
-			}
+			void this._controller?.trySetNodeIDType(NodeIDType.Long);
 
 			// Resume sending
 			this.unpauseSendQueue();


### PR DESCRIPTION
This PR changes the order of some commands during startup/controller identification in order to parse commands correctly if the controller is already in 16-bit node ID mode.

fixes: #6150
fixes: https://github.com/zwave-js/node-zwave-js/issues/6144
fixes: https://github.com/zwave-js/node-zwave-js/issues/6148

for: https://github.com/home-assistant/core/issues/98250
for: 