### PR TITLE
fix: label of notification event `0x0a` is `Emergency Alarm`

### DIFF
--- a/packages/config/config/notifications.json
+++ b/packages/config/config/notifications.json
@@ -928,7 +928,7 @@
 		}
 	},
 	"0x0a": {
-		"name": "System",
+		"name": "Emergency Alarm",
 		"events": {
 			"0x01": {
 				"label": "Contact police"


### PR DESCRIPTION
Per https://discord.com/channels/330944238910963714/800356888827002880/1159425020523724820 this label was wrong