### PR TITLE
feat(config): add Shelly Wave 1, Wave 2PM, update Wave 1PM association labels

### DIFF
--- a/packages/config/config/devices/0x0460/qnsw-001P16.json
+++ b/packages/config/config/devices/0x0460/qnsw-001P16.json
@@ -20,11 +20,11 @@
 			"isLifeline": true
 		},
 		"2": {
-			"label": "I1: On/Off",
+			"label": "SW1: On/Off",
 			"maxNodes": 9
 		},
 		"3": {
-			"label": "I1: Start/Stop Level Change",
+			"label": "SW1: Start/Stop Level Change",
 			"maxNodes": 9
 		}
 	},

--- a/packages/config/config/devices/0x0460/qnsw-001X16.json
+++ b/packages/config/config/devices/0x0460/qnsw-001X16.json
@@ -1,0 +1,268 @@
+{
+	"manufacturer": "Shelly",
+	"manufacturerId": "0x0460",
+	"label": "QNSW-001X16",
+	"description": "Wave 1",
+	"devices": [
+		{
+			"productType": "0x0002",
+			"productId": "0x0083"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 9,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "SW1: On/Off",
+			"maxNodes": 9
+		},
+		"3": {
+			"label": "SW1: Start/Stop Level Change",
+			"maxNodes": 9
+		}
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"label": "SW1 Switch Type",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 2,
+			"defaultValue": 2,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Momentary switch",
+					"value": 0
+				},
+				{
+					"label": "Toggle switch (follow switch)",
+					"value": 1
+				},
+				{
+					"label": "Toggle switch (change on toggle)",
+					"value": 2
+				}
+			]
+		},
+		{
+			"#": "17",
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off",
+			"label": "O1: State After Power Failure",
+			"minValue": 0,
+			"maxValue": 1,
+			"unsigned": true
+		},
+		{
+			"#": "19",
+			"label": "O1: Auto-Off Timer",
+			"description": "The timer resets to zero each time the Device receives an ON command",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 32535,
+			"defaultValue": 0,
+			"unsigned": true
+		},
+		{
+			"#": "20",
+			"label": "O1: Auto-On Timer",
+			"description": "The timer resets to zero each time the Device receives an OFF command",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 32535,
+			"defaultValue": 0,
+			"unsigned": true
+		},
+		{
+			"#": "25",
+			"label": "O1: Auto-On/Off Timer Unit",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Seconds",
+					"value": 0
+				},
+				{
+					"label": "10 ms",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "23",
+			"label": "O1: Relay Type",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "NO: normally open",
+					"value": 0
+				},
+				{
+					"label": "NC: normally closed",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "91",
+			"label": "Alarm Configuration: Water",
+			"description": "This parameter determines which alarm frames the Device should respond to and how.",
+			"valueSize": 4,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "No action",
+					"value": 0
+				},
+				{
+					"label": "Open relay",
+					"value": 1
+				},
+				{
+					"label": "Close relay",
+					"value": 2
+				}
+			]
+		},
+		{
+			"#": "92",
+			"label": "Alarm Configuration: Smoke",
+			"description": "This parameter determines which alarm frames the Device should respond to and how.",
+			"valueSize": 4,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "No action",
+					"value": 0
+				},
+				{
+					"label": "Open relay",
+					"value": 1
+				},
+				{
+					"label": "Close relay",
+					"value": 2
+				}
+			]
+		},
+		{
+			"#": "93",
+			"label": "Alarm Configuration: CO",
+			"description": "This parameter determines which alarm frames the Device should respond to and how.",
+			"valueSize": 4,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "No action",
+					"value": 0
+				},
+				{
+					"label": "Open relay",
+					"value": 1
+				},
+				{
+					"label": "Close relay",
+					"value": 2
+				}
+			]
+		},
+		{
+			"#": "94",
+			"label": "Alarm Configuration: Heat",
+			"description": "This parameter determines which alarm frames the Device should respond to and how.",
+			"valueSize": 4,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "No action",
+					"value": 0
+				},
+				{
+					"label": "Open relay",
+					"value": 1
+				},
+				{
+					"label": "Close relay",
+					"value": 2
+				}
+			]
+		},
+		{
+			"#": "120",
+			"label": "Factory Reset",
+			"description": "Reset to factory default settings and remove from the Z-Wave network.",
+			"valueSize": 4,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Idle",
+					"value": 0
+				},
+				{
+					"label": "Factory reset",
+					"value": 1431655765
+				}
+			]
+		},
+		{
+			"#": "201",
+			"label": "Serial Number: Part 1",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 2147483647,
+			"unsigned": true,
+			"readOnly": true
+		},
+		{
+			"#": "202",
+			"label": "Serial Number: Part 2",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 2147483647,
+			"unsigned": true,
+			"readOnly": true
+		},
+		{
+			"#": "203",
+			"label": "Serial Number: Part 3",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 2147483647,
+			"unsigned": true,
+			"readOnly": true
+		}
+	],
+	"metadata": {
+		"inclusion": "6.1 Adding the Device to a Z-Wave™ network (inclusion)\nNote! All Device outputs (O, O1, O2, etc. - depending on the Device type) will turn the load 1s on/1s off /1s on/1s off if the Device is successfully added to/removed from a Z-Wave™ network.\n\n6.1.1 SmartStart adding (inclusion)\nSmartStart enabled products can be added into a Z-Wave™ network by scanning the Z-Wave™ QR Code present on the Device with a gateway providing SmartStart inclusion. No further action is required, and the SmartStart device will be added automatically within 10 minutes of being switched on in the network vicinity.\n1. With the gateway application scan the QR code on the Device label and add the Security 2 (S2) Device Specific Key (DSK) to the provisioning list in the gateway.\n2. Connect the Device to a power supply.\n3. Check if the blue LED is blinking in Mode 1. If so, the Device is not added to a Z-Wave™ network.\n4. Adding will be initiated automatically within a few seconds after connecting the Device to a power supply, and the Device will be added to a Z-Wave™ network automatically.\n5. The blue LED will be blinking in Mode 2 during the adding process.\n6. The green LED will be blinking in Mode 1 if the Device is successfully added to a Z-Wave™ network.\n\n6.1.2 Adding (inclusion) with a switch/push-button\n1. Connect the Device to a power supply.\n2. Check if the blue LED is blinking in Mode 1. If so, the Device is not added to a Z-Wave™ network.\n3. Enable add/remove mode on the gateway.\n4. Toggle the switch/push-button connected to any of the SW terminals (SW, SW1, SW2, etc.) 3 times within 3 seconds (this procedure puts the Device in Learn mode*). The Device must receive on/off signal 3 times, which means pressing the momentary switch 3 times, or toggling the switch on and off 3 times.\n5. The blue LED will be blinking in Mode 2 during the adding process.\n6. The green LED will be blinking in Mode 1 if the Device is successfully added to a Z-Wave™ network.\n*Learn mode - a state that allows the Device to receive network information from the gateway.\n\n6.1.3 Adding (inclusion) with the S button\n1. Connect the Device to a power supply.\n2. Check if the blue LED is blinking in Mode 1. If so, the Device is not added to a Z-Wave™ network.\n3. Enable add/remove mode on the gateway.\n4. To enter the Setting mode, quickly press and hold the S button on the Device until the LED turns solid blue.\n5. Quickly release and then press and hold (> 2s) the S button on the Device until the blue LED starts blinking in Mode 3. Releasing the S button will start the Learn mode.\n6. The blue LED will be blinking in Mode 2 during the adding process.\n7. The green LED will be blinking in Mode 1 if the Device is successfully added to a Z-Wave™ network.\nNote! In Setting mode, the Device has a timeout of 10s before entering again into Normal mode",
+		"exclusion": "Removing the Device from a Z-Wave™ network (exclusion)\nNote! The Device will be removed from your Z-wave™ network, but any custom configuration parameters will not be erased.\nNote! All Device outputs (O, O1, O2, etc. - depending on the Device type) will turn the load 1s on/1s off /1s on/1s off if the Device is successfully added to/removed from a Z-Wave™ network.\n\n6.2.1 Removing (exclusion) with a switch/push-button\n1. Connect the Device to a power supply.\n2. Check if the green LED is blinking in Mode 1. If so, the Device is added to a Z-Wave™ network.\n3. Enable add/remove mode on the gateway.\n4. Toggle the switch/push-button connected to any of the SW terminals (SW, SW1, SW2,…) 3 times within 3 seconds (this procedure puts the Device in Learn mode). The Device must receive on/off signal 3 times, which means pressing the momentary switch 3 times, or toggling the switch on and off 3 times.\n5. The blue LED will be blinking in Mode 2 during the removing process.\n6. The blue LED will be blinking in Mode 1 if the Device is successfully removed from a Z-Wave™ network.\n\n6.2.2 Removing (exclusion) with the S button\n1. Connect the Device to a power supply.\n2. Check if the green LED is blinking in Mode 1. If so, the Device is added to a Z-Wave™ network.\n3. Enable add/remove mode on the gateway.\n4. To enter the Setting mode, quickly press and hold the S button on the Device until the LED turns solid blue.\n5. Quickly release and then press and hold (> 2s) the S button on the Device until the blue LED starts blinking in Mode 3. Releasing the S button will start the Learn mode.\n6. The blue LED will be blinking in Mode 2 during the removing process.\n7. The blue LED will be blinking in Mode 1 if the Device is successfully removed from a Z-Wave™ network.\nNote! In Setting mode, the Device has a timeout of 10s before entering again into Normal mode",
+		"reset": "6.3 Factory reset\n6.3.1 Factory reset general\nAfter Factory reset, all custom parameters and stored values (kWh, associations, routings, etc.) will return to their default state. HOME ID and NODE ID assigned to the Device will be deleted. Use this reset procedure only when the gateway is missing or otherwise inoperable.\n\n6.3.2 Factory reset with a switch/push-button\nNote! Factory reset with a switch/push-button is only possible within the first minute after the Device is connected to a power supply.\n1. Connect the Device to a power supply.\n2. Toggle the switch/push-button connected to any of the SW terminals (SW, SW1, SW2,…) 5 times within 3 seconds. The Device must receive on/off signal 5 times, which means pressing the push-button 5 times, or toggling the switch on and off 5 times.\n3. During factory reset, the LED will turn solid green for about 1s, then the blue and red LED will start blinking in Mode 3 for approx. 2s.\n4. The blue LED will be blinking in Mode 1 if the Factory reset is successful.\n\n6.3.3 Factory reset with the S button\nNote! Factory reset with the S button is possible anytime.\n1. To enter the Setting mode, quickly press and hold the S button on the Device until the LED turns solid blue.\n2. Press the S button multiple times until the LED turns solid red.\n3. Press and hold (> 2s) S button on the Device until the red LED starts blinking in Mode 3. Releasing the S button will start the factory reset.\n4. During factory reset, the LED will turn solid green for about 1s, then the blue and red LED will start blinking in Mode 3 for approx. 2s.\n5. The blue LED will be blinking in Mode 1 if the Factory reset is successful.\n\n6.3.4 Remote factory reset with parameter with the gateway\nFactory reset can be done remotely with the settings in Parameter No. 120"
+	}
+}

