### PR TITLE
feat: make timeout to send devices back to sleep configurable, lower default to 250 ms

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -253,6 +253,7 @@ const defaultOptions: ZWaveOptions = {
 		report: 1000, // ReportTime timeout SHOULD be set to CommandTime + 1 second
 		nonce: 5000,
 		sendDataCallback: 65000, // as defined in INS13954
+		sendToSleep: 250, // The default should be enough time for applications to react to devices waking up
 		refreshValue: 5000, // Default should handle most slow devices until we have a better solution
 		refreshValueAfterTransition: 1000, // To account for delays in the device
 		serialAPIStarted: 5000,
@@ -309,6 +310,14 @@ function checkOptions(options: ZWaveOptions): void {
 	if (options.timeouts.nonce < 3000 || options.timeouts.nonce > 20000) {
 		throw new ZWaveError(
 			`The Nonce timeout must be between 3000 and 20000 milliseconds!`,
+			ZWaveErrorCodes.Driver_InvalidOptions,
+		);
+	}
+	if (
+		options.timeouts.sendToSleep < 10 || options.timeouts.sendToSleep > 5000
+	) {
+		throw new ZWaveError(
+			`The Send To Sleep timeout must be between 10 and 5000 milliseconds!`,
 			ZWaveErrorCodes.Driver_InvalidOptions,
 		);
 	}
@@ -5882,7 +5891,10 @@ ${handlers.length} left`,
 			if (wakeUpInterval !== 0) {
 				this.sendNodeToSleepTimers.set(
 					node.id,
-					setTimeout(() => sendNodeToSleep(node), 500).unref(),
+					setTimeout(
+						() => sendNodeToSleep(node),
+						this.options.timeouts.sendToSleep,
+					).unref(),
 				);
 			}
 		}

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -5882,7 +5882,7 @@ ${handlers.length} left`,
 			if (wakeUpInterval !== 0) {
 				this.sendNodeToSleepTimers.set(
 					node.id,
-					setTimeout(() => sendNodeToSleep(node), 1000).unref(),
+					setTimeout(() => sendNodeToSleep(node), 500).unref(),
 				);
 			}
 		}

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -30,6 +30,12 @@ export interface ZWaveOptions extends ZWaveHostOptions {
 		nonce: number; // [3000...20000], default: 5000 ms
 
 		/**
+		 * How long to wait without pending commands before sending a node back to sleep.
+		 * Should be as short as possible to save battery, but long enough to give applications time to react.
+		 */
+		sendToSleep: number; // [10...5000], default: 250 ms
+
+		/**
 		 * **!!! INTERNAL !!!**
 		 *
 		 * Not intended to be used by applications

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3435,12 +3435,12 @@ protocol version:      ${this.protocolVersion}`;
 			// we've already measured the wake up interval, so we can check whether a refresh is necessary
 			const wakeUpInterval =
 				this.getValue<number>(WakeUpCCValues.wakeUpInterval.id) ?? 1;
-			// The wakeup interval is specified in seconds. Allow for 10% over the wakeup interval plus
-			// add 5 minutes tolerance to avoid unnecessary queries to reduce battery drain. 
-			// A wakeup interval of 0 means manual wakeup, so the interval shouldn't be verified
+			// The wakeup interval is specified in seconds. Also add 5 minutes tolerance to avoid
+			// unnecessary queries since there might be some delay. A wakeup interval of 0 means manual wakeup,
+			// so the interval shouldn't be verified
 			if (
 				wakeUpInterval > 0
-				&& (now - this.lastWakeUp) / 1000 > ((wakeUpInterval * 1.1) + (5 * 60))
+				&& (now - this.lastWakeUp) / 1000 > wakeUpInterval + 5 * 60
 			) {
 				this.commandClasses["Wake Up"].getInterval().catch(() => {
 					// Don't throw if there's an error

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3440,7 +3440,7 @@ protocol version:      ${this.protocolVersion}`;
 			// A wakeup interval of 0 means manual wakeup, so the interval shouldn't be verified
 			if (
 				wakeUpInterval > 0
-				&& (now - this.lastWakeUp) / 1000 > (wakeUpInterval * 1.1 + 5 * 60)
+				&& (now - this.lastWakeUp) / 1000 > ((wakeUpInterval * 1.1) + (5 * 60))
 			) {
 				this.commandClasses["Wake Up"].getInterval().catch(() => {
 					// Don't throw if there's an error

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3435,12 +3435,12 @@ protocol version:      ${this.protocolVersion}`;
 			// we've already measured the wake up interval, so we can check whether a refresh is necessary
 			const wakeUpInterval =
 				this.getValue<number>(WakeUpCCValues.wakeUpInterval.id) ?? 1;
-			// The wakeup interval is specified in seconds. Also add 5 minutes tolerance to avoid
-			// unnecessary queries since there might be some delay. A wakeup interval of 0 means manual wakeup,
-			// so the interval shouldn't be verified
+			// The wakeup interval is specified in seconds. Allow for 10% over the wakeup interval plus
+			// add 5 minutes tolerance to avoid unnecessary queries to reduce battery drain. 
+			// A wakeup interval of 0 means manual wakeup, so the interval shouldn't be verified
 			if (
 				wakeUpInterval > 0
-				&& (now - this.lastWakeUp) / 1000 > wakeUpInterval + 5 * 60
+				&& (now - this.lastWakeUp) / 1000 > (wakeUpInterval * 1.1 + 5 * 60)
 			) {
 				this.commandClasses["Wake Up"].getInterval().catch(() => {
 					// Don't throw if there's an error


### PR DESCRIPTION
On change from 1000 to 500: I do not think shorter sleep is worth a user parameter that then has to be checked. Active battery time is 12.5mA; sleep 1uA, so 1/2 second savings is 26 extra daya a year (700 device). More for 500 devices.

By the time this is called all pending messages are cleared, so all the work is done.
Signed-off-by: Bob Eckhoff <katmandodo@yahoo.com>

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->
