### PR TITLE
fix: forbid managing SUC routes with the non-SUC method variants

### DIFF
--- a/docs/getting-started/migrating-to-v12.md
+++ b/docs/getting-started/migrating-to-v12.md
@@ -54,6 +54,23 @@ const updateInfo = updateInfos[0];
 await controller.firmwareUpdateOTA(nodeId, updateInfo);
 ```
 
+## Managing (custom/priority) return routes to the SUC (primary controller) must be done with the `...SUCReturnRoutes` methods
+
+Managing return routes has been an inconsistent topic before. Since the protocol distinguishes between SUC return routes and return routes between end nodes, we do the same.
+Previously, calling `assignReturnRoutes` (and similar) with the SUC (Z-Wave JS's node ID) as the destination would automatically do the correct thing and call `assignSUCReturnRoutes` (and similar). However, calling `deleteReturnRoutes` would not delete the SUC return routes, but the return routes between end nodes. This was inconsistent and confusing.
+
+Attempting to manage the return routes to the SUC (where the destination node ID is `controller.ownNodeId`) without using the `...SUCReturnRoutes` methods will now throw an error, explaining which method to use instead.
+
+## Removed some deprecated methods
+
+The following methods were deprecated/renamed and have now been removed:
+
+- `Controller.assignSUCReturnRoute`: Use `Controller.assignSUCReturnRoutes` instead
+- `Controller.deleteSUCReturnRoute`: Use `Controller.deleteSUCReturnRoutes` instead
+- `Controller.assignReturnRoute`: Use `Controller.assignReturnRoutes` instead
+- `Controller.deleteReturnRoute`: Use `Controller.deleteReturnRoutes` instead
+- `Driver.enableErrorReporting`: Error reporting has been fully removed
+
 ## `ZWaveHost.getNextSupervisionSessionId` requires a node ID now
 
 This change only concerns custom implementations of the `ZWaveHost` interface and should not affect most users/codebases. The `Supervision` session IDs must be tracked per node now and not globally:
@@ -65,13 +82,3 @@ interface ZWaveHost {
 +	getNextSupervisionSessionId(nodeId: number): number;
 }
 ```
-
-## Removed some deprecated methods
-
-The following methods were deprecated/renamed and have now been removed:
-
-- `Controller.assignSUCReturnRoute`: Use `Controller.assignSUCReturnRoutes` instead
-- `Controller.deleteSUCReturnRoute`: Use `Controller.deleteSUCReturnRoutes` instead
-- `Controller.assignReturnRoute`: Use `Controller.assignReturnRoutes` instead
-- `Controller.deleteReturnRoute`: Use `Controller.deleteReturnRoutes` instead
-- `Driver.enableErrorReporting`: Error reporting has been fully removed

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -4536,7 +4536,10 @@ ${associatedNodes.join(", ")}`,
 	): Promise<boolean> {
 		// Make sure this is not misused by passing the controller's node ID
 		if (destinationNodeId === this.ownNodeId) {
-			return this.assignSUCReturnRoutes(nodeId);
+			throw new ZWaveError(
+				`To assign a return route to the SUC (node ID ${destinationNodeId}), assignSUCReturnRoutes() must be used!`,
+				ZWaveErrorCodes.Argument_Invalid,
+			);
 		}
 
 		this.driver.controllerLog.logNode(nodeId, {
@@ -4605,10 +4608,9 @@ ${associatedNodes.join(", ")}`,
 	): Promise<boolean> {
 		// Make sure this is not misused by passing the controller's node ID
 		if (destinationNodeId === this.ownNodeId) {
-			return this.assignCustomSUCReturnRoutes(
-				nodeId,
-				routes,
-				priorityRoute,
+			throw new ZWaveError(
+				`To assign custom return routes to the SUC (node ID ${destinationNodeId}), assignCustomSUCReturnRoutes() must be used!`,
+				ZWaveErrorCodes.Argument_Invalid,
 			);
 		}
 
@@ -4777,10 +4779,9 @@ ${associatedNodes.join(", ")}`,
 	): Promise<boolean> {
 		// Make sure this is not misused by passing the controller's node ID
 		if (destinationNodeId === this.ownNodeId) {
-			return this.assignPrioritySUCReturnRoute(
-				nodeId,
-				repeaters,
-				routeSpeed,
+			throw new ZWaveError(
+				`To assign a priority return route to the SUC (node ID ${destinationNodeId}), assignPrioritySUCReturnRoute() must be used!`,
+				ZWaveErrorCodes.Argument_Invalid,
 			);
 		}
 


### PR DESCRIPTION
Managing return routes has been an inconsistent topic before. Since the protocol distinguishes between SUC return routes and return routes between end nodes, we do the same.
Previously, calling `assignReturnRoutes` (and similar) with the SUC (Z-Wave JS's node ID) as the destination would automatically do the correct thing and call `assignSUCReturnRoutes` (and similar). However, calling `deleteReturnRoutes` would not delete the SUC return routes, but the return routes between end nodes. This was inconsistent and confusing.

Attempting to manage the return routes to the SUC (where the destination node ID is `controller.ownNodeId`) without using the `...SUCReturnRoutes` methods will now throw an error, explaining which method to use instead.

fixes: #5971