--- a/packages/config/config/devices/0x0460/qnsw-001X16.json
+++ b/packages/config/config/devices/0x0460/qnsw-001X16.json
@@ -6,7 +6,8 @@
 	"devices": [
 		{
 			"productType": "0x0002",
-			"productId": "0x0083"
+			"productId": "0x0083",
+			"zwaveAllianceId": 4922
 		}
 	],
 	"firmwareVersion": {

--- a/packages/config/config/devices/0x0460/qnsw-001X16.json
+++ b/packages/config/config/devices/0x0460/qnsw-001X16.json
@@ -34,10 +34,7 @@
 			"#": "1",
 			"label": "SW1 Switch Type",
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -69,8 +66,7 @@
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 32535,
-			"defaultValue": 0,
-			"unsigned": true
+			"defaultValue": 0
 		},
 		{
 			"#": "20",
@@ -79,17 +75,13 @@
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 32535,
-			"defaultValue": 0,
-			"unsigned": true
+			"defaultValue": 0
 		},
 		{
 			"#": "25",
 			"label": "O1: Auto-On/Off Timer Unit",
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -106,10 +98,7 @@
 			"#": "23",
 			"label": "O1: Relay Type",
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -128,7 +117,6 @@
 			"description": "This parameter determines which alarm frames the Device should respond to and how.",
 			"valueSize": 4,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -151,7 +139,6 @@
 			"description": "This parameter determines which alarm frames the Device should respond to and how.",
 			"valueSize": 4,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -174,7 +161,6 @@
 			"description": "This parameter determines which alarm frames the Device should respond to and how.",
 			"valueSize": 4,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -197,7 +183,6 @@
 			"description": "This parameter determines which alarm frames the Device should respond to and how.",
 			"valueSize": 4,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -220,7 +205,6 @@
 			"description": "Reset to factory default settings and remove from the Z-Wave network.",
 			"valueSize": 4,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -239,7 +223,6 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 2147483647,
-			"unsigned": true,
 			"readOnly": true
 		},
 		{
@@ -248,7 +231,6 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 2147483647,
-			"unsigned": true,
 			"readOnly": true
 		},
 		{
@@ -257,7 +239,6 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 2147483647,
-			"unsigned": true,
 			"readOnly": true
 		}
 	],

