### PR TITLE
feat(config): add NEO Cool Cam Repeater

### DIFF
--- a/packages/config/config/devices/0x0258/nas-rp01.json
+++ b/packages/config/config/devices/0x0258/nas-rp01.json
@@ -1,0 +1,148 @@
+{
+	"manufacturer": "Shenzhen Neo Electronics Co., Ltd",
+	"manufacturerId": "0x0258",
+	"label": "NAS-RP01",
+	"description": "Neo Coolcam Repeater",
+	"devices": [
+		{
+			"productType": "0x0010",
+			"productId": "0x0722"
+		},
+		{
+			"productType": "0x0010",
+			"productId": "0x0716"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5
+		},
+		"2": {
+			"label": "Low Temperature Basic Set",
+			"maxNodes": 5
+		},
+		"3": {
+			"label": "High (?) Temperature Basic Set",
+			"maxNodes": 5
+		},
+		"4": {
+			"label": "Low Humidity Basic Set",
+			"maxNodes": 5
+		},
+		"5": {
+			"label": "High (?) Humidity Basic Set",
+			"maxNodes": 5
+		}
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Red LED blink when measuring",
+			"defaultValue": 1
+		},
+		{
+			"#": "2",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Yellow LED blink during OTA",
+			"defaultValue": 1
+		},
+		{
+			"#": "3",
+			"label": "Temperature Offset Value",
+			"description": "[Value] * 0.1 Degree Celsius / Fahrenheit (US)",
+			"valueSize": 1,
+			"minValue": -120,
+			"maxValue": 120,
+			"defaultValue": 0,
+			"unsigned": false
+		},
+		{
+			"#": "4",
+			"label": "Humidity Offset Value",
+			"description": "[Value] * 0.1 RH%",
+			"valueSize": 1,
+			"minValue": -120,
+			"maxValue": 120,
+			"defaultValue": 0,
+			"unsigned": false
+		},
+		{
+			"#": "5",
+			"$import": "templates/shenzhen_neo_template.json#temperature_report_threshold",
+			"description": "[Value] * 0.1 Degree Celsius / Fahrenheit (US)",
+			"maxValue": 100,
+			"defaultValue": 10
+		},
+		{
+			"#": "6",
+			"label": "Humidity D-Value (report threshold) Setting",
+			"description": "[Value] * 0.1 RH%",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 100,
+			"defaultValue": 20
+		},
+		{
+			"#": "7",
+			"label": "Low Temperature Alarm Value",
+			"description": "[Value] * 0.1 Degree Celsius / Fahrenheit (US)",
+			"valueSize": 2,
+			"minValue": -200,
+			"maxValue": 600,
+			"defaultValue": 180,
+			"unsigned": false
+		},
+		{
+			"#": "8",
+			"label": "High Temperature Alarm Value",
+			"description": "[Value] * 0.1 Degree Celsius / Fahrenheit (US)",
+			"valueSize": 2,
+			"minValue": -200,
+			"maxValue": 600,
+			"defaultValue": 300,
+			"unsigned": false
+		},
+		{
+			"#": "9",
+			"label": "Low Humidity Alarm Value",
+			"description": "[Value] * 0.1 RH%",
+			"valueSize": 2,
+			"minValue": 200,
+			"maxValue": 850,
+			"defaultValue": 400
+		},
+		{
+			"#": "10",
+			"label": "High Humidity Alarm Value",
+			"description": "[Value] * 0.1 RH%",
+			"valueSize": 2,
+			"minValue": 200,
+			"maxValue": 850,
+			"defaultValue": 400
+		},
+		{
+			"#": "11",
+			"label": "Sensor Measuring Interval",
+			"valueSize": 2,
+			"unit": "Seconds",
+			"minValue": 0,
+			"maxValue": 30000,
+			"defaultValue": 10
+		},
+		{
+			"#": "12",
+			"label": "Heartbeat Time",
+			"valueSize": 2,
+			"unit": "Second",
+			"minValue": 0,
+			"maxValue": 30000,
+			"defaultValue": 3600
+		}
+	]
+}

