### PR TITLE
fix: create node instance for controller when node list is empty

### DIFF
--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -1321,10 +1321,10 @@ export class ZWaveController
 				`Controller reports no nodes in its network. This could be an indication of a corrupted controller memory.`,
 				"warn",
 			);
-			nodeIds.push(this._ownNodeId!);
+			nodeIds.unshift(this._ownNodeId!);
 		}
 
-		for (const nodeId of initData.nodeIds) {
+		for (const nodeId of nodeIds) {
 			this._nodes.set(
 				nodeId,
 				new ZWaveNode(


### PR DESCRIPTION
followup to #5745, mentioned in https://github.com/zwave-js/node-zwave-js/commit/a75a943945b0cbee7fb116b08ab01e74a95abc9a#r125614937