### PR TITLE
fix: don't abort transaction while still retrying

### DIFF
--- a/packages/zwave-js/src/lib/test/driver/fixtures/nodeDeadReject/7e570001.jsonl
+++ b/packages/zwave-js/src/lib/test/driver/fixtures/nodeDeadReject/7e570001.jsonl
@@ -1,0 +1,29 @@
+{"k":"cacheFormat","v":1}
+{"k":"node.1.isListening","v":true}
+{"k":"node.1.isFrequentListening","v":false}
+{"k":"node.1.isRouting","v":true}
+{"k":"node.1.supportedDataRates","v":[40000,9600,100000]}
+{"k":"node.1.protocolVersion","v":3}
+{"k":"node.1.nodeType","v":"Controller"}
+{"k":"node.1.supportsSecurity","v":false}
+{"k":"node.1.supportsBeaming","v":true}
+{"k":"node.1.deviceClass","v":{"basic":2,"generic":2,"specific":7}}
+{"k":"node.1.endpoint.0.commandClass.0x72","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x86","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x20","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x60","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.interviewStage","v":"Complete"}
+
+{"k":"node.2.isListening","v":true}
+{"k":"node.2.isFrequentListening","v":false}
+{"k":"node.2.isRouting","v":true}
+{"k":"node.2.supportedDataRates","v":[40000,9600,100000]}
+{"k":"node.2.protocolVersion","v":3}
+{"k":"node.2.nodeType","v":"End Node"}
+{"k":"node.2.supportsSecurity","v":false}
+{"k":"node.2.supportsBeaming","v":true}
+{"k":"node.2.deviceClass","v":{"basic":4,"generic":6,"specific":1}}
+// Basic
+{"k":"node.2.endpoint.0.commandClass.0x20","v":{"isSupported":true,"isControlled":false,"secure":false,"version":1}}
+{"k":"node.2.interviewStage","v":"Complete"}
+{"k":"node.2.hasSUCReturnRoute","v":true}

