### PR TITLE
fix: wait between multi-target firmware updates

### DIFF
--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -4943,6 +4943,8 @@ protocol version:      ${this.protocolVersion}`;
 					this.id,
 					`Continuing with next part in ${conservativeWaitTime} seconds...`,
 				);
+
+				await wait(conservativeWaitTime * 1000, true);
 			}
 		}
 


### PR DESCRIPTION
fixes: #5081

Turns out the only thing that prevented multi-target firmware updates from working was actually waiting between the updates, not just logging it...

![ughhh-face-palm](https://github.com/zwave-js/node-zwave-js/assets/17641229/7a6aaedd-3822-4a3b-ab09-e86a6b7701d7)
