### PR TITLE
fix: export `ConfigurationCCAPISetOptions`

### DIFF
--- a/packages/cc/src/cc/index.ts
+++ b/packages/cc/src/cc/index.ts
@@ -106,6 +106,7 @@ export {
 	ColorSwitchCCSupportedReport,
 	ColorSwitchCCValues,
 } from "./ColorSwitchCC";
+export type { ConfigurationCCAPISetOptions } from "./ConfigurationCC";
 export {
 	ConfigurationCC,
 	ConfigurationCCBulkGet,


### PR DESCRIPTION
Need this type available for the server to fix the `setRawConfigParameterValue` command so we can address https://github.com/zwave-js/certification-backlog/issues/12
