### PR TITLE
chore: extend auto-unsigned rule to exclusive predefined options

### DIFF
--- a/packages/config/config/devices/0x000c/hs-fls100-g2.json
+++ b/packages/config/config/devices/0x000c/hs-fls100-g2.json
@@ -36,7 +36,6 @@
 			"label": "Load Control Mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -55,7 +54,6 @@
 			"description": "Select which sensors control the load when parameter 5 is set to 1",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -82,7 +80,6 @@
 			"label": "PIR Sensitivity",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0014/wd500z.json
+++ b/packages/config/config/devices/0x0014/wd500z.json
@@ -35,7 +35,6 @@
 			"label": "Ignore Start Level",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -54,7 +53,6 @@
 			"description": "When enabled, the LED indicator will turn on when the light is turned off",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -72,7 +70,6 @@
 			"label": "Invert Switch",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -90,7 +87,6 @@
 			"label": "Shade Control Group 2",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -108,7 +104,6 @@
 			"label": "Shade Control Group 3",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -126,7 +121,6 @@
 			"label": "LED Indicator",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -148,7 +142,6 @@
 			"label": "Load Sense",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x001a/rf9501.json
+++ b/packages/config/config/devices/0x001a/rf9501.json
@@ -68,7 +68,6 @@
 			"description": "Power Up State of the switch",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -91,7 +90,6 @@
 			"description": "Enables this switch to participate in panic mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -110,7 +108,6 @@
 			"description": "Keep associated accessory switches in sync",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x001a/rf9536-n.json
+++ b/packages/config/config/devices/0x001a/rf9536-n.json
@@ -75,7 +75,6 @@
 			"description": "Power Up State of the switch",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -98,7 +97,6 @@
 			"description": "Enables this switch to participate in panic mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -128,7 +126,6 @@
 			"description": "Turn on or off rapid start feature",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x001a/rf9537.json
+++ b/packages/config/config/devices/0x001a/rf9537.json
@@ -75,7 +75,6 @@
 			"description": "Power Up State of the switch",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -98,7 +97,6 @@
 			"description": "Enables this switch to participate in panic mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -128,7 +126,6 @@
 			"description": "Turn on or off rapid start feature",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x001a/rf9540-n_0.0_1.1.json
+++ b/packages/config/config/devices/0x001a/rf9540-n_0.0_1.1.json
@@ -83,7 +83,6 @@
 			"description": "Power Up State of the switch",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -106,7 +105,6 @@
 			"description": "Enables this switch to participate in panic mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -136,7 +134,6 @@
 			"description": "Turn on or off rapid start feature",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -155,7 +152,6 @@
 			"description": "Keep associated accessory switches in sync",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x001a/rf9540-n_1.2.json
+++ b/packages/config/config/devices/0x001a/rf9540-n_1.2.json
@@ -79,7 +79,6 @@
 			"description": "Power Up State of the switch",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -102,7 +101,6 @@
 			"description": "Enables this switch to participate in panic mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -132,7 +130,6 @@
 			"description": "Turn on or off rapid start feature",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -151,7 +148,6 @@
 			"description": "Keep associated accessory switches in sync",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x001a/rf9542.json
+++ b/packages/config/config/devices/0x001a/rf9542.json
@@ -75,7 +75,6 @@
 			"description": "Power Up State of the switch",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -98,7 +97,6 @@
 			"description": "Enables this switch to participate in panic mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x001a/rf9640.json
+++ b/packages/config/config/devices/0x001a/rf9640.json
@@ -47,7 +47,6 @@
 			"label": "Power Up State",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x001a/rf96apm.json
+++ b/packages/config/config/devices/0x001a/rf96apm.json
@@ -21,7 +21,6 @@
 			"description": "1: remember (0: do not remember)",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x001a/rftr9605-t.json
+++ b/packages/config/config/devices/0x001a/rftr9605-t.json
@@ -47,7 +47,6 @@
 			"description": "1 = off 2 = on 3 = last state",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -69,7 +68,6 @@
 			"label": "Panic Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -88,7 +86,6 @@
 			"description": "Light intensity of indicator led",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -107,7 +104,6 @@
 			"description": "Light intensity of indicator led",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x002c/z-flexnet_dongl.json
+++ b/packages/config/config/devices/0x002c/z-flexnet_dongl.json
@@ -31,7 +31,6 @@
 			"valueSize": 2,
 			"unit": "hours",
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0039/39336_39443_zw3104.json
+++ b/packages/config/config/devices/0x0039/39336_39443_zw3104.json
@@ -37,7 +37,6 @@
 			"description": "LED status when device on or off.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -60,7 +59,6 @@
 			"description": "Number of steps or levels",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -136,7 +134,6 @@
 			"label": "Enable/disable switch mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0039/39337_39444_zw4103.json
+++ b/packages/config/config/devices/0x0039/39337_39444_zw4103.json
@@ -20,7 +20,6 @@
 			"label": "LED Indicator",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0039/39339_39346_zw3107.json
+++ b/packages/config/config/devices/0x0039/39339_39346_zw3107.json
@@ -37,7 +37,6 @@
 			"description": "LED status when device on or off.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -60,7 +59,6 @@
 			"description": "Dim up/down the light to the specified level quickly or slowly.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0039/39342_39449_zw4106.json
+++ b/packages/config/config/devices/0x0039/39342_39449_zw4106.json
@@ -37,7 +37,6 @@
 			"description": "LED status when device on or off.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0039/39348_39455_zw4005.json
+++ b/packages/config/config/devices/0x0039/39348_39455_zw4005.json
@@ -36,7 +36,6 @@
 			"label": "LED Indicator",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -76,7 +75,6 @@
 			"label": "Alternate Exclusion",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0039/39348_39455_zw4008.json
+++ b/packages/config/config/devices/0x0039/39348_39455_zw4008.json
@@ -37,7 +37,6 @@
 			"description": "LED status when device on or off.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -64,7 +63,6 @@
 			"description": "Change the default exclusion behavior",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0039/39349_39456_zw1002.json
+++ b/packages/config/config/devices/0x0039/39349_39456_zw1002.json
@@ -21,7 +21,6 @@
 			"description": "Invert LED light",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0039/39351_39458_zw3005.json
+++ b/packages/config/config/devices/0x0039/39351_39458_zw3005.json
@@ -37,7 +37,6 @@
 			"description": "LED status when device on or off.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -60,7 +59,6 @@
 			"description": "If the switch is accidentally installed upside down with “On” at the bottom and “Off” at the top, the default On/Off rocker settings can be reversed by changing parameter 4’s value to “1”",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0039/39351_39458_zw3010.json
+++ b/packages/config/config/devices/0x0039/39351_39458_zw3010.json
@@ -37,7 +37,6 @@
 			"description": "LED status when device on or off.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -81,7 +80,6 @@
 			"label": "Dim Up/Down Rate",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -99,7 +97,6 @@
 			"label": "Enable/Disable Switch Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -117,7 +114,6 @@
 			"label": "Alternate Exclusion",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0039/39354_39461_zw4003.json
+++ b/packages/config/config/devices/0x0039/39354_39461_zw4003.json
@@ -37,7 +37,6 @@
 			"description": "LED status when device on or off.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -73,7 +72,6 @@
 			"description": "Change the default exclusion behavior",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0039/39354_39461_zw4009.json
+++ b/packages/config/config/devices/0x0039/39354_39461_zw4009.json
@@ -37,7 +37,6 @@
 			"description": "LED status when device on or off.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -73,7 +72,6 @@
 			"description": "Change the default exclusion behavior",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0039/39357_39464_zw3004.json
+++ b/packages/config/config/devices/0x0039/39357_39464_zw3004.json
@@ -37,7 +37,6 @@
 			"description": "LED status when device on or off.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -63,7 +62,6 @@
 			"label": "Invert Switch",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0039/39357_39464_zw3011.json
+++ b/packages/config/config/devices/0x0039/39357_39464_zw3011.json
@@ -37,7 +37,6 @@
 			"description": "LED status when device on or off.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -63,7 +62,6 @@
 			"label": "Dim Up/Down Rate",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -81,7 +79,6 @@
 			"label": "Switch Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -99,7 +96,6 @@
 			"label": "Alternate Exclusion",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0039/39358_39465_zw4002.json
+++ b/packages/config/config/devices/0x0039/39358_39465_zw4002.json
@@ -36,7 +36,6 @@
 			"label": "Invert Switch",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0039/39363_39470_zw4203.json
+++ b/packages/config/config/devices/0x0039/39363_39470_zw4203.json
@@ -37,7 +37,6 @@
 			"description": "LED status when device on or off.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -59,7 +58,6 @@
 			"label": "Alternate Exclusion",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x004f/fxs-m08.json
+++ b/packages/config/config/devices/0x004f/fxs-m08.json
@@ -60,7 +60,6 @@
 			"valueSize": 1,
 			"unit": "seconds",
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -80,7 +79,6 @@
 			"valueSize": 1,
 			"unit": "seconds",
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0059/max10y-376.json
+++ b/packages/config/config/devices/0x0059/max10y-376.json
@@ -44,7 +44,6 @@
 			"description": "Used to select temperature scale '°c' or '°f' for unsolicited multilevel sensor report. note: (1) on every scale change config parameter 3 to 5 will be set to their default values. (2) parameter 2 to 5 available only if temperature sensor is connected while inclusion process",
 			"valueSize": 2,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -90,7 +89,6 @@
 			"description": "Configuration of delta temperature for delta temperature change based reporting. in case of °f scale: minimum value is 0 and maximum value is 500 (in 0.1 °f resolution)",
 			"valueSize": 2,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0059/ssp_302_anz.json
+++ b/packages/config/config/devices/0x0059/ssp_302_anz.json
@@ -142,7 +142,6 @@
 			"description": "This configuration is used to change the relay LED status when relay is open/close and also enable to whether to retain the last relay status over power cycle",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0060/ad146.json
+++ b/packages/config/config/devices/0x0060/ad146.json
@@ -37,7 +37,6 @@
 			"label": "Remember last status",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -56,7 +55,6 @@
 			"description": "Edge or toggle switch mode.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -75,7 +73,6 @@
 			"description": "Dimming or On/Off Switch",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0060/an158.json
+++ b/packages/config/config/devices/0x0060/an158.json
@@ -42,7 +42,6 @@
 			"description": "Enable or Disable the status message function",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0060/an179.json
+++ b/packages/config/config/devices/0x0060/an179.json
@@ -74,7 +74,6 @@
 			"description": "Edge or toggle switch mode.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0060/an196.json
+++ b/packages/config/config/devices/0x0060/an196.json
@@ -35,7 +35,6 @@
 			"label": "Switch 1 Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -53,7 +52,6 @@
 			"label": "Switch 2 Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0060/hsp02.json
+++ b/packages/config/config/devices/0x0060/hsp02.json
@@ -50,7 +50,6 @@
 			"label": "Sensor Detecting Function",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0060/sp814.json
+++ b/packages/config/config/devices/0x0060/sp814.json
@@ -40,7 +40,6 @@
 			"description": "The Detecting function can be Disabled or Enabled.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0060/sp816.json
+++ b/packages/config/config/devices/0x0060/sp816.json
@@ -28,7 +28,6 @@
 			"description": "The Detecting function can be Disabled or Enabled.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0063/38957_zw6305.json
+++ b/packages/config/config/devices/0x0063/38957_zw6305.json
@@ -21,7 +21,6 @@
 			"description": "This parameter allows you to reverse the detection values of the device",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -44,7 +43,6 @@
 			"description": "This parameter allows you to change the inclusion configuration settings of this device",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -63,7 +61,6 @@
 			"description": "This parameter gives you the option to turn the LED off on magnetic triggers",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -109,7 +106,6 @@
 			"description": "This parameter allows you to choose how often the LED will flash once the device/battery cover is tampered with",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0063/38959_zw6306.json
+++ b/packages/config/config/devices/0x0063/38959_zw6306.json
@@ -25,7 +25,6 @@
 			"description": "Only use with included probe",
 			"valueSize": 2,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -131,7 +130,6 @@
 			"label": "Tamper Alert Configuration",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0063/43973_zw6305.json
+++ b/packages/config/config/devices/0x0063/43973_zw6305.json
@@ -21,7 +21,6 @@
 			"description": "This parameter allows you to reverse the detection values of the device",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -44,7 +43,6 @@
 			"description": "This parameter allows you to change the inclusion configuration settings of this device",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -63,7 +61,6 @@
 			"description": "This parameter gives you the option to turn the LED off on magnetic triggers",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -109,7 +106,6 @@
 			"description": "This parameter allows you to choose how often the LED will flash once the device/battery cover is tampered with",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0063/43985_zw6306.json
+++ b/packages/config/config/devices/0x0063/43985_zw6306.json
@@ -24,7 +24,6 @@
 			"label": "Reverse Detection of Wet/Dry",
 			"valueSize": 2,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -120,7 +119,6 @@
 			"label": "Tamper Alert Configuration",
 			"valueSize": 2,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0063/52247_zw6309.json
+++ b/packages/config/config/devices/0x0063/52247_zw6309.json
@@ -25,7 +25,6 @@
 			"description": "Detection mode(1:wet 2:dry)",
 			"valueSize": 2,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -119,7 +118,6 @@
 			"label": "Temperature Report Interval (on USB)",
 			"valueSize": 2,
 			"defaultValue": 60,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -137,7 +135,6 @@
 			"label": "Led/Buzzer Action During Tamper Event",
 			"valueSize": 2,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0063/52249_zw6308.json
+++ b/packages/config/config/devices/0x0063/52249_zw6308.json
@@ -21,7 +21,6 @@
 			"description": "Invert open close door",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -44,7 +43,6 @@
 			"description": "Change cmd send of open/close door/window",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -94,7 +92,6 @@
 			"description": "Tamper remove LED continuous blink you can set",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0064/06436.json
+++ b/packages/config/config/devices/0x0064/06436.json
@@ -35,7 +35,6 @@
 			"description": "Set LED indication mode",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -81,7 +80,6 @@
 			"label": "RF Close Command Interpretation",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -155,7 +153,6 @@
 			"label": "Protected command",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -174,7 +171,6 @@
 			"description": "Defines behaviour on open press while closing and vice versa.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -196,7 +192,6 @@
 			"label": "Invert open and close relays",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -223,7 +218,6 @@
 			"description": "Allows exchanging the functionality of the buttons",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -242,7 +236,6 @@
 			"description": "Local operations by buttons will/will not/ switch the load",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -265,7 +258,6 @@
 			"description": "Defines which command should be sent on button single press or hold.",
 			"valueSize": 1,
 			"defaultValue": 4,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -300,7 +292,6 @@
 			"description": "Defines which command should be sent on button double press or press-hold.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -356,7 +347,6 @@
 			"label": "What to do on button Down press",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -379,7 +369,6 @@
 			"description": "Defines the action to perform upon auto open or auto close.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0064/duwi_z-wave_plugin_switch.json
+++ b/packages/config/config/devices/0x0064/duwi_z-wave_plugin_switch.json
@@ -30,7 +30,6 @@
 			"label": "LED indication mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -63,7 +62,6 @@
 			"description": "Defines how to interpret RF Off-Command.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -90,7 +88,6 @@
 			"description": "Defines if the switch should restore switch state.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -118,7 +115,6 @@
 			"description": "Color for Off state.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -149,7 +145,6 @@
 			"description": "Color for On state.",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0064/reitz_05431.json
+++ b/packages/config/config/devices/0x0064/reitz_05431.json
@@ -35,7 +35,6 @@
 			"label": "Set LED indication mode",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -71,7 +70,6 @@
 			"label": "Function of RF off command",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -97,7 +95,6 @@
 			"label": "Switch on dimming by buttons",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -115,7 +112,6 @@
 			"label": "restore switch state",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -141,7 +137,6 @@
 			"label": "Invert buttons",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -159,7 +154,6 @@
 			"label": "Switch by buttons",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -181,7 +175,6 @@
 			"label": "Action on button single press or hold",
 			"valueSize": 1,
 			"defaultValue": 4,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -215,7 +208,6 @@
 			"label": "Action on button double press or hold",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -271,7 +263,6 @@
 			"label": "What to do on button Down press",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0077/smartdimmer.json
+++ b/packages/config/config/devices/0x0077/smartdimmer.json
@@ -49,7 +49,6 @@
 			"description": "B&O IR support is disabled if 0 otherwise enabled.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -68,7 +67,6 @@
 			"description": "Dimming Type, trailing edge enabled if 0 otherwise leading edge enabled.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0077/smartpower.json
+++ b/packages/config/config/devices/0x0077/smartpower.json
@@ -41,7 +41,6 @@
 			"description": "Enable/Disable BO IR Support",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0084/mimolite.json
+++ b/packages/config/config/devices/0x0084/mimolite.json
@@ -65,7 +65,6 @@
 			"label": "Clear_Pulse_Meter_Counts",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -80,7 +79,6 @@
 			"description": "Input-to-relay Mapping",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -158,7 +156,6 @@
 			"label": "Trigger_Level_And_Input_Threshold",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -184,7 +181,6 @@
 			"label": "Multilevel_AutoReport_Interval",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0086/dsa38.json
+++ b/packages/config/config/devices/0x0086/dsa38.json
@@ -27,7 +27,6 @@
 			"label": "Button 1 Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0086/dsc11.json
