### PR TITLE
fix: implement workaround for some 500 series controllers replying with invalid callbacks in case of SUC route assignment failure

### DIFF
--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -364,6 +364,12 @@ Several command classes are refreshed regularly (every couple of hours) if they 
 
 By default, received `Basic CC::Report` commands are mapped to a more appropriate CC. Setting `disableBasicMapping` to `true` disables this feature.
 
+### `disableCallbackFunctionTypeCheck`
+
+By default, responses or callbacks for Serial API commands must have the same function type (command identifier) in order to be recognized. However, in some situations, certain controllers send a callback with an invalid function type. In this case, the faulty commands may be listed in the `disableCallbackFunctionTypeCheck` array to disable the check for a matching function type.
+
+> [!NOTE] This compat flag requires command-specific support and is not a generic escape hatch.
+
 ### `disableStrictEntryControlDataValidation`
 
 The specifications mandate strict rules for the data and sequence numbers in `Entry Control CC Notifications`, which some devices do not follow, causing the notifications to get dropped. Setting `disableStrictEntryControlDataValidation` to `true` disables these strict checks.

--- a/maintenance/schemas/device-config.json
+++ b/maintenance/schemas/device-config.json
@@ -568,6 +568,14 @@
 				"disableBasicMapping": {
 					"const": true
 				},
+				"disableCallbackFunctionTypeCheck": {
+					"type": "array",
+					"items": {
+						"type": "integer",
+						"minimum": 1
+					},
+					"minItems": 1
+				},
 				"disableStrictEntryControlDataValidation": {
 					"const": true
 				},

--- a/packages/config/config/devices/0x0000/husbzb-1.json
+++ b/packages/config/config/devices/0x0000/husbzb-1.json
@@ -12,5 +12,13 @@
 	"firmwareVersion": {
 		"min": "0.0",
 		"max": "255.255"
+	},
+	"compat": {
+		// In some situations, AssignSUCReturnRoute and DeleteSUCReturnRoute get answered with a wrong callback function type,
+		// triggering Z-Wave JS's unresponsive controller check.
+		"disableCallbackFunctionTypeCheck": [
+			81, // AssignSUCReturnRoute
+			85 // DeleteSUCReturnRoute
+		]
 	}
 }

--- a/packages/config/config/devices/0x0086/zw090.json
+++ b/packages/config/config/devices/0x0086/zw090.json
@@ -58,5 +58,13 @@
 	"metadata": {
 		"reset": "Use this procedure only in the event that the primary controller is missing or otherwise inoperable.\n\nPress and hold the Action Button on Z-Stick for 20 seconds and then release",
 		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/1345/Z%20Stick%20Gen5%20manual%201.pdf"
+	},
+	"compat": {
+		// In some situations, AssignSUCReturnRoute and DeleteSUCReturnRoute get answered with a wrong callback function type,
+		// triggering Z-Wave JS's unresponsive controller check.
+		"disableCallbackFunctionTypeCheck": [
+			81, // AssignSUCReturnRoute
+			85 // DeleteSUCReturnRoute
+		]
 	}
 }