--- a/packages/config/config/devices/0x0258/nas-rp01z1.json
+++ b/packages/config/config/devices/0x0258/nas-rp01z1.json
@@ -39,20 +39,20 @@
 		{
 			"#": "1",
 			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Red LED blink when measuring",
+			"label": "Red LED Blink When Measuring",
 			"defaultValue": 1
 		},
 		{
 			"#": "2",
 			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Yellow LED blink during OTA",
+			"label": "Yellow LED Blink During OTA",
 			"defaultValue": 1
 		},
 		{
 			"#": "3",
 			"label": "Temperature Offset Value",
-			"description": "[Value] * 0.1 Degree Celsius / Fahrenheit (US)",
 			"valueSize": 1,
+			"unit": "0.1 °C/°F",
 			"minValue": -120,
 			"maxValue": 120,
 			"defaultValue": 0,
@@ -61,8 +61,8 @@
 		{
 			"#": "4",
 			"label": "Humidity Offset Value",
-			"description": "[Value] * 0.1 RH%",
 			"valueSize": 1,
+			"unit": "0.1 %rH",
 			"minValue": -120,
 			"maxValue": 120,
 			"defaultValue": 0,
@@ -71,15 +71,15 @@
 		{
 			"#": "5",
 			"$import": "templates/shenzhen_neo_template.json#temperature_report_threshold",
-			"description": "[Value] * 0.1 Degree Celsius / Fahrenheit (US)",
+			"unit": "0.1 °C/°F",
 			"maxValue": 100,
 			"defaultValue": 10
 		},
 		{
 			"#": "6",
-			"label": "Humidity D-Value (report threshold) Setting",
-			"description": "[Value] * 0.1 RH%",
+			"label": "Humidity D-Value (Report Threshold) Setting",
 			"valueSize": 1,
+			"unit": "0.1 %rH",
 			"minValue": 0,
 			"maxValue": 100,
 			"defaultValue": 20
@@ -87,8 +87,8 @@
 		{
 			"#": "7",
 			"label": "Low Temperature Alarm Value",
-			"description": "[Value] * 0.1 Degree Celsius / Fahrenheit (US)",
 			"valueSize": 2,
+			"unit": "0.1 °C/°F",
 			"minValue": -200,
 			"maxValue": 600,
 			"defaultValue": 180,
@@ -97,8 +97,8 @@
 		{
 			"#": "8",
 			"label": "High Temperature Alarm Value",
-			"description": "[Value] * 0.1 Degree Celsius / Fahrenheit (US)",
 			"valueSize": 2,
+			"unit": "0.1 °C/°F",
 			"minValue": -200,
 			"maxValue": 600,
 			"defaultValue": 300,
@@ -107,8 +107,8 @@
 		{
 			"#": "9",
 			"label": "Low Humidity Alarm Value",
-			"description": "[Value] * 0.1 RH%",
 			"valueSize": 2,
+			"unit": "0.1 %rH",
 			"minValue": 200,
 			"maxValue": 850,
 			"defaultValue": 400
@@ -116,8 +116,8 @@
 		{
 			"#": "10",
 			"label": "High Humidity Alarm Value",
-			"description": "[Value] * 0.1 RH%",
 			"valueSize": 2,
+			"unit": "0.1 %rH",
 			"minValue": 200,
 			"maxValue": 850,
 			"defaultValue": 400
@@ -126,7 +126,7 @@
 			"#": "11",
 			"label": "Sensor Measuring Interval",
 			"valueSize": 2,
-			"unit": "Seconds",
+			"unit": "seconds",
 			"minValue": 0,
 			"maxValue": 30000,
 			"defaultValue": 10
@@ -135,7 +135,7 @@
 			"#": "12",
 			"label": "Heartbeat Time",
 			"valueSize": 2,
-			"unit": "Second",
+			"unit": "seconds",
 			"minValue": 0,
 			"maxValue": 30000,
 			"defaultValue": 3600

--- a/packages/config/config/devices/0x0258/nas-rp01z1.json
+++ b/packages/config/config/devices/0x0258/nas-rp01z1.json
@@ -1,13 +1,9 @@
 {
 	"manufacturer": "Shenzhen Neo Electronics Co., Ltd",
 	"manufacturerId": "0x0258",
-	"label": "NAS-RP01",
+	"label": "NAS-RP01Z1",
 	"description": "Neo Coolcam Repeater",
 	"devices": [
-		{
-			"productType": "0x0010",
-			"productId": "0x0722"
-		},
 		{
 			"productType": "0x0010",
 			"productId": "0x0716"

--- a/packages/config/config/devices/0x0258/nas-rp01z1.json
+++ b/packages/config/config/devices/0x0258/nas-rp01z1.json
@@ -23,7 +23,7 @@
 			"maxNodes": 5
 		},
 		"3": {
-			"label": "High (?) Temperature Basic Set",
+			"label": "High Temperature Basic Set",
 			"maxNodes": 5
 		},
 		"4": {
@@ -31,7 +31,7 @@
 			"maxNodes": 5
 		},
 		"5": {
-			"label": "High (?) Humidity Basic Set",
+			"label": "High Humidity Basic Set",
 			"maxNodes": 5
 		}
 	},

--- a/packages/config/config/devices/0x0258/nas-wr02zu.json
+++ b/packages/config/config/devices/0x0258/nas-wr02zu.json
@@ -39,20 +39,20 @@
 		{
 			"#": "1",
 			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Red LED blink when measuring",
+			"label": "Red LED Blink When Measuring",
 			"defaultValue": 1
 		},
 		{
 			"#": "2",
 			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Yellow LED blink during OTA",
+			"label": "Yellow LED Blink During OTA",
 			"defaultValue": 1
 		},
 		{
 			"#": "3",
 			"label": "Temperature Offset Value",
-			"description": "[Value] * 0.1 Degree Celsius / Fahrenheit (US)",
 			"valueSize": 1,
+			"unit": "0.1 °C/°F",
 			"minValue": -120,
 			"maxValue": 120,
 			"defaultValue": 0,
@@ -61,8 +61,8 @@
 		{
 			"#": "4",
 			"label": "Humidity Offset Value",
-			"description": "[Value] * 0.1 RH%",
 			"valueSize": 1,
+			"unit": "0.1 %rH",
 			"minValue": -120,
 			"maxValue": 120,
 			"defaultValue": 0,
@@ -71,15 +71,15 @@
 		{
 			"#": "5",
 			"$import": "templates/shenzhen_neo_template.json#temperature_report_threshold",
-			"description": "[Value] * 0.1 Degree Celsius / Fahrenheit (US)",
+			"unit": "0.1 °C/°F",
 			"maxValue": 100,
 			"defaultValue": 10
 		},
 		{
 			"#": "6",
-			"label": "Humidity D-Value (report threshold) Setting",
-			"description": "[Value] * 0.1 RH%",
+			"label": "Humidity D-Value (Report Threshold) Setting",
 			"valueSize": 1,
+			"unit": "0.1 %rH",
 			"minValue": 0,
 			"maxValue": 100,
 			"defaultValue": 20
@@ -87,8 +87,8 @@
 		{
 			"#": "7",
 			"label": "Low Temperature Alarm Value",
-			"description": "[Value] * 0.1 Degree Celsius / Fahrenheit (US)",
 			"valueSize": 2,
+			"unit": "0.1 °C/°F",
 			"minValue": -200,
 			"maxValue": 600,
 			"defaultValue": 180,
@@ -97,8 +97,8 @@
 		{
 			"#": "8",
 			"label": "High Temperature Alarm Value",
-			"description": "[Value] * 0.1 Degree Celsius / Fahrenheit (US)",
 			"valueSize": 2,
+			"unit": "0.1 °C/°F",
 			"minValue": -200,
 			"maxValue": 600,
 			"defaultValue": 300,
@@ -107,8 +107,8 @@
 		{
 			"#": "9",
 			"label": "Low Humidity Alarm Value",
-			"description": "[Value] * 0.1 RH%",
 			"valueSize": 2,
+			"unit": "0.1 %rH",
 			"minValue": 200,
 			"maxValue": 850,
 			"defaultValue": 400
@@ -116,8 +116,8 @@
 		{
 			"#": "10",
 			"label": "High Humidity Alarm Value",
-			"description": "[Value] * 0.1 RH%",
 			"valueSize": 2,
+			"unit": "0.1 %rH",
 			"minValue": 200,
 			"maxValue": 850,
 			"defaultValue": 400
@@ -126,7 +126,7 @@
 			"#": "11",
 			"label": "Sensor Measuring Interval",
 			"valueSize": 2,
-			"unit": "Seconds",
+			"unit": "seconds",
 			"minValue": 0,
 			"maxValue": 30000,
 			"defaultValue": 10
@@ -135,7 +135,7 @@
 			"#": "12",
 			"label": "Heartbeat Time",
 			"valueSize": 2,
-			"unit": "Second",
+			"unit": "seconds",
 			"minValue": 0,
 			"maxValue": 30000,
 			"defaultValue": 3600

--- a/packages/config/config/devices/0x0258/nas-wr02zu.json
+++ b/packages/config/config/devices/0x0258/nas-wr02zu.json
@@ -1,0 +1,144 @@
+{
+	"manufacturer": "Shenzhen Neo Electronics Co., Ltd",
+	"manufacturerId": "0x0258",
+	"label": "NAS-WR02ZU",
+	"description": "Neo Coolcam Repeater",
+	"devices": [
+		{
+			"productType": "0x0010",
+			"productId": "0x0722"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5
+		},
+		"2": {
+			"label": "Low Temperature Basic Set",
+			"maxNodes": 5
+		},
+		"3": {
+			"label": "High (?) Temperature Basic Set",
+			"maxNodes": 5
+		},
+		"4": {
+			"label": "Low Humidity Basic Set",
+			"maxNodes": 5
+		},
+		"5": {
+			"label": "High (?) Humidity Basic Set",
+			"maxNodes": 5
+		}
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Red LED blink when measuring",
+			"defaultValue": 1
+		},
+		{
+			"#": "2",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Yellow LED blink during OTA",
+			"defaultValue": 1
+		},
+		{
+			"#": "3",
+			"label": "Temperature Offset Value",
+			"description": "[Value] * 0.1 Degree Celsius / Fahrenheit (US)",
+			"valueSize": 1,
+			"minValue": -120,
+			"maxValue": 120,
+			"defaultValue": 0,
+			"unsigned": false
+		},
+		{
+			"#": "4",
+			"label": "Humidity Offset Value",
+			"description": "[Value] * 0.1 RH%",
+			"valueSize": 1,
+			"minValue": -120,
+			"maxValue": 120,
+			"defaultValue": 0,
+			"unsigned": false
+		},
+		{
+			"#": "5",
+			"$import": "templates/shenzhen_neo_template.json#temperature_report_threshold",
+			"description": "[Value] * 0.1 Degree Celsius / Fahrenheit (US)",
+			"maxValue": 100,
+			"defaultValue": 10
+		},
+		{
+			"#": "6",
+			"label": "Humidity D-Value (report threshold) Setting",
+			"description": "[Value] * 0.1 RH%",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 100,
+			"defaultValue": 20
+		},
+		{
+			"#": "7",
+			"label": "Low Temperature Alarm Value",
+			"description": "[Value] * 0.1 Degree Celsius / Fahrenheit (US)",
+			"valueSize": 2,
+			"minValue": -200,
+			"maxValue": 600,
+			"defaultValue": 180,
+			"unsigned": false
+		},
+		{
+			"#": "8",
+			"label": "High Temperature Alarm Value",
+			"description": "[Value] * 0.1 Degree Celsius / Fahrenheit (US)",
+			"valueSize": 2,
+			"minValue": -200,
+			"maxValue": 600,
+			"defaultValue": 300,
+			"unsigned": false
+		},
+		{
+			"#": "9",
+			"label": "Low Humidity Alarm Value",
+			"description": "[Value] * 0.1 RH%",
+			"valueSize": 2,
+			"minValue": 200,
+			"maxValue": 850,
+			"defaultValue": 400
+		},
+		{
+			"#": "10",
+			"label": "High Humidity Alarm Value",
+			"description": "[Value] * 0.1 RH%",
+			"valueSize": 2,
+			"minValue": 200,
+			"maxValue": 850,
+			"defaultValue": 400
+		},
+		{
+			"#": "11",
+			"label": "Sensor Measuring Interval",
+			"valueSize": 2,
+			"unit": "Seconds",
+			"minValue": 0,
+			"maxValue": 30000,
+			"defaultValue": 10
+		},
+		{
+			"#": "12",
+			"label": "Heartbeat Time",
+			"valueSize": 2,
+			"unit": "Second",
+			"minValue": 0,
+			"maxValue": 30000,
+			"defaultValue": 3600
+		}
+	]
+}

--- a/packages/config/config/devices/0x0258/nas-wr02zu.json
+++ b/packages/config/config/devices/0x0258/nas-wr02zu.json
@@ -23,7 +23,7 @@
 			"maxNodes": 5
 		},
 		"3": {
-			"label": "High (?) Temperature Basic Set",
+			"label": "High Temperature Basic Set",
 			"maxNodes": 5
 		},
 		"4": {
@@ -31,7 +31,7 @@
 			"maxNodes": 5
 		},
 		"5": {
-			"label": "High (?) Humidity Basic Set",
+			"label": "High Humidity Basic Set",
 			"maxNodes": 5
 		}
 	},


### PR DESCRIPTION
Merging should close #5348 and #5824. Although the numbers and model are different the manual for both is the same.

There is one issue that should be tested by someone with the device before merging.  The manual description for the Association groups is not logical. First the referenced param numbers appear low by one based on context.  Second, it appears all groups are for low alarms despite the parameter label.

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

PR description here
[15-NAS-WR02ZU-UserMan-4479208.1.pdf](https://github.com/zwave-js/node-zwave-js/files/12738655/15-NAS-WR02ZU-UserMan-4479208.1.pdf)
[NEO_NAS-RP01Z1_download_1.pdf](https://github.com/zwave-js/node-zwave-js/files/12738656/NEO_NAS-RP01Z1_download_1.pdf)

