### PR TITLE
fix: restart transaction when moving it to wakeup queue

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -5469,6 +5469,8 @@ ${handlers.length} left`,
 		const requeue: TransactionReducerResult = {
 			type: "requeue",
 			priority: MessagePriority.WakeUp,
+			// Reset the transaction so it doesn't simply resolve to `undefined` when we attempt to continue it
+			reset: true,
 		};
 		const requeueAndTagAsInterview: TransactionReducerResult = {
 			...requeue,
@@ -5580,6 +5582,9 @@ ${handlers.length} left`,
 					}
 					if (reducerResult.tag != undefined) {
 						transaction.tag = reducerResult.tag;
+					}
+					if (reducerResult.reset) {
+						transaction.reset();
 					}
 					if (source === "active") stopActive = transaction;
 					requeue.push(transaction);

--- a/packages/zwave-js/src/lib/driver/MessageGenerators.ts
+++ b/packages/zwave-js/src/lib/driver/MessageGenerators.ts
@@ -896,12 +896,11 @@ export function createMessageGenerator<TResponse extends Message = Message>(
 		parent: undefined as any, // The transaction will set this field on creation
 		current: undefined,
 		self: undefined,
+		reset: () => {
+			generator.current = undefined;
+			generator.self = undefined;
+		},
 		start: () => {
-			const resetGenerator = () => {
-				generator.current = undefined;
-				generator.self = undefined;
-			};
-
 			async function* gen() {
 				// Determine which message generator implementation should be used
 				let implementation: MessageGeneratorImplementation =
@@ -947,7 +946,7 @@ export function createMessageGenerator<TResponse extends Message = Message>(
 						} else if (isTransmitReport(e) && !e.isOK()) {
 							// The generator was prematurely ended by throwing a NOK transmit report.
 							// The driver may want to retry it, so reset the generator
-							resetGenerator();
+							generator.reset();
 							return;
 						} else {
 							// The generator was prematurely ended by throwing a Message
@@ -958,9 +957,10 @@ export function createMessageGenerator<TResponse extends Message = Message>(
 				}
 
 				resultPromise.resolve(result as TResponse);
-				resetGenerator();
+				generator.reset();
 				return;
 			}
+
 			generator.self = gen();
 			return generator.self;
 		},

--- a/packages/zwave-js/src/lib/driver/StateMachineShared.ts
+++ b/packages/zwave-js/src/lib/driver/StateMachineShared.ts
@@ -277,9 +277,11 @@ export type TransactionReducerResult =
 		message?: Message;
 	}
 	| {
-		// Changes the priority (and tag) of the transaction if a new one is given,
-		// and moves the current transaction back to the queue
+		// Moves the transaction back to the queue, resetting it if desired.
+		// Optionally change the priority and/or tag.
 		type: "requeue";
+		// TODO: Figure out if there's any situation where we don't want to reset the transaction
+		reset?: boolean;
 		priority?: MessagePriority;
 		tag?: any;
 	};

--- a/packages/zwave-js/src/lib/driver/Transaction.ts
+++ b/packages/zwave-js/src/lib/driver/Transaction.ts
@@ -21,6 +21,8 @@ export interface MessageGenerator {
 	parent: Transaction;
 	/** Start a new copy of this message generator */
 	start: () => AsyncGenerator<Message, void, Message>;
+	/** Resets this message generator so it can be started anew */
+	reset: () => void;
 	/** A reference to the currently running message generator if it was already started */
 	self?: ReturnType<MessageGenerator["start"]>;
 	/** A reference to the last generated message, or undefined if the generator wasn't started or has finished */
@@ -121,6 +123,13 @@ export class Transaction implements Comparable<Transaction> {
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Resets this transaction's message generator
+	 */
+	public reset(): void {
+		this.parts.reset();
 	}
 
 	public async generateNextMessage(

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepMessageOrder.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepMessageOrder.test.ts
@@ -1,7 +1,16 @@
-import { NoOperationCC } from "@zwave-js/cc";
+import {
+	BasicCCGet,
+	type CommandClass,
+	NoOperationCC,
+	WakeUpCCWakeUpNotification,
+} from "@zwave-js/cc";
 import { CommandClasses } from "@zwave-js/core";
 import { FunctionType } from "@zwave-js/serial";
-import { MockZWaveFrameType } from "@zwave-js/testing";
+import {
+	type MockNodeBehavior,
+	MockZWaveFrameType,
+	createMockZWaveRequestFrame,
+} from "@zwave-js/testing";
 import { wait } from "alcalzone-shared/async";
 import path from "path";
 import { integrationTest } from "../integrationTestSuiteMulti";
@@ -95,6 +104,121 @@ integrationTest(
 
 			// And it should fail since we don't ack:
 			t.false(await pingPromise17);
+		},
+	},
+);
+
+integrationTest.only(
+	"When a sleeping node with pending commands wakes up, the queue continues executing",
+	{
+		debug: true,
+
+		provisioningDirectory: path.join(
+			__dirname,
+			"fixtures/nodeAsleepMessageOrder",
+		),
+
+		nodeCapabilities: [
+			{
+				id: 10,
+				capabilities: {
+					commandClasses: [
+						CommandClasses.Basic,
+						CommandClasses["Wake Up"],
+					],
+					isListening: false,
+					isFrequentListening: false,
+				},
+			},
+			{
+				id: 17,
+				capabilities: {
+					commandClasses: [CommandClasses.Basic],
+				},
+			},
+		],
+
+		customSetup: async (driver, mockController, mockNodes) => {
+			const [mockNode10] = mockNodes;
+
+			const doNotAnswerWhenAsleep: MockNodeBehavior = {
+				onControllerFrame(controller, self, frame) {
+					if (!mockNode10.autoAckControllerFrames) return true;
+				},
+			};
+			mockNode10.defineBehavior(doNotAnswerWhenAsleep);
+		},
+
+		testBody: async (t, driver, nodes, mockController, mockNodes) => {
+			const [node10, node17] = nodes;
+			const [mockNode10, mockNode17] = mockNodes;
+
+			// Node 10 is assumed to be awake, but actually asleep
+			node10.markAsAwake();
+			mockNode10.autoAckControllerFrames = false;
+
+			// Query the node's BASIC state. This will fail and move the commands to the wakeup queue.
+			const queryBasicPromise1 = node10.commandClasses.Basic.get();
+
+			// Wait for the node to get marked as asleep
+			await new Promise((resolve) => node10.once("sleep", resolve));
+
+			driver.driverLog.sendQueue(driver["queue"]);
+
+			await wait(200);
+
+			// Node 10 wakes up
+			mockNode10.autoAckControllerFrames = true;
+			const cc: CommandClass = new WakeUpCCWakeUpNotification(
+				mockNode10.host,
+				{
+					nodeId: mockController.host.ownNodeId,
+				},
+			);
+			mockNode10.sendToController(createMockZWaveRequestFrame(cc, {
+				ackRequested: false,
+			}));
+
+			// Wait for the node to wake up
+			mockNode10.clearReceivedControllerFrames();
+			await new Promise((resolve) => node10.once("wake up", resolve));
+
+			driver.driverLog.print("AFTER WAKEUP:");
+			driver.driverLog.sendQueue(driver["queue"]);
+
+			let result: any = await Promise.race([
+				wait(5000).then(() => "timeout"),
+				queryBasicPromise1.catch(() => "error"),
+			]);
+			// The first command should have been sent
+			mockNode10.assertReceivedControllerFrame((f) =>
+				f.type === MockZWaveFrameType.Request
+				&& f.payload instanceof BasicCCGet
+			);
+			// and return a number
+			t.is(typeof result, "number");
+
+			// Query the node's BASIC state again. This should be handled relatively quickly
+			mockNode10.clearReceivedControllerFrames();
+			const queryBasicPromise2 = node10.commandClasses.Basic.get();
+
+			await wait(500);
+
+			driver.driverLog.print("AFTER Basic Get:");
+			driver.driverLog.sendQueue(driver["queue"]);
+
+			result = await Promise.race([
+				wait(5000).then(() => "timeout"),
+				queryBasicPromise2.catch(() => "error"),
+			]);
+
+			// The second command should also have been sent
+			mockNode10.assertReceivedControllerFrame((f) =>
+				f.type === MockZWaveFrameType.Request
+				&& f.payload instanceof BasicCCGet
+			);
+			// and return a number
+			t.is(typeof result, "number");
 		},
 	},
 );

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepMessageOrder.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepMessageOrder.test.ts
@@ -196,7 +196,7 @@ integrationTest.only(
 				&& f.payload instanceof BasicCCGet
 			);
 			// and return a number
-			t.is(typeof result, "number");
+			t.is(typeof result?.currentValue, "number");
 
 			// Query the node's BASIC state again. This should be handled relatively quickly
 			mockNode10.clearReceivedControllerFrames();
@@ -218,7 +218,7 @@ integrationTest.only(
 				&& f.payload instanceof BasicCCGet
 			);
 			// and return a number
-			t.is(typeof result, "number");
+			t.is(typeof result?.currentValue, "number");
 		},
 	},
 );

