### PR TITLE
fix: consider CCs supported by the sending endpoint before discarding unsupported reports

### DIFF
--- a/packages/cc/src/cc/MultilevelSensorCC.ts
+++ b/packages/cc/src/cc/MultilevelSensorCC.ts
@@ -772,11 +772,10 @@ export class MultilevelSensorCCGet extends MultilevelSensorCC {
 	) {
 		super(host, options);
 		if (gotDeserializationOptions(options)) {
-			// TODO: Deserialize payload
-			throw new ZWaveError(
-				`${this.constructor.name}: deserialization not implemented`,
-				ZWaveErrorCodes.Deserialization_NotImplemented,
-			);
+			if (this.payload.length >= 2) {
+				this.sensorType = this.payload[0];
+				this.scale = (this.payload[1] >> 3) & 0b11;
+			}
 		} else {
 			if ("sensorType" in options) {
 				this.sensorType = options.sensorType;

--- a/packages/core/src/values/Primitive.ts
+++ b/packages/core/src/values/Primitive.ts
@@ -178,6 +178,27 @@ export function getIntegerLimits(
 	return (IntegerLimits as any)[`${signed ? "" : "U"}Int${size * 8}`];
 }
 
+export function getFloatParameters(value: number): {
+	precision: number;
+	size: number;
+	roundedValue: number;
+} {
+	const precision = Math.min(getPrecision(value), 7);
+	value = Math.round(value * Math.pow(10, precision));
+	const size: number | undefined = getMinIntegerSize(value, true);
+	if (size == undefined) {
+		throw new ZWaveError(
+			`Cannot encode the value ${value} because its too large or too small to fit into 4 bytes`,
+			ZWaveErrorCodes.Arithmetic,
+		);
+	}
+	return {
+		precision,
+		size,
+		roundedValue: value,
+	};
+}
+
 /**
  * Encodes a floating point value with a scale into a buffer
  * @param override can be used to overwrite the automatic computation of precision and size with fixed values

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -3958,10 +3958,17 @@ ${handlers.length} left`,
 			cc.ccId === CommandClasses.Meter
 			|| cc.ccId === CommandClasses["Multilevel Sensor"]
 		) {
-			if (!node.supportsCC(cc.ccId) && !node.controlsCC(cc.ccId)) {
+			const endpoint = node.getEndpoint(cc.endpointIndex) ?? node;
+			if (
+				!endpoint.supportsCC(cc.ccId) && !endpoint.controlsCC(cc.ccId)
+			) {
 				this.controllerLog.logNode(
 					cc.nodeId as number,
-					`does not support CC ${
+					`${
+						cc.endpointIndex > 0
+							? `Endpoint ${cc.endpointIndex} `
+							: ""
+					}does not support CC ${
 						getCCName(
 							cc.ccId,
 						)

--- a/packages/zwave-js/src/lib/test/cc-specific/discardUnsupportedReports.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/discardUnsupportedReports.test.ts
@@ -1,35 +1,33 @@
 import {
-	BinarySensorCCReport,
-	BinarySensorCCValues,
-	BinarySensorType,
 	type CommandClass,
+	MeterCCReport,
+	MeterCCValues,
+	MultiChannelCCCommandEncapsulation,
 	MultilevelSensorCCReport,
 	MultilevelSensorCCValues,
+	RateType,
 } from "@zwave-js/cc";
-import { CommandClasses } from "@zwave-js/core";
 import { createMockZWaveRequestFrame } from "@zwave-js/testing";
 import { wait } from "alcalzone-shared/async";
+import path from "path";
 import { integrationTest } from "../integrationTestSuite";
 
 integrationTest(
-	"Discard Multilevel Sensor CC on nodes that do not support them",
+	"Discard Multilevel Sensor and Meter CC Reports on nodes and/or endpoints that do not support them",
 	{
-		// debug: true,
-		// provisioningDirectory: path.join(__dirname, "fixtures/configurationCC"),
-
-		nodeCapabilities: {
-			commandClasses: [
-				CommandClasses.Version,
-				CommandClasses["Binary Sensor"],
-			],
-		},
+		debug: true,
+		provisioningDirectory: path.join(
+			__dirname,
+			"fixtures/discardUnsupportedReports",
+		),
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
+			// Unsupported report from root endpoint
 			let cc: CommandClass = new MultilevelSensorCCReport(mockNode.host, {
 				nodeId: mockController.host.ownNodeId,
 				type: 0x01, // Temperature
 				scale: 0x00, // Celsius
-				value: 25.12,
+				value: 1.001,
 			});
 			await mockNode.sendToController(
 				createMockZWaveRequestFrame(cc, {
@@ -37,10 +35,50 @@ integrationTest(
 				}),
 			);
 
-			cc = new BinarySensorCCReport(mockNode.host, {
+			// Report from endpoint 1, unsupported on root
+			cc = new MultilevelSensorCCReport(mockNode.host, {
 				nodeId: mockController.host.ownNodeId,
-				type: BinarySensorType.CO2,
-				value: true,
+				type: 0x01, // Temperature
+				scale: 0x00, // Celsius
+				value: 25.12,
+			});
+			cc = new MultiChannelCCCommandEncapsulation(mockNode.host, {
+				nodeId: mockController.host.ownNodeId,
+				endpoint: 1,
+				destination: 0,
+				encapsulated: cc,
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+
+			// Unsupported Report from endpoint 1, supported on root
+			cc = new MeterCCReport(mockNode.host, {
+				nodeId: mockController.host.ownNodeId,
+				type: 0x01, // Electric
+				scale: 0x00, // kWh
+				value: 1.234,
+			});
+			cc = new MultiChannelCCCommandEncapsulation(mockNode.host, {
+				nodeId: mockController.host.ownNodeId,
+				endpoint: 1,
+				destination: 0,
+				encapsulated: cc,
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+
+			// Supported report from root endpoint
+			cc = new MeterCCReport(mockNode.host, {
+				nodeId: mockController.host.ownNodeId,
+				type: 0x01, // Electric
+				scale: 0x00, // kWh
+				value: 2.34,
 			});
 			await mockNode.sendToController(
 				createMockZWaveRequestFrame(cc, {
@@ -50,15 +88,27 @@ integrationTest(
 
 			await wait(100);
 
-			const temperature = node.getValue(
-				MultilevelSensorCCValues.value("Air temperature").id,
+			const sensorValue = MultilevelSensorCCValues.value(
+				"Air temperature",
 			);
-			t.is(temperature, undefined);
+			const temperature0 = node.getValue(
+				sensorValue.id,
+			);
+			t.is(temperature0, undefined);
 
-			const co2 = node.getValue(
-				BinarySensorCCValues.state(BinarySensorType.CO2).id,
+			const temperature1 = node.getValue(sensorValue.endpoint(1));
+			t.is(temperature1, 25.12);
+
+			const meterValue = MeterCCValues.value(
+				0x01,
+				RateType.Unspecified,
+				0x00,
 			);
-			t.is(co2, true);
+			const meter0 = node.getValue(meterValue.id);
+			t.is(meter0, 2.34);
+
+			const meter1 = node.getValue(meterValue.endpoint(1));
+			t.is(meter1, undefined);
 		},
 	},
 );

--- a/packages/zwave-js/src/lib/test/cc-specific/fixtures/discardUnsupportedReports/7e570001.jsonl
+++ b/packages/zwave-js/src/lib/test/cc-specific/fixtures/discardUnsupportedReports/7e570001.jsonl
@@ -1,0 +1,36 @@
+{"k":"cacheFormat","v":1}
+{"k":"node.1.isListening","v":true}
+{"k":"node.1.isFrequentListening","v":false}
+{"k":"node.1.isRouting","v":true}
+{"k":"node.1.supportedDataRates","v":[40000,9600,100000]}
+{"k":"node.1.protocolVersion","v":3}
+{"k":"node.1.nodeType","v":"Controller"}
+{"k":"node.1.supportsSecurity","v":false}
+{"k":"node.1.supportsBeaming","v":true}
+{"k":"node.1.deviceClass","v":{"basic":2,"generic":2,"specific":7}}
+{"k":"node.1.endpoint.0.commandClass.0x72","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x86","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x20","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x60","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.interviewStage","v":"Complete"}
+
+{"k":"node.2.isListening","v":true}
+{"k":"node.2.isFrequentListening","v":false}
+{"k":"node.2.isRouting","v":true}
+{"k":"node.2.supportedDataRates","v":[40000,9600,100000]}
+{"k":"node.2.protocolVersion","v":3}
+{"k":"node.2.nodeType","v":"End Node"}
+{"k":"node.2.supportsSecurity","v":false}
+{"k":"node.2.supportsBeaming","v":true}
+{"k":"node.2.deviceClass","v":{"basic":4,"generic":6,"specific":1}}
+{"k":"node.2.interviewStage","v":"NodeInfo"}
+{"k":"node.2.endpoint.0.commandClass.0x86","v":{"isSupported":true,"isControlled":false,"secure":false,"version":1}}
+{"k":"node.2.endpoint.0.commandClass.0x30","v":{"isSupported":true,"isControlled":false,"secure":false,"version":1}}
+{"k":"node.2.endpoint.0.commandClass.0x60","v":{"isSupported":true,"isControlled":false,"secure":false,"version":2}}
+{"k":"node.2.endpoint.0.commandClass.0x20","v":{"isSupported":true,"isControlled":false,"secure":false,"version":1}}
+// Support Meter CC only on the root endpoint
+{"k":"node.2.endpoint.0.commandClass.0x32","v":{"isSupported":true,"isControlled":false,"secure":false,"version":1}}
+// Support Multilevel Sensor CC only on endpoint 1
+{"k":"node.2.endpoint.1.commandClass.0x31","v":{"isSupported":true,"isControlled":false,"secure":false,"version":1}}
+{"k":"node.2.interviewStage","v":"Complete"}
+{"k":"node.2.hasSUCReturnRoute","v":true}

--- a/packages/zwave-js/src/lib/test/cc-specific/fixtures/discardUnsupportedReports/7e570001.values.jsonl
+++ b/packages/zwave-js/src/lib/test/cc-specific/fixtures/discardUnsupportedReports/7e570001.values.jsonl
@@ -1,0 +1,7 @@
+{"k":"{\"nodeId\":2,\"commandClass\":96,\"endpoint\":0,\"property\":\"countIsDynamic\"}","v":false,"ts":1693226159259}
+{"k":"{\"nodeId\":2,\"commandClass\":96,\"endpoint\":0,\"property\":\"identicalCapabilities\"}","v":false,"ts":1693226159260}
+{"k":"{\"nodeId\":2,\"commandClass\":96,\"endpoint\":0,\"property\":\"individualCount\"}","v":1,"ts":1693226159260}
+{"k":"{\"nodeId\":2,\"commandClass\":96,\"endpoint\":1,\"property\":\"deviceClass\"}","v":{"generic":6,"specific":1},"ts":1693226159330}
+{"k":"{\"nodeId\":2,\"commandClass\":96,\"endpoint\":1,\"property\":\"commandClasses\"}","v":[49],"ts":1693226159330}
+{"k":"{\"nodeId\":2,\"commandClass\":96,\"endpoint\":0,\"property\":\"endpointIndizes\"}","v":[1],"ts":1693226159395}
+{"k":"{\"nodeId\":2,\"commandClass\":96,\"endpoint\":0,\"property\":\"interviewComplete\"}","v":true,"ts":1693226159395}


### PR DESCRIPTION
This PR fixes a regression introduced by #6178, which causes valid reports to be discarded if the root endpoint doesn't support the CC, but the sending endpoint does.

fixes: https://github.com/zwave-js/node-zwave-js/issues/6217
fixes: https://github.com/zwave-js/node-zwave-js/issues/6215