### PR TITLE
fix: only rely on `AGI CC` to determine notification mode if supported

### DIFF
--- a/packages/cc/src/cc/NotificationCC.ts
+++ b/packages/cc/src/cc/NotificationCC.ts
@@ -858,11 +858,9 @@ export class NotificationCCSet extends NotificationCC {
 	) {
 		super(host, options);
 		if (gotDeserializationOptions(options)) {
-			// TODO: Deserialize payload
-			throw new ZWaveError(
-				`${this.constructor.name}: deserialization not implemented`,
-				ZWaveErrorCodes.Deserialization_NotImplemented,
-			);
+			validatePayload(this.payload.length >= 2);
+			this.notificationType = this.payload[0];
+			this.notificationStatus = this.payload[1] === 0xff;
 		} else {
 			this.notificationType = options.notificationType;
 			this.notificationStatus = options.notificationStatus;

--- a/packages/cc/src/cc/NotificationCC.ts
+++ b/packages/cc/src/cc/NotificationCC.ts
@@ -472,17 +472,19 @@ export class NotificationCC extends CommandClass {
 		// it may be concluded that the supporting node implements Pull Mode and discovery may be aborted.
 		if (!node.supportsCC(CommandClasses.Association)) return "pull";
 
-		try {
-			const groupsIssueingNotifications =
-				AssociationGroupInfoCC.findGroupsForIssuedCommand(
-					applHost,
-					node,
-					this.ccId,
-					NotificationCommand.Report,
-				);
-			return groupsIssueingNotifications.length > 0 ? "push" : "pull";
-		} catch {
-			// We might be dealing with an older cache file, fall back to testing
+		if (node.supportsCC(CommandClasses["Association Group Information"])) {
+			try {
+				const groupsIssueingNotifications =
+					AssociationGroupInfoCC.findGroupsForIssuedCommand(
+						applHost,
+						node,
+						this.ccId,
+						NotificationCommand.Report,
+					);
+				return groupsIssueingNotifications.length > 0 ? "push" : "pull";
+			} catch {
+				// We might be dealing with an older cache file, fall back to testing
+			}
 		}
 
 		applHost.controllerLog.logNode(node.id, {
@@ -511,6 +513,7 @@ export class NotificationCC extends CommandClass {
 				/* ignore */
 			}
 		}
+
 		// If everything failed, e.g. because the node is V1/V2, assume this is a "push" node.
 		// If we assumed "pull", we would have to query the node regularly, which can cause
 		// the node to return old (already handled) notifications.

--- a/packages/zwave-js/src/lib/test/driver/notificationPushNoAGI.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/notificationPushNoAGI.test.ts
@@ -1,0 +1,76 @@
+import {
+	NotificationCCGet,
+	NotificationCCReport,
+	NotificationCCValues,
+} from "@zwave-js/cc/NotificationCC";
+import { CommandClasses } from "@zwave-js/core";
+import {
+	MockZWaveFrameType,
+	ccCaps,
+	createMockZWaveRequestFrame,
+	type MockNodeBehavior,
+} from "@zwave-js/testing";
+import { integrationTest } from "../integrationTestSuite";
+
+integrationTest(
+	"Notification CC: Push nodes without AGI support are detected as push, not pull",
+	{
+		// Repro of #6143
+
+		debug: true,
+
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				CommandClasses.Association,
+
+				ccCaps({
+					ccId: CommandClasses.Notification,
+					version: 2,
+					notificationTypesAndEvents: {
+						[0x06]: [], // Access Control, no support for discovering events in V2
+						[0x07]: [], // Home Security, no support for discovering events in V2
+					},
+				}),
+			],
+		},
+
+		customSetup: async (driver, controller, mockNode) => {
+			// Respond to Basic CC Get, so the driver doesn't assume Basic CC is unsupported
+			const respondToBasicGet: MockNodeBehavior = {
+				async onControllerFrame(controller, self, frame) {
+					if (
+						frame.type === MockZWaveFrameType.Request &&
+						frame.payload instanceof NotificationCCGet
+					) {
+						const notificationType =
+							frame.payload.notificationType || 0x06;
+						const cc = new NotificationCCReport(self.host, {
+							nodeId: controller.host.ownNodeId,
+							notificationType,
+							notificationEvent:
+								notificationType === 0x06
+									? 0x06 /* Keypad unlock */
+									: 0xfe,
+						});
+						await self.sendToController(
+							createMockZWaveRequestFrame(cc, {
+								ackRequested: false,
+							}),
+						);
+						return true;
+					}
+					return false;
+				},
+			};
+			mockNode.defineBehavior(respondToBasicGet);
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const notificationMode = node.getValue(
+				NotificationCCValues.notificationMode.id,
+			);
+			t.is(notificationMode, "push");
+		},
+	},
+);


### PR DESCRIPTION
Without this check, `groupsIssueingNotifications` will always be an empty array for nodes that don't support AGI CC. This will incorrectly consider them using pull mode

fixes: #6143 