### PR TITLE
fix(cc): default to RF unprotected if not given for `Protection CC` V2+

### DIFF
--- a/packages/cc/src/cc/ProtectionCC.ts
+++ b/packages/cc/src/cc/ProtectionCC.ts
@@ -508,7 +508,7 @@ export class ProtectionCCSet extends ProtectionCC {
 			);
 		} else {
 			this.local = options.local;
-			this.rf = options.rf;
+			this.rf = options.rf ?? RFProtectionState.Unprotected;
 		}
 	}
 


### PR DESCRIPTION
fixes: #6246

Apparently, the RF protection flag was not set in some situation. We now default to `Unprotected` in this case.