--- a/packages/zwave-js/src/lib/test/driver/nodeDeadReject.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeDeadReject.test.ts
@@ -1,0 +1,196 @@
+import { BasicCCGet, BasicCCSet } from "@zwave-js/cc";
+import { NodeStatus, ZWaveErrorCodes, assertZWaveError } from "@zwave-js/core";
+import { MockZWaveFrameType } from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import path from "path";
+import { integrationTest } from "../integrationTestSuite";
+
+integrationTest(
+	"When a node does not respond because it is dead, the sendCommand() Promise gets rejected (maxSendAttempts: 1)",
+	{
+		// debug: true,
+		provisioningDirectory: path.join(
+			__dirname,
+			"fixtures/nodeDeadReject",
+		),
+
+		testBody: async (t, driver, node2, mockController, mockNode) => {
+			node2.markAsAlive();
+			mockNode.autoAckControllerFrames = false;
+
+			t.is(node2.status, NodeStatus.Alive);
+
+			const command1 = new BasicCCSet(driver, {
+				nodeId: 2,
+				targetValue: 99,
+			});
+			const basicSetPromise = driver.sendCommand(command1, {
+				maxSendAttempts: 1,
+			});
+			basicSetPromise.then(() => {
+				driver.driverLog.print("basicSetPromise resolved");
+			}).catch(() => {
+				driver.driverLog.print("basicSetPromise rejected");
+			}); // Don't throw here, do it below
+
+			const command2 = new BasicCCGet(driver, {
+				nodeId: 2,
+			});
+			const basicGetPromise = driver.sendCommand(command2, {
+				maxSendAttempts: 1,
+			});
+			basicGetPromise.then(() => {
+				driver.driverLog.print("basicGetPromise resolved");
+			}).catch(() => {
+				driver.driverLog.print("basicGetPromise rejected");
+			}); // Don't throw here, do it below
+
+			// The node should have received the first command
+			await wait(50);
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request
+					&& frame.payload instanceof BasicCCSet
+					&& frame.payload.targetValue === 99,
+				{
+					errorMessage: "The first command was not received",
+				},
+			);
+
+			// The command should be rejected
+			await assertZWaveError(t, () => basicSetPromise, {
+				errorCode: ZWaveErrorCodes.Controller_CallbackNOK,
+			});
+			t.is(node2.status, NodeStatus.Dead);
+
+			driver.driverLog.sendQueue(driver["queue"]);
+
+			// The second command should be rejected immediately because the node is dead
+			await assertZWaveError(t, () => basicGetPromise, {
+				errorCode: ZWaveErrorCodes.Controller_MessageDropped,
+			});
+		},
+	},
+);
+
+integrationTest(
+	"When a node does not respond because it is dead, the sendCommand() Promise gets rejected (maxSendAttempts: 2)",
+	{
+		// debug: true,
+		provisioningDirectory: path.join(
+			__dirname,
+			"fixtures/nodeDeadReject",
+		),
+
+		testBody: async (t, driver, node2, mockController, mockNode) => {
+			node2.markAsAlive();
+			mockNode.autoAckControllerFrames = false;
+
+			t.is(node2.status, NodeStatus.Alive);
+
+			const command1 = new BasicCCSet(driver, {
+				nodeId: 2,
+				targetValue: 99,
+			});
+			const basicSetPromise = driver.sendCommand(command1, {
+				maxSendAttempts: 2,
+			});
+			basicSetPromise.then(() => {
+				driver.driverLog.print("basicSetPromise resolved");
+			}).catch(() => {
+				driver.driverLog.print("basicSetPromise rejected");
+			});
+
+			const command2 = new BasicCCGet(driver, {
+				nodeId: 2,
+			});
+			const basicGetPromise = driver.sendCommand(command2, {
+				maxSendAttempts: 2,
+			});
+			basicGetPromise.then(() => {
+				driver.driverLog.print("basicGetPromise resolved");
+			}).catch(() => {
+				driver.driverLog.print("basicGetPromise rejected");
+			});
+
+			// The node should have received the first command
+			await wait(50);
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request
+					&& frame.payload instanceof BasicCCSet
+					&& frame.payload.targetValue === 99,
+				{
+					errorMessage: "The first command was not received",
+				},
+			);
+
+			// The command should be rejected
+			await assertZWaveError(t, () => basicSetPromise, {
+				errorCode: ZWaveErrorCodes.Controller_CallbackNOK,
+			});
+			t.is(node2.status, NodeStatus.Dead);
+
+			driver.driverLog.sendQueue(driver["queue"]);
+
+			// The second command should be rejected immediately because the node is dead
+			await assertZWaveError(t, () => basicGetPromise, {
+				errorCode: ZWaveErrorCodes.Controller_MessageDropped,
+			});
+		},
+	},
+);
+
+integrationTest(
+	"When a node does not respond because it is dead, commands sent via the commandClasses API get rejected",
+	{
+		// debug: true,
+		provisioningDirectory: path.join(
+			__dirname,
+			"fixtures/nodeDeadReject",
+		),
+
+		testBody: async (t, driver, node2, mockController, mockNode) => {
+			node2.markAsAlive();
+			mockNode.autoAckControllerFrames = false;
+
+			t.is(node2.status, NodeStatus.Alive);
+
+			const basicSetPromise = node2.commandClasses.Basic.set(99);
+			basicSetPromise.then(() => {
+				driver.driverLog.print("basicSetPromise resolved");
+			}).catch(() => {
+				driver.driverLog.print("basicSetPromise rejected");
+			});
+			const basicGetPromise = node2.commandClasses.Basic.get();
+			basicGetPromise.then(() => {
+				driver.driverLog.print("basicGetPromise resolved");
+			}).catch(() => {
+				driver.driverLog.print("basicGetPromise rejected");
+			});
+
+			// The node should have received the first command
+			await wait(50);
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request
+					&& frame.payload instanceof BasicCCSet
+					&& frame.payload.targetValue === 99,
+				{
+					errorMessage: "The first command was not received",
+				},
+			);
+
+			// The command should be rejected
+			await assertZWaveError(t, () => basicSetPromise, {
+				errorCode: ZWaveErrorCodes.Controller_CallbackNOK,
+			});
+			t.is(node2.status, NodeStatus.Dead);
+
+			// The second command should be rejected immediately because the node is dead
+			await assertZWaveError(t, () => basicGetPromise, {
+				errorCode: ZWaveErrorCodes.Controller_MessageDropped,
+			});
+		},
+	},
+);


### PR DESCRIPTION
This PR fixes an issue found while trying to reproduce https://github.com/home-assistant/core/issues/98491

Calling `sendCommand` (either directly or indirectly) with `maxSendAttempts > 1` for an unreachable node would result in the Promise being resolved after attempt 1, although the entire transaction would be rejected later.