### PR TITLE
fix: discard `Meter CC` and `Multilevel Sensor CC` reports when the node does not support them

### DIFF
--- a/packages/zwave-js/src/lib/test/cc-specific/discardUnsupportedReports.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/discardUnsupportedReports.test.ts
@@ -1,0 +1,64 @@
+import {
+	BinarySensorCCReport,
+	BinarySensorCCValues,
+	BinarySensorType,
+	MultilevelSensorCCReport,
+	MultilevelSensorCCValues,
+	type CommandClass,
+} from "@zwave-js/cc";
+import { CommandClasses } from "@zwave-js/core";
+import { createMockZWaveRequestFrame } from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import { integrationTest } from "../integrationTestSuite";
+
+integrationTest(
+	"Discard Multilevel Sensor CC on nodes that do not support them",
+	{
+		debug: true,
+		// provisioningDirectory: path.join(__dirname, "fixtures/configurationCC"),
+
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				CommandClasses["Binary Sensor"],
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			let cc: CommandClass = new MultilevelSensorCCReport(mockNode.host, {
+				nodeId: mockController.host.ownNodeId,
+				type: 0x01, // Temperature
+				scale: 0x00, // Celsius
+				value: 25.12,
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+
+			cc = new BinarySensorCCReport(mockNode.host, {
+				nodeId: mockController.host.ownNodeId,
+				type: BinarySensorType.CO2,
+				value: true,
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+
+			await wait(100);
+
+			const temperature = node.getValue(
+				MultilevelSensorCCValues.value("Air temperature").id,
+			);
+			t.is(temperature, undefined);
+
+			const co2 = node.getValue(
+				BinarySensorCCValues.state(BinarySensorType.CO2).id,
+			);
+			t.is(co2, true);
+		},
+	},
+);

--- a/packages/zwave-js/src/lib/test/cc-specific/discardUnsupportedReports.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/discardUnsupportedReports.test.ts
@@ -14,7 +14,7 @@ import { integrationTest } from "../integrationTestSuite";
 integrationTest(
 	"Discard Multilevel Sensor CC on nodes that do not support them",
 	{
-		debug: true,
+		// debug: true,
 		// provisioningDirectory: path.join(__dirname, "fixtures/configurationCC"),
 
 		nodeCapabilities: {

--- a/packages/zwave-js/src/lib/test/cc-specific/fixtures/meterCC/7e570001.jsonl
+++ b/packages/zwave-js/src/lib/test/cc-specific/fixtures/meterCC/7e570001.jsonl
@@ -1,0 +1,24 @@
+{"k":"cacheFormat","v":1}
+{"k":"node.1.isListening","v":true}
+{"k":"node.1.isFrequentListening","v":false}
+{"k":"node.1.isRouting","v":true}
+{"k":"node.1.supportedDataRates","v":[40000,9600,100000]}
+{"k":"node.1.protocolVersion","v":3}
+{"k":"node.1.nodeType","v":"Controller"}
+{"k":"node.1.supportsSecurity","v":false}
+{"k":"node.1.supportsBeaming","v":true}
+{"k":"node.1.deviceClass","v":{"basic":2,"generic":2,"specific":7}}
+{"k":"node.1.endpoint.0.commandClass.0x72","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x86","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x20","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x60","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.interviewStage","v":"Complete"}
+
+
+{"k":"node.2.hasSUCReturnRoute","v":true}
+{"k":"node.2.isListening","v":true}
+{"k":"node.2.isFrequentListening","v":false}
+{"k":"node.2.interviewStage","v":"Complete"}
+// Meter CC is supported
+{"k":"node.2.endpoint.0.commandClass.0x32","v":{"isSupported":true,"isControlled":false,"secure":false,"version":6}}
+

--- a/packages/zwave-js/src/lib/test/cc-specific/meterReportPropertyKeyName.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/meterReportPropertyKeyName.test.ts
@@ -7,7 +7,7 @@ integrationTest(
 	"When receiving a MeterCC::Report, the value event should contain the meter name in propertyKeyName",
 	{
 		// debug: true,
-		provisioningDirectory: path.join(__dirname, "fixtures/configurationCC"),
+		provisioningDirectory: path.join(__dirname, "fixtures/meterCC"),
 
 		testBody: async (t, driver, node, mockController, _mockNode) => {
 			const valueAddedPromise = new Promise<void>((resolve) => {


### PR DESCRIPTION
This PR helps with situations where reports get corrupted on air and get attributed to a different node ID. We may consider expanding this check to all CCs, but this will likely result in breaks for some users where devices don't report all their capabilities.

fixes: #5510