### PR TITLE
fix: argument type for `updateLogConfig` and `updateOptions`

### DIFF
--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -242,7 +242,7 @@ Unregisters a message handler that has been added with `registerRequestHandler`
 ### `updateLogConfig`
 
 ```ts
-updateLogConfig(config: DeepPartial<LogConfig>): void
+updateLogConfig(config: Partial<LogConfig>): void
 ```
 
 Updates the logging configuration without having to restart the driver.

--- a/packages/core/src/log/shared.ts
+++ b/packages/core/src/log/shared.ts
@@ -1,4 +1,4 @@
-import { type DeepPartial, flatMap } from "@zwave-js/shared";
+import { flatMap } from "@zwave-js/shared";
 import type { Format, TransformFunction } from "logform";
 import * as path from "node:path";
 import { MESSAGE, configs } from "triple-beam";
@@ -61,7 +61,7 @@ export class ZWaveLogContainer extends winston.Container {
 		forceConsole: false,
 	};
 
-	constructor(config: DeepPartial<LogConfig> = {}) {
+	constructor(config: Partial<LogConfig> = {}) {
 		super();
 		this.updateConfiguration(config);
 	}
@@ -80,7 +80,7 @@ export class ZWaveLogContainer extends winston.Container {
 		return this.get(label) as unknown as ZWaveLogger;
 	}
 
-	public updateConfiguration(config: DeepPartial<LogConfig>): void {
+	public updateConfiguration(config: Partial<LogConfig>): void {
 		// Avoid overwriting configuration settings with undefined if they shouldn't be
 		for (const key of nonUndefinedLogConfigKeys) {
 			if (key in config && config[key] === undefined) {

--- a/packages/zwave-js/src/Driver.ts
+++ b/packages/zwave-js/src/Driver.ts
@@ -10,6 +10,7 @@ export type {
 export { Driver, libName, libVersion } from "./lib/driver/Driver";
 export type {
 	EditableZWaveOptions,
+	PartialEditableZWaveOptions,
 	ZWaveOptions,
 } from "./lib/driver/ZWaveOptions";
 export type { DriverLogContext } from "./lib/log/Driver";

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -221,7 +221,7 @@ import {
 	installConfigUpdateInDocker,
 } from "./UpdateConfig";
 import { mergeUserAgent, userAgentComponentsToString } from "./UserAgent";
-import type { EditableZWaveOptions, ZWaveOptions } from "./ZWaveOptions";
+import type { PartialEditableZWaveOptions, ZWaveOptions } from "./ZWaveOptions";
 import { discoverRemoteSerialPorts } from "./mDNSDiscovery";
 
 const packageJsonPath = require.resolve("zwave-js/package.json");
@@ -827,7 +827,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks>
 	}
 
 	/** Updates the logging configuration without having to restart the driver. */
-	public updateLogConfig(config: DeepPartial<LogConfig>): void {
+	public updateLogConfig(config: Partial<LogConfig>): void {
 		this._logContainer.updateConfiguration(config);
 	}
 
@@ -898,7 +898,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks>
 	}
 
 	/** Updates a subset of the driver options on the fly */
-	public updateOptions(options: DeepPartial<EditableZWaveOptions>): void {
+	public updateOptions(options: PartialEditableZWaveOptions): void {
 		// This code is called from user code, so we need to make sure no options were passed
 		// which we are not able to update on the fly
 		const safeOptions = pick(options, [

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -1,6 +1,7 @@
 import type { LogConfig, RFRegion } from "@zwave-js/core";
 import type { FileSystem, ZWaveHostOptions } from "@zwave-js/host";
 import type { ZWaveSerialPortBase } from "@zwave-js/serial";
+import { type DeepPartial, type Expand } from "@zwave-js/shared";
 import type { SerialPort } from "serialport";
 import type { InclusionUserCallbacks } from "../controller/Inclusion";
 
@@ -285,3 +286,12 @@ export type EditableZWaveOptions =
 	& {
 		userAgent?: Record<string, string | null | undefined>;
 	};
+
+export type PartialEditableZWaveOptions = Expand<
+	& DeepPartial<
+		Omit<EditableZWaveOptions, "inclusionUserCallbacks" | "logConfig">
+	>
+	& Partial<
+		Pick<EditableZWaveOptions, "inclusionUserCallbacks" | "logConfig">
+	>
+>;


### PR DESCRIPTION
Turns out `DeepPartial` drilled a bit too deep into `winston`'s `Transport`s. Found in https://github.com/zwave-js/zwave-js-server/pull/1034