### PR TITLE
refactor: validate device IDs before installing firmware update instead of when checking for updates

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -1003,7 +1003,11 @@ interface FirmwareUpdateInfo {
 }
 ```
 
-where each entry in `files` looks like this:
+where the `device` field stores which device the update is for
+
+<!-- #import FirmwareUpdateDeviceID from "zwave-js" -->
+
+and each entry in `files` looks like this:
 
 <!-- #import FirmwareUpdateFileInfo from "zwave-js" -->
 
@@ -1046,18 +1050,18 @@ interface GetFirmwareUpdatesOptions {
 #### `firmwareUpdateOTA`
 
 ```ts
-firmwareUpdateOTA(nodeId: number, update: FirmwareUpdateFileInfo): Promise<FirmwareUpdateResult>
+firmwareUpdateOTA(nodeId: number, updateInfo: FirmwareUpdateInfo): Promise<FirmwareUpdateResult>
 ```
 
-> [!WARNING] We don't take any responsibility if devices upgraded using Z-Wave JS don't work after an update. Always double-check that the correct update is about to be installed.
+> [!WARNING] We don't take any responsibility if devices upgraded using Z-Wave JS don't work afterwards. Although there are security measures in place, always double-check that the correct update is about to be installed.
 
-Downloads the desired firmware update from the [Z-Wave JS firmware update service](https://github.com/zwave-js/firmware-updates/) and performs an over-the-air (OTA) firmware update for the given node. This is very similar to [`ZWaveNode.updateFirmware`](api/node#updatefirmware), except that the updates are officially provided by manufacturers and downloaded in the background.
+Downloads the desired firmware updates from the [Z-Wave JS firmware update service](https://github.com/zwave-js/firmware-updates/) and performs an over-the-air (OTA) firmware update for the given node. This is very similar to [`ZWaveNode.updateFirmware`](api/node#updatefirmware), except that the updates are officially provided by manufacturers and downloaded in the background.
 
 To keep track of the update progress, use the [`"firmware update progress"` and `"firmware update finished"` events](api/node#quotfirmware-update-progressquot) of the corresponding node.
 
 The return value indicates whether the update was successful and includes some additional information. This is the same information that is emitted using the `"firmware update finished"` event.
 
-> [!NOTE] Calling this will result in an HTTP request to the URL contained in the `update` parameter.
+> [!NOTE] Calling this will result in an HTTP request to the URLs referenced in the `updateInfo` parameter.
 
 #### `isAnyOTAFirmwareUpdateInProgress`
 

--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -990,22 +990,29 @@ interface GetFirmwareUpdatesOptions {
 
 This method returns an array with all available firmware updates for the given node. The entries of the array have the following form:
 
-<!-- #import FirmwareUpdateInfo from "zwave-js" -->
-
 ```ts
-interface FirmwareUpdateInfo {
+type FirmwareUpdateInfo = {
+	device: FirmwareUpdateDeviceID;
 	version: string;
 	changelog: string;
 	channel: "stable" | "beta";
 	files: FirmwareUpdateFileInfo[];
 	downgrade: boolean;
 	normalizedVersion: string;
-}
+};
 ```
 
-where the `device` field stores which device the update is for
+where the `device` field stores which device the update is for,
 
-<!-- #import FirmwareUpdateDeviceID from "zwave-js" -->
+```ts
+interface FirmwareUpdateDeviceID {
+	manufacturerId: number;
+	productType: number;
+	productId: number;
+	firmwareVersion: string;
+	rfRegion?: RFRegion;
+}
+```
 
 and each entry in `files` looks like this:
 

--- a/docs/getting-started/migrating-to-v12.md
+++ b/docs/getting-started/migrating-to-v12.md
@@ -15,6 +15,36 @@ type ZWaveNotificationCallback = (
 ): void;
 ```
 
+## Reworked firmware update checks
+
+Previously, checking whether a firmware update is available through the Z-Wave JS Firmware Update Service required waking up sleeping devices, because the device information was queried first. This can be difficult for sleeping devices that rarely wake up or are located in hard to reach spots. In addition, some Home Assistant users were having problems that their devices randomly responded with a corrupted fingerprint.
+
+To solve this, the firmware update checks now use cached information, removing the need for frequent communication with nodes. Only when an update should be applied, Z-Wave JS validates that the device information matches the update.
+
+To achieve this, the signature of `Controller.firmwareUpdateOTA` had to be changed. It now expects the full `FirmwareUpdateInfo` as the 2nd parameter, instead of just the individual files' info:
+
+```diff
+public async firmwareUpdateOTA(
+	nodeId: number,
+-	updates: FirmwareUpdateFileInfo[]
++	updateInfo: FirmwareUpdateInfo,
+): Promise<FirmwareUpdateResult>;
+```
+
+Since `Controller.getAvailableFirmwareUpdates` returns an array of these, the firmware update process should now look roughly like this in application code:
+
+```ts
+// Check for updates
+const updateInfos = await controller.getAvailableFirmwareUpdates(
+	nodeId,
+	options,
+);
+// Select one of the updates, e.g. though user input
+const updateInfo = updateInfos[0];
+// Apply the update
+await controller.firmwareUpdateOTA(nodeId, updateInfo);
+```
+
 ## `ZWaveHost.getNextSupervisionSessionId` requires a node ID now
 
 This change only concerns custom implementations of the `ZWaveHost` interface and should not affect most users/codebases. The `Supervision` session IDs must be tracked per node now and not globally:

