### PR TITLE
feat(config): add Qubino Shades Remote Controller

### DIFF
--- a/packages/config/config/devices/0x015a/jtb-zmnkgd1.json
+++ b/packages/config/config/devices/0x015a/jtb-zmnkgd1.json
@@ -1,0 +1,16 @@
+{
+	"manufacturer": "Jin Tao Bao",
+	"manufacturerId": "0x015a",
+	"label": "JTB-ZMNKGD1",
+	"description": "Shades Remote Controller",
+	"devices": [
+		{
+			"productType": "0x2000",
+			"productId": "0x0003"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	}
+}


### PR DESCRIPTION
This should close #5846 . There are no parameters and no association groups.

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

PR description here
[Qubino_Shades_Remote.pdf](https://github.com/zwave-js/node-zwave-js/files/12750157/Qubino_Shades_Remote.pdf)

memo: How this device appears to work 1) Includes in network (gets ID) 2) Includes Qubino blinds during operation.  Probably picks up zwave transmissions. 3) operate blinds with remote. Unclear how many blinds it can control.