--- a/packages/config/config/devices/0x0460/qnsw-002P16.json
+++ b/packages/config/config/devices/0x0460/qnsw-002P16.json
@@ -107,36 +107,34 @@
 		},
 		{
 			"#": "6",
-			"label": "SW1 & SW2: Swap",
-			"description": "swaped state SW1 control O2, SW2 control O1)",
+			"label": "Swap Inputs",
 			"valueSize": 1,
 			"defaultValue": 0,
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "default",
+					"label": "Normal (SW1 - O1, SW2 - O2)",
 					"value": 0
 				},
 				{
-					"label": "swapped",
+					"label": "Swapped (SW1 - O2, SW2 - O1)",
 					"value": 1
 				}
 			]
 		},
 		{
 			"#": "16",
-			"label": "O1 & O2: Swap",
-			"description": "swaped state O1 - close, O2 - open",
+			"label": "Swap Outputs",
 			"valueSize": 1,
 			"defaultValue": 0,
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "default",
+					"label": "Normal",
 					"value": 0
 				},
 				{
-					"label": "swapped",
+					"label": "Swapped",
 					"value": 1
 				}
 			]

--- a/packages/config/config/devices/0x0460/qnsw-002P16.json
+++ b/packages/config/config/devices/0x0460/qnsw-002P16.json
@@ -68,7 +68,6 @@
 			"label": "SW1 Switch Type",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -90,7 +89,6 @@
 			"label": "SW2 Switch Type",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -113,7 +111,6 @@
 			"description": "swaped state SW1 control O2, SW2 control O1)",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -121,7 +118,7 @@
 					"value": 0
 				},
 				{
-					"label": "swapped ",
+					"label": "swapped",
 					"value": 1
 				}
 			]
