### PR TITLE
fix: handle notification enum behavior "replace" correctly

### DIFF
--- a/packages/cc/src/cc/NotificationCC.ts
+++ b/packages/cc/src/cc/NotificationCC.ts
@@ -387,7 +387,7 @@ export class NotificationCCAPI extends PhysicalCCAPI {
 	}
 }
 
-function getNotificationEnumBehavior(
+export function getNotificationEnumBehavior(
 	notificationConfig: Notification,
 	valueConfig: NotificationValueDefinition & { type: "state" },
 ): "none" | "extend" | "replace" {
@@ -444,9 +444,10 @@ export function getNotificationValueMetadata(
 	}
 	if (valueConfig.parameter instanceof NotificationParameterWithEnum) {
 		for (const [value, label] of valueConfig.parameter.values) {
-			metadata.states![
-				getNotificationStateValueWithEnum(valueConfig.value, value)
-			] = label;
+			const stateKey = enumBehavior === "replace"
+				? value
+				: getNotificationStateValueWithEnum(valueConfig.value, value);
+			metadata.states![stateKey] = label;
 		}
 	}
 

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -89,6 +89,7 @@ import { NodeNamingAndLocationCCValues } from "@zwave-js/cc/NodeNamingCC";
 import {
 	NotificationCCReport,
 	NotificationCCValues,
+	getNotificationEnumBehavior,
 	getNotificationStateValueWithEnum,
 	getNotificationValueMetadata,
 } from "@zwave-js/cc/NotificationCC";
@@ -4367,12 +4368,22 @@ protocol version:      ${this.protocolVersion}`;
 				}
 			}
 			if (typeof command.eventParameters === "number") {
-				// This notification contains an enum value. We set "fake" values for these to distinguish them
+				// This notification contains an enum value. Depending on how the enum behaves,
+				// we may need to set "fake" values for these to distinguish them
 				// from states without enum values
-				const valueWithEnum = getNotificationStateValueWithEnum(
-					value,
-					command.eventParameters,
-				);
+				const enumBehavior = valueConfig
+					? getNotificationEnumBehavior(
+						notificationConfig,
+						valueConfig,
+					)
+					: "extend";
+
+				const valueWithEnum = enumBehavior === "replace"
+					? command.eventParameters
+					: getNotificationStateValueWithEnum(
+						value,
+						command.eventParameters,
+					);
 				this.valueDB.setValue(valueId, valueWithEnum);
 			} else {
 				this.valueDB.setValue(valueId, value);


### PR DESCRIPTION
We already had a test for this, but the test didn't match the expectations explained in the comment.
fixes: #6281