### PR TITLE
fix: remove auto-detection of soft-reset capability

### DIFF
--- a/docs/getting-started/migrating-to-v12.md
+++ b/docs/getting-started/migrating-to-v12.md
@@ -87,6 +87,12 @@ The following methods were deprecated/renamed and have now been removed:
 - `Controller.deleteReturnRoute`: Use `Controller.deleteReturnRoutes` instead
 - `Driver.enableErrorReporting`: Error reporting has been fully removed
 
+## Removed the controller's `supportsSoftReset` property
+
+This was meant to increase reliability of the automatic soft-reset in certain setups, however we've learned a few things since then. First of all, there don't seem to be any issues with 700+ series sticks, so soft-reset is always enabled for those since `v11.10.1`. Most importantly though, if the automatic soft-reset failed once but usually works, it is near impossible for some users to clear this flag, so their stick never gets soft-reset even if it would be needed.
+
+Therefore, this property and the checks around it are now removed. When soft-reset is not disabled through the config, 500 series sticks and older will now always be soft-reset, unless they are on the list of known problematic sticks.
+
 ## `ZWaveHost.getNextSupervisionSessionId` requires a node ID now
 
 This change only concerns custom implementations of the `ZWaveHost` interface and should not affect most users/codebases. The `Supervision` session IDs must be tracked per node now and not globally:

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -658,15 +658,6 @@ export class ZWaveController
 		return this._supportsTimers;
 	}
 
-	/** Whether the controller is known to support soft reset */
-	public get supportsSoftReset(): MaybeNotKnown<boolean> {
-		return this.driver.cacheGet(cacheKeys.controller.supportsSoftReset);
-	}
-	/** @internal */
-	public set supportsSoftReset(value: MaybeNotKnown<boolean>) {
-		this.driver.cacheSet(cacheKeys.controller.supportsSoftReset, value);
-	}
-
 	private _rfRegion: MaybeNotKnown<RFRegion>;
 	/** Which RF region the controller is currently set to, or `undefined` if it could not be determined (yet). This value is cached and can be changed through {@link setRFRegion}. */
 	public get rfRegion(): MaybeNotKnown<RFRegion> {
@@ -6341,8 +6332,6 @@ ${associatedNodes.join(", ")}`,
 		}
 
 		// After restoring an NVM backup, the controller's capabilities may have changed.
-		// At the very least reset the information about the soft reset capability.
-		this.supportsSoftReset = undefined;
 		// Also, we could be talking to different nodes than the cache file contains.
 		// Reset all info about all nodes, so they get re-interviewed.
 		this._nodes.clear();
@@ -6395,10 +6384,7 @@ ${associatedNodes.join(", ")}`,
 		// so you can figure out which pages you don't have to save or restore. If you do this, you need to make sure to issue a
 		// "factory reset" before restoring the NVM - that'll blank out the NVM to 0xffs before initializing it.
 
-		// After a restored NVM backup, the controller's capabilities may have changed. At the very least reset the information
-		// about soft reset capability
-		this.supportsSoftReset = undefined;
-
+		// After a restored NVM backup, the controller's capabilities may have changed.
 		// Normally we'd only need to soft reset the stick, but we also need to re-interview the controller and potentially all nodes.
 		// Just forcing a restart of the driver seems easier.
 

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1379,24 +1379,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks>
 			}
 
 			if (maySoftReset) {
-				try {
-					await this.softResetInternal(false);
-				} catch (e) {
-					if (
-						isZWaveError(e)
-						&& e.code === ZWaveErrorCodes.Driver_Failed
-					) {
-						// Remember that soft reset is not supported by this stick
-						this.driverLog.print(
-							"Soft reset seems not to be supported by this stick, disabling it.",
-							"warn",
-						);
-						this.controller.supportsSoftReset = false;
-						// Then fail the driver
-						await this.destroy();
-						return;
-					}
-				}
+				await this.softResetInternal(false);
 			}
 
 			// There are situations where a controller claims it has the ID 0,
@@ -2427,12 +2410,6 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks>
 	private maySoftReset(): boolean {
 		// 700+ series controllers have no problems with soft reset and MUST even be soft reset in some cases
 		if (this._controller?.sdkVersionGt("7.0")) return true;
-
-		// If we've previously determined a stick not to support soft reset, don't bother trying again
-		const supportsSoftReset = this._networkCache!.get(
-			cacheKeys.controller.supportsSoftReset,
-		) as boolean | undefined;
-		if (supportsSoftReset === false) return false;
 
 		// Blacklist some sticks that are known to not support soft reset
 		const { manufacturerId, productType, productId } = this.controller;

--- a/packages/zwave-js/src/lib/driver/NetworkCache.ts
+++ b/packages/zwave-js/src/lib/driver/NetworkCache.ts
@@ -27,7 +27,6 @@ import type { Driver } from "./Driver";
 export const cacheKeys = {
 	controller: {
 		provisioningList: "controller.provisioningList",
-		supportsSoftReset: "controller.supportsSoftReset",
 	},
 	// TODO: somehow these functions should be combined with the pattern matching below
 	node: (nodeId: number) => {
@@ -468,7 +467,6 @@ const legacyPaths = {
 	// something in the future without breaking migration
 	controller: {
 		provisioningList: "controller.provisioningList",
-		supportsSoftReset: "controller.supportsSoftReset",
 	},
 	node: {
 		// These are relative to the node object
@@ -518,17 +516,12 @@ export async function migrateLegacyNetworkCache(
 
 	// Translate all possible entries
 
-	// Controller provisioning list and supportsSoftReset info
+	// Controller provisioning list
 	tryMigrate(
 		cacheKeys.controller.provisioningList,
 		legacy,
 		legacyPaths.controller.provisioningList,
 		tryParseProvisioningList,
-	);
-	tryMigrate(
-		cacheKeys.controller.supportsSoftReset,
-		legacy,
-		legacyPaths.controller.supportsSoftReset,
 	);
 
 	// All nodes, ...


### PR DESCRIPTION
This was meant to increase reliability of the automatic soft-reset in certain setups, however we've learned a few things since then. First of all, there don't seem to be any issues with 700+ series sticks, so soft-reset is always enabled for those since `v11.10.1`. Most importantly though, if the automatic soft-reset failed once but usually works, it is near impossible for some users to clear this flag, so their stick never gets soft-reset even if it would be needed.

Therefore, this property and the checks around it are now removed. When soft-reset is not disabled through the config, 500 series sticks and older will now always be soft-reset, unless they are on the list of known problematic sticks.