### PR TITLE
fix: limit recovery after missing callback to `SendData` commands

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -5565,7 +5565,9 @@ ${handlers.length} left`,
 		if (this.isMissingNodeACK(transaction, error)) {
 			if (this.handleMissingNodeACK(transaction as any, error)) return;
 		} else if (
-			isMissingControllerACK(error) || isMissingControllerCallback(error)
+			isMissingControllerACK(error)
+			|| (isSendData(transaction.message)
+				&& isMissingControllerCallback(error))
 		) {
 			if (this.handleUnresponsiveController(transaction, error)) return;
 		}


### PR DESCRIPTION
Doing it for others may depend on correct end node behavior a bit too much.

Fixes: #6371