### PR TITLE
feat: store a hash of the device config used during the interview

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -736,6 +736,16 @@ Many devices using `Notification CC` do not idle their notification values, sinc
 
 > [!NOTE] This method will only do something if the node supports `Notification CC`, and the selected notification variable has an idle state.
 
+### `hasDeviceConfigChanged`
+
+```ts
+hasDeviceConfigChanged(): MaybeNotKnown<boolean>
+```
+
+Z-Wave JS discovers a lot of device metadata by interviewing the device. However, some of the information has to be loaded from a configuration file. Some of this information is only evaluated once, during the device interview.
+
+When a device config file is updated, this information may be stale and and the device must be re-interviewed using `refreshInfo()` to pick up the changes. This method can be used to determine whether a re-interview is necessary.
+
 ## ZWaveNode properties
 
 ### `id`
@@ -1077,6 +1087,8 @@ readonly deviceConfig: DeviceConfig | undefined
 ```
 
 Contains additional information about this node, loaded from a [config file](/development/config-files.md#device-configuration-files).
+
+This information may change after an update of the config files. To check whether a change occured that requires a re-interview, use the [`hasDeviceConfigChanged`](#hasdeviceconfigchanged) method.
 
 ### `deviceDatabaseUrl`
 

--- a/packages/config/src/devices/DeviceConfig.hash.test.ts
+++ b/packages/config/src/devices/DeviceConfig.hash.test.ts
@@ -19,7 +19,7 @@ test("hash() works", async (t) => {
 	t.not(config, undefined);
 
 	const hash = config.getHash();
-	t.is(typeof hash, "number");
+	t.true(Buffer.isBuffer(hash));
 });
 
 test("hash() changes when changing a parameter info", async (t) => {
@@ -43,7 +43,7 @@ test("hash() changes when changing a parameter info", async (t) => {
 	config.paramInformation!.get({ parameter: 2 })!.unit = "lightyears";
 	const hash2 = config.getHash();
 
-	t.not(hash1, hash2);
+	t.notDeepEqual(hash1, hash2);
 });
 
 test("hash() changes when removing a CC", async (t) => {
@@ -70,5 +70,5 @@ test("hash() changes when removing a CC", async (t) => {
 
 	const hash2 = config.getHash();
 
-	t.not(hash1, hash2);
+	t.notDeepEqual(hash1, hash2);
 });

--- a/packages/config/src/devices/DeviceConfig.hash.test.ts
+++ b/packages/config/src/devices/DeviceConfig.hash.test.ts
@@ -1,0 +1,74 @@
+import { CommandClasses } from "@zwave-js/core";
+import test from "ava";
+import path from "path";
+import { ConfigManager } from "../ConfigManager";
+
+test("hash() works", async (t) => {
+	// This test might take a while
+	t.timeout(60000);
+
+	const configManager = new ConfigManager({
+		deviceConfigPriorityDir: path.join(__dirname, "__fixtures/hash"),
+	});
+	const config = (await configManager.lookupDevice(
+		0xffff,
+		0xcafe,
+		0xbeef,
+		"1.0",
+	))!;
+	t.not(config, undefined);
+
+	const hash = config.getHash();
+	t.is(typeof hash, "number");
+});
+
+test("hash() changes when changing a parameter info", async (t) => {
+	// This test might take a while
+	t.timeout(60000);
+
+	const configManager = new ConfigManager({
+		deviceConfigPriorityDir: path.join(__dirname, "__fixtures/hash"),
+	});
+	const config = (await configManager.lookupDevice(
+		0xffff,
+		0xcafe,
+		0xbeef,
+		"1.0",
+	))!;
+	t.not(config, undefined);
+
+	const hash1 = config.getHash();
+
+	// @ts-expect-error
+	config.paramInformation!.get({ parameter: 2 })!.unit = "lightyears";
+	const hash2 = config.getHash();
+
+	t.not(hash1, hash2);
+});
+
+test("hash() changes when removing a CC", async (t) => {
+	// This test might take a while
+	t.timeout(60000);
+
+	const configManager = new ConfigManager({
+		deviceConfigPriorityDir: path.join(__dirname, "__fixtures/hash"),
+	});
+	const config = (await configManager.lookupDevice(
+		0xffff,
+		0xcafe,
+		0xbeef,
+		"1.0",
+	))!;
+	t.not(config, undefined);
+
+	const hash1 = config.getHash();
+
+	const removeCCs = new Map();
+	removeCCs.set(CommandClasses["All Switch"], "*");
+	// @ts-expect-error
+	config.compat!.removeCCs = removeCCs;
+
+	const hash2 = config.getHash();
+
+	t.not(hash1, hash2);
+});

--- a/packages/config/src/devices/DeviceConfig.ts
+++ b/packages/config/src/devices/DeviceConfig.ts
@@ -1,4 +1,4 @@
-import { CRC16_CCITT, ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
+import { ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
 import {
 	enumFilesRecursive,
 	formatId,
@@ -9,6 +9,7 @@ import {
 	type JSONObject,
 } from "@zwave-js/shared";
 import { isArray, isObject } from "alcalzone-shared/typeguards";
+import { createHash } from "crypto";
 import * as fs from "fs-extra";
 import { pathExists, readFile, writeFile } from "fs-extra";
 import JSON5 from "json5";
@@ -722,7 +723,7 @@ export class DeviceConfig {
 	/**
 	 * Returns a hash code that can be used to check whether a device config has changed enough to require a re-interview.
 	 */
-	public getHash(): number {
+	public getHash(): Buffer {
 		// We only need to compare the information that is persisted elsewhere:
 		// - config parameters
 		// - functional association settings
@@ -856,8 +857,9 @@ export class DeviceConfig {
 
 		hashable = sortObject(hashable);
 
-		// And create a 16-bit hash from it. This should be enough to detect changes
+		// And create a hash from it. This does not need to be cryptographically secure, just good enough to detect changes.
 		const buffer = Buffer.from(JSON.stringify(hashable), "utf8");
-		return CRC16_CCITT(buffer);
+		const md5 = createHash("md5");
+		return md5.update(buffer).digest();
 	}
 }

--- a/packages/config/src/devices/DeviceConfig.ts
+++ b/packages/config/src/devices/DeviceConfig.ts
@@ -1,8 +1,10 @@
-import { ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
+import { CRC16_CCITT, ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
 import {
 	enumFilesRecursive,
 	formatId,
+	num2hex,
 	padVersion,
+	pick,
 	stringify,
 	type JSONObject,
 } from "@zwave-js/shared";
@@ -38,6 +40,7 @@ import {
 	parseConditionalParamInformationMap,
 	type ConditionalParamInfoMap,
 	type ParamInfoMap,
+	type ParamInformation,
 } from "./ParamInformation";
 import type { DeviceID, FirmwareVersionRange } from "./shared";
 
@@ -714,5 +717,147 @@ export class DeviceConfig {
 			// The other endpoints can only have a configuration as part of "endpoints"
 			return this.endpoints?.get(endpointIndex)?.associations?.get(group);
 		}
+	}
+
+	/**
+	 * Returns a hash code that can be used to check whether a device config has changed enough to require a re-interview.
+	 */
+	public getHash(): number {
+		// We only need to compare the information that is persisted elsewhere:
+		// - config parameters
+		// - functional association settings
+		// - CC-related compat flags
+
+		let hashable: Record<string, any> = {
+			// endpoints: {
+			// 	associations: {},
+			// 	paramInformation: []
+			// },
+			// proprietary: {},
+			// compat: {},
+		};
+
+		const sortObject = (obj: Record<string, any>) => {
+			const ret: Record<string, any> = {};
+			for (const key of Object.keys(obj).sort()) {
+				ret[key] = obj[key];
+			}
+			return ret;
+		};
+
+		const cloneAssociationConfig = (a: AssociationConfig) => {
+			return sortObject(
+				pick(a, ["maxNodes", "multiChannel", "isLifeline"]),
+			);
+		};
+		const cloneAssociationMap = (
+			target: Record<string, any>,
+			map: ReadonlyMap<number, AssociationConfig> | undefined,
+		) => {
+			if (!map || !map.size) return;
+			target.associations = {};
+			for (const [key, value] of map) {
+				target.associations[key] = cloneAssociationConfig(value);
+			}
+			target.associations = sortObject(target.associations);
+		};
+
+		const cloneParamInformationMap = (
+			target: Record<string, any>,
+			map: ParamInfoMap | undefined,
+		) => {
+			if (!map || !map.size) return;
+			const getParamKey = (param: ParamInformation) =>
+				`${param.parameterNumber}${
+					param.valueBitMask ? `[${num2hex(param.valueBitMask)}]` : ""
+				}`;
+			target.paramInformation = [...map.values()].sort((a, b) =>
+				getParamKey(a).localeCompare(getParamKey(b)),
+			);
+		};
+
+		// Clone associations and param information on the root (ep 0) and endpoints
+		{
+			let ep0: Record<string, any> = {};
+			cloneAssociationMap(ep0, this.associations);
+			cloneParamInformationMap(ep0, this.paramInformation);
+			ep0 = sortObject(ep0);
+
+			if (Object.keys(ep0).length > 0) {
+				hashable.endpoints ??= {};
+				hashable.endpoints[0] = ep0;
+			}
+		}
+
+		if (this.endpoints) {
+			for (const [index, endpoint] of this.endpoints) {
+				let ep: Record<string, any> = {};
+
+				cloneAssociationMap(ep, endpoint.associations);
+				cloneParamInformationMap(ep, endpoint.paramInformation);
+
+				ep = sortObject(ep);
+
+				if (Object.keys(ep).length > 0) {
+					hashable.endpoints ??= {};
+					hashable.endpoints[index] = ep;
+				}
+			}
+		}
+
+		// Clone proprietary config
+		if (this.proprietary && Object.keys(hashable.proprietary).length > 0) {
+			hashable.proprietary = sortObject({ ...this.proprietary });
+		}
+
+		// Clone relevant compat flags
+		if (this.compat) {
+			let c: Record<string, any> = {};
+
+			// Copy some simple flags over
+			for (const prop of [
+				"enableBasicSetMapping",
+				"forceSceneControllerGroupCount",
+				"mapRootReportsToEndpoint",
+				"preserveRootApplicationCCValueIDs",
+				"preserveEndpoints",
+				"removeEndpoints",
+				"treatBasicSetAsEvent",
+				"treatMultilevelSwitchSetAsEvent",
+			] as const) {
+				if (this.compat[prop] != undefined) {
+					c[prop] = this.compat[prop];
+				}
+			}
+
+			// Copy other, more complex flags
+			if (this.compat.overrideQueries) {
+				c.overrideQueries = Object.fromEntries(
+					this.compat.overrideQueries["overrides"],
+				);
+			}
+			if (this.compat.addCCs) {
+				c.addCCs = Object.fromEntries(
+					[...this.compat.addCCs].map(([ccId, def]) => [
+						ccId,
+						Object.fromEntries(def.endpoints),
+					]),
+				);
+			}
+			if (this.compat.removeCCs) {
+				c.removeCCs = Object.fromEntries(this.compat.removeCCs);
+			}
+
+			c = sortObject(c);
+			if (Object.keys(c).length > 0) {
+				hashable.compat = c;
+			}
+		}
+
+		hashable = sortObject(hashable);
+
+		// And create a 16-bit hash from it. This should be enough to detect changes
+		const buffer = Buffer.from(JSON.stringify(hashable), "utf8");
+		return CRC16_CCITT(buffer);
 	}
 }

--- a/packages/config/src/devices/__fixtures/hash/config1.json
+++ b/packages/config/src/devices/__fixtures/hash/config1.json
@@ -1,0 +1,61 @@
+{
+	"manufacturer": "Z-Wave JS",
+	"manufacturerId": "0xffff",
+	"label": "700 Series",
+	"description": "USB Controller",
+	"devices": [
+		{
+			"productType": "0xcafe",
+			"productId": "0xbeef"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5,
+			"isLifeline": true,
+			"multiChannel": true
+		}
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"label": "Latch Hold Time",
+			"description": "Defines how long the latch is kept open.",
+			"unit": "s",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 20,
+			"defaultValue": 3
+		},
+		{
+			"#": "2",
+			"label": "Latch Torque",
+			"description": "Defines the torque of the latch.",
+			"valueSize": 1,
+			"defaultValue": 2,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "High",
+					"value": 1
+				},
+				{
+					"label": "Medium",
+					"value": 2
+				},
+				{
+					"label": "Low",
+					"value": 3
+				}
+			]
+		}
+	],
+	"compat": {
+		"preserveEndpoints": "*"
+	}
+}

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -5752,7 +5752,10 @@ ${handlers.length} left`,
 		// Now try to apply them to all known devices
 		if (this._controller) {
 			for (const node of this._controller.nodes.values()) {
-				if (node.ready) await node["loadDeviceConfig"]();
+				if (node.ready) {
+					await node["loadDeviceConfig"]();
+					// TODO: If the device config did change, expose this information
+				}
 			}
 		}
 

