### PR TITLE
feat: detect an unresponsive stick and reset it

### DIFF
--- a/packages/core/src/consts/Transmission.ts
+++ b/packages/core/src/consts/Transmission.ts
@@ -7,18 +7,18 @@ import { Duration } from "../values/Duration";
 
 /** The priority of messages, sorted from high (0) to low (>0) */
 export enum MessagePriority {
-	// Some messages like nonces, responses to Supervision and Transport Service
-	// need to be handled before all others. We use this priority to decide which
-	// message goes onto the immediate queue.
-	Immediate = 0,
+	// High-priority controller commands that must be handled before all other commands.
+	// We use this priority to decide which messages go onto the immediate queue.
+	ControllerImmediate = 0,
+	// Controller commands finish quickly and should be preferred over node queries
+	Controller,
+	// Some node commands like nonces, responses to Supervision and Transport Service
+	// need to be handled before all node commands.
+	// We use this priority to decide which messages go onto the immediate queue.
+	Immediate,
 	// To avoid S2 collisions, some commands that normally have Immediate priority
 	// have to go onto the normal queue, but still before all other messages
 	ImmediateLow,
-	// Controller commands usually finish quickly and should be preferred over node queries
-	Controller,
-	// Multistep controller commands typically require user interaction but still
-	// should happen at a higher priority than any node data exchange
-	MultistepController,
 	// Pings (NoOP) are used for device probing at startup and for network diagnostics
 	Ping,
 	// Whenever sleeping devices wake up, their queued messages must be handled quickly

--- a/packages/core/src/error/ZWaveError.ts
+++ b/packages/core/src/error/ZWaveError.ts
@@ -275,3 +275,11 @@ export function isRecoverableZWaveError(e: unknown): e is ZWaveError {
 	}
 	return false;
 }
+
+export function isMissingControllerACK(
+	e: unknown,
+): e is ZWaveError {
+	return isZWaveError(e)
+		&& e.code === ZWaveErrorCodes.Controller_Timeout
+		&& e.context === "ACK";
+}

