### PR TITLE
feat: optimize order of node communication during startup

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1502,7 +1502,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks>
 			// The controller node is always alive
 			controllerNode.markAsAlive();
 
-			// Then do all the nodes in parallel, but prioritize nodes that have more recently been in contact with the controller
+			// Then do all the nodes in parallel, but prioritize nodes that are more likely to be ready
 			const nodeInterviewOrder = [...this._controller.nodes.values()]
 				.filter((n) => n.id !== this._controller!.ownNodeId)
 				.sort((a, b) =>

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1499,12 +1499,34 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks>
 				this._controller.ownNodeId!,
 			)!;
 			await this.interviewNodeInternal(controllerNode);
+			// The controller node is always alive
+			controllerNode.markAsAlive();
 
-			// Then do all the nodes in parallel
-			for (const node of this._controller.nodes.values()) {
+			// Then do all the nodes in parallel, but prioritize nodes that have more recently been in contact with the controller
+			const nodeInterviewOrder = [...this._controller.nodes.values()]
+				.filter((n) => n.id !== this._controller!.ownNodeId)
+				.sort((a, b) =>
+					// Listening devices first
+					(
+						(b.isListening ? 2 : b.isFrequentListening ? 1 : 0)
+						- (a.isListening ? 2 : a.isFrequentListening ? 1 : 0)
+					)
+					// Then by last seen, more recently first
+					|| (
+						(b.lastSeen?.getTime() ?? 0)
+						- (a.lastSeen?.getTime() ?? 0)
+					)
+					// Then ascending by node ID
+					|| (a.nodeId - b.nodeId)
+				);
+
+			this.controllerLog.print(
+				`Interviewing nodes and/or determining their status: ${
+					nodeInterviewOrder.map((n) => n.id).join(", ")
+				}`,
+			);
+			for (const node of nodeInterviewOrder) {
 				if (node.id === this._controller.ownNodeId) {
-					// The controller is always alive
-					node.markAsAlive();
 					continue;
 				} else if (node.canSleep) {
 					// A node that can sleep should be assumed to be sleeping after resuming from cache
@@ -1515,8 +1537,6 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks>
 					// Continue the interview if necessary. If that is not necessary, at least
 					// determine the node's status
 					if (node.interviewStage < InterviewStage.Complete) {
-						// don't await the interview, because it may take a very long time
-						// if a node is asleep
 						await this.interviewNodeInternal(node);
 					} else if (node.isListening || node.isFrequentListening) {
 						// Ping non-sleeping nodes to determine their status

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1506,8 +1506,10 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks>
 			const nodeInterviewOrder = [...this._controller.nodes.values()]
 				.filter((n) => n.id !== this._controller!.ownNodeId)
 				.sort((a, b) =>
-					// Listening devices first
-					(
+					// Fully-interviewed devices first (need the least amount of communication now)
+					(b.interviewStage - a.interviewStage)
+					// Always listening -> FLiRS -> sleeping
+					|| (
 						(b.isListening ? 2 : b.isFrequentListening ? 1 : 0)
 						- (a.isListening ? 2 : a.isFrequentListening ? 1 : 0)
 					)
@@ -1516,7 +1518,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks>
 						(b.lastSeen?.getTime() ?? 0)
 						- (a.lastSeen?.getTime() ?? 0)
 					)
-					// Then ascending by node ID
+					// Lastly ascending by node ID
 					|| (a.nodeId - b.nodeId)
 				);
 

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1519,7 +1519,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks>
 						- (a.lastSeen?.getTime() ?? 0)
 					)
 					// Lastly ascending by node ID
-					|| (a.nodeId - b.nodeId)
+					|| (a.id - b.id)
 				);
 
 			this.controllerLog.print(


### PR DESCRIPTION
Prior to this PR, communication with nodes on startup was sequenced purely by node ID, which leads to unresponsive devices delaying the `"ready"` event for responsive devices.

We now use the following heuristic to prioritize devices during this phase:
- Fully-interviewed devices come first (often just need a ping or nothing at all)
- Always listening devices come first, then FLiRS, then sleeping devices
- Among those, the order is determined by the `lastSeen` flag, more recently active devices come first
- Lastly, we sort ascending by node ID

This should ensure that fully-interviewed responsive devices are ready almost immediately on startup, even if they have a high node ID.