### PR TITLE
fix: increase `response` timeout to 30 seconds and maximum to 60 seconds

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -249,7 +249,9 @@ const defaultOptions: ZWaveOptions = {
 	timeouts: {
 		ack: 1000,
 		byte: 150,
-		response: 10000,
+		// Ideally we'd want to have this as low as possible, but some
+		// 500 series controllers can take upwards of 10 seconds to respond sometimes.
+		response: 30000,
 		report: 1000, // ReportTime timeout SHOULD be set to CommandTime + 1 second
 		nonce: 5000,
 		sendDataCallback: 65000, // as defined in INS13954
@@ -297,9 +299,9 @@ function checkOptions(options: ZWaveOptions): void {
 			ZWaveErrorCodes.Driver_InvalidOptions,
 		);
 	}
-	if (options.timeouts.response < 500 || options.timeouts.response > 20000) {
+	if (options.timeouts.response < 500 || options.timeouts.response > 60000) {
 		throw new ZWaveError(
-			`The Response timeout must be between 500 and 20000 milliseconds!`,
+			`The Response timeout must be between 500 and 60000 milliseconds!`,
 			ZWaveErrorCodes.Driver_InvalidOptions,
 		);
 	}

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -18,7 +18,7 @@ export interface ZWaveOptions extends ZWaveHostOptions {
 		 * How long to wait for a controller response. Usually this timeout should never elapse,
 		 * so this is merely a safeguard against the driver stalling.
 		 */
-		response: number; // [500...20000], default: 10000 ms
+		response: number; // [500...60000], default: 30000 ms
 
 		/** How long to wait for a callback from the host for a SendData[Multicast]Request */
 		sendDataCallback: number; // >=10000, default: 65000 ms


### PR DESCRIPTION
Not sure why, but some 500 series controllers take upwards of 10 seconds sometimes to respond after trying to communicate with a node, even if successfully. Having a lower timeout has no benefit, but will cause the transmission to abort earlier.

fixes: https://github.com/zwave-js/node-zwave-js/issues/6374