### PR TITLE
fix: limit number of retries when sending a command results in the transmit status `Fail`

### DIFF
--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -698,6 +698,9 @@ interface ZWaveOptions extends ZWaveHostOptions {
 		/** How long generated nonces are valid */
 		nonce: number; // [3000...20000], default: 5000 ms
 
+		/** How long to wait before retrying a command when the controller is jammed */
+		retryJammed: number; // [10...5000], default: 1000 ms
+
 		/**
 		 * How long to wait without pending commands before sending a node back to sleep.
 		 * Should be as short as possible to save battery, but long enough to give applications time to react.
@@ -735,6 +738,9 @@ interface ZWaveOptions extends ZWaveHostOptions {
 
 		/** How often the driver should try sending SendData commands before giving up */
 		sendData: number; // [1...5], default: 3
+
+		/** How often the driver should retry SendData commands while the controller is jammed */
+		sendDataJammed: number; // [1...10], default: 5
 
 		/**
 		 * How many attempts should be made for each node interview before giving up

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -29,6 +29,9 @@ export interface ZWaveOptions extends ZWaveHostOptions {
 		/** How long generated nonces are valid */
 		nonce: number; // [3000...20000], default: 5000 ms
 
+		/** How long to wait before retrying a command when the controller is jammed */
+		retryJammed: number; // [10...5000], default: 1000 ms
+
 		/**
 		 * How long to wait without pending commands before sending a node back to sleep.
 		 * Should be as short as possible to save battery, but long enough to give applications time to react.
@@ -72,6 +75,9 @@ export interface ZWaveOptions extends ZWaveHostOptions {
 
 		/** How often the driver should try sending SendData commands before giving up */
 		sendData: number; // [1...5], default: 3
+
+		/** How often the driver should retry SendData commands while the controller is jammed */
+		sendDataJammed: number; // [1...10], default: 5
 
 		/**
 		 * How many attempts should be made for each node interview before giving up

--- a/packages/zwave-js/src/lib/test/driver/controllerJammed.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/controllerJammed.test.ts
@@ -1,4 +1,10 @@
-import { ControllerStatus, NodeStatus, TransmitStatus } from "@zwave-js/core";
+import {
+	ControllerStatus,
+	NodeStatus,
+	TransmitStatus,
+	ZWaveErrorCodes,
+	assertZWaveError,
+} from "@zwave-js/core";
 import { type MockControllerBehavior } from "@zwave-js/testing";
 import { wait } from "alcalzone-shared/async";
 import sinon from "sinon";
@@ -13,6 +19,7 @@ import {
 	SendDataResponse,
 } from "../../serialapi/transport/SendDataMessages";
 import { integrationTest } from "../integrationTestSuite";
+import { integrationTest as integrationTestMulti } from "../integrationTestSuiteMulti";
 
 let shouldFail = false;
 
@@ -130,3 +137,119 @@ integrationTest("update the controller status and wait if TX status is Fail", {
 		]);
 	},
 });
+
+integrationTestMulti.only(
+	"Prevent an infinite loop when the controller is unable to transmit a command to a specific node",
+	{
+		debug: true,
+		// provisioningDirectory: path.join(
+		// 	__dirname,
+		// 	"__fixtures/supervision_binary_switch",
+		// ),
+
+		additionalDriverOptions: {
+			testingHooks: {
+				skipNodeInterview: true,
+			},
+		},
+
+		nodeCapabilities: [
+			{
+				id: 2,
+				capabilities: {
+					isListening: true,
+				},
+			},
+			{
+				id: 3,
+				capabilities: {
+					isListening: true,
+				},
+			},
+		],
+
+		customSetup: async (driver, controller, mockNodes) => {
+			// Return a TX status of Fail when desired
+			const handleSendData: MockControllerBehavior = {
+				async onHostMessage(host, controller, msg) {
+					if (msg instanceof SendDataRequest) {
+						// Commands to node 3 work normally
+						if (msg.getNodeId() === 3) {
+							// Defer to the default behavior
+							return false;
+						}
+
+						// Check if this command is legal right now
+						const state = controller.state.get(
+							MockControllerStateKeys.CommunicationState,
+						) as MockControllerCommunicationState | undefined;
+						if (
+							state != undefined
+							&& state !== MockControllerCommunicationState.Idle
+						) {
+							throw new Error(
+								"Received SendDataRequest while not idle",
+							);
+						}
+
+						// Put the controller into sending state
+						controller.state.set(
+							MockControllerStateKeys.CommunicationState,
+							MockControllerCommunicationState.Sending,
+						);
+
+						// Notify the host that the message was sent
+						const res = new SendDataResponse(host, {
+							wasSent: true,
+						});
+						await controller.sendToHost(res.serialize());
+
+						await wait(100);
+
+						controller.state.set(
+							MockControllerStateKeys.CommunicationState,
+							MockControllerCommunicationState.Idle,
+						);
+
+						const cb = new SendDataRequestTransmitReport(host, {
+							callbackId: msg.callbackId,
+							transmitStatus: TransmitStatus.Fail,
+							txReport: {
+								txTicks: 0,
+								routeSpeed: 0 as any,
+								routingAttempts: 0,
+								ackRSSI: 0,
+							},
+						});
+						await controller.sendToHost(cb.serialize());
+
+						return true;
+					} else if (msg instanceof SendDataAbort) {
+						// Put the controller into idle state
+						controller.state.set(
+							MockControllerStateKeys.CommunicationState,
+							MockControllerCommunicationState.Idle,
+						);
+					}
+				},
+			};
+			controller.defineBehavior(handleSendData);
+		},
+		testBody: async (t, driver, nodes, mockController, mockNodes) => {
+			const [node2, node3] = nodes;
+			node2.markAsAlive();
+			node3.markAsAlive();
+
+			driver.options.timeouts.retryJammed = 100;
+
+			t.true(await node3.ping());
+			await assertZWaveError(
+				t,
+				() => node2.commandClasses.Basic.set(99),
+				{
+					errorCode: ZWaveErrorCodes.Controller_MessageDropped,
+				},
+			);
+		},
+	},
+);

--- a/packages/zwave-js/src/lib/test/driver/controllerJammed.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/controllerJammed.test.ts
@@ -138,10 +138,10 @@ integrationTest("update the controller status and wait if TX status is Fail", {
 	},
 });
 
-integrationTestMulti.only(
+integrationTestMulti(
 	"Prevent an infinite loop when the controller is unable to transmit a command to a specific node",
 	{
-		debug: true,
+		// debug: true,
 		// provisioningDirectory: path.join(
 		// 	__dirname,
 		// 	"__fixtures/supervision_binary_switch",


### PR DESCRIPTION
The controller immediately responding with a transmit status of `Fail` usually means that it is unable to transmit due to being RF jammed. Apparently there are other, non-temporary reasons for this status, so our logic of permanently retrying would result in an infinite loop.

With this PR, commands in this situation are retried up to 5 times before giving up. This should resolve some of the issues users are experiencing in the v12 release.