--- a/packages/zwave-js/src/lib/test/integrationTestSuiteMulti.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuiteMulti.ts
@@ -23,7 +23,7 @@ interface IntegrationTestOptions {
 	provisioningDirectory?: string;
 	/** Whether the recorded messages and frames should be cleared before executing the test body. Default: true. */
 	clearMessageStatsBeforeTest?: boolean;
-	nodeCapabilities: Pick<MockNodeOptions, "id" | "capabilities">[];
+	nodeCapabilities?: Pick<MockNodeOptions, "id" | "capabilities">[];
 	customSetup?: (
 		driver: Driver,
 		mockController: MockController,
@@ -97,6 +97,8 @@ function suite(
 		({ mockController, mockNodes } = prepareMocks(
 			mockPort,
 			undefined,
+			// TODO: This isn't ideal as it requires us to provide the
+			// node capabilities in addition to the provisioning directory
 			nodeCapabilities,
 		));
 


### PR DESCRIPTION
Fixes the issue reported in https://github.com/home-assistant/core/issues/99736

Not sure which specific change caused this, but the message generator for transactions moved to the wakeup queue after failing with `NoACK` was no longer reset. This resulted in them immediately resolving to `undefined` when continuing. For queries, this also resulted in the command time to include the time the node was asleep, causing an extremely long timeout waiting for the node's response, which would never come since no command was actually sent.