--- a/packages/shared/src/wrappingCounter.ts
+++ b/packages/shared/src/wrappingCounter.ts
@@ -7,16 +7,10 @@ export function createWrappingCounter(
 	maxValue: number,
 	randomSeed: boolean = false,
 ): () => number {
-	const ret = (() => {
-		ret.value = (ret.value + 1) & maxValue;
-		if (ret.value === 0) ret.value = 1;
-		return ret.value;
-	}) as {
-		(): number;
-		// Little hack for testing purposes.
-		// TODO: Remove when packages/zwave-js/src/lib/test/driver/nodeAsleepBlockNonceReport.test.ts no longer needs this
-		value: number;
+	let value = randomSeed ? Math.round(Math.random() * maxValue) : 0;
+	return () => {
+		value = (value + 1) & maxValue;
+		if (value === 0) value = 1;
+		return value;
 	};
-	ret.value = randomSeed ? Math.round(Math.random() * maxValue) : 0;
-	return ret;
 }

--- a/packages/testing/src/MockController.ts
+++ b/packages/testing/src/MockController.ts
@@ -100,6 +100,7 @@ export class MockController {
 
 	public readonly serial: MockPortBinding;
 	private readonly serialParser: SerialAPIParser;
+
 	private expectedHostACKs: TimedExpectation[] = [];
 	private expectedHostMessages: TimedExpectation<Message, Message>[] = [];
 	private expectedNodeFrames: Map<
@@ -140,6 +141,8 @@ export class MockController {
 	/** Can be used by behaviors to store controller related state */
 	public readonly state = new Map<string, unknown>();
 
+	/** Controls whether the controller automatically ACKs messages from the host before handling them */
+	public autoAckHostMessages: boolean = true;
 	/** Controls whether the controller automatically ACKs node frames before handling them */
 	public autoAckNodeFrames: boolean = true;
 
@@ -179,8 +182,10 @@ export class MockController {
 				parseCCs: false,
 			});
 			this.receivedHostMessages.push(msg);
-			// all good, respond with ACK
-			this.sendHeaderToHost(MessageHeaders.ACK);
+			if (this.autoAckHostMessages) {
+				// all good, respond with ACK
+				this.sendHeaderToHost(MessageHeaders.ACK);
+			}
 		} catch (e: any) {
 			throw new Error(
 				`Mock controller received an invalid message from the host: ${e.stack}`,

--- a/packages/testing/src/MockController.ts
+++ b/packages/testing/src/MockController.ts
@@ -184,7 +184,7 @@ export class MockController {
 			this.receivedHostMessages.push(msg);
 			if (this.autoAckHostMessages) {
 				// all good, respond with ACK
-				this.sendHeaderToHost(MessageHeaders.ACK);
+				this.ackHostMessage();
 			}
 		} catch (e: any) {
 			throw new Error(
@@ -330,6 +330,13 @@ export class MockController {
 		this.serial.emitData(data);
 		// TODO: make the timeout match the configured ACK timeout
 		await this.expectHostACK(1000);
+	}
+
+	/**
+	 * Sends an ACK frame to the host
+	 */
+	public ackHostMessage(): void {
+		this.sendHeaderToHost(MessageHeaders.ACK);
 	}
 
 	/** Gets called when a {@link MockZWaveFrame} is received from a {@link MockNode} */

--- a/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
+++ b/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
@@ -225,7 +225,7 @@ const respondToGetSerialApiInitData: MockControllerBehavior = {
 };
 
 const respondToSoftReset: MockControllerBehavior = {
-	async onHostMessage(host, controller, msg) {
+	onHostMessage(host, controller, msg) {
 		if (msg instanceof SoftResetRequest) {
 			const ret = new SerialAPIStartedRequest(host, {
 				wakeUpReason: SerialAPIWakeUpReason.SoftwareReset,
@@ -234,7 +234,9 @@ const respondToSoftReset: MockControllerBehavior = {
 				...determineNIF(),
 				supportsLongRange: controller.capabilities.supportsLongRange,
 			});
-			await controller.sendToHost(ret.serialize());
+			setImmediate(async () => {
+				await controller.sendToHost(ret.serialize());
+			});
 			return true;
 		}
 	},

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -84,6 +84,7 @@ import {
 	deserializeCacheValue,
 	getCCName,
 	highResTimestamp,
+	isMissingControllerACK,
 	isZWaveError,
 	messageRecordToLines,
 	securityClassIsS2,
@@ -533,8 +534,16 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks>
 
 		this.immediateQueue = new TransactionQueue({
 			name: "immediate",
-			// Messages on the immediate queue may always be sent unless the queue is paused
-			mayStartNextTransaction: () => !this.queuePaused,
+			mayStartNextTransaction: (t) => {
+				// While the controller is unresponsive, only soft resetting is allowed
+				if (this.controller.status === ControllerStatus.Unresponsive) {
+					return t.message instanceof SoftResetRequest;
+				}
+
+				// All other messages on the immediate queue may always be sent as long as the controller is ready to send
+				return !this.queuePaused
+					&& this.controller.status === ControllerStatus.Ready;
+			},
 		});
 		this.queue = new TransactionQueue({
 			name: "normal",
@@ -1341,7 +1350,11 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks>
 			this._controller = new ZWaveController(this);
 			this._controller
 				.on("node added", this.onNodeAdded.bind(this))
-				.on("node removed", this.onNodeRemoved.bind(this));
+				.on("node removed", this.onNodeRemoved.bind(this))
+				.on(
+					"status changed",
+					this.onControllerStatusChanged.bind(this),
+				);
 		}
 
 		if (!this._options.testingHooks?.skipControllerIdentification) {
@@ -2105,6 +2118,10 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks>
 		this.checkAllNodesReady();
 	}
 
+	private onControllerStatusChanged(_status: ControllerStatus): void {
+		this.triggerQueues();
+	}
+
 	/**
 	 * Returns the time in seconds to actually wait after a firmware upgrade, depending on what the device said.
 	 * This number will always be a bit greater than the advertised duration, because devices have been found to take longer to actually reboot.
@@ -2634,6 +2651,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks>
 				this.unpauseSendQueue();
 				await this.sendMessage(new GetControllerVersionRequest(this), {
 					supportCheck: false,
+					priority: MessagePriority.ControllerImmediate,
 				});
 				this.pauseSendQueue();
 				this.controllerLog.print("Serial API responded");
@@ -3463,6 +3481,55 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks>
 			this.rejectAllTransactionsForNode(node.id, errorMsg);
 
 			return true;
+		}
+	}
+
+	private handleMissingControllerACK(
+		transaction: Transaction,
+		_error: ZWaveError,
+	): boolean {
+		if (!this._controller) return false;
+
+		const fail = () => {
+			this.driverLog.print(
+				"Recovering unresponsive controller failed. Restarting the driver...",
+				"error",
+			);
+			void this.destroy();
+		};
+
+		if (this._controller.status !== ControllerStatus.Unresponsive) {
+			// The controller was responsive before this transaction failed.
+			// Mark it as unresponsive and try to soft-reset it.
+			this.controller.setStatus(
+				ControllerStatus.Unresponsive,
+			);
+
+			this.driverLog.print(
+				"Attempting to recover unresponsive controller...",
+				"warn",
+			);
+
+			// Re-queue the transaction.
+			// Its message generator may have finished, so reset that too.
+			transaction.reset();
+			this.queue.add(transaction.clone());
+
+			// Execute the soft-reset asynchronously
+			void this.softReset().then(() => {
+				// The controller responded. It is no longer unresponsive
+				this._controller?.setStatus(ControllerStatus.Ready);
+			}).catch(() => {
+				// Soft-reset failed, try restarting the driver
+				fail();
+			});
+
+			return true;
+		} else {
+			// We already attempted to recover from an unresponsive controller.
+			// Ending up here means the soft-reset also failed
+			fail();
+			return false;
 		}
 	}
 
@@ -4459,11 +4526,20 @@ ${handlers.length} left`,
 	}
 
 	private mayStartTransaction(transaction: Transaction): boolean {
-		// We may not send anything if the send thread is paused
-		if (this.queuePaused) return false;
+		// We may not send anything on the normal queue if the send thread is paused
+		// or the controller is unresponsive
+		if (
+			this.queuePaused
+			|| this.controller.status === ControllerStatus.Unresponsive
+		) {
+			return false;
+		}
 
 		const message = transaction.message;
 		const targetNode = message.getNodeUnsafe(this);
+
+		// Messages to the controller may always be sent...
+		if (!targetNode) return true;
 
 		// The transaction queue is sorted automatically. If the first message is for a sleeping node, all messages in the queue are.
 		// There are a few exceptions:
@@ -4477,8 +4553,6 @@ ${handlers.length} left`,
 
 		// Pings may always be sent
 		if (messageIsPing(message)) return true;
-		// Or messages to the controller
-		if (!targetNode) return true;
 
 		return (
 			targetNode.status !== NodeStatus.Asleep
@@ -4548,7 +4622,6 @@ ${handlers.length} left`,
 					);
 					if (isTransmitReport(prevResult)) {
 						// Figure out if the controller is jammed. If it is, wait a second and try again.
-
 						// https://github.com/zwave-js/node-zwave-js/issues/6199
 						// In some cases, the transmit status can be Fail, even after transmitting for a couple of seconds.
 						// Not sure what causes this, but it doesn't mean that the controller is jammed.
@@ -4568,7 +4641,7 @@ ${handlers.length} left`,
 						if (
 							this.controller.status === ControllerStatus.Jammed
 						) {
-							// The controller status is no longer uncertain
+							// A command could be sent, so the controller is no longer jammed
 							this.controller.setStatus(ControllerStatus.Ready);
 						}
 
@@ -4610,6 +4683,9 @@ ${handlers.length} left`,
 							await this.abortSendData();
 							// Wait a short amount of time so everything can settle
 							delay = 50;
+						} else if (isMissingControllerACK(e)) {
+							// The controller is unresponsive. Reject the transaction, so we can attempt to recover
+							throw e;
 						}
 
 						if (
@@ -4906,7 +4982,10 @@ ${handlers.length} left`,
 		transaction.tag = options.tag;
 
 		// And queue it
-		if (transaction.priority === MessagePriority.Immediate) {
+		if (
+			transaction.priority === MessagePriority.Immediate
+			|| transaction.priority === MessagePriority.ControllerImmediate
+		) {
 			this.immediateQueue.add(transaction);
 		} else {
 			this.queue.add(transaction);
@@ -5424,6 +5503,9 @@ ${handlers.length} left`,
 		// If a node failed to respond in time, it might be sleeping
 		if (this.isMissingNodeACK(transaction, error)) {
 			if (this.handleMissingNodeACK(transaction as any, error)) return;
+		} else if (isMissingControllerACK(error)) {
+			// If the controller failed to respond in time, we attempt to recover from this
+			if (this.handleMissingControllerACK(transaction, error)) return;
 		}
 
 		transaction.setProgress({

--- a/packages/zwave-js/src/lib/driver/MessageGenerators.ts
+++ b/packages/zwave-js/src/lib/driver/MessageGenerators.ts
@@ -896,12 +896,11 @@ export function createMessageGenerator<TResponse extends Message = Message>(
 		parent: undefined as any, // The transaction will set this field on creation
 		current: undefined,
 		self: undefined,
+		reset: () => {
+			generator.current = undefined;
+			generator.self = undefined;
+		},
 		start: () => {
-			const resetGenerator = () => {
-				generator.current = undefined;
-				generator.self = undefined;
-			};
-
 			async function* gen() {
 				// Determine which message generator implementation should be used
 				let implementation: MessageGeneratorImplementation =
@@ -947,7 +946,7 @@ export function createMessageGenerator<TResponse extends Message = Message>(
 						} else if (isTransmitReport(e) && !e.isOK()) {
 							// The generator was prematurely ended by throwing a NOK transmit report.
 							// The driver may want to retry it, so reset the generator
-							resetGenerator();
+							generator.reset();
 							return;
 						} else {
 							// The generator was prematurely ended by throwing a Message
@@ -958,9 +957,10 @@ export function createMessageGenerator<TResponse extends Message = Message>(
 				}
 
 				resultPromise.resolve(result as TResponse);
-				resetGenerator();
+				generator.reset();
 				return;
 			}
+
 			generator.self = gen();
 			return generator.self;
 		},

--- a/packages/zwave-js/src/lib/driver/Transaction.ts
+++ b/packages/zwave-js/src/lib/driver/Transaction.ts
@@ -21,6 +21,8 @@ export interface MessageGenerator {
 	parent: Transaction;
 	/** Start a new copy of this message generator */
 	start: () => AsyncGenerator<Message, void, Message>;
+	/** Resets this message generator so it can be started anew */
+	reset: () => void;
 	/** A reference to the currently running message generator if it was already started */
 	self?: ReturnType<MessageGenerator["start"]>;
 	/** A reference to the last generated message, or undefined if the generator wasn't started or has finished */
@@ -121,6 +123,13 @@ export class Transaction implements Comparable<Transaction> {
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Resets this transaction's message generator
+	 */
+	public reset(): void {
+		this.parts.reset();
 	}
 
 	public async generateNextMessage(

--- a/packages/zwave-js/src/lib/log/Driver.test.ts
+++ b/packages/zwave-js/src/lib/log/Driver.test.ts
@@ -226,11 +226,11 @@ test.serial(
 		const { driver, driverLogger, spyTransport } = t.context;
 		driverLogger.transaction(
 			createTransaction(driver, {
-				priority: MessagePriority.MultistepController,
+				priority: MessagePriority.Controller,
 			}),
 		);
 		assertMessage(t, spyTransport, {
-			predicate: (msg) => msg.includes("[P: MultistepController]"),
+			predicate: (msg) => msg.includes("[P: Controller]"),
 		});
 	},
 );

--- a/packages/zwave-js/src/lib/serialapi/misc/SoftResetRequest.ts
+++ b/packages/zwave-js/src/lib/serialapi/misc/SoftResetRequest.ts
@@ -8,5 +8,5 @@ import {
 } from "@zwave-js/serial";
 
 @messageTypes(MessageType.Request, FunctionType.SoftReset)
-@priority(MessagePriority.Controller)
+@priority(MessagePriority.ControllerImmediate)
 export class SoftResetRequest extends Message {}

--- a/packages/zwave-js/src/lib/test/cc-specific/discardUnsupportedReports.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/discardUnsupportedReports.test.ts
@@ -15,7 +15,8 @@ import { integrationTest } from "../integrationTestSuite";
 integrationTest(
 	"Discard Multilevel Sensor and Meter CC Reports on nodes and/or endpoints that do not support them",
 	{
-		debug: true,
+		// debug: true,
+
 		provisioningDirectory: path.join(
 			__dirname,
 			"fixtures/discardUnsupportedReports",

--- a/packages/zwave-js/src/lib/test/driver/fixtures/nodeAsleepBlockNonceReport/7e570001.jsonl
+++ b/packages/zwave-js/src/lib/test/driver/fixtures/nodeAsleepBlockNonceReport/7e570001.jsonl
@@ -1,0 +1,36 @@
+{"k":"cacheFormat","v":1}
+{"k":"node.1.isListening","v":true}
+{"k":"node.1.isFrequentListening","v":false}
+{"k":"node.1.isRouting","v":true}
+{"k":"node.1.supportedDataRates","v":[40000,9600,100000]}
+{"k":"node.1.protocolVersion","v":3}
+{"k":"node.1.nodeType","v":"Controller"}
+{"k":"node.1.supportsSecurity","v":false}
+{"k":"node.1.supportsBeaming","v":true}
+{"k":"node.1.deviceClass","v":{"basic":2,"generic":2,"specific":7}}
+{"k":"node.1.endpoint.0.commandClass.0x72","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x86","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x20","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x60","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.interviewStage","v":"Complete"}
+
+{"k":"node.2.isListening","v":false}
+{"k":"node.2.isFrequentListening","v":false}
+{"k":"node.2.isRouting","v":true}
+{"k":"node.2.supportedDataRates","v":[40000,9600,100000]}
+{"k":"node.2.protocolVersion","v":3}
+{"k":"node.2.nodeType","v":"End Node"}
+{"k":"node.2.supportsSecurity","v":false}
+{"k":"node.2.supportsBeaming","v":true}
+{"k":"node.2.deviceClass","v":{"basic":4,"generic":6,"specific":1}}
+
+// Basic
+{"k":"node.2.endpoint.0.commandClass.0x20","v":{"isSupported":true,"isControlled":false,"secure":false,"version":1}}
+// Wakeup
+{"k":"node.2.endpoint.0.commandClass.0x84","v":{"isSupported":true,"isControlled":false,"secure":false,"version":1}}
+// Security S0
+{"k":"node.2.endpoint.0.commandClass.0x98","v":{"isSupported":true,"isControlled":false,"secure":true,"version":1}}
+{"k":"node.2.securityClasses.S0_Legacy","v":true}
+
+{"k":"node.2.interviewStage","v":"Complete"}
+{"k":"node.2.hasSUCReturnRoute","v":true}

--- a/packages/zwave-js/src/lib/test/driver/unresponsiveStick.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/unresponsiveStick.test.ts
@@ -1,0 +1,35 @@
+import { type MockControllerBehavior } from "@zwave-js/testing";
+import {
+	GetControllerIdRequest,
+	type GetControllerIdResponse,
+} from "../../serialapi/memory/GetControllerIdMessages";
+import { integrationTest } from "../integrationTestSuite";
+
+let shouldRespond = true;
+
+integrationTest("Detect an unresponsive stick and reset it", {
+	debug: true,
+
+	async customSetup(driver, mockController, mockNode) {
+		const doNotRespond: MockControllerBehavior = {
+			onHostMessage(host, controller, msg) {
+				if (!shouldRespond) return true;
+
+				return false;
+			},
+		};
+		mockController.defineBehavior(doNotRespond);
+	},
+
+	async testBody(t, driver, node, mockController, mockNode) {
+		shouldRespond = false;
+		mockController.autoAckHostMessages = false;
+
+		const ids = await driver.sendMessage<GetControllerIdResponse>(
+			new GetControllerIdRequest(driver),
+			{ supportCheck: false },
+		);
+
+		t.not(ids, undefined);
+	},
+});

--- a/packages/zwave-js/src/lib/test/driver/unresponsiveStick.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/unresponsiveStick.test.ts
@@ -9,7 +9,7 @@ import { integrationTest } from "../integrationTestSuite";
 let shouldRespond = true;
 
 integrationTest("Attempt to soft-reset the stick when it is unresponsive", {
-	debug: true,
+	// debug: true,
 
 	async customSetup(driver, mockController, mockNode) {
 		const doNotRespond: MockControllerBehavior = {


### PR DESCRIPTION
This PR makes use of the previously-added `Unresponsive` controller status by adding a detection for an unresponsive controller (not ACKing serial API commands). When this situation happens, we soft-reset the controller in an attempt to recover. If that does not help either, the driver instance gets destroyed.
This should trigger a restart in most applications, which effectively closes and re-opens the serial port.

fixes: #2723