--- a/packages/core/src/error/ZWaveError.ts
+++ b/packages/core/src/error/ZWaveError.ts
@@ -69,6 +69,8 @@ export enum ZWaveErrorCodes {
 	FWUpdateService_RequestError,
 	/** The integrity check of the downloaded firmware update failed */
 	FWUpdateService_IntegrityCheckFailed,
+	/** The firmware update is for a different device */
+	FWUpdateService_DeviceMismatch,
 
 	/** The given NVM version/format is unsupported */
 	NVM_NotSupported = 280,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -37,3 +37,13 @@ export type OnlyMethods<T> = {
 export type MethodsNamesOf<T> = OnlyMethods<T>[keyof T];
 
 export type IsAny<T> = 0 extends 1 & T ? true : false;
+
+// expands object types recursively
+export type Expand<T> =
+	// Expand object types
+	T extends object
+		? T extends infer O
+			? { [K in keyof O]: O[K] }
+			: never
+		: // Fallback to the type itself if no match
+		  T;

--- a/packages/zwave-js/src/Controller.ts
+++ b/packages/zwave-js/src/Controller.ts
@@ -20,6 +20,7 @@ export { ControllerFirmwareUpdateStatus } from "./lib/controller/_Types";
 export type {
 	ControllerFirmwareUpdateProgress,
 	ControllerFirmwareUpdateResult,
+	FirmwareUpdateDeviceID,
 	FirmwareUpdateFileInfo,
 	FirmwareUpdateInfo,
 	GetFirmwareUpdatesOptions,

--- a/packages/zwave-js/src/Controller_safe.ts
+++ b/packages/zwave-js/src/Controller_safe.ts
@@ -12,6 +12,7 @@ export { ControllerFirmwareUpdateStatus } from "./lib/controller/_Types";
 export type {
 	ControllerFirmwareUpdateProgress,
 	ControllerFirmwareUpdateResult,
+	FirmwareUpdateDeviceID,
 	GetFirmwareUpdatesOptions,
 	HealNetworkOptions,
 	HealNodeStatus,

--- a/packages/zwave-js/src/lib/controller/_Types.ts
+++ b/packages/zwave-js/src/lib/controller/_Types.ts
@@ -1,5 +1,6 @@
 import { type DeviceID } from "@zwave-js/config";
 import { type RFRegion } from "@zwave-js/core";
+import { type Expand } from "@zwave-js/shared/safe";
 
 export type HealNodeStatus = "pending" | "done" | "failed" | "skipped";
 
@@ -19,10 +20,12 @@ export interface FirmwareUpdateFileInfo {
 }
 
 /** The information sent to the firmware update service to identify which updates are available for a device. */
-export type FirmwareUpdateDeviceID = DeviceID & {
-	firmwareVersion: string;
-	rfRegion?: RFRegion;
-};
+export type FirmwareUpdateDeviceID = Expand<
+	DeviceID & {
+		firmwareVersion: string;
+		rfRegion?: RFRegion;
+	}
+>;
 
 export interface FirmwareUpdateServiceResponse {
 	version: string;
@@ -33,10 +36,12 @@ export interface FirmwareUpdateServiceResponse {
 	normalizedVersion: string;
 }
 
-export type FirmwareUpdateInfo = FirmwareUpdateServiceResponse & {
-	/** Which device this update is for */
-	device: FirmwareUpdateDeviceID;
-};
+export type FirmwareUpdateInfo = Expand<
+	FirmwareUpdateServiceResponse & {
+		/** Which device this update is for */
+		device: FirmwareUpdateDeviceID;
+	}
+>;
 
 export interface GetFirmwareUpdatesOptions {
 	/** Allows overriding the API key for the firmware update service */

--- a/packages/zwave-js/src/lib/controller/_Types.ts
+++ b/packages/zwave-js/src/lib/controller/_Types.ts
@@ -1,3 +1,6 @@
+import { type DeviceID } from "@zwave-js/config";
+import { type RFRegion } from "@zwave-js/core";
+
 export type HealNodeStatus = "pending" | "done" | "failed" | "skipped";
 
 export interface HealNetworkOptions {
@@ -15,7 +18,13 @@ export interface FirmwareUpdateFileInfo {
 	integrity: `sha256:${string}`;
 }
 
-export interface FirmwareUpdateInfo {
+/** The information sent to the firmware update service to identify which updates are available for a device. */
+export type FirmwareUpdateDeviceID = DeviceID & {
+	firmwareVersion: string;
+	rfRegion?: RFRegion;
+};
+
+export interface FirmwareUpdateServiceResponse {
 	version: string;
 	changelog: string;
 	channel: "stable" | "beta";
@@ -23,6 +32,11 @@ export interface FirmwareUpdateInfo {
 	downgrade: boolean;
 	normalizedVersion: string;
 }
+
+export type FirmwareUpdateInfo = FirmwareUpdateServiceResponse & {
+	/** Which device this update is for */
+	device: FirmwareUpdateDeviceID;
+};
 
 export interface GetFirmwareUpdatesOptions {
 	/** Allows overriding the API key for the firmware update service */


### PR DESCRIPTION
With this PR, checking the availability of firmware updates now uses cached information, instead of requesting it fresh from the nodes. One one hand, this reduces the likelyhood of [this issue](https://github.com/home-assistant/core/issues/80398) happening, on the other hand, it prevents users from having to wake up sleeping devices in strange locations when manually checking for updates.

Since the check for changed information now needs to be done before applying the update, we now store the device information used to request updates in the returned objects. To accomodate for this, the signature of `firmwareUpdateOTA` needed to be changed to accept the full `FirmwareUpdateInfo` object.

fixes: #6177