@@ -132,7 +129,6 @@
 			"description": "swaped state O1 - close, O2 - open",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -162,8 +158,7 @@
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 32535,
-			"defaultValue": 0,
-			"unsigned": true
+			"defaultValue": 0
 		},
 		{
 			"#": "20",
@@ -172,8 +167,7 @@
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 32535,
-			"defaultValue": 0,
-			"unsigned": true
+			"defaultValue": 0
 		},
 		{
 			"#": "21",
@@ -182,8 +176,7 @@
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 32535,
-			"defaultValue": 0,
-			"unsigned": true
+			"defaultValue": 0
 		},
 		{
 			"#": "22",
@@ -192,15 +185,13 @@
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 32535,
-			"defaultValue": 0,
-			"unsigned": true
+			"defaultValue": 0
 		},
 		{
 			"#": "25",
 			"label": "O1: Auto-On/Off Timer Unit",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -218,7 +209,6 @@
 			"label": "O2: Auto-On/Off Timer Unit",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -236,7 +226,6 @@
 			"label": "O1: Relay Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -254,7 +243,6 @@
 			"label": "O2: Relay Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -274,8 +262,7 @@
 			"unit": "%",
 			"minValue": 0,
 			"maxValue": 100,
-			"defaultValue": 50,
-			"unsigned": true
+			"defaultValue": 50
 		},
 		{
 			"#": "37",
@@ -284,8 +271,7 @@
 			"unit": "%",
 			"minValue": 0,
 			"maxValue": 100,
-			"defaultValue": 50,
-			"unsigned": true
+			"defaultValue": 50
 		},
 		{
 			"#": "39",
@@ -294,8 +280,7 @@
 			"unit": "seconds",
 			"minValue": 0,
 			"maxValue": 120,
-			"defaultValue": 30,
-			"unsigned": true
+			"defaultValue": 30
 		},
 		{
 			"#": "40",
@@ -304,8 +289,7 @@
 			"unit": "seconds",
 			"minValue": 0,
 			"maxValue": 120,
-			"defaultValue": 30,
-			"unsigned": true
+			"defaultValue": 30
 		},
 		{
 			"#": "91",
@@ -313,7 +297,6 @@
 			"description": "This parameter determines which alarm frames the Device should respond to and how.",
 			"valueSize": 4,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -336,7 +319,6 @@
 			"description": "This parameter determines which alarm frames the Device should respond to and how.",
 			"valueSize": 4,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -359,7 +341,6 @@
 			"description": "This parameter determines which alarm frames the Device should respond to and how.",
 			"valueSize": 4,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -382,7 +363,6 @@
 			"description": "This parameter determines which alarm frames the Device should respond to and how.",
 			"valueSize": 4,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -405,7 +385,6 @@
 			"description": "Reset to factory default settings and remove from the Z-Wave network.",
 			"valueSize": 4,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -425,7 +404,6 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 2147483647,
-			"unsigned": true,
 			"readOnly": true
 		},
 		{
@@ -435,7 +413,6 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 2147483647,
-			"unsigned": true,
 			"readOnly": true
 		},
 		{
@@ -445,7 +422,6 @@
 			"valueSize": 4,
 			"minValue": 0,
 			"maxValue": 2147483647,
-			"unsigned": true,
 			"readOnly": true
 		}
 	],

