### PR TITLE
fix(config): update Zooz ZEN32 config to the latest firmware, include 800 series

### DIFF
--- a/packages/config/config/devices/0x027a/templates/zooz_template.json
+++ b/packages/config/config/devices/0x027a/templates/zooz_template.json
@@ -189,6 +189,45 @@
 			}
 		]
 	},
+	"led_indicator_color_extended": {
+		"label": "LED Indicator Color",
+		"valueSize": 1,
+		"minValue": 0,
+		"maxValue": 3,
+		"defaultValue": 1,
+		"unsigned": true,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "White",
+				"value": 0
+			},
+			{
+				"label": "Blue",
+				"value": 1
+			},
+			{
+				"label": "Green",
+				"value": 2
+			},
+			{
+				"label": "Red",
+				"value": 3
+			},
+			{
+				"label": "Magenta",
+				"value": 4
+			},
+			{
+				"label": "Yellow",
+				"value": 5
+			},
+			{
+				"label": "Cyan",
+				"value": 6
+			}
+		]
+	},
 	"led_indicator_brightness": {
 		"label": "LED Indicator Brightness",
 		"valueSize": 1,

--- a/packages/config/config/devices/0x027a/templates/zooz_template.json
+++ b/packages/config/config/devices/0x027a/templates/zooz_template.json
@@ -193,7 +193,7 @@
 		"label": "LED Indicator Color",
 		"valueSize": 1,
 		"minValue": 0,
-		"maxValue": 3,
+		"maxValue": 6,
 		"defaultValue": 1,
 		"unsigned": true,
 		"allowManualEntry": false,

--- a/packages/config/config/devices/0x027a/zen32.json
+++ b/packages/config/config/devices/0x027a/zen32.json
@@ -93,8 +93,22 @@
 		},
 		{
 			"#": "6",
+			"$if": "firmwareVersion >= 10.40",
+			"$import": "templates/zooz_template.json#led_indicator_color_extended",
+			"label": "LED Indicator Color (Relay)",
+			"defaultValue": 0
+		},
+		{
+			"#": "6",
 			"$import": "templates/zooz_template.json#led_indicator_color",
 			"label": "LED Indicator Color (Relay)",
+			"defaultValue": 0
+		},
+		{
+			"#": "7",
+			"$if": "firmwareVersion >= 10.40",
+			"$import": "templates/zooz_template.json#led_indicator_color_extended",
+			"label": "LED Indicator Color (Button 1)",
 			"defaultValue": 0
 		},
 		{
@@ -105,14 +119,35 @@
 		},
 		{
 			"#": "8",
+			"$if": "firmwareVersion >= 10.40",
+			"$import": "templates/zooz_template.json#led_indicator_color_extended",
+			"label": "LED Indicator Color (Button 2)",
+			"defaultValue": 0
+		},
+		{
+			"#": "8",
 			"$import": "templates/zooz_template.json#led_indicator_color",
 			"label": "LED Indicator Color (Button 2)",
 			"defaultValue": 0
 		},
 		{
 			"#": "9",
+			"$if": "firmwareVersion >= 10.40",
+			"$import": "templates/zooz_template.json#led_indicator_color_extended",
+			"label": "LED Indicator Color (Button 3)",
+			"defaultValue": 0
+		},
+		{
+			"#": "9",
 			"$import": "templates/zooz_template.json#led_indicator_color",
 			"label": "LED Indicator Color (Button 3)",
+			"defaultValue": 0
+		},
+		{
+			"#": "10",
+			"$if": "firmwareVersion >= 10.40",
+			"$import": "templates/zooz_template.json#led_indicator_color_extended",
+			"label": "LED Indicator Color (Button 4)",
 			"defaultValue": 0
 		},
 		{

--- a/packages/config/config/devices/0x027a/zen32.json
+++ b/packages/config/config/devices/0x027a/zen32.json
@@ -1,7 +1,24 @@
+// The firmware versions on this device are a mess
+// 1.1 -> 10.0 -> 10.10 -> 10.20 -> 10.30 -> (10.40 ≅ 2.10) -> 2.20
+
+// Conditionals:
+// 10.0  and later: firmwareVersion >= 10.0 || firmwareVersion >= 2.10 && firmwareVersion < 10.0
+// 10.10 and later: firmwareVersion >= 10.10 || firmwareVersion >= 2.10 && firmwareVersion < 10.0
+// 10.20 and later: firmwareVersion >= 10.20 || firmwareVersion >= 2.10 && firmwareVersion < 10.0
+// 10.30 and later: firmwareVersion >= 10.30 || firmwareVersion >= 2.10 && firmwareVersion < 10.0
+// 10.40 and later: firmwareVersion >= 10.40 || firmwareVersion >= 2.10 && firmwareVersion < 10.0
+// 800 series: firmwareVersion >= 2.10 && firmwareVersion < 10.0
+
 {
 	"manufacturer": "Zooz",
 	"manufacturerId": "0x027a",
-	"label": "ZEN32",
+	"label": [
+		{
+			"$if": "firmwareVersion >= 2.10 && firmwareVersion < 10.0",
+			"value": "ZEN32 800LR"
+		},
+		"ZEN32"
+	],
 	"description": "Scene Controller",
 	"devices": [
 		{
@@ -93,7 +110,7 @@
 		},
 		{
 			"#": "6",
-			"$if": "firmwareVersion >= 10.40",
+			"$if": "firmwareVersion >= 10.40 || firmwareVersion >= 2.10 && firmwareVersion < 10.0",
 			"$import": "templates/zooz_template.json#led_indicator_color_extended",
 			"label": "LED Indicator Color (Relay)",
 			"defaultValue": 0
@@ -106,7 +123,7 @@
 		},
 		{
 			"#": "7",
-			"$if": "firmwareVersion >= 10.40",
+			"$if": "firmwareVersion >= 10.40 || firmwareVersion >= 2.10 && firmwareVersion < 10.0",
 			"$import": "templates/zooz_template.json#led_indicator_color_extended",
 			"label": "LED Indicator Color (Button 1)",
 			"defaultValue": 0
@@ -119,7 +136,7 @@
 		},
 		{
 			"#": "8",
-			"$if": "firmwareVersion >= 10.40",
+			"$if": "firmwareVersion >= 10.40 || firmwareVersion >= 2.10 && firmwareVersion < 10.0",
 			"$import": "templates/zooz_template.json#led_indicator_color_extended",
 			"label": "LED Indicator Color (Button 2)",
 			"defaultValue": 0
@@ -132,7 +149,7 @@
 		},
 		{
 			"#": "9",
-			"$if": "firmwareVersion >= 10.40",
+			"$if": "firmwareVersion >= 10.40 || firmwareVersion >= 2.10 && firmwareVersion < 10.0",
 			"$import": "templates/zooz_template.json#led_indicator_color_extended",
 			"label": "LED Indicator Color (Button 3)",
 			"defaultValue": 0
@@ -145,7 +162,7 @@
 		},
 		{
 			"#": "10",
-			"$if": "firmwareVersion >= 10.40",
+			"$if": "firmwareVersion >= 10.40 || firmwareVersion >= 2.10 && firmwareVersion < 10.0",
 			"$import": "templates/zooz_template.json#led_indicator_color_extended",
 			"label": "LED Indicator Color (Button 4)",
 			"defaultValue": 0
@@ -207,17 +224,17 @@
 		},
 		{
 			"#": "21",
-			"$if": "firmwareVersion >= 1.2",
+			"$if": "firmwareVersion >= 10.0 || firmwareVersion >= 2.10 && firmwareVersion < 10.0",
 			"$import": "templates/zooz_template.json#3way_switch_type"
 		},
 		{
 			"#": "22",
-			"$if": "firmwareVersion >= 10.0",
+			"$if": "firmwareVersion >= 10.0 || firmwareVersion >= 2.10 && firmwareVersion < 10.0",
 			"$import": "templates/zooz_template.json#local_programming"
 		},
 		{
 			"#": "23",
-			"$if": "firmwareVersion >= 10.20",
+			"$if": "firmwareVersion >= 10.20 || firmwareVersion >= 2.10 && firmwareVersion < 10.0",
 			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
 			"label": "LED Settings Indicator",
 			"defaultValue": 0
@@ -225,9 +242,47 @@
 		{
 			"#": "24",
 			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
-			"$if": "firmwareVersion >= 10.30",
+			"$if": "firmwareVersion >= 10.30 || firmwareVersion >= 2.10 && firmwareVersion < 10.0",
 			"label": "Scene Control (Relay)",
 			"defaultValue": 0
+		},
+		{
+			"#": "26",
+			"$import": "templates/zooz_template.json#enable_scene_control_3way",
+			"$if": "firmwareVersion >= 10.40 || firmwareVersion >= 2.10 && firmwareVersion < 10.0",
+			"label": "Scene Control (Relay)"
+		},
+		{
+			"#": "25[0x01]",
+			"$if": "firmwareVersion >= 10.40 || firmwareVersion >= 2.10 && firmwareVersion < 10.0",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Send Status Change Report: Local Control",
+			"description": "Determine whether a trigger of this type should prompt a status change report to associated devices.",
+			"defaultValue": 1
+		},
+		{
+			"#": "25[0x02]",
+			"$if": "firmwareVersion >= 10.40 || firmwareVersion >= 2.10 && firmwareVersion < 10.0",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Send Status Change Report: 3-Way",
+			"description": "Determine whether a trigger of this type should prompt a status change report to associated devices.",
+			"defaultValue": 1
+		},
+		{
+			"#": "25[0x04]",
+			"$if": "firmwareVersion >= 10.40 || firmwareVersion >= 2.10 && firmwareVersion < 10.0",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Send Status Change Report: Z-Wave",
+			"description": "Determine whether a trigger of this type should prompt a status change report to associated devices.",
+			"defaultValue": 1
+		},
+		{
+			"#": "25[0x08]",
+			"$if": "firmwareVersion >= 10.40 || firmwareVersion >= 2.10 && firmwareVersion < 10.0",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Send Status Change Report: Timer",
+			"description": "Determine whether a trigger of this type should prompt a status change report to associated devices.",
+			"defaultValue": 1
 		}
 	],
 	"compat": {


### PR DESCRIPTION
As of 09/2023 Zooz released a firmware update for the [ZEN32 Scene Controller](https://www.getzooz.com/zooz-zen32-scene-controller/) that added three additional LED indicator color options (Magenta, Yellow, and Cyan). Other Zooz products still only support 4 colors (White, Blue, Green, and Red) so I added a new property template called **"led_indicator_color_extended"** that incorporates the new color values for products that support them without effecting other products. 
 
Supporting Documentation:
- [ZEN32 Change Log (Look at 10.40 for new options)](https://www.support.getzooz.com/kb/article/706-zen32-scene-controller-change-log/)
- [ZEN32 Advanced Configuration Documentation (Look at Parameters 6-10)](https://www.support.getzooz.com/kb/article/608-zen32-scene-controller-advanced-settings/)