### PR TITLE
fix: use `getSensorTypeName` to print label of dropped sensor reading

### DIFF
--- a/packages/cc/src/cc/MultilevelSensorCC.ts
+++ b/packages/cc/src/cc/MultilevelSensorCC.ts
@@ -670,7 +670,7 @@ export class MultilevelSensorCCReport extends MultilevelSensorCC {
 				if (supportedSensorTypes?.length) {
 					validatePayload.withReason(
 						`Unsupported sensor type ${
-							sensorType!.label
+							applHost.configManager.getSensorTypeName(this.type)
 						} or corrupted data`,
 					)(supportedSensorTypes.includes(this.type));
 				}


### PR DESCRIPTION
fixes: https://github.com/zwave-js/node-zwave-js/issues/6355