--- a/packages/config/src/devices/CompatConfig.ts
+++ b/packages/config/src/devices/CompatConfig.ts
@@ -88,6 +88,23 @@ compat option disableBasicMapping must be true or omitted`,
 			this.disableBasicMapping = definition.disableBasicMapping;
 		}
 
+		if (definition.disableCallbackFunctionTypeCheck != undefined) {
+			if (
+				!isArray(definition.disableCallbackFunctionTypeCheck)
+				|| !definition.disableCallbackFunctionTypeCheck.every(
+					(d: any) => typeof d === "number" && d % 1 === 0 && d > 0,
+				)
+			) {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+when present, compat option disableCallbackFunctionTypeCheck msut be an array of positive integers`,
+				);
+			}
+			this.disableCallbackFunctionTypeCheck =
+				definition.disableCallbackFunctionTypeCheck;
+		}
+
 		if (definition.disableStrictEntryControlDataValidation != undefined) {
 			if (definition.disableStrictEntryControlDataValidation !== true) {
 				throwInvalidConfig(
@@ -568,6 +585,7 @@ compat option overrideQueries must be an object!`,
 	public readonly disableBasicMapping?: boolean;
 	public readonly disableStrictEntryControlDataValidation?: boolean;
 	public readonly disableStrictMeasurementValidation?: boolean;
+	public readonly disableCallbackFunctionTypeCheck?: number[];
 	public readonly enableBasicSetMapping?: boolean;
 	public readonly forceNotificationIdleReset?: boolean;
 	public readonly forceSceneControllerGroupCount?: number;
@@ -608,6 +626,7 @@ compat option overrideQueries must be an object!`,
 			"removeCCs",
 			"disableAutoRefresh",
 			"disableBasicMapping",
+			"disableCallbackFunctionTypeCheck",
 			"disableStrictEntryControlDataValidation",
 			"disableStrictMeasurementValidation",
 			"enableBasicSetMapping",

--- a/packages/testing/src/MockControllerCapabilities.ts
+++ b/packages/testing/src/MockControllerCapabilities.ts
@@ -31,23 +31,27 @@ export interface MockControllerCapabilities {
 	watchdogEnabled: boolean;
 }
 
+export function getDefaultSupportedFunctionTypes(): FunctionType[] {
+	return [
+		FunctionType.GetSerialApiInitData,
+		FunctionType.GetControllerCapabilities,
+		FunctionType.SendData,
+		FunctionType.SendDataMulticast,
+		FunctionType.GetControllerVersion,
+		FunctionType.GetControllerId,
+		FunctionType.GetNodeProtocolInfo,
+		FunctionType.RequestNodeInfo,
+		FunctionType.AssignSUCReturnRoute,
+	];
+}
+
 export function getDefaultMockControllerCapabilities(): MockControllerCapabilities {
 	return {
 		firmwareVersion: "1.0",
 		manufacturerId: 0xffff,
 		productType: 0xffff,
 		productId: 0xfffe,
-		supportedFunctionTypes: [
-			FunctionType.GetSerialApiInitData,
-			FunctionType.GetControllerCapabilities,
-			FunctionType.SendData,
-			FunctionType.SendDataMulticast,
-			FunctionType.GetControllerVersion,
-			FunctionType.GetControllerId,
-			FunctionType.GetNodeProtocolInfo,
-			FunctionType.RequestNodeInfo,
-			FunctionType.AssignSUCReturnRoute,
-		],
+		supportedFunctionTypes: getDefaultSupportedFunctionTypes(),
 
 		controllerType: ZWaveLibraryTypes["Static Controller"],
 		libraryVersion: "Z-Wave 7.17.99",

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./CCSpecificCapabilities";
 export * from "./MockController";
+export { getDefaultSupportedFunctionTypes } from "./MockControllerCapabilities";
 export * from "./MockNode";
 export { ccCaps } from "./MockNodeCapabilities";
 export type { PartialCCCapabilities } from "./MockNodeCapabilities";

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -215,7 +215,7 @@ import {
 } from "../serialapi/network-mgmt/AssignReturnRouteMessages";
 import {
 	AssignSUCReturnRouteRequest,
-	type AssignSUCReturnRouteRequestTransmitReport,
+	AssignSUCReturnRouteRequestTransmitReport,
 } from "../serialapi/network-mgmt/AssignSUCReturnRouteMessages";
 import {
 	DeleteReturnRouteRequest,
@@ -223,7 +223,7 @@ import {
 } from "../serialapi/network-mgmt/DeleteReturnRouteMessages";
 import {
 	DeleteSUCReturnRouteRequest,
-	type DeleteSUCReturnRouteRequestTransmitReport,
+	DeleteSUCReturnRouteRequestTransmitReport,
 } from "../serialapi/network-mgmt/DeleteSUCReturnRouteMessages";
 import {
 	GetPriorityRouteRequest,
@@ -4319,13 +4319,22 @@ ${associatedNodes.join(", ")}`,
 		await this.deleteSUCReturnRoutes(nodeId);
 
 		try {
-			const result = await this.driver.sendMessage<
-				AssignSUCReturnRouteRequestTransmitReport
-			>(
+			const result = await this.driver.sendMessage(
 				new AssignSUCReturnRouteRequest(this.driver, {
 					nodeId,
 				}),
 			);
+
+			if (
+				!(result instanceof AssignSUCReturnRouteRequestTransmitReport)
+			) {
+				this.driver.controllerLog.logNode(
+					nodeId,
+					`Assigning SUC return route failed: Invalid callback received`,
+					"error",
+				);
+				return false;
+			}
 
 			const success = this.handleRouteAssignmentTransmitReport(
 				result,
@@ -4492,13 +4501,22 @@ ${associatedNodes.join(", ")}`,
 		});
 
 		try {
-			const result = await this.driver.sendMessage<
-				DeleteSUCReturnRouteRequestTransmitReport
-			>(
+			const result = await this.driver.sendMessage(
 				new DeleteSUCReturnRouteRequest(this.driver, {
 					nodeId,
 				}),
 			);
+
+			if (
+				!(result instanceof DeleteSUCReturnRouteRequestTransmitReport)
+			) {
+				this.driver.controllerLog.logNode(
+					nodeId,
+					`Deleting SUC return route failed: Invalid callback received`,
+					"error",
+				);
+				return false;
+			}
 
 			const success = this.handleRouteAssignmentTransmitReport(
 				result,

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/AssignSUCReturnRouteMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/AssignSUCReturnRouteMessages.ts
@@ -53,8 +53,25 @@ export interface AssignSUCReturnRouteRequestOptions extends MessageBaseOptions {
 	nodeId: number;
 }
 
+function testAssignSUCReturnRouteCallback(
+	sent: AssignSUCReturnRouteRequest,
+	callback: Message,
+): boolean {
+	// Some controllers have a bug where they incorrectly respond with DeleteSUCReturnRoute
+	if (
+		callback.host
+			.getDeviceConfig?.(callback.host.ownNodeId)
+			?.compat
+			?.disableCallbackFunctionTypeCheck
+			?.includes(FunctionType.AssignSUCReturnRoute)
+	) {
+		return true;
+	}
+	return callback.functionType === FunctionType.AssignSUCReturnRoute;
+}
+
 @expectedResponse(FunctionType.AssignSUCReturnRoute)
-@expectedCallback(FunctionType.AssignSUCReturnRoute)
+@expectedCallback(testAssignSUCReturnRouteCallback)
 export class AssignSUCReturnRouteRequest extends AssignSUCReturnRouteRequestBase
 	implements INodeQuery
 {

--- a/packages/zwave-js/src/lib/test/compat/invalidCallbackFunctionTypes.test.ts
+++ b/packages/zwave-js/src/lib/test/compat/invalidCallbackFunctionTypes.test.ts
@@ -1,0 +1,241 @@
+import { WakeUpTime, ZWaveProtocolCCAssignSUCReturnRoute } from "@zwave-js/cc";
+import { TransmitStatus, ZWaveDataRate } from "@zwave-js/core";
+import { FunctionType } from "@zwave-js/serial";
+import {
+	type MockControllerBehavior,
+	createMockZWaveRequestFrame,
+	getDefaultSupportedFunctionTypes,
+} from "@zwave-js/testing";
+import {
+	MockControllerCommunicationState,
+	MockControllerStateKeys,
+} from "../../controller/MockControllerState";
+import {
+	AssignSUCReturnRouteRequest,
+	AssignSUCReturnRouteResponse,
+} from "../../serialapi/network-mgmt/AssignSUCReturnRouteMessages";
+import {
+	DeleteSUCReturnRouteRequest,
+	DeleteSUCReturnRouteRequestTransmitReport,
+	DeleteSUCReturnRouteResponse,
+} from "../../serialapi/network-mgmt/DeleteSUCReturnRouteMessages";
+import { integrationTest } from "../integrationTestSuite";
+
+// Repro for https://github.com/zwave-js/node-zwave-js/issues/6363
+
+integrationTest(
+	"Invalid callback function types don't trigger the unresponsive controller detection",
+	{
+		// debug: true,
+
+		controllerCapabilities: {
+			// Aeotec Z-Stick Gen5+, FW 1.2
+			manufacturerId: 0x0086,
+			productType: 0x0001,
+			productId: 0x005a,
+			firmwareVersion: "1.2",
+			supportedFunctionTypes: [
+				...getDefaultSupportedFunctionTypes(),
+				FunctionType.AssignSUCReturnRoute,
+				FunctionType.DeleteSUCReturnRoute,
+			],
+		},
+
+		customSetup: async (driver, controller, mockNode) => {
+			// Incorrectly respond to AssignSUCReturnRoute with DeleteSUCReturnRoute
+			const handleAssignSUCReturnRoute: MockControllerBehavior = {
+				async onHostMessage(host, controller, msg) {
+					if (msg instanceof AssignSUCReturnRouteRequest) {
+						// Check if this command is legal right now
+						const state = controller.state.get(
+							MockControllerStateKeys.CommunicationState,
+						) as MockControllerCommunicationState | undefined;
+						if (
+							state != undefined
+							&& state !== MockControllerCommunicationState.Idle
+						) {
+							throw new Error(
+								"Received AssignSUCReturnRouteRequest while not idle",
+							);
+						}
+
+						// Put the controller into sending state
+						controller.state.set(
+							MockControllerStateKeys.CommunicationState,
+							MockControllerCommunicationState.Sending,
+						);
+
+						const expectCallback = msg.callbackId !== 0;
+
+						// Send the command to the node
+						const node = controller.nodes.get(msg.getNodeId()!)!;
+						const command = new ZWaveProtocolCCAssignSUCReturnRoute(
+							host,
+							{
+								nodeId: node.id,
+								destinationNodeId: controller.host.ownNodeId,
+								repeaters: [], // don't care
+								routeIndex: 0, // don't care
+								destinationSpeed: ZWaveDataRate["100k"],
+								destinationWakeUp: WakeUpTime.None,
+							},
+						);
+						const frame = createMockZWaveRequestFrame(command, {
+							ackRequested: expectCallback,
+						});
+						const ackPromise = controller.sendToNode(node, frame);
+
+						// Notify the host that the message was sent
+						const res = new AssignSUCReturnRouteResponse(host, {
+							wasExecuted: true,
+						});
+						await controller.sendToHost(res.serialize());
+
+						let ack = false;
+						if (expectCallback) {
+							// Put the controller into waiting state
+							controller.state.set(
+								MockControllerStateKeys.CommunicationState,
+								MockControllerCommunicationState.WaitingForNode,
+							);
+
+							// Wait for the ACK and notify the host
+							try {
+								const ackResult = await ackPromise;
+								ack = !!ackResult?.ack;
+							} catch {
+								// No response
+							}
+						}
+						controller.state.set(
+							MockControllerStateKeys.CommunicationState,
+							MockControllerCommunicationState.Idle,
+						);
+
+						if (expectCallback) {
+							const cb =
+								new DeleteSUCReturnRouteRequestTransmitReport(
+									host,
+									{
+										callbackId: msg.callbackId,
+										transmitStatus: ack
+											? TransmitStatus.OK
+											: TransmitStatus.NoAck,
+									},
+								);
+
+							await controller.sendToHost(cb.serialize());
+						}
+						return true;
+					}
+				},
+			};
+			controller.defineBehavior(handleAssignSUCReturnRoute);
+
+			// Incorrectly respond to DeleteSUCReturnRoute with a message with function type 0
+			const handleDeleteSUCReturnRoute: MockControllerBehavior = {
+				async onHostMessage(host, controller, msg) {
+					if (msg instanceof DeleteSUCReturnRouteRequest) {
+						// Check if this command is legal right now
+						const state = controller.state.get(
+							MockControllerStateKeys.CommunicationState,
+						) as MockControllerCommunicationState | undefined;
+						if (
+							state != undefined
+							&& state !== MockControllerCommunicationState.Idle
+						) {
+							throw new Error(
+								"Received DeleteSUCReturnRouteRequest while not idle",
+							);
+						}
+
+						// Put the controller into sending state
+						controller.state.set(
+							MockControllerStateKeys.CommunicationState,
+							MockControllerCommunicationState.Sending,
+						);
+
+						const expectCallback = msg.callbackId !== 0;
+
+						// Send the command to the node
+						const node = controller.nodes.get(msg.getNodeId()!)!;
+						const command = new ZWaveProtocolCCAssignSUCReturnRoute(
+							host,
+							{
+								nodeId: node.id,
+								destinationNodeId: controller.host.ownNodeId,
+								repeaters: [], // don't care
+								routeIndex: 0, // don't care
+								destinationSpeed: ZWaveDataRate["100k"],
+								destinationWakeUp: WakeUpTime.None,
+							},
+						);
+						const frame = createMockZWaveRequestFrame(command, {
+							ackRequested: expectCallback,
+						});
+						const ackPromise = controller.sendToNode(node, frame);
+
+						// Notify the host that the message was sent
+						const res = new DeleteSUCReturnRouteResponse(host, {
+							wasExecuted: true,
+						});
+						await controller.sendToHost(res.serialize());
+
+						let ack = false;
+						if (expectCallback) {
+							// Put the controller into waiting state
+							controller.state.set(
+								MockControllerStateKeys.CommunicationState,
+								MockControllerCommunicationState.WaitingForNode,
+							);
+
+							// Wait for the ACK and notify the host
+							try {
+								const ackResult = await ackPromise;
+								ack = !!ackResult?.ack;
+							} catch {
+								// No response
+							}
+						}
+						controller.state.set(
+							MockControllerStateKeys.CommunicationState,
+							MockControllerCommunicationState.Idle,
+						);
+
+						if (expectCallback) {
+							const cb =
+								new DeleteSUCReturnRouteRequestTransmitReport(
+									host,
+									{
+										callbackId: msg.callbackId,
+										transmitStatus: ack
+											? TransmitStatus.OK
+											: TransmitStatus.NoAck,
+									},
+								);
+							// @ts-expect-error 0 is not a valid function type
+							cb.functionType = 0;
+
+							await controller.sendToHost(cb.serialize());
+						}
+						return true;
+					}
+				},
+			};
+			controller.defineBehavior(handleDeleteSUCReturnRoute);
+		},
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			mockController.clearReceivedHostMessages();
+			driver.options.timeouts.sendDataCallback = 1000;
+			let result = await driver.controller.assignSUCReturnRoutes(
+				node.id,
+			);
+			t.false(result);
+
+			result = await driver.controller.deleteSUCReturnRoutes(
+				node.id,
+			);
+			t.false(result);
+		},
+	},
+);

--- a/packages/zwave-js/src/lib/test/integrationTestSuiteMulti.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuiteMulti.ts
@@ -2,6 +2,7 @@ import type { MockPortBinding } from "@zwave-js/serial/mock";
 import { noop } from "@zwave-js/shared";
 import {
 	type MockController,
+	type MockControllerOptions,
 	type MockNode,
 	type MockNodeOptions,
 } from "@zwave-js/testing";
@@ -12,7 +13,7 @@ import crypto from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import type { Driver } from "../driver/Driver";
-import type { ZWaveOptions } from "../driver/ZWaveOptions";
+import type { PartialZWaveOptions } from "../driver/ZWaveOptions";
 import type { ZWaveNode } from "../node/Node";
 import { prepareDriver, prepareMocks } from "./integrationTestSuiteShared";
 
@@ -23,6 +24,7 @@ interface IntegrationTestOptions {
 	provisioningDirectory?: string;
 	/** Whether the recorded messages and frames should be cleared before executing the test body. Default: true. */
 	clearMessageStatsBeforeTest?: boolean;
+	controllerCapabilities?: MockControllerOptions["capabilities"];
 	nodeCapabilities?: Pick<MockNodeOptions, "id" | "capabilities">[];
 	customSetup?: (
 		driver: Driver,
@@ -36,7 +38,7 @@ interface IntegrationTestOptions {
 		mockController: MockController,
 		mockNodes: MockNode[],
 	) => Promise<void>;
-	additionalDriverOptions?: Partial<ZWaveOptions>;
+	additionalDriverOptions?: PartialZWaveOptions;
 }
 
 export interface IntegrationTestFn {
@@ -55,6 +57,7 @@ function suite(
 	modifier?: "only" | "skip",
 ) {
 	const {
+		controllerCapabilities,
 		nodeCapabilities,
 		customSetup,
 		testBody,
@@ -96,7 +99,9 @@ function suite(
 		));
 		({ mockController, mockNodes } = prepareMocks(
 			mockPort,
-			undefined,
+			{
+				capabilities: controllerCapabilities,
+			},
 			// TODO: This isn't ideal as it requires us to provide the
 			// node capabilities in addition to the provisioning directory
 			nodeCapabilities,

--- a/packages/zwave-js/src/lib/test/integrationTestSuiteShared.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuiteShared.ts
@@ -1,5 +1,4 @@
 import { type MockPortBinding } from "@zwave-js/serial/mock";
-import { type DeepPartial } from "@zwave-js/shared";
 import {
 	MockController,
 	type MockControllerOptions,
@@ -15,12 +14,12 @@ import {
 	type CreateAndStartDriverWithMockPortResult,
 	createAndStartDriverWithMockPort,
 } from "../driver/DriverMock";
-import { type ZWaveOptions } from "../driver/ZWaveOptions";
+import { type PartialZWaveOptions } from "../driver/ZWaveOptions";
 
 export function prepareDriver(
 	cacheDir: string = path.join(__dirname, "cache"),
 	logToFile: boolean = false,
-	additionalOptions: DeepPartial<ZWaveOptions> = {},
+	additionalOptions: PartialZWaveOptions = {},
 ): Promise<CreateAndStartDriverWithMockPortResult> {
 	return createAndStartDriverWithMockPort({
 		...additionalOptions,


### PR DESCRIPTION
When assigning or deleting a SUC return route fails, some 500 series controllers reply with an invalid callback that triggers the "unresponsive controller" detection added in version 12, effectively causing a boot loop.

This PR adds a workaround that considers these non-matching callbacks a command failure, so they are no longer "missing".

fixes: #6363