### PR TITLE
fix(docs): move `Driver.interviewNode` to `Node.interview`

### DIFF
--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -42,18 +42,6 @@ If supported by the controller, this instructs it to shut down the Z-Wave API, s
 
 > [!WARNING] The controller will have to be restarted manually (e.g. by unplugging and plugging it back in) before it can be used again!
 
-### `interviewNode`
-
-```ts
-interviewNode(node: ZWaveNode): Promise<void>
-```
-
-Starts or resumes the interview of a Z-Wave node.
-
-> [!WARNING] This is only allowed when the initial interview was bypassed using the `interview.disableOnNodeAdded` option. Otherwise, this method will throw an error.
-
-> [!NOTE] It is advised to NOT await this method as it can take a very long time (minutes to hours)!
-
 ### `enableErrorReporting`
 
 ```ts

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -65,6 +65,18 @@ getDefinedValueIDs(): TranslatedValueID[]
 
 When building a user interface for a Z-Wave application, you might need to know all possible values in advance. This method returns an array of all ValueIDs that are available for this node.
 
+### `interview`
+
+```ts
+interview(): Promise<void>
+```
+
+Starts or resumes the interview of a Z-Wave node.
+
+> [!WARNING] This is only allowed when the initial interview was bypassed using the `interview.disableOnNodeAdded` option. Otherwise, this method will throw an error.
+
+> [!NOTE] It is advised to NOT await this method as it can take a very long time (minutes to hours)!
+
 ### `setValue`
 
 ```ts

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -88,7 +88,7 @@ export interface ZWaveOptions extends ZWaveHostOptions {
 		 * Disable the automatic node interview after successful inclusion.
 		 * Note: When this is `true`, the interview must be started manually using
 		 * ```ts
-		 * driver.interviewNode(node: ZWaveNode)
+		 * node.interview()
 		 * ```
 		 *
 		 * Default: `false` (automatic interviews enabled)


### PR DESCRIPTION
As titled.

I'm not sure what format wizardry happens with the docs, so I may be missing a trick or 2?
This method was moved in V10.