### PR TITLE
Zen32 Color Updates

### DIFF
--- a/packages/config/config/devices/0x027a/templates/zooz_template.json
+++ b/packages/config/config/devices/0x027a/templates/zooz_template.json
@@ -186,7 +186,21 @@
 			{
 				"label": "Red",
 				"value": 3
-			}
+			},
+			{
+				"label": "Magenta",
+				"value": 4
+			},
+			{
+				"label": "Yellow",
+				"value": 5
+			},
+			{
+				"label": "Cyan",
+				"value": 6
+			}			
+
+
 		]
 	},
 	"led_indicator_brightness": {


### PR DESCRIPTION
The Zen32 Scene Controller received a firmware update with new colors for the LEDs.  Magenta, Yellow and Cyan are new options now.
https://www.support.getzooz.com/kb/article/608-zen32-scene-controller-advanced-settings/

