### PR TITLE
fix(config): correct reporting frequency parameter values for Sensative AB Strips Comfort / Drips Multisensor

### DIFF
--- a/packages/config/config/devices/0x019a/11_02_011.json
+++ b/packages/config/config/devices/0x019a/11_02_011.json
@@ -64,11 +64,11 @@
 			"options": [
 				{
 					"label": "Normal",
-					"value": 0
+					"value": 1
 				},
 				{
 					"label": "Frequent",
-					"value": 1
+					"value": 2
 				}
 			]
 		},


### PR DESCRIPTION
The Sensative Strips Comfort has incorrect parameters stored in the device configuration. This PR changes the parameters to match the manual.

I have two of these devices, and have manually set one of them to frequent reporting, value 2. The result is as expected; the frequently reporting one reports more often as described in https://sensative.com/strips-comfort-reporting/

The default value for this option is Normal (1) and does not need changing.