### PR TITLE
fix(config): extend version range for Vesternet VES-ZW-DIM-001

### DIFF
--- a/packages/config/config/devices/0x0330/ves-zw-dim-001.json
+++ b/packages/config/config/devices/0x0330/ves-zw-dim-001.json
@@ -12,7 +12,7 @@
 	],
 	"firmwareVersion": {
 		"min": "1.21",
-		"max": "1.24"
+		"max": "1.26"
 	},
 	"paramInformation": [
 		{


### PR DESCRIPTION
Update firmwareVersion max to account for newer version of the Vesternet 2-Wire Capable Dimmer module.