--- a/packages/config/config/devices/0x0460/qnsw-002P16.json
+++ b/packages/config/config/devices/0x0460/qnsw-002P16.json
@@ -1,0 +1,457 @@
+{
+	"manufacturer": "Shelly",
+	"manufacturerId": "0x0460",
+	"label": "QNSW-002P16",
+	"description": "Wave 2PM",
+	"devices": [
+		{
+			"productType": "0x0002",
+			"productId": "0x0081"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"endpoints": {
+		"0": {
+			"associations": {
+				"1": {
+					"label": "Lifeline",
+					"maxNodes": 9,
+					"isLifeline": true
+				},
+				"2": {
+					"label": "SW1: On/Off",
+					"maxNodes": 9
+				},
+				"3": {
+					"label": "SW1: Start/Stop Level Change",
+					"maxNodes": 9
+				},
+				"4": {
+					"label": "SW2: On/Off",
+					"maxNodes": 9
+				},
+				"5": {
+					"label": "SW2: Start/Stop Level Change",
+					"maxNodes": 9
+				}
+			}
+		},
+		"1": {
+			"associations": {
+				"1": {
+					"$import": "#endpoints/0/associations/2",
+					"isLifeline": false
+				},
+				"2": {
+					"$import": "#endpoints/0/associations/3"
+				}
+			}
+		},
+		"2": {
+			"associations": {
+				"1": {
+					"$import": "#endpoints/0/associations/4",
+					"isLifeline": false
+				},
+				"2": {
+					"$import": "#endpoints/0/associations/5"
+				}
+			}
+		}
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"label": "SW1 Switch Type",
+			"valueSize": 1,
+			"defaultValue": 2,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Momentary switch",
+					"value": 0
+				},
+				{
+					"label": "Toggle switch (follow switch)",
+					"value": 1
+				},
+				{
+					"label": "Toggle switch (change on toggle)",
+					"value": 2
+				}
+			]
+		},
+		{
+			"#": "2",
+			"label": "SW2 Switch Type",
+			"valueSize": 1,
+			"defaultValue": 2,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Momentary switch",
+					"value": 0
+				},
+				{
+					"label": "Toggle switch (follow switch)",
+					"value": 1
+				},
+				{
+					"label": "Toggle switch (change on toggle)",
+					"value": 2
+				}
+			]
+		},
+		{
+			"#": "6",
+			"label": "SW1 & SW2: Swap",
+			"description": "swaped state SW1 control O2, SW2 control O1)",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "default",
+					"value": 0
+				},
+				{
+					"label": "swapped ",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "16",
+			"label": "O1 & O2: Swap",
+			"description": "swaped state O1 - close, O2 - open",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "default",
+					"value": 0
+				},
+				{
+					"label": "swapped",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "17",
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off",
+			"label": "O1: State After Power Failure"
+		},
+		{
+			"#": "18",
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off",
+			"label": "O2: State After Power Failure"
+		},
+		{
+			"#": "19",
+			"label": "O1: Auto-Off Timer",
+			"description": "The timer resets to zero each time the Device receives an ON command",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 32535,
+			"defaultValue": 0,
+			"unsigned": true
+		},
+		{
+			"#": "20",
+			"label": "O1: Auto-On Timer",
+			"description": "The timer resets to zero each time the Device receives an OFF command",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 32535,
+			"defaultValue": 0,
+			"unsigned": true
+		},
+		{
+			"#": "21",
+			"label": "O2: Auto-Off Timer",
+			"description": "The timer resets to zero each time the Device receives an ON command",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 32535,
+			"defaultValue": 0,
+			"unsigned": true
+		},
+		{
+			"#": "22",
+			"label": "O2: Auto-On Timer",
+			"description": "The timer resets to zero each time the Device receives an OFF command",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 32535,
+			"defaultValue": 0,
+			"unsigned": true
+		},
+		{
+			"#": "25",
+			"label": "O1: Auto-On/Off Timer Unit",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Seconds",
+					"value": 0
+				},
+				{
+					"label": "10 ms",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "26",
+			"label": "O2: Auto-On/Off Timer Unit",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Seconds",
+					"value": 0
+				},
+				{
+					"label": "10 ms",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "23",
+			"label": "O1: Relay Type",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "NO: normally open",
+					"value": 0
+				},
+				{
+					"label": "NC: normally closed",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "24",
+			"label": "O2: Relay Type",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "NO: normally open",
+					"value": 0
+				},
+				{
+					"label": "NC: normally closed",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "36",
+			"label": "O1: Power Change Report Threshold",
+			"valueSize": 1,
+			"unit": "%",
+			"minValue": 0,
+			"maxValue": 100,
+			"defaultValue": 50,
+			"unsigned": true
+		},
+		{
+			"#": "37",
+			"label": "O2: Power Change Report Threshold",
+			"valueSize": 1,
+			"unit": "%",
+			"minValue": 0,
+			"maxValue": 100,
+			"defaultValue": 50,
+			"unsigned": true
+		},
+		{
+			"#": "39",
+			"label": "O1: Minimum Time Between Power Reports",
+			"valueSize": 1,
+			"unit": "seconds",
+			"minValue": 0,
+			"maxValue": 120,
+			"defaultValue": 30,
+			"unsigned": true
+		},
+		{
+			"#": "40",
+			"label": "O2: Minimum Time Between Power Reports",
+			"valueSize": 1,
+			"unit": "seconds",
+			"minValue": 0,
+			"maxValue": 120,
+			"defaultValue": 30,
+			"unsigned": true
+		},
+		{
+			"#": "91",
+			"label": "Alarm Configuration: Water",
+			"description": "This parameter determines which alarm frames the Device should respond to and how.",
+			"valueSize": 4,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "No action",
+					"value": 0
+				},
+				{
+					"label": "Open relay",
+					"value": 1
+				},
+				{
+					"label": "Close relay",
+					"value": 2
+				}
+			]
+		},
+		{
+			"#": "92",
+			"label": "Alarm Configuration: Smoke",
+			"description": "This parameter determines which alarm frames the Device should respond to and how.",
+			"valueSize": 4,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "No action",
+					"value": 0
+				},
+				{
+					"label": "Open relay",
+					"value": 1
+				},
+				{
+					"label": "Close relay",
+					"value": 2
+				}
+			]
+		},
+		{
+			"#": "93",
+			"label": "Alarm Configuration: CO",
+			"description": "This parameter determines which alarm frames the Device should respond to and how.",
+			"valueSize": 4,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "No action",
+					"value": 0
+				},
+				{
+					"label": "Open relay",
+					"value": 1
+				},
+				{
+					"label": "Close relay",
+					"value": 2
+				}
+			]
+		},
+		{
+			"#": "94",
+			"label": "Alarm Configuration: Heat",
+			"description": "This parameter determines which alarm frames the Device should respond to and how.",
+			"valueSize": 4,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "No action",
+					"value": 0
+				},
+				{
+					"label": "Open relay",
+					"value": 1
+				},
+				{
+					"label": "Close relay",
+					"value": 2
+				}
+			]
+		},
+		{
+			"#": "120",
+			"label": "Factory Reset",
+			"description": "Reset to factory default settings and remove from the Z-Wave network.",
+			"valueSize": 4,
+			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Idle",
+					"value": 0
+				},
+				{
+					"label": "Factory reset",
+					"value": 1431655765
+				}
+			]
+		},
+		{
+			"#": "201",
+			"label": "Serial Number: Part 1",
+			"description": "This parameter contains a part of devices serial number.",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 2147483647,
+			"unsigned": true,
+			"readOnly": true
+		},
+		{
+			"#": "202",
+			"label": "Serial Number: Part 2",
+			"description": "This parameter contains a part of devices serial number.",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 2147483647,
+			"unsigned": true,
+			"readOnly": true
+		},
+		{
+			"#": "203",
+			"label": "Serial Number: Part 3",
+			"description": "This parameter contains a part of devices serial number.",
+			"valueSize": 4,
+			"minValue": 0,
+			"maxValue": 2147483647,
+			"unsigned": true,
+			"readOnly": true
+		}
+	],
+	"metadata": {
+		"inclusion": "6.1 Adding the Device to a Z-Wave™ network (inclusion)\nNote! All Device outputs (O, O1, O2, etc. - depending on the Device type) will turn the load 1s on/1s off /1s on/1s off if the Device is successfully added to/removed from a Z-Wave™ network.\n\n6.1.1 SmartStart adding (inclusion)\nSmartStart enabled products can be added into a Z-Wave™ network by scanning the Z-Wave™ QR Code present on the Device with a gateway providing SmartStart inclusion. No further action is required, and the SmartStart device will be added automatically within 10 minutes of being switched on in the network vicinity.\n1. With the gateway application scan the QR code on the Device label and add the Security 2 (S2) Device Specific Key (DSK) to the provisioning list in the gateway.\n2. Connect the Device to a power supply.\n3. Check if the blue LED is blinking in Mode 1. If so, the Device is not added to a Z-Wave™ network.\n4. Adding will be initiated automatically within a few seconds after connecting the Device to a power supply, and the Device will be added to a Z-Wave™ network automatically.\n5. The blue LED will be blinking in Mode 2 during the adding process.\n6. The green LED will be blinking in Mode 1 if the Device is successfully added to a Z-Wave™ network.\n\n6.1.2 Adding (inclusion) with a switch/push-button\n1. Connect the Device to a power supply.\n2. Check if the blue LED is blinking in Mode 1. If so, the Device is not added to a Z-Wave™ network.\n3. Enable add/remove mode on the gateway.\n4. Toggle the switch/push-button connected to any of the SW terminals (SW, SW1, SW2, etc.) 3 times within 3 seconds (this procedure puts the Device in Learn mode*). The Device must receive on/off signal 3 times, which means pressing the momentary switch 3 times, or toggling the switch on and off 3 times.\n5. The blue LED will be blinking in Mode 2 during the adding process.\n6. The green LED will be blinking in Mode 1 if the Device is successfully added to a Z-Wave™ network.\n*Learn mode - a state that allows the Device to receive network information from the gateway.\n\n6.1.3 Adding (inclusion) with the S button\n1. Connect the Device to a power supply.\n2. Check if the blue LED is blinking in Mode 1. If so, the Device is not added to a Z-Wave™ network.\n3. Enable add/remove mode on the gateway.\n4. To enter the Setting mode, quickly press and hold the S button on the Device until the LED turns solid blue.\n5. Quickly release and then press and hold (> 2s) the S button on the Device until the blue LED starts blinking in Mode 3. Releasing the S button will start the Learn mode.\n6. The blue LED will be blinking in Mode 2 during the adding process.\n7. The green LED will be blinking in Mode 1 if the Device is successfully added to a Z-Wave™ network.\nNote! In Setting mode, the Device has a timeout of 10s before entering again into Normal mode",
+		"exclusion": "Removing the Device from a Z-Wave™ network (exclusion)\nNote! The Device will be removed from your Z-wave™ network, but any custom configuration parameters will not be erased.\nNote! All Device outputs (O, O1, O2, etc. - depending on the Device type) will turn the load 1s on/1s off /1s on/1s off if the Device is successfully added to/removed from a Z-Wave™ network.\n\n6.2.1 Removing (exclusion) with a switch/push-button\n1. Connect the Device to a power supply.\n2. Check if the green LED is blinking in Mode 1. If so, the Device is added to a Z-Wave™ network.\n3. Enable add/remove mode on the gateway.\n4. Toggle the switch/push-button connected to any of the SW terminals (SW, SW1, SW2,…) 3 times within 3 seconds (this procedure puts the Device in Learn mode). The Device must receive on/off signal 3 times, which means pressing the momentary switch 3 times, or toggling the switch on and off 3 times.\n5. The blue LED will be blinking in Mode 2 during the removing process.\n6. The blue LED will be blinking in Mode 1 if the Device is successfully removed from a Z-Wave™ network.\n\n6.2.2 Removing (exclusion) with the S button\n1. Connect the Device to a power supply.\n2. Check if the green LED is blinking in Mode 1. If so, the Device is added to a Z-Wave™ network.\n3. Enable add/remove mode on the gateway.\n4. To enter the Setting mode, quickly press and hold the S button on the Device until the LED turns solid blue.\n5. Quickly release and then press and hold (> 2s) the S button on the Device until the blue LED starts blinking in Mode 3. Releasing the S button will start the Learn mode.\n6. The blue LED will be blinking in Mode 2 during the removing process.\n7. The blue LED will be blinking in Mode 1 if the Device is successfully removed from a Z-Wave™ network.\nNote! In Setting mode, the Device has a timeout of 10s before entering again into Normal mode",
+		"reset": "6.3 Factory reset\n6.3.1 Factory reset general\nAfter Factory reset, all custom parameters and stored values (kWh, associations, routings, etc.) will return to their default state. HOME ID and NODE ID assigned to the Device will be deleted. Use this reset procedure only when the gateway is missing or otherwise inoperable.\n\n6.3.2 Factory reset with a switch/push-button\nNote! Factory reset with a switch/push-button is only possible within the first minute after the Device is connected to a power supply.\n1. Connect the Device to a power supply.\n2. Toggle the switch/push-button connected to any of the SW terminals (SW, SW1, SW2,…) 5 times within 3 seconds. The Device must receive on/off signal 5 times, which means pressing the push-button 5 times, or toggling the switch on and off 5 times.\n3. During factory reset, the LED will turn solid green for about 1s, then the blue and red LED will start blinking in Mode 3 for approx. 2s.\n4. The blue LED will be blinking in Mode 1 if the Factory reset is successful.\n\n6.3.3 Factory reset with the S button\nNote! Factory reset with the S button is possible anytime.\n1. To enter the Setting mode, quickly press and hold the S button on the Device until the LED turns solid blue.\n2. Press the S button multiple times until the LED turns solid red.\n3. Press and hold (> 2s) S button on the Device until the red LED starts blinking in Mode 3. Releasing the S button will start the factory reset.\n4. During factory reset, the LED will turn solid green for about 1s, then the blue and red LED will start blinking in Mode 3 for approx. 2s.\n5. The blue LED will be blinking in Mode 1 if the Factory reset is successful.\n\n6.3.4 Remote factory reset with parameter with the gateway\nFactory reset can be done remotely with the settings in Parameter No. 120"
+	}
+}


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

fix: Wave 1 added zwavealliance id
feat: config new device Wave 2PM
fix: Wave 1PM association text
