### PR TITLE
fix(config): add link to manual of Honeywell T6 Pro Thermostat

### DIFF
--- a/packages/config/config/devices/0x0039/th6320zw.json
+++ b/packages/config/config/devices/0x0039/th6320zw.json
@@ -187,5 +187,8 @@
 		// The device responds in a weird way to these requests which causes S2 collisions
 		"skipConfigurationNameQuery": true,
 		"skipConfigurationInfoQuery": true
+	},
+	"metadata": {
+		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=Manuals/2893/33-00414-01-min.pdf"
 	}
 }


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

Adds a link to the Z-Wave Alliance-provided manual: [link](https://products.z-wavealliance.org/ProductManual/File?folder=&filename=Manuals/2893/33-00414-01-min.pdf)