--- a/packages/zwave-js/src/lib/driver/NetworkCache.ts
+++ b/packages/zwave-js/src/lib/driver/NetworkCache.ts
@@ -75,6 +75,7 @@ export const cacheKeys = {
 			defaultTransitionDuration: `${nodeBaseKey}defaultTransitionDuration`,
 			defaultVolume: `${nodeBaseKey}defaultVolume`,
 			lastSeen: `${nodeBaseKey}lastSeen`,
+			deviceConfigHash: `${nodeBaseKey}deviceConfigHash`,
 		};
 	},
 } as const;

--- a/packages/zwave-js/src/lib/driver/NetworkCache.ts
+++ b/packages/zwave-js/src/lib/driver/NetworkCache.ts
@@ -362,6 +362,15 @@ export function deserializeNetworkCacheValue(
 			if (value) return value;
 			throw fail();
 		}
+
+		case "deviceConfigHash": {
+			if (typeof value !== "string") throw fail();
+			try {
+				return Buffer.from(value, "hex");
+			} catch {
+				throw fail();
+			}
+		}
 	}
 
 	// Other properties
@@ -413,6 +422,10 @@ export function serializeNetworkCacheValue(
 		case "lastSeen": {
 			// Dates are stored as timestamps
 			return (value as Date).getTime();
+		}
+
+		case "deviceConfigHash": {
+			return (value as Buffer).toString("hex");
 		}
 	}
 

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -971,11 +971,11 @@ export class ZWaveNode
 	 * @internal
 	 * The hash of the device config that was applied during the last interview.
 	 */
