### PR TITLE
feat: allow putting mock configs outside the repo

### DIFF
--- a/packages/zwave-js/bin/mock-server.js
+++ b/packages/zwave-js/bin/mock-server.js
@@ -82,7 +82,12 @@ Each node ID may only be used once in mock configs. Node ID ${nodeConfig.id} is 
  */
 function getConfig(filename) {
 	if (filename.endsWith(".js")) {
-		return require(filename).default(childRequire);
+		// The export can either be a static config object or a function that accepts a require
+		let config = require(filename).default;
+		if (typeof config === "function") {
+			config = config({ require: childRequire });
+		}
+		return config;
 	} else if (filename.endsWith(".json")) {
 		// TODO: JSON5 support
 		return JSON.parse(readFileSync(filename, "utf8"));

--- a/packages/zwave-js/bin/mock-server.js
+++ b/packages/zwave-js/bin/mock-server.js
@@ -3,6 +3,10 @@ const { MockServer } = require("../build/mockServer");
 const { readFileSync, statSync, readdirSync } = require("fs");
 const path = require("path");
 
+// Allow putting .js mock configs outside the repo
+const { createRequire } = require("module");
+const childRequire = createRequire(module.filename);
+
 const args = process.argv.slice(2);
 
 /** @returns {never} */
@@ -78,7 +82,7 @@ Each node ID may only be used once in mock configs. Node ID ${nodeConfig.id} is 
  */
 function getConfig(filename) {
 	if (filename.endsWith(".js")) {
-		return require(filename).default;
+		return require(filename).default(childRequire);
 	} else if (filename.endsWith(".json")) {
 		// TODO: JSON5 support
 		return JSON.parse(readFileSync(filename, "utf8"));


### PR DESCRIPTION
With this PR, configs for the `mock-server` can be put in locations where they don't have direct access to the `zwave-js` node-modules. When this is desired, the mock configs need to be refactored so their default export is a function that accepts an object with a scoped `require` function:

**Before:**
```js
const { CommandClasses } = require("@zwave-js/core");
const { ccCaps } = require("@zwave-js/testing");
const { ThermostatMode, ThermostatSetpointType } = require("zwave-js");

module.exports.default = {
	// config
}
```

**After:**
```js
module.exports.default = ({ require }) => {
	const { CommandClasses } = require("@zwave-js/core");
	const { ccCaps } = require("@zwave-js/testing");
	const { ThermostatMode, ThermostatSetpointType } = require("zwave-js");
		
	return {
		// config
	}
}
```