+++ b/packages/config/config/devices/0x0086/dsc11.json
@@ -358,7 +358,6 @@
 			"label": "Meter Calibration Mode",
 			"valueSize": 4,
 			"defaultValue": 0,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [

--- a/packages/config/config/devices/0x0086/zw056.json
+++ b/packages/config/config/devices/0x0086/zw056.json
@@ -84,7 +84,6 @@
 			"description": "This parameter is used to implement the control items",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0086/zw095.json
+++ b/packages/config/config/devices/0x0086/zw095.json
@@ -38,7 +38,6 @@
 			"label": "Energy Detection Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0086/zw098.json
+++ b/packages/config/config/devices/0x0086/zw098.json
@@ -72,7 +72,6 @@
 			"label": "Color Change Report Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -131,7 +130,6 @@
 			"label": "Reboot/Save/Exit Colorful Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -349,7 +347,6 @@
 			"label": "Dimmer Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0086/zw100.json
+++ b/packages/config/config/devices/0x0086/zw100.json
@@ -403,7 +403,6 @@
 			"label": "LED Blinking",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0086/zw111.json
+++ b/packages/config/config/devices/0x0086/zw111.json
@@ -432,7 +432,6 @@
 			"label": "LED Indicator When Off",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0086/zw120.json
+++ b/packages/config/config/devices/0x0086/zw120.json
@@ -62,7 +62,6 @@
 			"label": "Sensor Report Type",
 			"valueSize": 4,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0086/zw121.json
+++ b/packages/config/config/devices/0x0086/zw121.json
@@ -39,7 +39,6 @@
 			"label": "Report Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -96,7 +95,6 @@
 			"label": "Reboot/Save/Exit Colorful Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -310,7 +308,6 @@
 			"label": "Colorful Mode Configuration",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -345,7 +342,6 @@
 			"label": "Dimmer Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0086/zw122.json
+++ b/packages/config/config/devices/0x0086/zw122.json
@@ -157,7 +157,6 @@
 			"label": "Tilt Sensor State",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -213,7 +212,6 @@
 			"description": "Report is sent to Association Group 3",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -236,7 +234,6 @@
 			"description": "Report is sent to Association Group 4",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -280,7 +277,6 @@
 			"description": "For non-multichannel devices - Configuration CC will report to the Water Leak Status parameters",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -344,7 +340,6 @@
 			"label": "Automatic Secondary Report Type",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0086/zw141.json
+++ b/packages/config/config/devices/0x0086/zw141.json
@@ -54,7 +54,6 @@
 			"description": "Refer to user manual for a description of operation modes 1 or 2",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x008a/builtindimmer.json
+++ b/packages/config/config/devices/0x008a/builtindimmer.json
@@ -45,7 +45,6 @@
 			"label": "The way how the button reacts when press/released",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -68,7 +67,6 @@
 			"description": "The way the Built-in Dimmer reacts when light is turned on/off with button",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -86,7 +84,6 @@
 			"label": "Enable dimming",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x008a/doorsensor.json
+++ b/packages/config/config/devices/0x008a/doorsensor.json
@@ -46,7 +46,6 @@
 			"description": "Configure what the external contact sends when triggered.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -65,7 +64,6 @@
 			"description": "The main operating mode for the device.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x008a/plugindimmer.json
+++ b/packages/config/config/devices/0x008a/plugindimmer.json
@@ -42,7 +42,6 @@
 			"label": "Enable dimming",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x008a/tag_reader_500.json
+++ b/packages/config/config/devices/0x008a/tag_reader_500.json
@@ -64,7 +64,6 @@
 			"label": "Always awake mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -99,7 +98,6 @@
 			"label": "Gateway confirmation",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x008b/t400.json
+++ b/packages/config/config/devices/0x008b/t400.json
@@ -36,7 +36,6 @@
 			"label": "Schedule Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x008b/t500.json
+++ b/packages/config/config/devices/0x008b/t500.json
@@ -37,7 +37,6 @@
 			"label": "Schedule Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0090/hc620.json
+++ b/packages/config/config/devices/0x0090/hc620.json
@@ -30,7 +30,6 @@
 			"label": "Status LED",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -49,7 +48,6 @@
 			"label": "Buzzer",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -68,7 +66,6 @@
 			"label": "User Program Button",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -88,7 +85,6 @@
 			"description": "Control the secure screen functionality (on touch locks only)",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -108,7 +104,6 @@
 			"description": "Indicates the direction of the lock. Set to 1 (Right handed lock) to initiate direction detection.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -130,7 +125,6 @@
 			"label": "Reset to Factory Default Settings",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [

--- a/packages/config/config/devices/0x0096/nq-9021.json
+++ b/packages/config/config/devices/0x0096/nq-9021.json
@@ -41,7 +41,6 @@
 			"label": "Sensor type",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -153,7 +152,6 @@
 			"label": "Debug mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0096/nq-9022.json
+++ b/packages/config/config/devices/0x0096/nq-9022.json
@@ -28,7 +28,6 @@
 			"label": "Sensor type",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -143,7 +142,6 @@
 			"label": "Debug mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0096/nq-9121.json
+++ b/packages/config/config/devices/0x0096/nq-9121.json
@@ -40,7 +40,6 @@
 			"label": "Sensor type",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0098/ct100.json
+++ b/packages/config/config/devices/0x0098/ct100.json
@@ -148,7 +148,6 @@
 			"label": "Lock Setpoint Changes",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -184,7 +183,6 @@
 			"label": "Humidity Reporting Threshold",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -210,7 +208,6 @@
 			"label": "Auxiliary/Emergency Heating",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0098/ct100_plus.json
+++ b/packages/config/config/devices/0x0098/ct100_plus.json
@@ -60,7 +60,6 @@
 			"description": "Prevents setpoint changes at thermostat",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -90,7 +89,6 @@
 			"description": "Reporting threshold for changes in the relative humidity",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -117,7 +115,6 @@
 			"description": "Enables or disables auxiliary / emergency heating",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0098/ct101.json
+++ b/packages/config/config/devices/0x0098/ct101.json
@@ -138,7 +138,6 @@
 			"label": "Lock Setpoint Changes",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -174,7 +173,6 @@
 			"label": "Humidity Reporting Threshold",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -200,7 +198,6 @@
 			"label": "Auxiliary/Emergency Heating",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0098/ct30.json
+++ b/packages/config/config/devices/0x0098/ct30.json
@@ -56,7 +56,6 @@
 			"label": "Temperature Reporting Threshold",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -86,7 +85,6 @@
 			"label": "Utility Lock Enable/Disable",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -104,7 +102,6 @@
 			"label": "Humidity Reporting Threshold",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -130,7 +127,6 @@
 			"label": "Auxiliary/Emergency",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -148,7 +144,6 @@
 			"label": "Thermostat Swing Temperature",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -170,7 +165,6 @@
 			"label": "Thermostat Diff Temperature",
 			"valueSize": 1,
 			"defaultValue": 4,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0098/ct32.json
+++ b/packages/config/config/devices/0x0098/ct32.json
@@ -59,7 +59,6 @@
 			"description": "Enables or Disables the Utility Lock.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -210,7 +209,6 @@
 			"description": "If set to 0, multicast is disabled, if set to 1, will enable the multicast.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0098/ct80.json
+++ b/packages/config/config/devices/0x0098/ct80.json
@@ -75,7 +75,6 @@
 			"description": "Prevents setpoint changes at thermostat.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -104,7 +103,6 @@
 			"description": "Reporting threshold for changes in the relative humidity.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -131,7 +129,6 @@
 			"description": "Enables or disables auxiliary / emergency heating",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -192,7 +189,6 @@
 			"description": "Configures additional stages",
 			"valueSize": 1,
 			"defaultValue": 4,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0109/zd2201.json
+++ b/packages/config/config/devices/0x0109/zd2201.json
@@ -28,7 +28,6 @@
 			"description": "Choose °C or °F",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0109/zd2301eu-5.json
+++ b/packages/config/config/devices/0x0109/zd2301eu-5.json
@@ -20,7 +20,6 @@
 			"label": "Temperature Unit",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0109/zl7431.json
+++ b/packages/config/config/devices/0x0109/zl7431.json
@@ -31,7 +31,6 @@
 			"label": "Indicator Light",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0109/zl7435-5.json
+++ b/packages/config/config/devices/0x0109/zl7435-5.json
@@ -21,7 +21,6 @@
 			"description": "This parameter sets the mode for the wall switch inputs",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0109/zm1602-5.json
+++ b/packages/config/config/devices/0x0109/zm1602-5.json
@@ -39,7 +39,6 @@
 			"description": "Defines the reaction of the siren",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -62,7 +61,6 @@
 			"description": "Defines the auto time out of the alarm indication",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0109/zm1602.json
+++ b/packages/config/config/devices/0x0109/zm1602.json
@@ -33,7 +33,6 @@
 			"description": "Defines the reaction of the siren",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -56,7 +55,6 @@
 			"description": "Defines the auto time out of the alarm indication",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0109/zp3113-7.json
+++ b/packages/config/config/devices/0x0109/zp3113-7.json
@@ -92,7 +92,6 @@
 			"label": "Led Indicator",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010b/dn3g6ja069.json
+++ b/packages/config/config/devices/0x010b/dn3g6ja069.json
@@ -21,7 +21,6 @@
 			"description": "Configure arbitrarily to send which sensor values. the sensor values can be selected from humidity, luminance, and temperature",
 			"valueSize": 1,
 			"defaultValue": 7,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -64,7 +63,6 @@
 			"description": "Configure to send which the sensor values arbitrarily. the sensor values can be selected from human detect and open/close",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -92,7 +90,6 @@
 			"valueSize": 1,
 			"unit": "%",
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010b/dn3g6ja082.json
+++ b/packages/config/config/devices/0x010b/dn3g6ja082.json
@@ -21,7 +21,6 @@
 			"description": "Enable switch of \"alarm notification\" report",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010b/dn3g6ja084.json
+++ b/packages/config/config/devices/0x010b/dn3g6ja084.json
@@ -21,7 +21,6 @@
 			"description": "Enable switch of \"alarm notification\" report",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010e/danalock_v3-btze.json
+++ b/packages/config/config/devices/0x010e/danalock_v3-btze.json
@@ -20,7 +20,6 @@
 			"label": "Twin Assist",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -52,7 +51,6 @@
 			"label": "Block to Block",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -79,7 +77,6 @@
 			"label": "BLE: Always",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010f/fgbs001.json
+++ b/packages/config/config/devices/0x010f/fgbs001.json
@@ -74,7 +74,6 @@
 			"description": "Type of input no. 1, what the input 1 will report if no contact is made",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -101,7 +100,6 @@
 			"description": "Type of input no. 2, what the input 2 will report if no contact is made",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -223,7 +221,6 @@
 			"label": "Deactivate transmission of frame canceling alarm",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -274,7 +271,6 @@
 			"label": "Transmitting alarm/control frame broadcast mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -301,7 +297,6 @@
 			"description": "Enable/Disable scene functionality.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010f/fgbs222.json
+++ b/packages/config/config/devices/0x010f/fgbs222.json
@@ -50,7 +50,6 @@
 			"label": "Input 1 - Operating Mode",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -145,7 +144,6 @@
 			"description": "This parameter allows to choose mode of 2nd input (in2). change it depending on connected device",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -334,7 +332,6 @@
 			"label": "Output 1: Default State ",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -367,7 +364,6 @@
 			"label": "Output 2: Default State",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010f/fgd211.json
+++ b/packages/config/config/devices/0x010f/fgd211.json
@@ -89,7 +89,6 @@
 			"label": "Send Commands to Association Group 1",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -112,7 +111,6 @@
 			"description": "Key no. 2 is not represented by any physical device",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -210,7 +208,6 @@
 			"description": "Binary inputs type configuration",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -230,7 +227,6 @@
 			"description": "Binary inputs type configuration",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -254,7 +250,6 @@
 			"description": "Double-click set lighting at 100%",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -274,7 +269,6 @@
 			"description": "Double-click set lighting at 100%",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -297,7 +291,6 @@
 			"description": "Function of 3-way switch",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -316,7 +309,6 @@
 			"description": "The dimmer communicate the level to the associated devices. (default value 0)",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -334,7 +326,6 @@
 			"label": "Change [On-Off] bi-stable keys",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -361,7 +352,6 @@
 			"label": "Relay 1: Response to General Alarm",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -420,7 +410,6 @@
 			"description": "Command class scene activation for group no. 3",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010f/fgd212.json
+++ b/packages/config/config/devices/0x010f/fgd212.json
@@ -154,7 +154,6 @@
 			"label": "ALL ON/ALL OFF Function",
 			"valueSize": 2,
 			"defaultValue": 255,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -180,7 +179,6 @@
 			"label": "Force Auto-Calibration",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -265,7 +263,6 @@
 			"label": "Input Button/Switch Configuration",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -287,7 +284,6 @@
 			"label": "Value Sent to Associated Devices on Single Click",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -305,7 +301,6 @@
 			"label": "Change Toggle Switch Behavior",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -423,7 +418,6 @@
 			"label": "Dimmer Mode",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -465,7 +459,6 @@
 			"description": "Useful when connecting non-dimmable loads",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -507,7 +500,6 @@
 			"description": "Time required to warm up the filament of halogen bulb",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -529,7 +521,6 @@
 			"label": "Perform Auto-Calibration",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -559,7 +550,6 @@
 			"label": "Behavior After Overcurrent or Surge",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -638,7 +628,6 @@
 			"description": "Load power consumption too high",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -657,7 +646,6 @@
 			"description": "No load, load failure, burnt out bulb",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -676,7 +664,6 @@
 			"description": "Short circuit, burnt out bulb causing overcurrent",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -695,7 +682,6 @@
 			"description": "Dimmer output overvoltage",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -714,7 +700,6 @@
 			"description": "Critical temperature and low voltage",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -753,7 +738,6 @@
 			"label": "Active Power Calculation Method",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010f/fgfs101.json
+++ b/packages/config/config/devices/0x010f/fgfs101.json
@@ -193,7 +193,6 @@
 			"description": "Transmit the alarm or control frame in 'broadcast' mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010f/fgk101.json
+++ b/packages/config/config/devices/0x010f/fgk101.json
@@ -132,7 +132,6 @@
 			"label": "Input 1 Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010f/fgms001.json
+++ b/packages/config/config/devices/0x010f/fgms001.json
@@ -406,7 +406,6 @@
 			"description": "The parameter determines the behaviour of tamper and how it reports.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -480,7 +479,6 @@
 			"description": "Alarm frame will or will not be sent in broadcast mode.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -660,7 +658,6 @@
 			"description": "How the light behaves after motion has been detected.",
 			"valueSize": 1,
 			"defaultValue": 10,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -878,7 +875,6 @@
 			"description": "Indicating mode resembles a police car (white, red and blue).",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010f/fgpb101.json
+++ b/packages/config/config/devices/0x010f/fgpb101.json
@@ -88,7 +88,6 @@
 			"label": "Single Click - Association Group 2: Command Type",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -129,7 +128,6 @@
 			"label": "Single Click - Association Group 3: Command Type",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -176,7 +174,6 @@
 			"label": "Double Click - Association Group 2: Command Type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -217,7 +214,6 @@
 			"label": "Double Click - Association Group 3: Command Type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -264,7 +260,6 @@
 			"label": "Triple Click - Association Group 2: Command Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -305,7 +300,6 @@
 			"label": "Triple Click - Association Group 3: Command Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -376,7 +370,6 @@
 			"label": "Key Held - Association Group 3: Command Type",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010f/fgr221.json
+++ b/packages/config/config/devices/0x010f/fgr221.json
@@ -77,7 +77,6 @@
 			"description": "Turning off the shutter positioning function",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -96,7 +95,6 @@
 			"description": "Binary inputs type configuration",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -127,7 +125,6 @@
 			"description": "set for shutter no. 1",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -150,7 +147,6 @@
 			"description": "set for relay the shutter",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -173,7 +169,6 @@
 			"description": "Set for the roller shutter.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -196,7 +191,6 @@
 			"description": "set for roller shutter",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -219,7 +213,6 @@
 			"description": "Only valid for the 1.9 version of FGR221.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010f/fgr222_24.24_255.255.json
+++ b/packages/config/config/devices/0x010f/fgr222_24.24_255.255.json
@@ -288,7 +288,6 @@
 			"description": "0 no change, 1 extreme position",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010f/fgrgbw.json
+++ b/packages/config/config/devices/0x010f/fgrgbw.json
@@ -83,7 +83,6 @@
 			"label": "Associations command class choice",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -114,7 +113,6 @@
 			"description": "MODE1, Example: change saturation level from 0% to 99%",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010f/fgrm222_0_24.23.json
+++ b/packages/config/config/devices/0x010f/fgrm222_0_24.23.json
@@ -47,7 +47,6 @@
 			"description": "Enable Venetian Blind mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -65,7 +64,6 @@
 			"label": "Roller Shutter operating modes",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -105,7 +103,6 @@
 			"label": "Lamellas positioning mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -128,7 +125,6 @@
 			"description": "Parameter settings for Roller and Venetian Blind Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -181,7 +177,6 @@
 			"description": "Roller Shutter enters the calibration mode.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -199,7 +194,6 @@
 			"label": "Response to General Alarm",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -221,7 +215,6 @@
 			"label": "Response to Water Flood Alarm",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -243,7 +236,6 @@
 			"label": "Response to Smoke, CO, CO2 Alarm",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -265,7 +257,6 @@
 			"label": "Response to Temperature Alarm",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -288,7 +279,6 @@
 			"description": "Lamellas reaction upon alarm detection.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -334,7 +324,6 @@
 			"description": "Enables/disables power and energy report used by itself",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -353,7 +342,6 @@
 			"description": "Determine whether scenes or associations are activated",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010f/fgs211.json
+++ b/packages/config/config/devices/0x010f/fgs211.json
@@ -97,7 +97,6 @@
 			"description": "Activate/Deactivate Automatic turning off relay after set time",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -138,7 +137,6 @@
 			"description": "Activate/Deactivate association sending for group 1 - Also see param #16",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -161,7 +159,6 @@
 			"description": "In case of bi-stable switches, define their behaviour (toggle or follow)",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -180,7 +177,6 @@
 			"description": "Binary inputs type configuration",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -199,7 +195,6 @@
 			"description": "Enable/Disable operation associated to group 1.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -221,7 +216,6 @@
 			"label": "Relay 1: Response to General Alarm",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -247,7 +241,6 @@
 			"label": "Relay 1: Response to Water Flood Alarm",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -273,7 +266,6 @@
 			"label": "Relay 1: Response to Smoke, CO, CO2 Alarm",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -299,7 +291,6 @@
 			"label": "Relay 1: Response to Temperature Alarm",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010f/fgs212.json
+++ b/packages/config/config/devices/0x010f/fgs212.json
@@ -93,7 +93,6 @@
 			"description": "Sending commands to control devices assigned ...",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -116,7 +115,6 @@
 			"description": "Assigns bistable key status to the device status.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -135,7 +133,6 @@
 			"description": "Binary inputs type configuration",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -154,7 +151,6 @@
 			"description": "Enable/Disable operation of dimmer or roller shutter devices ...",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -176,7 +172,6 @@
 			"label": "Relay 1: Response to General Alarm",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -202,7 +197,6 @@
 			"label": "Relay 1: Response to Water Flood Alarm",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -228,7 +222,6 @@
 			"label": "Relay 1: Response to Smoke, CO, CO2 Alarm",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -254,7 +247,6 @@
 			"label": "Relay 1: Response to Temperature Alarm",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010f/fgs214.json
+++ b/packages/config/config/devices/0x010f/fgs214.json
@@ -417,7 +417,6 @@
 			"label": "Q Output Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010f/fgs221.json
+++ b/packages/config/config/devices/0x010f/fgs221.json
@@ -103,7 +103,6 @@
 			"description": "Activate/Deactivate Automatic turning off relay after set time",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -130,7 +129,6 @@
 			"label": "Auto off relay after specified time",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -192,7 +190,6 @@
 			"label": "Sending commands to group 1 devices",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -216,7 +213,6 @@
 			"description": "Activate/Deactivate association sending for group 2",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -241,7 +237,6 @@
 			"description": "Map status to devices in group 2.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -260,7 +255,6 @@
 			"label": "Sending commands to group 2 devices",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -283,7 +277,6 @@
 			"description": "In case of bi-stable switches, define their behaviour (toggle or follow)",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -302,7 +295,6 @@
 			"description": "Switch type connector, you may choose between momentary and toggle switches",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -321,7 +313,6 @@
 			"description": "Enable/Disable operation associated to group 1",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -343,7 +334,6 @@
 			"label": "Relay 1: Response to General Alarm",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -369,7 +359,6 @@
 			"label": "Relay 1: Response to Water Flood Alarm",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -395,7 +384,6 @@
 			"label": "Relay 1: Response to Smoke, CO, CO2 Alarm",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -421,7 +409,6 @@
 			"label": "Relay 1: Response to Temperature Alarm",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -457,7 +444,6 @@
 			"label": "Relay 2: Response to General Alarm",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -483,7 +469,6 @@
 			"label": "Relay 2: Response to Water Flood Alarm",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -509,7 +494,6 @@
 			"label": "Relay 2: Response to Smoke, CO, CO2 Alarm",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -535,7 +519,6 @@
 			"label": "Relay 2: Response to Temperature Alarm",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010f/fgs222.json
+++ b/packages/config/config/devices/0x010f/fgs222.json
@@ -119,7 +119,6 @@
 			"description": "Activate/Deactivate association sending for group 1 - Also see param #16",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -142,7 +141,6 @@
 			"description": "![CDATA[NOTE: Parameter 15 value must be set to 1 to work properly.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -165,7 +163,6 @@
 			"description": "In case of bi-stable switches, define their behaviour (toggle or follow)",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -184,7 +181,6 @@
 			"description": "Binary inputs type configuration",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -203,7 +199,6 @@
 			"description": "Enable/Disable operation of devices associated to group 1",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -225,7 +220,6 @@
 			"label": "Relay 1: Response to General Alarm",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -251,7 +245,6 @@
 			"label": "Relay 1: Response to Water Flood Alarm",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -277,7 +270,6 @@
 			"label": "Relay 1: Response to Smoke, CO, CO2 Alarm",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -303,7 +295,6 @@
 			"label": "Relay 1: Response to Temperature Alarm",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -339,7 +330,6 @@
 			"label": "Relay 2: Response to General Alarm",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -365,7 +355,6 @@
 			"label": "Relay 2: Response to Water Flood Alarm",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -391,7 +380,6 @@
 			"label": "Relay 2: Response to Smoke, CO, CO2 Alarm",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -417,7 +405,6 @@
 			"label": "Relay 2: Response to Temperature Alarm",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010f/fgs223.json
+++ b/packages/config/config/devices/0x010f/fgs223.json
@@ -49,7 +49,6 @@
 			"label": "First Channel - Operating Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -83,7 +82,6 @@
 			"label": "First Channel - Reaction to Key S1 for Delay/Auto ON/OFF Modes",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -129,7 +127,6 @@
 			"label": "Second Channel - Operating Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -164,7 +161,6 @@
 			"valueSize": 1,
 			"unit": "seconds",
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -210,7 +206,6 @@
 			"label": "Input Button/Switch Configuration",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010f/fgs224.json
+++ b/packages/config/config/devices/0x010f/fgs224.json
@@ -495,7 +495,6 @@
 			"label": "Q1 Output Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -513,7 +512,6 @@
 			"label": "Q2 Output Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -531,7 +529,6 @@
 			"label": "Prevent Simultaneous Switching of Outputs",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010f/fgsd002.json
+++ b/packages/config/config/devices/0x010f/fgsd002.json
@@ -28,7 +28,6 @@
 			"description": "There are 3 levels of sensitivity to smoke presence.",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -61,7 +60,6 @@
 			"description": "This parameter allows to activate visual indications",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -104,7 +102,6 @@
 			"description": "This parameter allows to activate sound signals...",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -147,7 +144,6 @@
 			"description": "This parameter defines which frames will be sent ...",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -188,7 +184,6 @@
 			"description": "A value other than 0 means that alarms are being ...",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010f/fgss001.json
+++ b/packages/config/config/devices/0x010f/fgss001.json
@@ -46,7 +46,6 @@
 			"label": "Alarm acoustic and visual signals",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -115,7 +114,6 @@
 			"label": "Frame broadcast mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -187,7 +185,6 @@
 			"label": "Black Box sensitivity level",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -241,7 +238,6 @@
 			"label": "Temperature measurement compensation for report",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -260,7 +256,6 @@
 			"description": "Activates/inactivates temper switch alarm",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010f/fgwp101.json
+++ b/packages/config/config/devices/0x010f/fgwp101.json
@@ -40,7 +40,6 @@
 			"description": "Once activated, Wall Plug will keep a connected device ...",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -72,7 +71,6 @@
 			"description": "Parameter defines how the Wall Plug will respond to alarms ...",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -155,7 +153,6 @@
 			"description": "This parameter determines whether energy metering ...",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -194,7 +191,6 @@
 			"description": "Parameter defines the way 2nd association group devices ...",
 			"valueSize": 1,
 			"defaultValue": 6,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -242,7 +238,6 @@
 			"label": "LED color when device is on",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -292,7 +287,6 @@
 			"label": "LED color when device is off",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -338,7 +332,6 @@
 			"label": "LED color when Z Wave alarm",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x010f/fgwp102.json
+++ b/packages/config/config/devices/0x010f/fgwp102.json
@@ -317,7 +317,6 @@
 			"description": "Defines responds to alarms (device's status change).",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -564,7 +563,6 @@
 			"label": "Metering energy consumed by the Wall Plug itself.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -633,7 +631,6 @@
 			"description": "Defines the way 2nd association group devices are controlled",
 			"valueSize": 1,
 			"defaultValue": 6,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -683,7 +680,6 @@
 			"label": "LED color when device is on",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -734,7 +730,6 @@
 			"label": "LED color when device is off",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -781,7 +776,6 @@
 			"label": "LED color when Z Wave alarm",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0113/ldm-15w.json
+++ b/packages/config/config/devices/0x0113/ldm-15w.json
@@ -19,7 +19,6 @@
 			"label": "Load Sense",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0113/lfm-20.json
+++ b/packages/config/config/devices/0x0113/lfm-20.json
@@ -19,7 +19,6 @@
 			"label": "Night Light",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0113/lpm-15.json
+++ b/packages/config/config/devices/0x0113/lpm-15.json
@@ -20,7 +20,6 @@
 			"description": "Defines the behavior of the blue LED; default has LED on when switch is off.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -43,7 +42,6 @@
 			"description": "Change the top of the switch to OFF and the bottom of the switch to ON.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0113/lrm-1000.json
+++ b/packages/config/config/devices/0x0113/lrm-1000.json
@@ -34,7 +34,6 @@
 			"label": "Ignore Start Level",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -52,7 +51,6 @@
 			"label": "Night Light",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -70,7 +68,6 @@
 			"label": "Invert Switch",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -88,7 +85,6 @@
 			"label": "Shade Control Group 2",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -106,7 +102,6 @@
 			"label": "Shade Control Group 3",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -124,7 +119,6 @@
 			"label": "LED Indicator",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -146,7 +140,6 @@
 			"label": "Load Sense",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0113/lrm-as.json
+++ b/packages/config/config/devices/0x0113/lrm-as.json
@@ -34,7 +34,6 @@
 			"label": "Ignore Start Level",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -52,7 +51,6 @@
 			"label": "Night Light",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -70,7 +68,6 @@
 			"label": "Invert Switch",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -88,7 +85,6 @@
 			"label": "Shade Control Group 2",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -106,7 +102,6 @@
 			"label": "Shade Control Group 3",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -124,7 +119,6 @@
 			"label": "LED Indicator",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -146,7 +140,6 @@
 			"label": "Load Sense",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0113/lsm-15.json
+++ b/packages/config/config/devices/0x0113/lsm-15.json
@@ -20,7 +20,6 @@
 			"description": "By default, the LED will turn OFF when the lead attached is turned ON.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -39,7 +38,6 @@
 			"description": "To change the top of the switch to OFF and the bottom of the switch ON.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0113/ltm-5.json
+++ b/packages/config/config/devices/0x0113/ltm-5.json
@@ -28,7 +28,6 @@
 			"description": "Dimmers controlled by this switch will start dimming from their current level.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -47,7 +46,6 @@
 			"description": "In night-light mode the LED on the switch will turn ON when the switch is turned OFF.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -66,7 +64,6 @@
 			"description": "Change the top of the switch to OFF and the bottom of the switch to ON.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -85,7 +82,6 @@
 			"description": "The dimmer will start dimming from its current level.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -104,7 +100,6 @@
 			"description": "Flicker LED while transmitting.",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -137,7 +132,6 @@
 			"description": "Poll only the first node in Group 1.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0115/kfob.json
+++ b/packages/config/config/devices/0x0115/kfob.json
@@ -51,7 +51,6 @@
 			"label": "Button 1 and 3 pair mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -73,7 +72,6 @@
 			"label": "Button 2 and 4 pair mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -95,7 +93,6 @@
 			"label": "Action on group A",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -133,7 +130,6 @@
 			"label": "Action on group B",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -171,7 +167,6 @@
 			"label": "Action on group C",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -209,7 +204,6 @@
 			"label": "Action on group D",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -279,7 +273,6 @@
 			"label": "Invert buttons",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -297,7 +290,6 @@
 			"label": "LED confirmation mode",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -319,7 +311,6 @@
 			"label": "Send unsolicited Battery Report on Wake Up",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0115/v3.json
+++ b/packages/config/config/devices/0x0115/v3.json
@@ -21,7 +21,6 @@
 			"description": "Debug mode to apply channels, associations and power mode changes on the fly without exclusion-inclusion sequence. Use for debugging only!",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -40,7 +39,6 @@
 			"description": "Blink with service LED during operation",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -59,7 +57,6 @@
 			"description": "Enable or disable Security S0 during inclusion (requires re-inclusion). Same as changing Tools → Security in the Arduino IDE",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -78,7 +75,6 @@
 			"description": "Enable or disable logging via Z-Wave. Same as changing Tools → Logging in the Arduino IDE",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -97,7 +93,6 @@
 			"description": "Set Z-Wave frequency and reboot. Same as changing Tools → Frequency in the Arduino IDE. Note that after issuing this command the device will stop change frequency and your controller will loose communications with it!",
 			"valueSize": 2,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -163,7 +158,6 @@
 			"description": "Change channel type from Notification to legacy Sensor Binary to help Fibaro Home Center, Vera and some other controllers having problems with the latest Z-Wave Plus to understand the channel type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -182,7 +176,6 @@
 			"description": "Confirmation of OTA operations (for bootloader and sketch upgrades). Do it right before or right after initiating the firmware upgrade process",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0115/wallc-s.json
+++ b/packages/config/config/devices/0x0115/wallc-s.json
@@ -42,7 +42,6 @@
 			"label": "Button 1 and 3 pair mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -64,7 +63,6 @@
 			"label": "Button 2 and 4 pair mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -86,7 +84,6 @@
 			"label": "Action on group A",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -128,7 +125,6 @@
 			"label": "Action on group B",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -170,7 +166,6 @@
 			"label": "Action on group C",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -212,7 +207,6 @@
 			"label": "Action on group D",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -276,7 +270,6 @@
 			"label": "Invert buttons",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -294,7 +287,6 @@
 			"label": "Blocks wakeup even when wakeup interval is set",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -312,7 +304,6 @@
 			"label": "Send unsolicited Battery Report on Wake Up",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0115/wcd2.json
+++ b/packages/config/config/devices/0x0115/wcd2.json
@@ -37,7 +37,6 @@
 			"label": "Button 1 and 3 pair mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -59,7 +58,6 @@
 			"label": "Button 2 and 4 pair mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -81,7 +79,6 @@
 			"label": "Action on group 1",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -115,7 +112,6 @@
 			"label": "Action on group 2",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -149,7 +145,6 @@
 			"label": "Action on group 3",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -183,7 +178,6 @@
 			"label": "Action on group 4",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -249,7 +243,6 @@
 			"label": "Invert buttons",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -268,7 +261,6 @@
 			"description": "This allows to save battery",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -290,7 +282,6 @@
 			"label": "Send unsolicited Battery Report on Wake Up",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0115/zme_05459.json
+++ b/packages/config/config/devices/0x0115/zme_05459.json
@@ -35,7 +35,6 @@
 			"description": "Set LED indication mode",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -82,7 +81,6 @@
 			"description": "Defines how to interpret RF Off command.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -159,7 +157,6 @@
 			"description": "Which command from the blocking Node should be interpreted as 'unprotected'",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -178,7 +175,6 @@
 			"description": "Defines behaviour on open press while closing and vice versa.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -200,7 +196,6 @@
 			"label": "Invert open and close relays",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -228,7 +223,6 @@
 			"description": "Allows exchanging the functionality of the buttons",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -247,7 +241,6 @@
 			"description": "Local operations by buttons will/will not/ switch the load",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -270,7 +263,6 @@
 			"description": "Defines which command should be sent on button single press or hold.",
 			"valueSize": 1,
 			"defaultValue": 4,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -305,7 +297,6 @@
 			"description": "Defines which command should be sent on button double press or press-hold.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -361,7 +352,6 @@
 			"label": "What to do on button Down press",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -384,7 +374,6 @@
 			"description": "Defines the action to perform upon auto open or auto close.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0115/zme_05461.json
+++ b/packages/config/config/devices/0x0115/zme_05461.json
@@ -34,7 +34,6 @@
 			"label": "Set LED indication mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -66,7 +65,6 @@
 			"label": "Function of RF off command on first channel",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -92,7 +90,6 @@
 			"label": "Switch on/off by holding buttons",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -118,7 +115,6 @@
 			"label": "Restore switch state after power cycle",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -145,7 +141,6 @@
 			"description": "Allows for exchanging ON and OFF.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -163,7 +158,6 @@
 			"label": "Switch by buttons (first channel)",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -185,7 +179,6 @@
 			"label": "Action on button single press or hold",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -211,7 +204,6 @@
 			"label": "Action on button double press or hold",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -237,7 +229,6 @@
 			"label": "What to do on button Down press (both)",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -283,7 +274,6 @@
 			"label": "Function of RF off command on second channel",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -309,7 +299,6 @@
 			"label": "Switch by buttons (second channel)",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0115/zme_06436.json
+++ b/packages/config/config/devices/0x0115/zme_06436.json
@@ -20,7 +20,6 @@
 			"description": "Set LED indication mode",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -67,7 +66,6 @@
 			"description": "Defines how to interpret RF Off command.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -144,7 +142,6 @@
 			"description": "Which command from the blocking Node should be interpreted as 'unprotected'",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -162,7 +159,6 @@
 			"label": "Opposite button reaction",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -180,7 +176,6 @@
 			"label": "Invert open and close relays",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -208,7 +203,6 @@
 			"description": "Allows exchanging the functionality of the buttons",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -226,7 +220,6 @@
 			"label": "Switch by buttons",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -249,7 +242,6 @@
 			"description": "Defines which command should be sent on button single press or hold.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -272,7 +264,6 @@
 			"description": "Defines which command should be sent on button double press or press-hold.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0115/zme_06437.json
+++ b/packages/config/config/devices/0x0115/zme_06437.json
@@ -50,7 +50,6 @@
 			"label": "Function of RF off command",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -76,7 +75,6 @@
 			"label": "Restore switch state after power cycle",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -102,7 +100,6 @@
 			"label": "Off Color",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -132,7 +129,6 @@
 			"label": "On Color",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0115/zme_06443.json
+++ b/packages/config/config/devices/0x0115/zme_06443.json
@@ -43,7 +43,6 @@
 			"label": "Invert buttons",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -90,7 +89,6 @@
 			"description": "Defines which command should be sent on button double press or press-hold.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -138,7 +136,6 @@
 			"label": "Send unsolicited Battery Report on Wake Up",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0115/zme_kfob-s.json
+++ b/packages/config/config/devices/0x0115/zme_kfob-s.json
@@ -23,7 +23,6 @@
 			"label": "Button 1 and 3 pair mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -45,7 +44,6 @@
 			"label": "Button 2 and 4 pair mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -67,7 +65,6 @@
 			"label": "Command to Control Group A",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -113,7 +110,6 @@
 			"label": "Command to Control Group B",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -159,7 +155,6 @@
 			"label": "Command to Control Group C",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -205,7 +200,6 @@
 			"label": "Command to Control Group D",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -273,7 +267,6 @@
 			"label": "Invert buttons",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -291,7 +284,6 @@
 			"label": "Blocks wakeup even when wakeup interval is set",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -309,7 +301,6 @@
 			"label": "Send unsolicited Battery Report on Wake Up",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0115/zme_rc2.json
+++ b/packages/config/config/devices/0x0115/zme_rc2.json
@@ -71,7 +71,6 @@
 			"description": "Defines the command sent to group 1 when the button is pressed (Assoc. Group 2)",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -105,7 +104,6 @@
 			"label": "Command to Control Group No2 (association group 3)",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -139,7 +137,6 @@
 			"label": "Command to Control Group No3 (association group 4)",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -173,7 +170,6 @@
 			"label": "Command to Control Group No4 (association group 5)",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -207,7 +203,6 @@
 			"label": "Command to Control Group No5 (association group 6)",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -241,7 +236,6 @@
 			"label": "Command to Control Group No6 (association group 7)",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -275,7 +269,6 @@
 			"label": "Command to Control Group No7 (association group 8)",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -309,7 +302,6 @@
 			"label": "Command to Control Scene No1 (association group 9)",
 			"valueSize": 1,
 			"defaultValue": 4,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -343,7 +335,6 @@
 			"label": "Command to Control Scene No2",
 			"valueSize": 1,
 			"defaultValue": 4,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -377,7 +368,6 @@
 			"label": "Command to Control Scene No3",
 			"valueSize": 1,
 			"defaultValue": 4,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -411,7 +401,6 @@
 			"label": "Command to Control group All On/Off",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0116/hsp02.json
+++ b/packages/config/config/devices/0x0116/hsp02.json
@@ -41,7 +41,6 @@
 			"label": "Sensor Detecting Function",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0116/itemp.json
+++ b/packages/config/config/devices/0x0116/itemp.json
@@ -34,7 +34,6 @@
 			"description": "Delete configuration but keeps inclusion",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -53,7 +52,6 @@
 			"description": "Configure what the external contact sends when triggered",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -71,7 +69,6 @@
 			"label": "Operating Mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0118/tz04.json
+++ b/packages/config/config/devices/0x0118/tz04.json
@@ -118,7 +118,6 @@
 			"label": "Restore switch state mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -149,7 +148,6 @@
 			"label": "RF off command mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -175,7 +173,6 @@
 			"label": "Endpoint 3",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x011a/zw500dm.json
+++ b/packages/config/config/devices/0x011a/zw500dm.json
@@ -39,7 +39,6 @@
 			"description": "Synchronization of load power and LED indicator",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x011a/zwn-rsm2.json
+++ b/packages/config/config/devices/0x011a/zwn-rsm2.json
@@ -41,7 +41,6 @@
 			"description": "Send unsolicited status report to primary controller",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x012a/iq_dimmer.json
+++ b/packages/config/config/devices/0x012a/iq_dimmer.json
@@ -49,7 +49,6 @@
 			"label": "LED Indicator",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x012a/iq_outlet.json
+++ b/packages/config/config/devices/0x012a/iq_outlet.json
@@ -31,7 +31,6 @@
 			"label": "LED Indicator",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x012a/qz2142-840.json
+++ b/packages/config/config/devices/0x012a/qz2142-840.json
@@ -74,7 +74,6 @@
 			"label": "Brightness on Single Tap",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -100,7 +99,6 @@
 			"label": "Brightness on Double Tap",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -145,7 +143,6 @@
 			"label": "Association Reports",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -182,7 +179,6 @@
 			"label": "Led Indicator Color",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -208,7 +204,6 @@
 			"label": "Led Indicator Brightness",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0130/6500-1400-6000.json
+++ b/packages/config/config/devices/0x0130/6500-1400-6000.json
@@ -27,7 +27,6 @@
 			"label": "Analog Gas/Heat Port Mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -59,7 +58,6 @@
 			"label": "Analog Electricity Port Mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -91,7 +89,6 @@
 			"label": "Restart Device",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0131/ne_nas_ab02z.json
+++ b/packages/config/config/devices/0x0131/ne_nas_ab02z.json
@@ -32,7 +32,6 @@
 			"label": "Operating Mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -50,7 +49,6 @@
 			"label": "Alarm Volume",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -76,7 +74,6 @@
 			"label": "Alarm Duration",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -132,7 +129,6 @@
 			"label": "Doorbell Volume",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0131/vs-zd2301.json
+++ b/packages/config/config/devices/0x0131/vs-zd2301.json
@@ -20,7 +20,6 @@
 			"label": "Temperature Unit",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0138/zcombo.json
+++ b/packages/config/config/devices/0x0138/zcombo.json
@@ -31,7 +31,6 @@
 			"description": "Causes the device to send double alarm messages",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0138/zsmoke.json
+++ b/packages/config/config/devices/0x0138/zsmoke.json
@@ -28,7 +28,6 @@
 			"description": "Causes the device to send double alarm messages",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x013c/pad07.json
+++ b/packages/config/config/devices/0x013c/pad07.json
@@ -21,7 +21,6 @@
 			"description": "Whenever dimmer on/off state changes, it will send multilevel_switch_report to the nodes of group1. the default setting is enable the function",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -41,7 +40,6 @@
 			"valueSize": 1,
 			"unit": "seconds",
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -64,7 +62,6 @@
 			"description": "1. one switch mode：only s1 can dim up the light bulb to brightest level, then dim down to darkest level, and so on…  2. two switch mode：s1 and s2 can dim up the light bulb to brightest level, then dim down to darkest level, and so on…  3. up/down switch mode：s1 can only dim up the light bulb to brightest level, and s2 can only dim down to off",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -87,7 +84,6 @@
 			"description": "Whenever the ac power return from lost, pad02 will restore the switch state which could be dimmer off、last dimmer state、dimmer on. the default setting is last dimmer state",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x013c/pad15.json
+++ b/packages/config/config/devices/0x013c/pad15.json
@@ -20,7 +20,6 @@
 			"label": "Switch Set",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -46,7 +45,6 @@
 			"label": "Send Multilevel Switch Reports",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x013c/pan04.json
+++ b/packages/config/config/devices/0x013c/pan04.json
@@ -52,7 +52,6 @@
 			"description": "Which relay is addressed by the BASIC command class",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -74,7 +73,6 @@
 			"label": "External Switch Mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -118,7 +116,6 @@
 			"label": "State after Power Loss",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -155,7 +152,6 @@
 			"label": "RF Off Command Mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -181,7 +177,6 @@
 			"label": "Endpoint 3",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -229,7 +224,6 @@
 			"description": "Enable this to distinguish between the relays.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x013c/pan06.json
+++ b/packages/config/config/devices/0x013c/pan06.json
@@ -161,7 +161,6 @@
 			"description": "Enable this to distinguish between the relays.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x013c/pan11.json
+++ b/packages/config/config/devices/0x013c/pan11.json
@@ -62,7 +62,6 @@
 			"label": "Restore switch state mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -84,7 +83,6 @@
 			"label": "Mode of switch Off function",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -102,7 +100,6 @@
 			"label": "LED indication mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -133,7 +130,6 @@
 			"label": "RF Off command mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x013c/pan15-1-nes.json
+++ b/packages/config/config/devices/0x013c/pan15-1-nes.json
@@ -21,7 +21,6 @@
 			"description": "Whenever the status of switches changes, it will send a binary switch report to the group1 node. the default setting is 1 (enable)",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -40,7 +39,6 @@
 			"description": "Whenever the ac power return from lost, pan15 will restore the switch state which could be switch off、last switch state、switch on. the default setting is last switch state",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -63,7 +61,6 @@
 			"description": "When the mode of switch on/off is set to 0, any command of switch off will be disabled and the on/off function of include button will be disabled. the default setting is enable mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -97,7 +94,6 @@
 			"description": "Whenever a switch off command, basic_set、binary_switch_set、switch_all_off, is received, it could be interpreted as 4 variety of commands.  1.switch off：it switches to off state. the default setting is switch off.  2.ignore：the switch off command will be ignored.  3.switch toggle：it switches to the inverse of current state.  4.switch on：it switches to on state",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x013c/pan30.json
+++ b/packages/config/config/devices/0x013c/pan30.json
@@ -122,7 +122,6 @@
 			"label": "External Switch Mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x013c/pan34.json
+++ b/packages/config/config/devices/0x013c/pan34.json
@@ -42,7 +42,6 @@
 			"label": "External Switch Mode",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x013c/psr07.json
+++ b/packages/config/config/devices/0x013c/psr07.json
@@ -49,7 +49,6 @@
 			"description": "Dimmer setting method. 0 : auto send command Basic Set after rotating. 1 : send command Basic Set by touching key after rotating",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x013c/pst02-a-br.json
+++ b/packages/config/config/devices/0x013c/pst02-a-br.json
@@ -79,7 +79,6 @@
 			"description": "Operation mode. using bit to control.caution: the value is unsigned byte, the range is from 0x00 ~ 0xff. bit0: reserve. bit1: 1 means test mode,   0 means normal mode. bit2: disable the door/window  function. (1:disable, 0:enable) bit3: setting the temperature scale.  0: fahrenheit, 1:celsius bit4: disable the illumination report  after event triggered. (1:disable, 0:enable) bit5: disable the temperature report  after event triggered. (1:disable, 0:enable) bit6: reserve. bit7: disable the back key release into test mode.  (1:disable, 0:enable)",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -126,7 +125,6 @@
 			"description": "Multisensor function switch. using bit to control.caution: the value is unsigned byte, the range is from 0x00 ~ 0xff.  bit0: disable magnetic integrate  illumination to turn on the lighting  nodes in the association group 2.  (1:disable, 0:enable) bit1: disable PIR integrate  illumination to turn on the lighting  nodes in the association group 2.  (1:disable, 0:enable) bit2: disable magnetic integrate PIR  to turn on the lighting nodes in the  association group 2. (1:disable,  0:enable) (default is disable) bit3: when bit2 is 0 (enable), are the  device and the lighting in the same  room? 0: in the same room(default),1: in the different room. bit4: disable delay 5 seconds to turn off the light, when door/window closed. (1:disable, 0:enable) bit5: disable auto turn off the light, after door/window opened to turn on the light. (1:disable, 0:enable) bit6: reserve. bit7: reserve",
 			"valueSize": 1,
 			"defaultValue": 4,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -173,7 +171,6 @@
 			"description": "Customer function switch, using bit control.caution: the value is unsigned byte, the range is from 0x00 ~ 0xff.  bit0: reserve. bit1: enable sending motion off report. (0:disable, 1:enable) bit2: enable PIR super sensitivity mode. (0:disable, 1:enable) bit3: disable send out basic off after door closed. (1:disable, 0:enable) bit4: notification type,  0: using notification report.  1: using sensor binary report. bit5: disable multi cc in auto report. (1:disable, 0:enable) bit6: disable to report battery state when the device triggered.(1:disable, 0:enable) bit7: reserve",
 			"valueSize": 1,
 			"defaultValue": 4,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0148/eur_airquality.json
+++ b/packages/config/config/devices/0x0148/eur_airquality.json
@@ -60,7 +60,6 @@
 			"label": "Temperature Scale",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -78,7 +77,6 @@
 			"label": "Temperature Resolution",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -100,7 +98,6 @@
 			"label": "Humidity Resolution",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -152,7 +149,6 @@
 			"label": "Air Quality Indication via LED",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0148/temp_humidity_sensor.json
+++ b/packages/config/config/devices/0x0148/temp_humidity_sensor.json
@@ -60,7 +60,6 @@
 			"label": "Temperature Scale",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -78,7 +77,6 @@
 			"label": "Temperature Resolution",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -100,7 +98,6 @@
 			"label": "Humidity Resolution",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x014a/iszw7-eco.json
+++ b/packages/config/config/devices/0x014a/iszw7-eco.json
@@ -37,7 +37,6 @@
 			"label": "Supervision Encapsulation for Get Requests",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -75,7 +74,6 @@
 			"label": "Allow Volume Adjustments for Intrusion/Smoke/CO Alarms",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x014f/wt00z-1.json
+++ b/packages/config/config/devices/0x014f/wt00z-1.json
@@ -120,7 +120,6 @@
 			"description": "Activate/Deactivate polling of first node in Group 1",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x014f/zm1601.json
+++ b/packages/config/config/devices/0x014f/zm1601.json
@@ -20,7 +20,6 @@
 			"description": "Defines the reaction of the siren",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -43,7 +42,6 @@
 			"description": "Defines the auto time out of the alarm indication",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0154/004001.json
+++ b/packages/config/config/devices/0x0154/004001.json
@@ -73,7 +73,6 @@
 			"description": "Inform other smoke detectors of same type about smoke alarms",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -92,7 +91,6 @@
 			"description": "Inform other smoke detectors of same type about battery alarms",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0154/009204.json
+++ b/packages/config/config/devices/0x0154/009204.json
@@ -20,7 +20,6 @@
 			"description": "In separate mode button 1 works with Group A, button 3 with Group C.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -43,7 +42,6 @@
 			"description": "In separate mode button 2 works with group B, button 4 with group D.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -66,7 +64,6 @@
 			"description": "This parameter defines the command to be sent to devices of control group A",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -113,7 +110,6 @@
 			"description": "This parameter defines the command to be sent to devices of control group B",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -160,7 +156,6 @@
 			"description": "This parameter defines the command to be sent to devices of control group C",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -207,7 +202,6 @@
 			"description": "This parameter defines the command to be sent to devices of control group D",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -275,7 +269,6 @@
 			"label": "Invert buttons",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -310,7 +303,6 @@
 			"label": "Send unsolicited Battery Report on Wake Up",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0154/009303.json
+++ b/packages/config/config/devices/0x0154/009303.json
@@ -19,7 +19,6 @@
 			"label": "Button 1 and 3 pair mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -41,7 +40,6 @@
 			"label": "Button 2 and 4 pair mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -63,7 +61,6 @@
 			"label": "Command to control Group A",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -109,7 +106,6 @@
 			"label": "Command to control Group B",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -155,7 +151,6 @@
 			"label": "Command to control Group C",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -201,7 +196,6 @@
 			"label": "Command to control Group D",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -269,7 +263,6 @@
 			"label": "Invert buttons",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -287,7 +280,6 @@
 			"label": "Block wake up even when Wake Up Interval is set",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -305,7 +297,6 @@
 			"label": "End unsolicited battery report on Wake Up.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0154/05438.json
+++ b/packages/config/config/devices/0x0154/05438.json
@@ -30,7 +30,6 @@
 			"label": "LED indication mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -63,7 +62,6 @@
 			"description": "Defines how to interpret RF Off-Command.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -90,7 +88,6 @@
 			"description": "Defines if the switch should restore switch state.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -118,7 +115,6 @@
 			"description": "Color for Off state.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -149,7 +145,6 @@
 			"description": "Color for On state.",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0154/123610.json
+++ b/packages/config/config/devices/0x0154/123610.json
@@ -26,7 +26,6 @@
 			"label": "Set LED indication mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -62,7 +61,6 @@
 			"label": "RF Off command",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -88,7 +86,6 @@
 			"label": "Restore switch state after power cycle",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0159/zmnhaa.json
+++ b/packages/config/config/devices/0x0159/zmnhaa.json
@@ -38,7 +38,6 @@
 			"label": "Input 1 switch type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -56,7 +55,6 @@
 			"label": "Input 2 contact type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -74,7 +72,6 @@
 			"label": "Input 3 contact type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0159/zmnhad.json
+++ b/packages/config/config/devices/0x0159/zmnhad.json
@@ -19,7 +19,6 @@
 			"label": "Input 1 switch type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -37,7 +36,6 @@
 			"label": "Input 2 contact type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -55,7 +53,6 @@
 			"label": "Input 3 contact type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -119,7 +116,6 @@
 			"description": "NOTE: Parameter is the same for turning OFF or ON.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -177,7 +173,6 @@
 			"description": "After changing this parameter, the device MUST be excluded and then re-included after waiting 30 seconds.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -220,7 +215,6 @@
 			"description": "After changing this parameter, the device MUST be excluded and then re-included after waiting 30 seconds.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0159/zmnhba.json
+++ b/packages/config/config/devices/0x0159/zmnhba.json
@@ -34,7 +34,6 @@
 			"label": "Input 1 switch type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -52,7 +51,6 @@
 			"label": "Input 2 switch type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0159/zmnhbd.json
+++ b/packages/config/config/devices/0x0159/zmnhbd.json
@@ -55,7 +55,6 @@
 			"label": "Input 1 switch type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -73,7 +72,6 @@
 			"label": "Input 2 switch type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -200,7 +198,6 @@
 			"label": "Output Q1 Switch selection",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -218,7 +215,6 @@
 			"label": "Output Q2 Switch selection",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0159/zmnhda.json
+++ b/packages/config/config/devices/0x0159/zmnhda.json
@@ -39,7 +39,6 @@
 			"description": "Switch type (input I1)",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -57,7 +56,6 @@
 			"label": "Input 2 contact type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -75,7 +73,6 @@
 			"label": "Input 3 contact type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0159/zmnhdd.json
+++ b/packages/config/config/devices/0x0159/zmnhdd.json
@@ -78,7 +78,6 @@
 			"label": "Input 1 switch type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -96,7 +95,6 @@
 			"label": "Input 2 switch type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -114,7 +112,6 @@
 			"label": "Input 2 contact type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -132,7 +129,6 @@
 			"label": "Input 3 contact type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -151,7 +147,6 @@
 			"description": "Flush dimmer module responds to commands ALL ON / ALL OFF",
 			"valueSize": 2,
 			"defaultValue": 255,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -196,7 +191,6 @@
 			"description": "Dimming is done by push button or switch connected to I1.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -219,7 +213,6 @@
 			"description": "A fast double click on the push button will set dimming power at maximum.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -296,7 +289,6 @@
 			"description": "This parameter is used with association group 3",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -324,7 +316,6 @@
 			"description": "Enabling I2 means that Endpoint (I2) will be present on UI.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -367,7 +358,6 @@
 			"description": "Enabling I3 means that Endpoint (I3) will be present on UI.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0159/zmnhhd.json
+++ b/packages/config/config/devices/0x0159/zmnhhd.json
@@ -39,7 +39,6 @@
 			"label": "In-wall Switch Type for Load to Control I1",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -74,7 +73,6 @@
 			"label": "Load Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -232,7 +230,6 @@
 			"label": "Calibration Trigger",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -273,7 +270,6 @@
 			"label": "Action on Alarm/Notification Events",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0159/zmnhia.json
+++ b/packages/config/config/devices/0x0159/zmnhia.json
@@ -46,7 +46,6 @@
 			"label": "Input 1 switch type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -64,7 +63,6 @@
 			"label": "Input 2 switch type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -82,7 +80,6 @@
 			"label": "Input 3 switch type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -100,7 +97,6 @@
 			"label": "Input 2 contact type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -118,7 +114,6 @@
 			"label": "Input 3 contact type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0159/zmnhid.json
+++ b/packages/config/config/devices/0x0159/zmnhid.json
@@ -46,7 +46,6 @@
 			"label": "Input 1 switch type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -64,7 +63,6 @@
 			"label": "Input 2 switch type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -82,7 +80,6 @@
 			"label": "Input 3 switch type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -100,7 +97,6 @@
 			"label": "Input 1 contact type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -118,7 +114,6 @@
 			"label": "Input 2 contact type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -137,7 +132,6 @@
 			"description": "Input 3 contact type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0159/zmnhla.json
+++ b/packages/config/config/devices/0x0159/zmnhla.json
@@ -46,7 +46,6 @@
 			"label": "Input 1 switch type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -64,7 +63,6 @@
 			"label": "Input 2 switch type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -82,7 +80,6 @@
 			"label": "Input 3 switch type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -100,7 +97,6 @@
 			"label": "Input 1 contact type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -118,7 +114,6 @@
 			"label": "Input 2 contact type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -136,7 +131,6 @@
 			"label": "Input 3 contact type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -257,7 +251,6 @@
 			"label": "PID Value Inside Deadband",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -318,7 +311,6 @@
 			"label": "Thermostat Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -352,7 +344,6 @@
 			"label": "Output Switch Selection",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0159/zmnhnd.json
+++ b/packages/config/config/devices/0x0159/zmnhnd.json
@@ -19,7 +19,6 @@
 			"label": "Input 1 switch type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -37,7 +36,6 @@
 			"label": "Input 2 contact type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -111,7 +109,6 @@
 			"label": "Auto turn off / on seconds or milliseconds",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -133,7 +130,6 @@
 			"label": "Output Switch selection",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -151,7 +147,6 @@
 			"label": "Endpoint I2 Notification and Event",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0159/zmnhod.json
+++ b/packages/config/config/devices/0x0159/zmnhod.json
@@ -19,7 +19,6 @@
 			"label": "Activate/deactivate functions ALL ON / ALL OFF",
 			"valueSize": 2,
 			"defaultValue": 255,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -61,7 +60,6 @@
 			"label": "Operating modes",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -87,7 +85,6 @@
 			"label": "Slats position",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -121,7 +118,6 @@
 			"label": "Forced Shutter DC calibration",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0159/zmnhsd.json
+++ b/packages/config/config/devices/0x0159/zmnhsd.json
@@ -79,7 +79,6 @@
 			"description": "DIN dimmer module responds to commands ALL ON / ALL OFF",
 			"valueSize": 2,
 			"defaultValue": 255,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -136,7 +135,6 @@
 			"description": "If Double click function is enabled, double click to maximum dimming power",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -214,7 +212,6 @@
 			"description": "Ignore or respect start level when used together with association group 3",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0159/zmnhvd.json
+++ b/packages/config/config/devices/0x0159/zmnhvd.json
@@ -19,7 +19,6 @@
 			"label": "Input 1 Switch Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0159/zmnkad1.json
+++ b/packages/config/config/devices/0x0159/zmnkad1.json
@@ -43,7 +43,6 @@
 			"label": "Relay Contact Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x015d/zw97.json
+++ b/packages/config/config/devices/0x015d/zw97.json
@@ -20,7 +20,6 @@
 			"label": "LED Status",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x015f/a8-9.json
+++ b/packages/config/config/devices/0x015f/a8-9.json
@@ -140,7 +140,6 @@
 			"label": "PIR Sensor: Report Changes",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -320,7 +319,6 @@
 			"label": "Temperature Unit",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x015f/mh-3901z.json
+++ b/packages/config/config/devices/0x015f/mh-3901z.json
@@ -26,7 +26,6 @@
 			"label": "Temperature Reporting",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x015f/mh-c421.json
+++ b/packages/config/config/devices/0x015f/mh-c421.json
@@ -37,7 +37,6 @@
 			"label": "Level Report Trigger",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -56,7 +55,6 @@
 			"description": "Run the motor for 3 seconds to read motor data",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -82,7 +80,6 @@
 			"label": "Read Motor Data and Auto Calibrate",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -100,7 +97,6 @@
 			"label": "Auto Calibrate",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -134,7 +130,6 @@
 			"label": "External Switch Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -152,7 +147,6 @@
 			"label": "External Switch Input",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -182,7 +176,6 @@
 			"label": "Factory Reset",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x015f/mh-dt311_411.json
+++ b/packages/config/config/devices/0x015f/mh-dt311_411.json
@@ -50,7 +50,6 @@
 			"label": "Dimming Mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -72,7 +71,6 @@
 			"label": "Auto Detection of Load Type When Powered On",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -183,7 +181,6 @@
 			"label": "External Switch Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -201,7 +198,6 @@
 			"label": "External Switch Input",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -313,7 +309,6 @@
 			"label": "Beep",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -358,7 +353,6 @@
 			"label": "Overload Shutoff",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -431,7 +425,6 @@
 			"label": "Factory Reset",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x015f/mh-p220.json
+++ b/packages/config/config/devices/0x015f/mh-p220.json
@@ -292,7 +292,6 @@
 			"label": "Factory reset",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [

--- a/packages/config/config/devices/0x015f/mh-s212.json
+++ b/packages/config/config/devices/0x015f/mh-s212.json
@@ -153,7 +153,6 @@
 			"label": "Factory Reset",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [

--- a/packages/config/config/devices/0x015f/mh-s220_0.0-3.1.json
+++ b/packages/config/config/devices/0x015f/mh-s220_0.0-3.1.json
@@ -152,7 +152,6 @@
 			"label": "Factory Reset",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [

--- a/packages/config/config/devices/0x015f/mh-s220_3.2.json
+++ b/packages/config/config/devices/0x015f/mh-s220_3.2.json
@@ -252,7 +252,6 @@
 			"label": "Factory Reset",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [

--- a/packages/config/config/devices/0x015f/mh-s314-1502.json
+++ b/packages/config/config/devices/0x015f/mh-s314-1502.json
@@ -81,7 +81,6 @@
 			"label": "Button Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -130,7 +129,6 @@
 			"label": "Basic CC Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -156,7 +154,6 @@
 			"label": "Button 1 Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -194,7 +191,6 @@
 			"label": "Button 2 Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -232,7 +228,6 @@
 			"label": "Button 3 Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -270,7 +265,6 @@
 			"label": "Button 4 Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -308,7 +302,6 @@
 			"label": "Local Relay Control",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -326,7 +319,6 @@
 			"label": "Z-Wave Relay Control",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -416,7 +408,6 @@
 			"label": "Button 1 Scene Activate Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -461,7 +452,6 @@
 			"label": "Button 2 Scene Activate Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -506,7 +496,6 @@
 			"label": "Button 3 Scene Activate Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -551,7 +540,6 @@
 			"label": "Button 4 Scene Activate Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -596,7 +584,6 @@
 			"label": "Factory Reset",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x015f/mh-s314.json
+++ b/packages/config/config/devices/0x015f/mh-s314.json
@@ -84,7 +84,6 @@
 			"label": "Button Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -125,7 +124,6 @@
 			"label": "Factory Reset",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x015f/mh-s411-5102.json
+++ b/packages/config/config/devices/0x015f/mh-s411-5102.json
@@ -68,7 +68,6 @@
 			"label": "Button Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -109,7 +108,6 @@
 			"label": "Basic CC Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -135,7 +133,6 @@
 			"label": "Respond to Scenes",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -153,7 +150,6 @@
 			"label": "Scene Activate Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -198,7 +194,6 @@
 			"label": "Factory Reset",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x015f/mh-s411-7102.json
+++ b/packages/config/config/devices/0x015f/mh-s411-7102.json
@@ -68,7 +68,6 @@
 			"label": "Button Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -109,7 +108,6 @@
 			"label": "Basic CC Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -135,7 +133,6 @@
 			"label": "Respond to Scenes",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -153,7 +150,6 @@
 			"label": "Scene Activate Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -198,7 +194,6 @@
 			"label": "Factory Reset",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x015f/mh-s412-5102.json
+++ b/packages/config/config/devices/0x015f/mh-s412-5102.json
@@ -72,7 +72,6 @@
 			"label": "Button Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -113,7 +112,6 @@
 			"label": "Basic CC Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -175,7 +173,6 @@
 			"label": "Button 1 Scene Activate Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -220,7 +217,6 @@
 			"label": "Button 2 Scene Activate Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -265,7 +261,6 @@
 			"label": "Factory Reset",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x015f/mh-s412-7102.json
+++ b/packages/config/config/devices/0x015f/mh-s412-7102.json
@@ -72,7 +72,6 @@
 			"label": "Button Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -113,7 +112,6 @@
 			"label": "Basic CC Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -139,7 +137,6 @@
 			"label": "Respond to Scenes",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -157,7 +154,6 @@
 			"label": "Scene Activate Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -202,7 +198,6 @@
 			"label": "Factory Reset",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x015f/mh-s510.json
+++ b/packages/config/config/devices/0x015f/mh-s510.json
@@ -39,7 +39,6 @@
 			"label": "Key Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -76,7 +75,6 @@
 			"label": "External Aux Switch Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x015f/mh-s511.json
+++ b/packages/config/config/devices/0x015f/mh-s511.json
@@ -104,7 +104,6 @@
 			"label": "Basic CC Integration Setting",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -130,7 +129,6 @@
 			"label": "Key 1 Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -299,7 +297,6 @@
 			"label": "Factory reset",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [

--- a/packages/config/config/devices/0x015f/mh-s512.json
+++ b/packages/config/config/devices/0x015f/mh-s512.json
@@ -104,7 +104,6 @@
 			"label": "Basic CC Integration Setting",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -130,7 +129,6 @@
 			"label": "Key 1 Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -168,7 +166,6 @@
 			"label": "Key 2 Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -393,7 +390,6 @@
 			"label": "Factory reset",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [

--- a/packages/config/config/devices/0x015f/mh-s513.json
+++ b/packages/config/config/devices/0x015f/mh-s513.json
@@ -104,7 +104,6 @@
 			"label": "Basic CC Integration Setting",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -130,7 +129,6 @@
 			"label": "Key 1 Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -168,7 +166,6 @@
 			"label": "Key 2 Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -206,7 +203,6 @@
 			"label": "Key 3 Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -487,7 +483,6 @@
 			"label": "Factory reset",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [

--- a/packages/config/config/devices/0x015f/mh10-pm2_5-wa_wd.json
+++ b/packages/config/config/devices/0x015f/mh10-pm2_5-wa_wd.json
@@ -77,7 +77,6 @@
 			"description": "85 (0x55) to restore factory setting",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [

--- a/packages/config/config/devices/0x015f/mh5-2a.json
+++ b/packages/config/config/devices/0x015f/mh5-2a.json
@@ -26,7 +26,6 @@
 			"label": "Temperature Unit",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -80,7 +79,6 @@
 			"label": "Display Brightness",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -110,7 +108,6 @@
 			"label": "Beep Volume",
 			"valueSize": 1,
 			"defaultValue": 5,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -203,7 +200,6 @@
 			"label": "Outdoor Temperature Sensor Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -222,7 +218,6 @@
 			"description": "Automatic heating at 41°F/5°C",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -240,7 +235,6 @@
 			"label": "Fan Mode Above Set Temperature",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -258,7 +252,6 @@
 			"label": "Fan Working Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -284,7 +277,6 @@
 			"label": "Key Lock Function",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -302,7 +294,6 @@
 			"label": "Ventilation Function",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -348,7 +339,6 @@
 			"label": "Factory Reset",
 			"valueSize": 1,
 			"defaultValue": 53,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x015f/mh9-co2.json
+++ b/packages/config/config/devices/0x015f/mh9-co2.json
@@ -114,7 +114,6 @@
 			"label": "Reset to Factory Settings",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [

--- a/packages/config/config/devices/0x0165/crc-3100.json
+++ b/packages/config/config/devices/0x0165/crc-3100.json
@@ -20,7 +20,6 @@
 			"description": "To set-up the profile of buttons 1 and 3",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -43,7 +42,6 @@
 			"description": "To set-up the profile of buttons 2 and 4",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -66,7 +64,6 @@
 			"description": "To choose the way of sending Scene to the gateway",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -85,7 +82,6 @@
 			"description": "To set-up the how button 1 behaves, when set in MONO Profile",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -108,7 +104,6 @@
 			"description": "To set-up the how button 2 behaves, when set in MONO Profile",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -131,7 +126,6 @@
 			"description": "To set-up the how button 3 behaves, when set in MONO Profile",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -154,7 +148,6 @@
 			"description": "To set-up the how button 4 behaves, when set in MONO Profile",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -177,7 +170,6 @@
 			"description": "How to set up LED behaviour",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0165/cws-3101.json
+++ b/packages/config/config/devices/0x0165/cws-3101.json
@@ -51,7 +51,6 @@
 			"description": "To set-up the profile of buttons 1 and 3",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -74,7 +73,6 @@
 			"description": "To set-up the profile of buttons 2 and 4",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -97,7 +95,6 @@
 			"description": "To choose the way of sending Scene to the gateway",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -116,7 +113,6 @@
 			"description": "To set-up the how button 1 behaves, when set in MONO Profile",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -139,7 +135,6 @@
 			"description": "To set-up the how button 2 behaves, when set in MONO Profile",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -162,7 +157,6 @@
 			"description": "To set-up the how button 3 behaves, when set in MONO Profile",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -185,7 +179,6 @@
 			"description": "To set-up the how button 4 behaves, when set in MONO Profile",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -208,7 +201,6 @@
 			"description": "How to set up LED behaviour",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0165/soft_remote.json
+++ b/packages/config/config/devices/0x0165/soft_remote.json
@@ -20,7 +20,6 @@
 			"description": "To set-up the profile of buttons 1 and 3",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -43,7 +42,6 @@
 			"description": "To set-up the profile of buttons 2 and 4",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -66,7 +64,6 @@
 			"description": "To choose the way of sending Scene to the gateway",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -85,7 +82,6 @@
 			"description": "To set-up the how button 1 behaves, when set in MONO Profile",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -108,7 +104,6 @@
 			"description": "To set-up the how button 2 behaves, when set in MONO Profile",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -131,7 +126,6 @@
 			"description": "To set-up the how button 3 behaves, when set in MONO Profile",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -154,7 +148,6 @@
 			"description": "To set-up the how button 4 behaves, when set in MONO Profile",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -177,7 +170,6 @@
 			"description": "How to set up LED behaviour",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0166/sw-zrc.json
+++ b/packages/config/config/devices/0x0166/sw-zrc.json
@@ -21,7 +21,6 @@
 			"description": "Set priority Association Group number for an Association Source Node",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -39,7 +38,6 @@
 			"label": "Function Device Key A",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -65,7 +63,6 @@
 			"label": "Function Device Key B",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -91,7 +88,6 @@
 			"label": "Function Device Key C",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -117,7 +113,6 @@
 			"label": "Function Device Key D",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -143,7 +138,6 @@
 			"label": "Function Device Key E",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -169,7 +163,6 @@
 			"label": "Function Device Key F",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -195,7 +188,6 @@
 			"label": "Function Device Key G",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -221,7 +213,6 @@
 			"label": "Function Device Key H",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -247,7 +238,6 @@
 			"label": "Send Unsolicited Battery Report On Wake Up",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -265,7 +255,6 @@
 			"label": "Dimming Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x016a/ft098-k55.json
+++ b/packages/config/config/devices/0x016a/ft098-k55.json
@@ -20,7 +20,6 @@
 			"label": "Set The Bulbs State After It is Re-powered On",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -42,7 +41,6 @@
 			"label": "Enable/Disable to Send Out a Report When The Color is Changed",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -60,7 +58,6 @@
 			"label": "Get The Bulb’s Color Value",
 			"valueSize": 4,
 			"defaultValue": 0,
-			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -79,7 +76,6 @@
 			"label": "Enable/Disable The Function of Using External Switch to Turn On/Off The Bulb",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -97,7 +93,6 @@
 			"label": "Enable/Disable The Function of Using External Switch to Changes The Bulb’s Color",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -115,7 +110,6 @@
 			"label": "Reboot/Save/Exit Colorful Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -141,7 +135,6 @@
 			"label": "Colorful Mode Configuration",
 			"valueSize": 4,
 			"defaultValue": 157483008,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -201,7 +194,6 @@
 			"label": "Color Index Configuration When The Bulb is in Multi Color Mode",
 			"valueSize": 4,
 			"defaultValue": 2003125025,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -243,7 +235,6 @@
 			"label": "To Set Which Notification Can Be Sent to The Associated Devices (group 1) When The State of LED Bulb is Changed",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -265,7 +256,6 @@
 			"label": "Set The Dimmer Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -291,7 +281,6 @@
 			"label": "Enable/Disable Lock Configuration",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -309,7 +298,6 @@
 			"label": "Reset The Bulb",
 			"valueSize": 4,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x016a/ft102.json
+++ b/packages/config/config/devices/0x016a/ft102.json
@@ -20,7 +20,6 @@
 			"label": "Command Type When Triggered",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -38,7 +37,6 @@
 			"label": "Reset the Device",
 			"valueSize": 4,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x016a/ft111.json
+++ b/packages/config/config/devices/0x016a/ft111.json
@@ -419,7 +419,6 @@
 			"label": "LED Indicator When Off",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x016a/ft130-k.json
+++ b/packages/config/config/devices/0x016a/ft130-k.json
@@ -20,7 +20,6 @@
 			"label": "Enable/Disable Touch Sound",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -38,7 +37,6 @@
 			"label": "Enable/Disable Touch Vibration",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -56,7 +54,6 @@
 			"label": "Enable/Disable Button Slide",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -74,7 +71,6 @@
 			"label": "Type of Report When Button Pressed",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -92,7 +88,6 @@
 			"label": "Type of Command to Send to Association Groups 2, 4, 6, 8",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -119,7 +114,6 @@
 			"label": "Enable/Disable LED on Wake Up",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -137,7 +131,6 @@
 			"label": "Enable/Disable Blinking LED on Command Failure",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -155,7 +148,6 @@
 			"label": "Enable/Disable LED When Charging",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -173,7 +165,6 @@
 			"label": "Enable/Disable LED on Button Press",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -191,7 +182,6 @@
 			"label": "Lock Configuration Parameters",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -209,7 +199,6 @@
 			"label": "Reset Device",
 			"valueSize": 4,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x016a/ufa01.json
+++ b/packages/config/config/devices/0x016a/ufa01.json
@@ -20,7 +20,6 @@
 			"label": "Value to Send When Triggered",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -38,7 +37,6 @@
 			"label": "Enable/Disable Wake-up When Re-powered",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -56,7 +54,6 @@
 			"label": "Normal Operation State",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -98,7 +95,6 @@
 			"label": "Type of Command to Send to Nodes When Triggered",
 			"valueSize": 4,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -120,7 +116,6 @@
 			"label": "Notification Type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -174,7 +169,6 @@
 			"label": "Reset The Device",
 			"valueSize": 4,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0175/mt02646.json
+++ b/packages/config/config/devices/0x0175/mt02646.json
@@ -70,7 +70,6 @@
 			"label": "Restore switch state mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -92,7 +91,6 @@
 			"label": "Mode of switch off function",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -111,7 +109,6 @@
 			"description": "Restore switch state mode.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -148,7 +145,6 @@
 			"label": "RF off command mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0175/mt2652.json
+++ b/packages/config/config/devices/0x0175/mt2652.json
@@ -20,7 +20,6 @@
 			"label": "Button 1 and 3 pair mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -42,7 +41,6 @@
 			"label": "Button 2 and 4 pair mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -64,7 +62,6 @@
 			"label": "Command to control Group A",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -110,7 +107,6 @@
 			"label": "Command to control Group B",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -156,7 +152,6 @@
 			"label": "Command to control Group C",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -202,7 +197,6 @@
 			"label": "Command to control Group D",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -270,7 +264,6 @@
 			"label": "Invert buttons",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -288,7 +281,6 @@
 			"label": "Block wake up even when Wake Up Interval is set",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -306,7 +298,6 @@
 			"label": "Send unsolicited Battery Report on Wake Up",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0175/mt2653.json
+++ b/packages/config/config/devices/0x0175/mt2653.json
@@ -19,7 +19,6 @@
 			"label": "Button 1 and 3 pair mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -41,7 +40,6 @@
 			"label": "Button 2 and 4 pair mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -63,7 +61,6 @@
 			"label": "Action on group 1",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -109,7 +106,6 @@
 			"label": "Action on group 2",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -155,7 +151,6 @@
 			"label": "Action on group 3",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -201,7 +196,6 @@
 			"label": "Action on group 4",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -269,7 +263,6 @@
 			"label": "Invert buttons",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -305,7 +298,6 @@
 			"label": "Send unsolicited Battery Report on Wake Up",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0175/mt2756.json
+++ b/packages/config/config/devices/0x0175/mt2756.json
@@ -38,7 +38,6 @@
 			"label": "Disable the Flood function",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0175/mt2760.json
+++ b/packages/config/config/devices/0x0175/mt2760.json
@@ -78,7 +78,6 @@
 			"label": "Input 1 switch type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -96,7 +95,6 @@
 			"label": "Input 2 switch type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -114,7 +112,6 @@
 			"label": "Input 2 contact type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -132,7 +129,6 @@
 			"label": "Input 3 contact type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -151,7 +147,6 @@
 			"description": "Dimmer module responds to commands ALL ON / ALL OFF",
 			"valueSize": 2,
 			"defaultValue": 255,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -196,7 +191,6 @@
 			"description": "Dimming is done by push button or switch connected to I1.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -219,7 +213,6 @@
 			"description": "A fast double click on the push button will set dimming power at maximum.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -296,7 +289,6 @@
 			"description": "This parameter is used with association group 3",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -324,7 +316,6 @@
 			"description": "Enabling I2 means that Endpoint (I2) will be present on UI.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -367,7 +358,6 @@
 			"description": "Enabling I3 means that Endpoint (I3) will be present on UI.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0175/mt2761.json
+++ b/packages/config/config/devices/0x0175/mt2761.json
@@ -109,7 +109,6 @@
 			"description": "Operation Mode (Shutter or Venetian)",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -192,7 +191,6 @@
 			"description": "Defines if reporting regarding power level, etc is reported to controller.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0175/mt_2653.json
+++ b/packages/config/config/devices/0x0175/mt_2653.json
@@ -43,7 +43,6 @@
 			"label": "Button 1 And 3 Pair Mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -66,7 +65,6 @@
 			"description": " works with group b, double click with group d",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -88,7 +86,6 @@
 			"label": "Command to Send Control Group A",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -134,7 +131,6 @@
 			"label": "Command to Send Control Group B",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -180,7 +176,6 @@
 			"label": "Command to Send Control Group C",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -226,7 +221,6 @@
 			"label": "Command to to Send Control Group D",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -294,7 +288,6 @@
 			"label": "Invert Buttons",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -312,7 +305,6 @@
 			"label": "Block Wakeup",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -330,7 +322,6 @@
 			"label": "Send Battery Report On Wake Up",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0178/9125051.json
+++ b/packages/config/config/devices/0x0178/9125051.json
@@ -29,7 +29,6 @@
 			"description": "Start, stop, or get the results of discovery mode. Retrieve the configuration parameter to obtain the results.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -55,7 +54,6 @@
 			"label": "Sleep Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0178/ZSENS930.json
+++ b/packages/config/config/devices/0x0178/ZSENS930.json
@@ -133,7 +133,6 @@
 			"description": "Determines which combination of Basic Set commands will be sent",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0178/nx1000.json
+++ b/packages/config/config/devices/0x0178/nx1000.json
@@ -207,7 +207,6 @@
 			"label": "Button 1 Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -370,7 +369,6 @@
 			"label": "Screen Timeout: Primary Page",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0178/th100nx.json
+++ b/packages/config/config/devices/0x0178/th100nx.json
@@ -110,7 +110,6 @@
 			"label": "Temperature Units",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -286,7 +285,6 @@
 			"description": "Determines which combination of Basic Set commands will be sent",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x017f/wink_motion_sensor.json
+++ b/packages/config/config/devices/0x017f/wink_motion_sensor.json
@@ -61,7 +61,6 @@
 			"label": "Enable/Disable Motion Detection",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -106,7 +105,6 @@
 			"label": "Enable/Disable Group 2 Ambient Light Threshold",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -134,7 +132,6 @@
 			"label": "Enable/Disable LED Indicator",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0184/pa-100.json
+++ b/packages/config/config/devices/0x0184/pa-100.json
@@ -20,7 +20,6 @@
 			"description": "Controls LED behavior when switch state is on/off",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0184/pd-100.json
+++ b/packages/config/config/devices/0x0184/pd-100.json
@@ -20,7 +20,6 @@
 			"label": "LED Backlight",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0184/ws-100.json
+++ b/packages/config/config/devices/0x0184/ws-100.json
@@ -20,7 +20,6 @@
 			"description": "Controls LED behavior when switch state is on/off",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -43,7 +42,6 @@
 			"description": "Controls the on/off orientation of the rocker switch",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0185/zm-800.json
+++ b/packages/config/config/devices/0x0185/zm-800.json
@@ -20,7 +20,6 @@
 			"label": "LED Light",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0189/117001.json
+++ b/packages/config/config/devices/0x0189/117001.json
@@ -147,7 +147,6 @@
 			"label": "Night Light Duration",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -176,7 +175,6 @@
 			"label": "Walk Test Mode Duration",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x018f/zme_wallc-s.json
+++ b/packages/config/config/devices/0x018f/zme_wallc-s.json
@@ -44,7 +44,6 @@
 			"description": "In separate mode button 1 works with group a, button 3 with groups c. click is on, hold is dimming up, double click is off, click-hold is dimming down. in pair button 1/3 are up/down correspondingly. click is on/off, hold is dimming up/down. single clicks works with group a, double click with group c",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -67,7 +66,6 @@
 			"description": "In separate mode button 2 works with control group b, button 4 with control group d. click is on, hold is dimming up, double click is off, click-hold is dimming down. in pair button b/d are up/down correspondingly. click is on/off, hold is dimming up/down. single clicks works with group b, double click with group d",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -90,7 +88,6 @@
 			"description": "This parameter defines the command to be sent to devices of control group a when the related button is pressed",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -133,7 +130,6 @@
 			"description": "This parameter defines the command to be sent to devices of control group b when the related button is pressed",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -176,7 +172,6 @@
 			"description": "This parameter defines the command to be sent to devices of control group c when the related button is pressed",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -219,7 +214,6 @@
 			"description": "This parameter defines the command to be sent to devices of control group d when the related button is pressed",
 			"valueSize": 1,
 			"defaultValue": 8,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -283,7 +277,6 @@
 			"label": "Invert Buttons",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -301,7 +294,6 @@
 			"label": "Blocks Wakeup Even When Wakeup Interval is Set",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -319,7 +311,6 @@
 			"label": "Send Unsolicited Battery Report On Wake Up",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x019a/11-01-011.json
+++ b/packages/config/config/devices/0x019a/11-01-011.json
@@ -26,7 +26,6 @@
 			"label": "Notification type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -49,7 +48,6 @@
 			"description": "Specify if LED should indicate special event.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x019a/11_01_022.json
+++ b/packages/config/config/devices/0x019a/11_01_022.json
@@ -27,7 +27,6 @@
 			"label": "Notification type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -49,7 +48,6 @@
 			"label": "Led Indicator",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -67,7 +65,6 @@
 			"label": "Send Supervision Commands",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -130,7 +127,6 @@
 			"label": "Security Level",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x019a/11_02_022.json
+++ b/packages/config/config/devices/0x019a/11_02_022.json
@@ -203,7 +203,6 @@
 			"label": "Slider Switch Function",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x019a/11_04_21_22_28.json
+++ b/packages/config/config/devices/0x019a/11_04_21_22_28.json
@@ -138,7 +138,6 @@
 			"label": "Supervision Commands",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x019b/z-ph_wall_controller.json
+++ b/packages/config/config/devices/0x019b/z-ph_wall_controller.json
@@ -39,7 +39,6 @@
 			"label": "Button Reports",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -62,7 +61,6 @@
 			"description": "Disabling this does not turn of factory reset/inclusion indication.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -80,7 +78,6 @@
 			"label": "Installed Rocker",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x019b/z-water2.json
+++ b/packages/config/config/devices/0x019b/z-water2.json
@@ -63,7 +63,6 @@
 			"label": "Output Behavior",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x019b/zm_single_relay_16.json
+++ b/packages/config/config/devices/0x019b/zm_single_relay_16.json
@@ -67,7 +67,6 @@
 			"label": "Switch Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -85,7 +84,6 @@
 			"label": "S1/Button Operation",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -104,7 +102,6 @@
 			"description": "Configure which buttons cause notifications to be sent",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -165,7 +162,6 @@
 			"label": "Inverted Output",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x019b/zm_thermostat_16.json
+++ b/packages/config/config/devices/0x019b/zm_thermostat_16.json
@@ -31,7 +31,6 @@
 			"label": "Operating Mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0208/hkzw_so03.json
+++ b/packages/config/config/devices/0x0208/hkzw_so03.json
@@ -38,7 +38,6 @@
 			"label": "Notification When Load Status Change",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -60,7 +59,6 @@
 			"label": "LED Power Indication",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x020e/zrksw.json
+++ b/packages/config/config/devices/0x020e/zrksw.json
@@ -20,7 +20,6 @@
 			"label": "Dim Level When Powered On",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0212/gda-a2e6b-k0.json
+++ b/packages/config/config/devices/0x0212/gda-a2e6b-k0.json
@@ -20,7 +20,6 @@
 			"label": "Silent Mode On/Off",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0212/gdm-m2d6d-k0.json
+++ b/packages/config/config/devices/0x0212/gdm-m2d6d-k0.json
@@ -20,7 +20,6 @@
 			"label": "Silent Mode On/Off",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x021d/ml2.json
+++ b/packages/config/config/devices/0x021d/ml2.json
@@ -31,7 +31,6 @@
 			"label": "Configure Volume Level",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -72,7 +71,6 @@
 			"label": "Basic Set Value",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0234/zhc5010.json
+++ b/packages/config/config/devices/0x0234/zhc5010.json
@@ -557,7 +557,6 @@
 			"label": "Scene notification offset",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0249/psr07.json
+++ b/packages/config/config/devices/0x0249/psr07.json
@@ -45,7 +45,6 @@
 			"label": "Dimmer Set Method",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x024d/dn3g6ja062.json
+++ b/packages/config/config/devices/0x024d/dn3g6ja062.json
@@ -29,7 +29,6 @@
 			"label": "LED Blinking Mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x024f/ad1-10v.json
+++ b/packages/config/config/devices/0x024f/ad1-10v.json
@@ -21,7 +21,6 @@
 			"description": "",
 			"valueSize": 1,
 			"defaultValue": 18,
-			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -57,7 +56,6 @@
 			"label": "Dimmer Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -91,7 +89,6 @@
 			"label": "Back Unit Type",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false,
 			"options": [

--- a/packages/config/config/devices/0x024f/am.json
+++ b/packages/config/config/devices/0x024f/am.json
@@ -20,7 +20,6 @@
 			"label": "Hardware Combination Identifier",
 			"valueSize": 1,
 			"defaultValue": 18,
-			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -57,7 +56,6 @@
 			"label": "Dimmer Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -91,7 +89,6 @@
 			"label": "Back Unit Type",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false,
 			"options": [

--- a/packages/config/config/devices/0x024f/ar1p.json
+++ b/packages/config/config/devices/0x024f/ar1p.json
@@ -20,7 +20,6 @@
 			"label": "Hardware Combination Identifier",
 			"valueSize": 1,
 			"defaultValue": 19,
-			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -74,7 +73,6 @@
 			"label": "Back Unit Type",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false,
 			"options": [

--- a/packages/config/config/devices/0x024f/ar2p.json
+++ b/packages/config/config/devices/0x024f/ar2p.json
@@ -20,7 +20,6 @@
 			"label": "Hardware Combination Identifier",
 			"valueSize": 1,
 			"defaultValue": 19,
-			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -74,7 +73,6 @@
 			"label": "Back Unit Type",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false,
 			"options": [

--- a/packages/config/config/devices/0x025d/da_vinci_v9.json
+++ b/packages/config/config/devices/0x025d/da_vinci_v9.json
@@ -327,7 +327,6 @@
 			"label": "Button 1 attributes",
 			"valueSize": 1,
 			"defaultValue": 7,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -501,7 +500,6 @@
 			"label": "Button 2 attributes",
 			"valueSize": 1,
 			"defaultValue": 7,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -671,7 +669,6 @@
 			"label": "Button 3 attributes",
 			"valueSize": 1,
 			"defaultValue": 7,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -841,7 +838,6 @@
 			"label": "Button 4 attributes",
 			"valueSize": 1,
 			"defaultValue": 7,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -1011,7 +1007,6 @@
 			"label": "Button 5 attributes",
 			"valueSize": 1,
 			"defaultValue": 7,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -1181,7 +1176,6 @@
 			"label": "Button 6 attributes",
 			"valueSize": 1,
 			"defaultValue": 7,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -1351,7 +1345,6 @@
 			"label": "Button 7 attribute",
 			"valueSize": 1,
 			"defaultValue": 7,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -1521,7 +1514,6 @@
 			"label": "Button 8 attribute",
 			"valueSize": 1,
 			"defaultValue": 7,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -1691,7 +1683,6 @@
 			"label": "Button 9 attributes",
 			"valueSize": 1,
 			"defaultValue": 7,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0267/10002081-13x.json
+++ b/packages/config/config/devices/0x0267/10002081-13x.json
@@ -75,7 +75,6 @@
 			"label": "Short Press Action",
 			"valueSize": 1,
 			"defaultValue": 7,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0270/bvs-zwu.json
+++ b/packages/config/config/devices/0x0270/bvs-zwu.json
@@ -44,7 +44,6 @@
 			"description": "When enabled, the device will report off (0x00) when the valve is open, and on (0xff) when the valve is closed; ",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -63,7 +62,6 @@
 			"description": "Note: If parameter 17 is enabled, this level will be set when the valve is off",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -86,7 +84,6 @@
 			"description": "Note: If parameter 17 is enabled, this level will be set when the valve is on",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -108,7 +105,6 @@
 			"label": "Association Group 3: Water Leak Basic Set Value (Trigger)",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -130,7 +126,6 @@
 			"label": "Association Group 3: Water Leak Basic Set Value (Cancel)",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -152,7 +147,6 @@
 			"label": "Temperature Report Unit",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -292,7 +286,6 @@
 			"label": "Association Group 4: Overheat Basic Set Value (Trigger)",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -314,7 +307,6 @@
 			"label": "Association Group 4: Overheat Basic Set Value (Cancel)",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -390,7 +382,6 @@
 			"label": "Association Group 5: Freeze Basic Set Value (Trigger)",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -412,7 +403,6 @@
 			"label": "Association Group 5: Freeze Basic Set Value (Cancel)",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -434,7 +424,6 @@
 			"label": "Allow Valve Control - Water Leak Detected",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -452,7 +441,6 @@
 			"label": "Allow Valve Control - Water Leak Detected During Freeze Mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -470,7 +458,6 @@
 			"label": "Buzzer",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -496,7 +483,6 @@
 			"label": "Touch Keylock Protection",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x027a/zac36.json
+++ b/packages/config/config/devices/0x027a/zac36.json
@@ -72,7 +72,6 @@
 			"label": "Temperature Report Unit",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -248,7 +247,6 @@
 			"description": "Causes the valve to periodically make a 1/8 turn to ensure it is operational",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x027a/zen15.json
+++ b/packages/config/config/devices/0x027a/zen15.json
@@ -30,7 +30,6 @@
 			"label": "On/Off Status Change Notifications",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -92,7 +91,6 @@
 			"label": "LED Indicator",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -112,7 +110,6 @@
 			"description": "Pink = Power Switch is off; Blue = 0–300 W; Cyan = 300–600 W; Green = 600–900 W; Yellow = 900–1200 W; Red = 1200–1500 W; Purple = 1500–1800 W; Purple blink = over 1800 W",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x027a/zen16.json
+++ b/packages/config/config/devices/0x027a/zen16.json
@@ -38,7 +38,6 @@
 			"label": "Status After Power Failure",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -104,7 +103,6 @@
 			"label": "LED Indicator",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -146,7 +144,6 @@
 			"label": "Relay 1: Auto Turn-Off Timer Unit",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -281,7 +278,6 @@
 			"label": "Switch 1: Manual Control",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -330,7 +326,6 @@
 			"label": "Relay 1: Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x027a/zen17.json
+++ b/packages/config/config/devices/0x027a/zen17.json
@@ -39,7 +39,6 @@
 			"label": "Status After Power Failure",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -71,7 +70,6 @@
 			"description": "Note: The device must be excluded (without resetting it) and re-included after changing to/from values 4-10",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -127,7 +125,6 @@
 			"description": "Note: The device must be excluded (without resetting it) and re-included after changing to/from values 4-11",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -187,7 +184,6 @@
 			"description": "Select the same value as you chose for parameter 2 to reverse the values for open and closed circuit",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -231,7 +227,6 @@
 			"description": "Note: The device must be excluded (without resetting it) and re-included after changing to/from values 4-10",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -287,7 +282,6 @@
 			"description": "Note: The device must be excluded (without resetting it) and re-included after changing to/from values 4-11",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -352,7 +346,6 @@
 			"label": "LED Indicator",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -415,7 +408,6 @@
 			"description": "If disabled and Parameter 2 is >= 4, a Z-Wave report will be sent but R1 will not be triggered",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -434,7 +426,6 @@
 			"description": "If disabled and Parameter 3 is >= 4, a Z-Wave report will be sent but R2 will not be triggered",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -452,7 +443,6 @@
 			"label": "Auto Turn-Off Timer Unit (Relay 1)",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -474,7 +464,6 @@
 			"label": "Auto Turn-On Timer Unit (Relay 1)",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -497,7 +486,6 @@
 			"description": "Choose between second, minutes, and hours as the unit for Auto Turn-Off time for Relay 2.  Default: minutes",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -519,7 +507,6 @@
 			"label": "Auto Turn-On Timer Unit (Relay 2)",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -542,7 +529,6 @@
 			"description": "Sync R1 and R2 together to prevent both being activated at the same time",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -579,7 +565,6 @@
 			"description": "How the relay should react to state changes of IN1 and IN2. This setting is designed for rare and niche scenarios and should not be used unless your unique situation requires it.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x027a/zen31.json
+++ b/packages/config/config/devices/0x027a/zen31.json
@@ -117,7 +117,6 @@
 			"description": "Choose how switches connected to the input terminals control your LED strip. In the default RGBW mode, each switch connected to each input terminal controls the RGBW chnnels separately (so IN1 for red, IN2 for green, etc.) with a single click for ON/OFF, double click to full brightness, and press-and-hold to dim (momentary switches only). In the HSB, IN1 controls hue, IN2 - saturation, IN3 - brightness, IN4 - white with single click for last set value or value 0, double click to max value, and press-and-hold to set custom value. Default: RGBW mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -166,7 +165,6 @@
 			"description": "Enable one of the preset animated color programs to set the mood with a click.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x027a/zen53.json
+++ b/packages/config/config/devices/0x027a/zen53.json
@@ -156,7 +156,6 @@
 			"label": "External Switch Type (S1)",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -174,7 +173,6 @@
 			"label": "External Switch Type (S2)",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x027a/zse11.json
+++ b/packages/config/config/devices/0x027a/zse11.json
@@ -48,7 +48,6 @@
 			"label": "Temperature Scale",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x027a/zse41.json
+++ b/packages/config/config/devices/0x027a/zse41.json
@@ -44,7 +44,6 @@
 			"label": "Sensor Behavior",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x027a/zse42.json
+++ b/packages/config/config/devices/0x027a/zse42.json
@@ -50,7 +50,6 @@
 			"label": "Group 2: Basic Set Commands",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x027a/zse43.json
+++ b/packages/config/config/devices/0x027a/zse43.json
@@ -34,7 +34,6 @@
 			"label": "LED Indicator",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -69,7 +68,6 @@
 			"valueSize": 1,
 			"unit": "%",
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -103,7 +101,6 @@
 			"label": "Enable Sensors",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -125,7 +122,6 @@
 			"label": "Group 2: Tilt Sensor Basic Reports",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -151,7 +147,6 @@
 			"label": "Group 3: Shock Sensor Basic Reports",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x027a/zse44.json
+++ b/packages/config/config/devices/0x027a/zse44.json
@@ -93,7 +93,6 @@
 			"label": "High Temperature Alert Reporting",
 			"valueSize": 1,
 			"defaultValue": 7,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -155,7 +154,6 @@
 			"label": "Low Temperature Alert Reporting",
 			"valueSize": 1,
 			"defaultValue": 7,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -204,7 +202,6 @@
 			"label": "High Humidity Alert Reporting",
 			"valueSize": 1,
 			"defaultValue": 7,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -253,7 +250,6 @@
 			"label": "Low Humidity Alert Reporting",
 			"valueSize": 1,
 			"defaultValue": 7,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x027a/zw6302.json
+++ b/packages/config/config/devices/0x027a/zw6302.json
@@ -64,7 +64,6 @@
 			"label": "Basic Set, Notification and Basic Report",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0299/0000_9518.json
+++ b/packages/config/config/devices/0x0299/0000_9518.json
@@ -20,7 +20,6 @@
 			"label": "Enable/Disable Basic Set Command",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -39,7 +38,6 @@
 			"description": "Door/window sensor can reverse its value of Basic Set when the magnet is triggered",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0300/7aa-ss-ve-a0.json
+++ b/packages/config/config/devices/0x0300/7aa-ss-ve-a0.json
@@ -31,7 +31,6 @@
 			"label": "Magnetic Field Range",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0300/7ca-ss-ve-a0.json
+++ b/packages/config/config/devices/0x0300/7ca-ss-ve-a0.json
@@ -78,7 +78,6 @@
 			"label": "Reporting Value",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0307/86-100.json
+++ b/packages/config/config/devices/0x0307/86-100.json
@@ -21,7 +21,6 @@
 			"description": "The LED indicator will be on whenever the connected appliance is off, and turns off when the connected device is on",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0307/86_102.json
+++ b/packages/config/config/devices/0x0307/86_102.json
@@ -21,7 +21,6 @@
 			"description": "The LED indicator will be on when the connected appliance is on, and vice versa",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -44,7 +43,6 @@
 			"description": "The orientation of the on/off on the rocker switch can be inverted by changing the following configuration with a controller(if supported)",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x030a/dt82tv_f-1_2_14.json
+++ b/packages/config/config/devices/0x030a/dt82tv_f-1_2_14.json
@@ -21,7 +21,6 @@
 			"description": "",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -40,7 +39,6 @@
 			"description": "",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -59,7 +57,6 @@
 			"description": "",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -86,7 +83,6 @@
 			"description": "",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -109,7 +105,6 @@
 			"description": "",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -129,7 +124,6 @@
 			"description": "",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -153,7 +147,6 @@
 			"description": "",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -173,7 +166,6 @@
 			"description": "",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -192,7 +184,6 @@
 			"description": "",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -211,7 +202,6 @@
 			"description": "",
 			"valueSize": 1,
 			"defaultValue": 127,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [

--- a/packages/config/config/devices/0x0312/mse30z.json
+++ b/packages/config/config/devices/0x0312/mse30z.json
@@ -65,7 +65,6 @@
 			"label": "Invert Sensor",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -159,7 +158,6 @@
 			"label": "Association Group 2 Function",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0312/zks31.json
+++ b/packages/config/config/devices/0x0312/zks31.json
@@ -36,7 +36,6 @@
 			"label": "LED Indicator Color",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -89,7 +88,6 @@
 			"description": "Adjust brightness value with parameter 5",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -186,7 +184,6 @@
 			"label": "Center Press: Brightness",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -240,7 +237,6 @@
 			"label": "External Switch Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0312/zw30.json
+++ b/packages/config/config/devices/0x0312/zw30.json
@@ -25,7 +25,6 @@
 			"label": "Button Orientation",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0312/zw31.json
+++ b/packages/config/config/devices/0x0312/zw31.json
@@ -44,7 +44,6 @@
 			"label": "Button Orientation",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -138,7 +137,6 @@
 			"label": "Dim Level on Double Tap",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -156,7 +154,6 @@
 			"label": "Double Tap Behavior",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0315/wd-100.json
+++ b/packages/config/config/devices/0x0315/wd-100.json
@@ -20,7 +20,6 @@
 			"description": "Controls the on/off orientation of the rocker switch",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0315/ws-100.json
+++ b/packages/config/config/devices/0x0315/ws-100.json
@@ -20,7 +20,6 @@
 			"description": "Controls LED behavior when switch state is on/off",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -43,7 +42,6 @@
 			"description": "Controls the on/off orientation of the rocker switch",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0315/zl-ld-100.json
+++ b/packages/config/config/devices/0x0315/zl-ld-100.json
@@ -22,7 +22,6 @@
 			"valueSize": 1,
 			"unit": "minutes",
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -56,7 +55,6 @@
 			"description": "",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x031e/lzw30.json
+++ b/packages/config/config/devices/0x031e/lzw30.json
@@ -248,7 +248,6 @@
 			"label": "Instant On",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x031e/lzw36.json
+++ b/packages/config/config/devices/0x031e/lzw36.json
@@ -200,7 +200,6 @@
 			"label": "Default Fan Speed",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -226,7 +225,6 @@
 			"label": "Default Fan Speed (Z-Wave)",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -343,7 +341,6 @@
 			"label": "Light LED Strip Brightness",
 			"valueSize": 1,
 			"defaultValue": 5,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -440,7 +437,6 @@
 			"label": "Fan LED Strip Brightness",
 			"valueSize": 1,
 			"defaultValue": 5,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -955,7 +951,6 @@
 			"label": "Local Protection",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -983,7 +978,6 @@
 			"description": "Enabling this disables the 700ms button delay and multi-tap scenes.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x031e/lzw40.json
+++ b/packages/config/config/devices/0x031e/lzw40.json
@@ -20,7 +20,6 @@
 			"label": "State After Power Outage",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x031e/lzw41.json
+++ b/packages/config/config/devices/0x031e/lzw41.json
@@ -20,7 +20,6 @@
 			"label": "State After Power Outage",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -39,7 +38,6 @@
 			"description": "What notifications should be sent to associated devices when the state of the LED bulb is changed",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x031e/lzw42.json
+++ b/packages/config/config/devices/0x031e/lzw42.json
@@ -28,7 +28,6 @@
 			"description": "This state will be chosen when the power is restored",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x031e/lzw45.json
+++ b/packages/config/config/devices/0x031e/lzw45.json
@@ -1086,7 +1086,6 @@
 			"description": "The 700ms delay that occurs after pressing the physical button to turn the switch on/off is removed. Consequently this also removes the following scenes: 2x, 3x, 4x, 5x tap. Still working are the 1x tap, held, released, and the level up/down scenes.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x031e/lzw60.json
+++ b/packages/config/config/devices/0x031e/lzw60.json
@@ -54,7 +54,6 @@
 			"label": "Send Basic Set After PIR Trigger",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -72,7 +71,6 @@
 			"label": "Reverse Basic Set Behavior",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x031e/vzw31-sn.json
+++ b/packages/config/config/devices/0x031e/vzw31-sn.json
@@ -245,7 +245,6 @@
 			"label": "Power Type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -263,7 +262,6 @@
 			"label": "Switch Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -377,7 +375,6 @@
 			"label": "Exclusion Behavior",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -595,7 +592,6 @@
 			"label": "LED Brightness Scaling",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0329/lizy0005.json
+++ b/packages/config/config/devices/0x0329/lizy0005.json
@@ -40,7 +40,6 @@
 			"description": "Remember or not",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -59,7 +58,6 @@
 			"description": "",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0330/sr-zv9021a.json
+++ b/packages/config/config/devices/0x0330/sr-zv9021a.json
@@ -27,7 +27,6 @@
 			"label": "Operating Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0330/sr-zv9092a.json
+++ b/packages/config/config/devices/0x0330/sr-zv9092a.json
@@ -47,7 +47,6 @@
 			"label": "Button Vibrations & Sounds",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -69,7 +68,6 @@
 			"label": "Settings After Power Failure",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -117,7 +115,6 @@
 			"label": "Temperature Sensor Type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -143,7 +140,6 @@
 			"label": "Temperature Control Reference",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -192,7 +188,6 @@
 			"label": "Mode to Set After Drying Mode",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -304,7 +299,6 @@
 			"label": "Display Brightness",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -326,7 +320,6 @@
 			"label": "Home Page Sensor Display",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -354,7 +347,6 @@
 			"description": "Specifies the temperature change within three minutes to trigger window open detection",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0330/ves-zw-dim-001.json
+++ b/packages/config/config/devices/0x0330/ves-zw-dim-001.json
@@ -55,7 +55,6 @@
 			"label": "Switch Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -214,7 +213,6 @@
 			"label": "Dimming Curve",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0330/ves-zw-hld-016.json
+++ b/packages/config/config/devices/0x0330/ves-zw-hld-016.json
@@ -36,7 +36,6 @@
 			"label": "Switch Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0330/ves-zw-mot-018.json
+++ b/packages/config/config/devices/0x0330/ves-zw-mot-018.json
@@ -90,7 +90,6 @@
 			"description": "Only valid in Light Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -126,7 +125,6 @@
 			"label": "Send Central Scene Commands In Response To Inputs",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0330/ves-zw-soc-28.json
+++ b/packages/config/config/devices/0x0330/ves-zw-soc-28.json
@@ -35,7 +35,6 @@
 			"label": "LED Indicator",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0330/ves-zw-swi-002.json
+++ b/packages/config/config/devices/0x0330/ves-zw-swi-002.json
@@ -36,7 +36,6 @@
 			"label": "Switch Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0330/ves-zw-swi-014.json
+++ b/packages/config/config/devices/0x0330/ves-zw-swi-014.json
@@ -37,7 +37,6 @@
 			"description": "Only valid in Light Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -73,7 +72,6 @@
 			"label": "Send Central Scene Commands In Response To Inputs",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0346/contact_sensor_gen2.json
+++ b/packages/config/config/devices/0x0346/contact_sensor_gen2.json
@@ -58,7 +58,6 @@
 			"label": "LED Indicator",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0346/keypad_v2.json
+++ b/packages/config/config/devices/0x0346/keypad_v2.json
@@ -148,7 +148,6 @@
 			"label": "Proximity Detection",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -263,7 +262,6 @@
 			"label": "Calibrate Speaker",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0346/outdoor_contact_sensor.json
+++ b/packages/config/config/devices/0x0346/outdoor_contact_sensor.json
@@ -56,7 +56,6 @@
 			"label": "LED Indicator",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0346/range_extender_gen2.json
+++ b/packages/config/config/devices/0x0346/range_extender_gen2.json
@@ -50,7 +50,6 @@
 			"label": "LED Indicator",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0363/iotx-z-actmotor001.json
+++ b/packages/config/config/devices/0x0363/iotx-z-actmotor001.json
@@ -31,7 +31,6 @@
 			"description": "",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -50,7 +49,6 @@
 			"description": "",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -77,7 +75,6 @@
 			"description": "",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0364/t8344.json
+++ b/packages/config/config/devices/0x0364/t8344.json
@@ -21,7 +21,6 @@
 			"description": "",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0371/zw141.json
+++ b/packages/config/config/devices/0x0371/zw141.json
@@ -46,7 +46,6 @@
 			"label": "Motor Run Direction",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -108,7 +107,6 @@
 			"label": "Enter/Exit Calibration",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -130,7 +128,6 @@
 			"label": "User Confirmation For Calibration",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -144,7 +141,6 @@
 			"label": "Calibration Status",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -179,7 +175,6 @@
 			"label": "Curtain Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -197,7 +192,6 @@
 			"label": "Inititiate Repositioning",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -212,7 +206,6 @@
 			"label": "Repositioning Status",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -231,7 +224,6 @@
 			"label": "Calibration Lock",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -258,7 +250,6 @@
 			"label": "External Button Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -280,7 +271,6 @@
 			"label": "Switch S1 Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -310,7 +300,6 @@
 			"label": "Switch S2 Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -349,7 +338,6 @@
 			"label": "External Switch: Network/Reset Functions",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0371/zw175.json
+++ b/packages/config/config/devices/0x0371/zw175.json
@@ -96,7 +96,6 @@
 			"label": "Switch Action on Alarm",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0371/zw187.json
+++ b/packages/config/config/devices/0x0371/zw187.json
@@ -50,7 +50,6 @@
 			"label": "Association Group 2: Basic Set Value",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -117,7 +116,6 @@
 			"description": "Configure whether the LED will flash or not when sending Basic Set, Sensor Binary Report, Notification Report (Access Control) or Wake Up Notification.",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0371/zwa005.json
+++ b/packages/config/config/devices/0x0371/zwa005.json
@@ -85,7 +85,6 @@
 			"label": "Send Basic Set to Associated Nodes",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -111,7 +110,6 @@
 			"label": "Basic Set Value For Group 2",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0371/zwa021.json
+++ b/packages/config/config/devices/0x0371/zwa021.json
@@ -25,7 +25,6 @@
 			"label": "Invert LCD orientation",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -58,7 +57,6 @@
 			"label": "Backlight",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -76,7 +74,6 @@
 			"label": "Battery Report",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0371/zwa022.json
+++ b/packages/config/config/devices/0x0371/zwa022.json
@@ -51,7 +51,6 @@
 			"label": "Define Button Output",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -73,7 +72,6 @@
 			"label": "Association Group 2/4/6 Report Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -91,7 +89,6 @@
 			"label": "Association Group 3/5/7: Double Tap Behavior",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0371/zwa024.json
+++ b/packages/config/config/devices/0x0371/zwa024.json
@@ -112,7 +112,6 @@
 			"label": "Motion Report Type",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -189,7 +188,6 @@
 			"label": "Direct Association (Motion): Basic Set Value",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0371/zwa039.json
+++ b/packages/config/config/devices/0x0371/zwa039.json
@@ -291,7 +291,6 @@
 			"description": "To determine the battery calibration value, set each step in order and wait for the value to update. If the returned values are NOT 0, the battery is still calibrated.",
 			"valueSize": 4,
 			"defaultValue": 83951616,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0371/zwa042.json
+++ b/packages/config/config/devices/0x0371/zwa042.json
@@ -27,7 +27,6 @@
 			"label": "LED Indicator",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -132,7 +131,6 @@
 			"label": "Local & Z-Wave Control",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x037b/gkdl-5000z.json
+++ b/packages/config/config/devices/0x037b/gkdl-5000z.json
@@ -20,7 +20,6 @@
 			"label": "Volume",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -42,7 +41,6 @@
 			"label": "Door Lock Mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x037b/gkdl-5100z.json
+++ b/packages/config/config/devices/0x037b/gkdl-5100z.json
@@ -25,7 +25,6 @@
 			"label": "Volume",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -47,7 +46,6 @@
 			"label": "Door Lock Mode",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x037c/pad07-3e.json
+++ b/packages/config/config/devices/0x037c/pad07-3e.json
@@ -21,7 +21,6 @@
 			"description": "Whenever dimmer on/off state changes, it will send multilevel_switch_report to the nodes of group1. the default setting is enable the function",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -40,7 +39,6 @@
 			"description": "1. show dimmer state：when dimmer is on, LED is on. when dimmer is off, LED is off. the default setting is show dimmer state.  2. show night mode：when dimmer is on, LED is off. when dimmer is off, LED is on.  3. one flash mode : when dimmer on/off state changes, LED will light on one second and then off",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -63,7 +61,6 @@
 			"description": "1. one switch mode：only s1 can dim up the light bulb to brightest level, then dim down to darkest level, and so on…  2. two switch mode：s1 and s2 can dim up the light bulb to brightest level, then dim down to darkest level, and so on…  3. up/down switch mode：s1 can only dim up the light bulb to brightest level, and s2 can only dim down to off",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -86,7 +83,6 @@
 			"description": "Whenever the ac power return from lost, pad02 will restore the switch state which could be dimmer off、last dimmer state、dimmer on. the default setting is last dimmer state",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0384/ha-zw-5pa.json
+++ b/packages/config/config/devices/0x0384/ha-zw-5pa.json
@@ -27,7 +27,6 @@
 			"valueSize": 1,
 			"unit": "seconds",
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -45,7 +44,6 @@
 			"label": "Set Meter Report Intervals to Default",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"writeOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -159,7 +157,6 @@
 			"label": "Load Status: Change Reports",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -181,7 +178,6 @@
 			"label": "Load Status: LED Indicator",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -199,7 +195,6 @@
 			"label": "Lock Configuration Parameters",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0384/ha-zw-5sab.json
+++ b/packages/config/config/devices/0x0384/ha-zw-5sab.json
@@ -109,7 +109,6 @@
 			"label": "Status Change (Temperature/Humidity/Luminance/Battery) Reporting",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -188,7 +187,6 @@
 			"label": "Send Basic Set On Motion",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -206,7 +204,6 @@
 			"label": "Motion: Basic Set Value",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0384/ha-zw-5sf.json
+++ b/packages/config/config/devices/0x0384/ha-zw-5sf.json
@@ -40,7 +40,6 @@
 			"label": "Beeping Rate",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -66,7 +65,6 @@
 			"label": "Lock Configuration Parameters",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0409/cfa3010.json
+++ b/packages/config/config/devices/0x0409/cfa3010.json
@@ -147,7 +147,6 @@
 			"label": "Lock status",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false,
 			"options": [

--- a/packages/config/config/devices/0x041b/39446_zw3107.json
+++ b/packages/config/config/devices/0x041b/39446_zw3107.json
@@ -37,7 +37,6 @@
 			"description": "LED status when device on or off.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -60,7 +59,6 @@
 			"description": "Adjust the speed at which the ramps to a specific value",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x041b/39449_zw4106.json
+++ b/packages/config/config/devices/0x041b/39449_zw4106.json
@@ -37,7 +37,6 @@
 			"description": "LED status when device on or off.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x041b/39453_zw4203.json
+++ b/packages/config/config/devices/0x041b/39453_zw4203.json
@@ -37,7 +37,6 @@
 			"description": "LED status when device on or off.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -63,7 +62,6 @@
 			"label": "Alternate Exclusion",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x041b/39455_zw4008.json
+++ b/packages/config/config/devices/0x041b/39455_zw4008.json
@@ -36,7 +36,6 @@
 			"label": "LED Light",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -62,7 +61,6 @@
 			"label": "Alternate Exclusion",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x041b/39456_zw1002.json
+++ b/packages/config/config/devices/0x041b/39456_zw1002.json
@@ -37,7 +37,6 @@
 			"description": "LED status when device on or off.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x041b/39458_zw3010.json
+++ b/packages/config/config/devices/0x041b/39458_zw3010.json
@@ -37,7 +37,6 @@
 			"description": "LED status when device on or off.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -64,7 +63,6 @@
 			"description": "Adjust the speed at which the ramps to a specific value",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -82,7 +80,6 @@
 			"label": "Switch Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -100,7 +97,6 @@
 			"label": "Alternate Exclusion",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0427/c03.json
+++ b/packages/config/config/devices/0x0427/c03.json
@@ -21,7 +21,6 @@
 			"description": "",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -40,7 +39,6 @@
 			"description": "",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0427/zns10.json
+++ b/packages/config/config/devices/0x0427/zns10.json
@@ -21,7 +21,6 @@
 			"description": "",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -40,7 +39,6 @@
 			"description": "",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0431/ecodim.json
+++ b/packages/config/config/devices/0x0431/ecodim.json
@@ -48,7 +48,6 @@
 			"description": "The Dimmer will send notification to associated device (Group Lifeline) when the status of Dimmer load is changed.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -80,7 +79,6 @@
 			"label": "Enable or Disable external switch to pair network",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -99,7 +97,6 @@
 			"description": "Setting dimming way.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0433/q-light_puck.json
+++ b/packages/config/config/devices/0x0433/q-light_puck.json
@@ -107,7 +107,6 @@
 			"description": "Choose between momentary, ON/OFF and roller blind switch. Available settings: 0 – momentary (Push) switch. 1 – ON/OFF switch. 2– roller blind switch-two switches operate the device(S1 to brighter, S2 to dim",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -130,7 +129,6 @@
 			"description": "Set the desired value from 0 to 1 to turn on/off the memory function. Setting this value to 0 turns off the dimmer's Memory function. Setting this value to 1 turns on the dimmer's Memory function.",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0438/4512725.json
+++ b/packages/config/config/devices/0x0438/4512725.json
@@ -27,7 +27,6 @@
 			"description": "In Switch Mode, the device operates as a regular switch. In Thermostat Mode, the binary set command class will be invalid and the action button is disabled.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0438/4512744.json
+++ b/packages/config/config/devices/0x0438/4512744.json
@@ -46,7 +46,6 @@
 			"label": "Button Vibrations & Sounds",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -102,7 +101,6 @@
 			"label": "Temperature Sensor Type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -128,7 +126,6 @@
 			"label": "Temperature Control Reference",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -177,7 +174,6 @@
 			"label": "Mode to Set After Drying Mode",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -289,7 +285,6 @@
 			"label": "Display Brightness",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -311,7 +306,6 @@
 			"label": "Home Page Sensor Display",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -339,7 +333,6 @@
 			"description": "Specifies the temperature change within three minutes to trigger window open detection",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0438/4512745.json
+++ b/packages/config/config/devices/0x0438/4512745.json
@@ -46,7 +46,6 @@
 			"label": "Button Vibrations & Sounds",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -102,7 +101,6 @@
 			"label": "Temperature Sensor Type",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -128,7 +126,6 @@
 			"label": "Temperature Control Reference",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -177,7 +174,6 @@
 			"label": "Mode to Set After Drying Mode",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -289,7 +285,6 @@
 			"label": "Display Brightness",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -311,7 +306,6 @@
 			"label": "Home Page Sensor Display",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -339,7 +333,6 @@
 			"description": "Specifies the temperature change within three minutes to trigger window open detection",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0438/4512746.json
+++ b/packages/config/config/devices/0x0438/4512746.json
@@ -58,7 +58,6 @@
 			"label": "External Switch Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -77,7 +76,6 @@
 			"description": "When enabled, triple pressing will put the device into inclusion/exclusion mode and not send status reports.",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0438/4512757.json
+++ b/packages/config/config/devices/0x0438/4512757.json
@@ -46,7 +46,6 @@
 			"valueSize": 4,
 			"unit": "°C",
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -73,7 +72,6 @@
 			"label": "Work Days Set",
 			"valueSize": 4,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -105,7 +103,6 @@
 			"label": "Sensor Mode",
 			"valueSize": 4,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -139,7 +136,6 @@
 			"label": "Run Mode",
 			"valueSize": 4,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -173,7 +169,6 @@
 			"description": "Allowable range: 10-100 (increment by 10)",
 			"valueSize": 4,
 			"defaultValue": 10,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -224,7 +219,6 @@
 			"description": "Allowable range: 10-100 (increment by 10)",
 			"valueSize": 4,
 			"defaultValue": 100,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -275,7 +269,6 @@
 			"description": "Allowable range: 0-100 (increment by 10)",
 			"valueSize": 4,
 			"defaultValue": 20,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0455/ora-zrx.json
+++ b/packages/config/config/devices/0x0455/ora-zrx.json
@@ -200,7 +200,6 @@
 			"label": "Sun Activation",
 			"valueSize": 1,
 			"defaultValue": 5,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -256,7 +255,6 @@
 			"label": "Send Multilevel Report",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x045a/Z-CM-V01.json
+++ b/packages/config/config/devices/0x045a/Z-CM-V01.json
@@ -19,7 +19,6 @@
 			"label": "Hand Button Action",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -37,7 +36,6 @@
 			"label": "Motor Direction",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -61,7 +59,6 @@
 			"label": "Manually Set Open Boundary",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -79,7 +76,6 @@
 			"label": "Manually Set Closed Boundary",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -97,7 +93,6 @@
 			"label": "Control Motor",
 			"valueSize": 1,
 			"defaultValue": 3,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -119,7 +114,6 @@
 			"label": "Calibrate Limit Position",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -141,7 +135,6 @@
 			"label": "Delete Limit Position",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x045a/Z-DWS-V01.json
+++ b/packages/config/config/devices/0x045a/Z-DWS-V01.json
@@ -30,7 +30,6 @@
 			"label": "Basic Set Value",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x0460/qnsw-001P16.json
+++ b/packages/config/config/devices/0x0460/qnsw-001P16.json
@@ -34,7 +34,6 @@
 			"label": "SW1 Switch Type",
 			"valueSize": 1,
 			"defaultValue": 2,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -79,7 +78,6 @@
 			"label": "O1: Relay Type",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -97,7 +95,6 @@
 			"label": "O1: Auto-On/Off Timer Unit",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -134,7 +131,6 @@
 			"description": "This parameter determines which alarm frames the Device should respond to and how.",
 			"valueSize": 4,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -157,7 +153,6 @@
 			"description": "This parameter determines which alarm frames the Device should respond to and how.",
 			"valueSize": 4,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -180,7 +175,6 @@
 			"description": "This parameter determines which alarm frames the Device should respond to and how.",
 			"valueSize": 4,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -203,7 +197,6 @@
 			"description": "This parameter determines which alarm frames the Device should respond to and how.",
 			"valueSize": 4,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -226,7 +219,6 @@
 			"description": "Reset to factory default settings and remove from the Z-Wave network.",
 			"valueSize": 4,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x5254/zts-110.json
+++ b/packages/config/config/devices/0x5254/zts-110.json
@@ -76,7 +76,6 @@
 			"label": "Temperature Scale",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -111,7 +110,6 @@
 			"description": "Set Easy Mode 0:DISABLE 1:ENABLED DEFAULT:ENABLED",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -129,7 +127,6 @@
 			"label": "Time Format",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x5254/zxt-120.json
+++ b/packages/config/config/devices/0x5254/zxt-120.json
@@ -89,7 +89,6 @@
 			"label": "AC function Swing control",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x5254/zxt-310.json
+++ b/packages/config/config/devices/0x5254/zxt-310.json
@@ -39,7 +39,6 @@
 			"label": "Download Status Register",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -80,7 +79,6 @@
 			"label": "Learning Status Register",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"readOnly": true,
 			"allowManualEntry": false,
 			"options": [
@@ -120,7 +118,6 @@
 			"label": "IR Port Mapping",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -172,7 +169,6 @@
 			"label": "Endpoint Selection Control",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/config/config/devices/0x5254/zxt-800.json
+++ b/packages/config/config/devices/0x5254/zxt-800.json
@@ -99,7 +99,6 @@
 			"label": "Air Conditioner Swing Function",
 			"valueSize": 1,
 			"defaultValue": 1,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -117,7 +116,6 @@
 			"label": "Temperature & Humidity Reporting Interval",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -207,7 +205,6 @@
 			"label": "BLE Advertising Timeout",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{

--- a/packages/eslint-plugin/src/rules/auto-unsigned.ts
+++ b/packages/eslint-plugin/src/rules/auto-unsigned.ts
@@ -16,6 +16,56 @@ export const autoUnsigned: JSONCRule.RuleModule = {
 		if (!context.parserServices.isJSON) {
 			return {};
 		}
+
+		function suggestUnsigned(
+			parent: AST.JSONObjectExpression,
+			valueSizeNode: AST.JSONProperty,
+			valueSize: number,
+			minValue: number,
+			maxValue: number,
+			minLimit: number,
+			maxLimit: number,
+		) {
+			// Find the property after which we should insert the unsigned property
+			const unsignedIndex = paramInfoPropertyOrder.indexOf(
+				"unsigned",
+			);
+			const insertAfter = parent.properties.findLast((p) =>
+				p.key.type === "JSONLiteral"
+				&& typeof p.key.value === "string"
+				&& paramInfoPropertyOrder.indexOf(p.key.value)
+					< unsignedIndex
+			);
+			context.report({
+				loc: valueSizeNode.loc,
+				messageId: "incompatible-size",
+				data: {
+					minValue: minValue.toString(),
+					maxValue: maxValue.toString(),
+					valueSize: valueSize.toString(),
+					sizeMin: minLimit.toString(),
+					sizeMax: maxLimit.toString(),
+				},
+				suggest: [
+					{
+						messageId: "convert-to-unsigned",
+						fix: insertAfter
+							? insertAfterJSONProperty(
+								context,
+								insertAfter,
+								`"unsigned": true,`,
+								{ insertComma: true },
+							)
+							: insertBeforeJSONProperty(
+								context,
+								parent.properties[0],
+								`"unsigned": true,`,
+							),
+					},
+				],
+			});
+		}
+
 		return {
 			// Ensure `unsigned` is only used when necessary and not used when not
 			"JSONProperty[key.value='paramInformation'] > JSONArrayExpression > JSONObjectExpression"(
@@ -38,30 +88,66 @@ export const autoUnsigned: JSONCRule.RuleModule = {
 				// TODO: Properly support partial parameters
 				if (valueBitMask) return;
 
-				// We're also not looking at options with allowManualEntry = false yet
+				// To determine the min or max value, we look at options if allowManualEntry is false
+				let minValueNode: AST.JSONProperty | undefined;
+				let maxValueNode: AST.JSONProperty | undefined;
+				let minValue: number;
+				let maxValue: number;
+				let isUsingOptions: boolean;
+
 				const allowManualEntry =
 					getJSONBoolean(node, "allowManualEntry")?.value !== false;
-				const hasOptions = node.properties.some((p) =>
-					p.key.type === "JSONLiteral"
-					&& p.key.value === "options"
-					&& p.value.type === "JSONArrayExpression"
-					&& p.value.elements.length > 0
-				);
+				const options =
+					(node.properties.find((p) =>
+						p.key.type === "JSONLiteral"
+						&& p.key.value === "options"
+						&& p.value.type === "JSONArrayExpression"
+						&& p.value.elements.length > 0
+					)?.value as AST.JSONArrayExpression | undefined)
+						?.elements
+						?.filter((e): e is AST.JSONObjectExpression => !!e);
 
-				// TODO: Look at options
-				if (!allowManualEntry && hasOptions) return;
+				if (!allowManualEntry && !!options) {
+					// Deduce min/max value from options
+					const sortedOptions = options
+						.map((o) => {
+							const valueProp = getJSONNumber(o, "value");
+							const label = getJSONString(o, "label")?.value;
+							if (label == undefined || valueProp == undefined) {
+								return;
+							}
+							return {
+								valueNode: valueProp.node,
+								value: valueProp.value,
+								label,
+							};
+						}).filter(Boolean)
+						.sort((a, b) => a!.value - b!.value);
+
+					if (sortedOptions.length === 0) return;
+
+					minValueNode = sortedOptions[0]!.valueNode;
+					minValue = sortedOptions[0]!.value;
+					maxValueNode = sortedOptions.at(-1)!.valueNode;
+					maxValue = sortedOptions.at(-1)!.value;
+					isUsingOptions = true;
+				} else {
+					// Otherwise consider min/max value
+					const minValueProperty = getJSONNumber(node, "minValue");
+					if (!minValueProperty) return;
+					minValueNode = minValueProperty.node;
+					minValue = minValueProperty.value;
+
+					const maxValueProperty = getJSONNumber(node, "maxValue");
+					if (!maxValueProperty) return;
+					maxValueNode = maxValueProperty.node;
+					maxValue = maxValueProperty.value;
+					isUsingOptions = false;
+				}
 
 				const valueSizeProperty = getJSONNumber(node, "valueSize");
 				if (!valueSizeProperty) return;
 				const { value: valueSize } = valueSizeProperty;
-
-				const minValueProperty = getJSONNumber(node, "minValue");
-				if (!minValueProperty) return;
-				const { value: minValue } = minValueProperty;
-
-				const maxValueProperty = getJSONNumber(node, "maxValue");
-				if (!maxValueProperty) return;
-				const { value: maxValue } = maxValueProperty;
 
 				const unsignedProperty = getJSONBoolean(node, "unsigned");
 				const isUnsigned = !!unsignedProperty?.value;
@@ -92,49 +178,22 @@ export const autoUnsigned: JSONCRule.RuleModule = {
 
 				if (!isUnsigned && !fitsSignedLimits) {
 					if (fitsUnsignedLimits) {
-						// Find the property after which we should insert the unsigned property
-						const unsignedIndex = paramInfoPropertyOrder.indexOf(
-							"unsigned",
+						suggestUnsigned(
+							node,
+							valueSizeProperty.node,
+							valueSize,
+							minValue,
+							maxValue,
+							limits.min,
+							limits.max,
 						);
-						const insertAfter = node.properties.findLast((p) =>
-							p.key.type === "JSONLiteral"
-							&& typeof p.key.value === "string"
-							&& paramInfoPropertyOrder.indexOf(p.key.value)
-								< unsignedIndex
-						);
-						context.report({
-							loc: valueSizeProperty.node.loc,
-							messageId: "incompatible-size",
-							data: {
-								minValue: minValue.toString(),
-								maxValue: maxValue.toString(),
-								valueSize: valueSize.toString(),
-								sizeMin: limits.min.toString(),
-								sizeMax: limits.max.toString(),
-							},
-							suggest: [
-								{
-									messageId: "convert-to-unsigned",
-									fix: insertAfter
-										? insertAfterJSONProperty(
-											context,
-											insertAfter,
-											`"unsigned": true,`,
-											{ insertComma: true },
-										)
-										: insertBeforeJSONProperty(
-											context,
-											node.properties[0],
-											`"unsigned": true,`,
-										),
-								},
-							],
-						});
 					} else {
 						if (minValue < limits.min) {
 							context.report({
-								loc: minValueProperty.node.loc,
-								messageId: "incompatible-min-value",
+								loc: minValueNode.loc,
+								messageId: isUsingOptions
+									? "incompatible-min-option-value"
+									: "incompatible-min-value",
 								data: {
 									minValue: minValue.toString(),
 									valueSize: valueSize.toString(),
@@ -144,8 +203,10 @@ export const autoUnsigned: JSONCRule.RuleModule = {
 						}
 						if (maxValue > limits.max) {
 							context.report({
-								loc: maxValueProperty.node.loc,
-								messageId: "incompatible-max-value",
+								loc: maxValueNode.loc,
+								messageId: isUsingOptions
+									? "incompatible-max-option-value"
+									: "incompatible-max-value",
 								data: {
 									maxValue: maxValue.toString(),
 									valueSize: valueSize.toString(),
@@ -157,8 +218,10 @@ export const autoUnsigned: JSONCRule.RuleModule = {
 				} else if (isUnsigned && !fitsUnsignedLimits) {
 					if (minValue < unsignedLimits.min) {
 						context.report({
-							loc: minValueProperty.node.loc,
-							messageId: "incompatible-min-value",
+							loc: minValueNode.loc,
+							messageId: isUsingOptions
+								? "incompatible-min-option-value"
+								: "incompatible-min-value",
 							data: {
 								minValue: minValue.toString(),
 								valueSize: valueSize.toString(),
@@ -168,8 +231,10 @@ export const autoUnsigned: JSONCRule.RuleModule = {
 					}
 					if (maxValue > unsignedLimits.max) {
 						context.report({
-							loc: maxValueProperty.node.loc,
-							messageId: "incompatible-max-value",
+							loc: maxValueNode.loc,
+							messageId: isUsingOptions
+								? "incompatible-max-option-value"
+								: "incompatible-max-value",
 							data: {
 								maxValue: maxValue.toString(),
 								valueSize: valueSize.toString(),
@@ -202,6 +267,10 @@ export const autoUnsigned: JSONCRule.RuleModule = {
 			"invalid-value-size": "Value size {{valueSize}} is invalid!",
 			"incompatible-size":
 				"The defined value range {{minValue}}...{{maxValue}} is incompatible with valueSize {{valueSize}} ({{sizeMin}}...{{sizeMax}})",
+			"incompatible-min-option-value":
+				"Option value {{minValue}} is incompatible with valueSize {{valueSize}} (min = {{sizeMin}})",
+			"incompatible-max-option-value":
+				"Option value {{maxValue}} is incompatible with valueSize {{valueSize}} (max = {{sizeMax}})",
 			"incompatible-min-value":
 				"minValue {{minValue}} is incompatible with valueSize {{valueSize}} (min = {{sizeMin}})",
 			"incompatible-max-value":


### PR DESCRIPTION
As a follow-up to #6325, the `auto-unsigned` rule now also considers predefined options with `allowManualEntry: false`.