-	public get deviceConfigHash(): number | undefined {
+	public get deviceConfigHash(): Buffer | undefined {
 		return this.driver.cacheGet(cacheKeys.node(this.id).deviceConfigHash);
 	}
 
-	private set deviceConfigHash(value: number | undefined) {
+	private set deviceConfigHash(value: Buffer | undefined) {
 		this.driver.cacheSet(cacheKeys.node(this.id).deviceConfigHash, value);
 	}
 
@@ -6423,6 +6423,9 @@ ${formatRouteHealthCheckSummary(this.id, otherNode.id, summary)}`,
 		}
 
 		// If it was, a change in hash means the config has changed
-		return actualHash !== this.deviceConfigHash;
+		if (actualHash && this.deviceConfigHash) {
+			return actualHash.equals(this.deviceConfigHash);
+		}
+		return true;
 	}
 }

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -967,6 +967,18 @@ export class ZWaveNode
 		);
 	}
 
+	/**
+	 * @internal
+	 * The hash of the device config that was applied during the last interview.
+	 */
+	public get deviceConfigHash(): number | undefined {
+		return this.driver.cacheGet(cacheKeys.node(this.id).deviceConfigHash);
+	}
+
+	private set deviceConfigHash(value: number | undefined) {
+		this.driver.cacheSet(cacheKeys.node(this.id).deviceConfigHash, value);
+	}
+
 	private _valueDB: ValueDB;
 	/**
 	 * Provides access to this node's values
@@ -1653,6 +1665,7 @@ export class ZWaveNode
 		this.supportsSecurity = undefined;
 		this.supportsBeaming = undefined;
 		this._deviceConfig = undefined;
+		this.deviceConfigHash = undefined;
 		this._hasEmittedNoS0NetworkKeyError = false;
 		this._hasEmittedNoS2NetworkKeyError = false;
 		this._valueDB.clear({ noEvent: true });
@@ -1780,6 +1793,9 @@ export class ZWaveNode
 			// Load a config file for this node if it exists and overwrite the previously reported information
 			await this.overwriteConfig();
 		}
+
+		// Remember the state of the device config that is used for this node
+		this.deviceConfigHash = this._deviceConfig?.getHash();
 
 		this.setInterviewStage(InterviewStage.Complete);
 		this.readyMachine.send("INTERVIEW_DONE");
@@ -6390,5 +6406,23 @@ ${formatRouteHealthCheckSummary(this.id, otherNode.id, summary)}`,
 		);
 
 		await api.sendNotification();
+	}
+
+	/**
+	 * Returns whether the device config for this node has changed since the last interview.
+	 * If it has, the node likely needs to be re-interviewed for the changes to be picked up.
+	 */
+	public hasDeviceConfigChanged(): MaybeNotKnown<boolean> {
+		// We can't know if the node is not fully interviewed
+		if (this.interviewStage !== InterviewStage.Complete) return NOT_KNOWN;
+
+		// If the hash was never stored, we can only (very likely) know if the config has not changed
+		const actualHash = this.deviceConfig?.getHash();
+		if (this.deviceConfigHash == undefined) {
+			return actualHash == undefined ? false : NOT_KNOWN;
+		}
+
+		// If it was, a change in hash means the config has changed
+		return actualHash !== this.deviceConfigHash;
 	}
 }


### PR DESCRIPTION
This PR implements a hash method that condenses the configuration file used during an interview into a buffer that can easily be compared. This is stored and can be used to keep track of changes to config files which likely require a re-interview to be picked up.

fixes: https://github.com/zwave-js/node-zwave-js/issues/4079
for: https://github.com/zwave-js/node-zwave-js/issues/2909