### PR TITLE
fix: always enable soft-reset on 700+ series controllers

### DIFF
--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -809,6 +809,8 @@ interface ZWaveOptions extends ZWaveHostOptions {
 	 * Soft Reset is required after some commands like changing the RF region or restoring an NVM backup.
 	 * Because it may be problematic in certain environments, we provide the user with an option to opt out.
 	 * Default: `true,` except when ZWAVEJS_DISABLE_SOFT_RESET env variable is set.
+	 *
+	 * **Note:** This option has no effect on 700+ series controllers. For those, soft reset is always enabled.
 	 */
 	enableSoftReset?: boolean;
 

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -166,6 +166,8 @@ export interface ZWaveOptions extends ZWaveHostOptions {
 	 * Soft Reset is required after some commands like changing the RF region or restoring an NVM backup.
 	 * Because it may be problematic in certain environments, we provide the user with an option to opt out.
 	 * Default: `true,` except when ZWAVEJS_DISABLE_SOFT_RESET env variable is set.
+	 *
+	 * **Note:** This option has no effect on 700+ series controllers. For those, soft reset is always enabled.
 	 */
 	enableSoftReset?: boolean;
 


### PR DESCRIPTION
Experience has shown that the problems caused by soft reset are limited to 500 series and older controllers (shutting down, reconnecting with a different port, etc...)
On 700+ series, soft-resetting is however required in lots of cases. Here, having soft-reset disabled by the users rather causes problems.

This PR changes how we handle the `enableSoftReset` driver option. On 700+ series, this is now ignored and soft-reset is always performed, regardless of user preference. On 500 series and older, we still respect the setting, unless a stick is known not to support soft reset.