### PR TITLE
fix: normalize result of `Controller.getAvailableFirmwareUpdates` to always include `channel` field

### DIFF
--- a/packages/zwave-js/src/lib/controller/FirmwareUpdateService.ts
+++ b/packages/zwave-js/src/lib/controller/FirmwareUpdateService.ts
@@ -226,6 +226,7 @@ export async function getAvailableFirmwareUpdates(
 	return result.map((update) => ({
 		device: deviceId,
 		...update,
+		channel: update.channel ?? "stable",
 	}));
 }
 

--- a/packages/zwave-js/src/lib/controller/_Types.ts
+++ b/packages/zwave-js/src/lib/controller/_Types.ts
@@ -30,8 +30,7 @@ export type FirmwareUpdateDeviceID = Expand<
 export interface FirmwareUpdateServiceResponse {
 	version: string;
 	changelog: string;
-	/** When using the V1 API, channel is not returned and should be assumed to be
-	 * stable */
+	/** When using the V1 API, channel is not returned and should be assumed to be stable */
 	channel?: "stable" | "beta";
 	files: FirmwareUpdateFileInfo[];
 	downgrade: boolean;

--- a/packages/zwave-js/src/lib/controller/_Types.ts
+++ b/packages/zwave-js/src/lib/controller/_Types.ts
@@ -30,7 +30,9 @@ export type FirmwareUpdateDeviceID = Expand<
 export interface FirmwareUpdateServiceResponse {
 	version: string;
 	changelog: string;
-	channel: "stable" | "beta";
+	/** When using the V1 API, channel is not returned and should be assumed to be
+	 * stable */
+	channel?: "stable" | "beta";
 	files: FirmwareUpdateFileInfo[];
 	downgrade: boolean;
 	normalizedVersion: string;

--- a/packages/zwave-js/src/lib/controller/_Types.ts
+++ b/packages/zwave-js/src/lib/controller/_Types.ts
@@ -30,8 +30,7 @@ export type FirmwareUpdateDeviceID = Expand<
 export interface FirmwareUpdateServiceResponse {
 	version: string;
 	changelog: string;
-	/** When using the V1 API, channel is not returned and should be assumed to be stable */
-	channel?: "stable" | "beta";
+	channel: "stable" | "beta";
 	files: FirmwareUpdateFileInfo[];
 	downgrade: boolean;
 	normalizedVersion: string;


### PR DESCRIPTION
The V1 API for the firmware update service doesn't include `channel` in the payload so we have to insert it
