### PR TITLE
fix: abort transmission after response timeout, do not retry, do not restart controller unless callback is missing

### DIFF
--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -684,10 +684,10 @@ interface ZWaveOptions extends ZWaveHostOptions {
 		byte: number; // >=1, default: 150 ms
 
 		/**
-		 * How long to wait for a controller response. Usually this timeout should never elapse,
-		 * so this is merely a safeguard against the driver stalling.
+		 * How long to wait for a controller response. Usually this should never elapse, but when it does,
+		 * the driver will abort the transmission and try to recover the controller if it is unresponsive.
 		 */
-		response: number; // [500...60000], default: 30000 ms
+		response: number; // [500...60000], default: 10000 ms
 
 		/** How long to wait for a callback from the host for a SendData[Multicast]Request */
 		sendDataCallback: number; // >=10000, default: 65000 ms

--- a/packages/core/src/error/ZWaveError.ts
+++ b/packages/core/src/error/ZWaveError.ts
@@ -293,6 +293,17 @@ export function isMissingControllerACK(
 		&& e.context === "ACK";
 }
 
+export function isMissingControllerResponse(
+	e: unknown,
+): e is ZWaveError & {
+	code: ZWaveErrorCodes.Controller_Timeout;
+	context: "response";
+} {
+	return isZWaveError(e)
+		&& e.code === ZWaveErrorCodes.Controller_Timeout
+		&& e.context === "response";
+}
+
 export function isMissingControllerCallback(
 	e: unknown,
 ): e is ZWaveError & {

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -4936,7 +4936,8 @@ ${handlers.length} left`,
 		const machine = createSerialAPICommandMachine(
 			msg,
 			{
-				sendData: this.writeSerial.bind(this),
+				sendData: (data) => this.writeSerial(data),
+				sendDataAbort: () => this.abortSendData(false),
 				notifyUnsolicited: (msg) => {
 					void this.handleUnsolicitedMessage(msg);
 				},
@@ -5020,6 +5021,14 @@ ${handlers.length} left`,
 						cmdResult.result,
 						transactionSource,
 					),
+				);
+			}
+		});
+
+		this.serialAPIInterpreter.onTransition((state) => {
+			if (state.changed) {
+				this.driverLog.print(
+					`CMDMACHINE: ${JSON.stringify(state.toStrings())}`,
 				);
 			}
 		});

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -251,8 +251,8 @@ const defaultOptions: ZWaveOptions = {
 		ack: 1000,
 		byte: 150,
 		// Ideally we'd want to have this as low as possible, but some
-		// 500 series controllers can take upwards of 10 seconds to respond sometimes.
-		response: 30000,
+		// 500 series controllers can take several seconds to respond sometimes.
+		response: 10000,
 		report: 1000, // ReportTime timeout SHOULD be set to CommandTime + 1 second
 		nonce: 5000,
 		sendDataCallback: 65000, // as defined in INS13954
@@ -5040,13 +5040,14 @@ ${handlers.length} left`,
 			}
 		});
 
-		this.serialAPIInterpreter.onTransition((state) => {
-			if (state.changed) {
-				this.driverLog.print(
-					`CMDMACHINE: ${JSON.stringify(state.toStrings())}`,
-				);
-			}
-		});
+		// Uncomment this for debugging state machine transitions
+		// this.serialAPIInterpreter.onTransition((state) => {
+		// 	if (state.changed) {
+		// 		this.driverLog.print(
+		// 			`CMDMACHINE: ${JSON.stringify(state.toStrings())}`,
+		// 		);
+		// 	}
+		// });
 
 		this.serialAPIInterpreter.start();
 

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -86,6 +86,7 @@ import {
 	highResTimestamp,
 	isMissingControllerACK,
 	isMissingControllerCallback,
+	isMissingControllerResponse,
 	isZWaveError,
 	messageRecordToLines,
 	securityClassIsS2,
@@ -3556,17 +3557,21 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks>
 	 * Handles the case that the controller didn't send the callback for a SendData in time
 	 * Returns `true` if the transaction failure was handled, `false` if it needs to be rejected.
 	 */
-	private handleMissingSendDataCallback(
+	private handleMissingSendDataResponseOrCallback(
 		transaction: Transaction,
 		error: ZWaveError & {
 			code: ZWaveErrorCodes.Controller_Timeout;
-			context: "callback";
+			context: "callback" | "response";
 		},
 	): boolean {
 		if (!this._controller) return false;
 
 		if (
-			this._recoveryPhase
+			// The SendData response can time out on older controllers trying to reach a dead node.
+			// In this case, we do not want to reset the controller, but just mark the node as dead.
+			error.context === "response"
+			// Also do this if the callback is timing out even after restarting the controller
+			|| this._recoveryPhase
 				=== ControllerRecoveryPhase.CallbackTimeoutAfterReset
 		) {
 			const node = this.getNodeUnsafe(transaction.message);
@@ -4849,7 +4854,7 @@ ${handlers.length} left`,
 								msg,
 								// Ignore the number of attempts while jammed
 								attemptNumber - jammedAttempts,
-								e.code,
+								e,
 							)
 						) {
 							// Retry the command
@@ -4909,19 +4914,29 @@ ${handlers.length} left`,
 	private mayRetrySerialAPICommand(
 		msg: Message,
 		attemptNumber: number,
-		errorCode: ZWaveErrorCodes,
+		error: ZWaveError,
 	): boolean {
+		// Only retry Send Data, nothing else
 		if (!isSendData(msg)) return false;
+
+		// Don't try to resend SendData commands when the response times out
 		if (
-			msg instanceof SendDataMulticastRequest
-			|| msg instanceof SendDataMulticastBridgeRequest
+			error.code === ZWaveErrorCodes.Controller_Timeout
+			&& error.context === "response"
 		) {
-			// Don't try to resend multicast messages if they were already transmitted.
-			// One or more nodes might have already reacted
-			if (errorCode === ZWaveErrorCodes.Controller_CallbackNOK) {
-				return false;
-			}
+			return false;
 		}
+
+		// Don't try to resend multicast messages if they were already transmitted.
+		// One or more nodes might have already reacted
+		if (
+			(msg instanceof SendDataMulticastRequest
+				|| msg instanceof SendDataMulticastBridgeRequest)
+			&& error.code === ZWaveErrorCodes.Controller_CallbackNOK
+		) {
+			return false;
+		}
+
 		return attemptNumber < msg.maxSendAttempts;
 	}
 
@@ -5672,9 +5687,12 @@ ${handlers.length} left`,
 			if (this.handleMissingControllerACK(transaction, error)) return;
 		} else if (
 			isSendData(transaction.message)
-			&& isMissingControllerCallback(error)
+			&& (isMissingControllerResponse(error)
+				|| isMissingControllerCallback(error))
 		) {
-			if (this.handleMissingSendDataCallback(transaction, error)) return;
+			if (
+				this.handleMissingSendDataResponseOrCallback(transaction, error)
+			) return;
 		}
 
 		this.rejectTransaction(transaction, error);

--- a/packages/zwave-js/src/lib/driver/SerialAPICommandMachine.test.ts
+++ b/packages/zwave-js/src/lib/driver/SerialAPICommandMachine.test.ts
@@ -41,7 +41,8 @@ interface TestMachineStateSchema {
 		waitForACK: {};
 		waitForResponse: {};
 		waitForCallback: {};
-		waitForCallbackAfterTimeout: {};
+		// FIXME: This is relevant for SendData, but we're not using SendData messages in this test
+		// waitForCallbackAfterTimeout: {};
 		unsolicited: {};
 		success: {};
 		failure: {};
@@ -228,10 +229,11 @@ const testMachine = Machine<
 						{ target: "failure" },
 					],
 					RESPONSE_TIMEOUT: [
-						{
-							target: "waitForCallbackAfterTimeout",
-							cond: "expectsCallback",
-						},
+						// FIXME: This is relevant for SendData, but we're not using SendData messages in this test
+						// {
+						// 	target: "waitForCallbackAfterTimeout",
+						// 	cond: "expectsCallback",
+						// },
 						{ target: "failure" },
 					],
 					UNSOLICITED: "unsolicited",
@@ -251,13 +253,13 @@ const testMachine = Machine<
 					UNSOLICITED: "unsolicited",
 				},
 			},
-			waitForCallbackAfterTimeout: {
-				on: {
-					CALLBACK_NOK: "failure",
-					// FIXME: The callback should be able to time out too
-					// CALLBACK_TIMEOUT: "failure",
-				},
-			},
+			// FIXME: This is relevant for SendData, but we're not using SendData messages in this test
+			// waitForCallbackAfterTimeout: {
+			// 	on: {
+			// 		CALLBACK_NOK: "failure",
+			// 		CALLBACK_TIMEOUT: "failure",
+			// 	},
+			// },
 			unsolicited: {
 				meta: {
 					test: ({
@@ -397,13 +399,14 @@ testPlans.forEach((plan) => {
 	);
 
 	plan.paths.forEach((path) => {
-		if (
-			!path.description.includes(
-				`CREATE ({"resp":true,"cb":true}) → SEND_FAILURE → SEND_FAILURE → SEND_SUCCESS → ACK → RESPONSE_TIMEOUT → CALLBACK_TIMEOUT`,
-			)
-		) {
-			return;
-		}
+		// Uncomment this and change the path description to only run a single test
+		// if (
+		// 	!path.description.includes(
+		// 		`CREATE ({"resp":true,"cb":true}) → SEND_FAILURE → SEND_FAILURE → SEND_SUCCESS → ACK → RESPONSE_TIMEOUT → CALLBACK_NOK`,
+		// 	)
+		// ) {
+		// 	return;
+		// }
 		test.serial(`${planDescription} ${path.description}`, async (t) => {
 			// eslint-disable-next-line prefer-const
 			let context: TestContext;
@@ -455,9 +458,9 @@ testPlans.forEach((plan) => {
 			context.interpreter.onDone((evt) => {
 				context.machineResult = evt.data;
 			});
-			context.interpreter.onTransition((state) => {
-				if (state.changed) console.log(state.value);
-			});
+			// context.interpreter.onTransition((state) => {
+			// 	if (state.changed) console.log(state.value);
+			// });
 			context.interpreter.start();
 
 			if (plan.state.value === "failure") {

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -15,10 +15,10 @@ export interface ZWaveOptions extends ZWaveHostOptions {
 		byte: number; // >=1, default: 150 ms
 
 		/**
-		 * How long to wait for a controller response. Usually this timeout should never elapse,
-		 * so this is merely a safeguard against the driver stalling.
+		 * How long to wait for a controller response. Usually this should never elapse, but when it does,
+		 * the driver will abort the transmission and try to recover the controller if it is unresponsive.
 		 */
-		response: number; // [500...60000], default: 30000 ms
+		response: number; // [500...60000], default: 10000 ms
 
 		/** How long to wait for a callback from the host for a SendData[Multicast]Request */
 		sendDataCallback: number; // >=10000, default: 65000 ms

--- a/packages/zwave-js/src/lib/test/cc-specific/discardUnsupportedReports.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/discardUnsupportedReports.test.ts
@@ -87,7 +87,7 @@ integrationTest(
 				}),
 			);
 
-			await wait(100);
+			await wait(200);
 
 			const sensorValue = MultilevelSensorCCValues.value(
 				"Air temperature",

--- a/packages/zwave-js/src/lib/test/driver/sendDataMissingResponse.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/sendDataMissingResponse.test.ts
@@ -1,0 +1,356 @@
+import { FunctionType } from "@zwave-js/serial";
+import { type MockControllerBehavior } from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import {
+	MockControllerCommunicationState,
+	MockControllerStateKeys,
+} from "../../controller/MockControllerState";
+
+import {
+	TransmitStatus,
+	ZWaveErrorCodes,
+	assertZWaveError,
+} from "@zwave-js/core";
+
+import {
+	SendDataAbort,
+	SendDataRequest,
+	SendDataRequestTransmitReport,
+} from "../../serialapi/transport/SendDataMessages";
+import { integrationTest } from "../integrationTestSuite";
+
+let shouldTimeOut: boolean;
+
+integrationTest(
+	"Abort transmission and wait for callback if SendData is missing the response",
+	{
+		debug: true,
+
+		// provisioningDirectory: path.join(
+		// 	__dirname,
+		// 	"__fixtures/supervision_binary_switch",
+		// ),
+
+		additionalDriverOptions: {
+			testingHooks: {
+				skipNodeInterview: true,
+			},
+		},
+
+		customSetup: async (driver, mockController, mockNode) => {
+			// This is almost a 1:1 copy of the default behavior, except that the response and callback never get sent
+			const handleBrokenSendData: MockControllerBehavior = {
+				async onHostMessage(host, controller, msg) {
+					// If the controller is operating normally, defer to the default behavior
+					if (!shouldTimeOut) return false;
+
+					if (msg instanceof SendDataRequest) {
+						// Check if this command is legal right now
+						const state = controller.state.get(
+							MockControllerStateKeys.CommunicationState,
+						) as MockControllerCommunicationState | undefined;
+						if (
+							state != undefined
+							&& state !== MockControllerCommunicationState.Idle
+						) {
+							throw new Error(
+								"Received SendDataRequest while not idle",
+							);
+						}
+
+						return true;
+					} else if (msg instanceof SendDataAbort) {
+						// Finish the transmission by sending the callback
+						const cb = new SendDataRequestTransmitReport(host, {
+							callbackId: msg.callbackId,
+							transmitStatus: TransmitStatus.NoAck,
+						});
+
+						setTimeout(() => {
+							controller.sendToHost(cb.serialize());
+						}, 100);
+
+						// Put the controller into idle state
+						controller.state.set(
+							MockControllerStateKeys.CommunicationState,
+							MockControllerCommunicationState.Idle,
+						);
+
+						return true;
+					}
+				},
+			};
+			mockController.defineBehavior(handleBrokenSendData);
+		},
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// Circumvent the options validation so the test doesn't take forever
+			driver.options.timeouts.response = 500;
+			driver.options.timeouts.sendDataCallback = 1500;
+
+			shouldTimeOut = true;
+
+			const basicSetPromise = node.commandClasses.Basic.set(99);
+
+			await wait(2000);
+
+			mockController.assertReceivedHostMessage(
+				(msg) => msg.functionType === FunctionType.SendDataAbort,
+			);
+			mockController.clearReceivedHostMessages();
+
+			// // The stick should have been soft-reset
+			// await wait(1000);
+			// mockController.assertReceivedHostMessage(
+			// 	(msg) => msg.functionType === FunctionType.SoftReset,
+			// );
+
+			await assertZWaveError(t, () => basicSetPromise, {
+				errorCode: ZWaveErrorCodes.Controller_CallbackNOK,
+			});
+		},
+	},
+);
+
+// integrationTest(
+// 	"Mark node as dead if SendData is still missing the callback after soft-reset",
+// 	{
+// 		// Real-world experience has shown that for older controllers this situation can be caused by dead nodes
+// 		// We don't want to restart the driver in that case, but mark the node as dead instead
+// 		// debug: true,
+
+// 		// provisioningDirectory: path.join(
+// 		// 	__dirname,
+// 		// 	"__fixtures/supervision_binary_switch",
+// 		// ),
+
+// 		additionalDriverOptions: {
+// 			testingHooks: {
+// 				skipNodeInterview: true,
+// 			},
+// 		},
+
+// 		customSetup: async (driver, mockController, mockNode) => {
+// 			// This is almost a 1:1 copy of the default behavior, except that the callback never gets sent
+// 			const handleBrokenSendData: MockControllerBehavior = {
+// 				async onHostMessage(host, controller, msg) {
+// 					if (msg instanceof SendDataRequest) {
+// 						// Check if this command is legal right now
+// 						const state = controller.state.get(
+// 							MockControllerStateKeys.CommunicationState,
+// 						) as MockControllerCommunicationState | undefined;
+// 						if (
+// 							state != undefined
+// 							&& state !== MockControllerCommunicationState.Idle
+// 						) {
+// 							throw new Error(
+// 								"Received SendDataRequest while not idle",
+// 							);
+// 						}
+
+// 						// Put the controller into sending state
+// 						controller.state.set(
+// 							MockControllerStateKeys.CommunicationState,
+// 							MockControllerCommunicationState.Sending,
+// 						);
+
+// 						// Notify the host that the message was sent
+// 						const res = new SendDataResponse(host, {
+// 							wasSent: true,
+// 						});
+// 						await controller.sendToHost(res.serialize());
+
+// 						return true;
+// 					} else if (msg instanceof SendDataAbort) {
+// 						// Put the controller into idle state
+// 						controller.state.set(
+// 							MockControllerStateKeys.CommunicationState,
+// 							MockControllerCommunicationState.Idle,
+// 						);
+
+// 						return true;
+// 					}
+// 				},
+// 			};
+// 			mockController.defineBehavior(handleBrokenSendData);
+// 		},
+// 		testBody: async (t, driver, node, mockController, mockNode) => {
+// 			// Circumvent the options validation so the test doesn't take forever
+// 			driver.options.timeouts.sendDataCallback = 1500;
+// 			shouldTimeOut = true;
+
+// 			const errorSpy = Sinon.spy();
+// 			driver.on("error", errorSpy);
+
+// 			const pingPromise = node.ping();
+
+// 			await wait(2000);
+
+// 			mockController.assertReceivedHostMessage(
+// 				(msg) => msg.functionType === FunctionType.SendDataAbort,
+// 			);
+// 			mockController.clearReceivedHostMessages();
+
+// 			// The stick should have been soft-reset
+// 			await wait(1000);
+// 			mockController.assertReceivedHostMessage(
+// 				(msg) => msg.functionType === FunctionType.SoftReset,
+// 			);
+
+// 			// The ping should eventually fail and the node be marked dead
+// 			t.false(await pingPromise);
+
+// 			t.is(node.status, NodeStatus.Dead);
+
+// 			// The error event should not have been emitted
+// 			await wait(300);
+// 			t.is(errorSpy.callCount, 0);
+// 		},
+// 	},
+// );
+
+// integrationTest(
+// 	"Missing callback recovery works if the command can be retried",
+// 	{
+// 		// debug: true,
+
+// 		// provisioningDirectory: path.join(
+// 		// 	__dirname,
+// 		// 	"__fixtures/supervision_binary_switch",
+// 		// ),
+
+// 		additionalDriverOptions: {
+// 			testingHooks: {
+// 				skipNodeInterview: true,
+// 			},
+// 		},
+
+// 		customSetup: async (driver, mockController, mockNode) => {
+// 			// This is almost a 1:1 copy of the default behavior, except that the callback never gets sent
+// 			const handleBrokenSendData: MockControllerBehavior = {
+// 				async onHostMessage(host, controller, msg) {
+// 					// If the controller is operating normally, defer to the default behavior
+// 					if (!shouldTimeOut) return false;
+
+// 					if (msg instanceof SendDataRequest) {
+// 						// Check if this command is legal right now
+// 						const state = controller.state.get(
+// 							MockControllerStateKeys.CommunicationState,
+// 						) as MockControllerCommunicationState | undefined;
+// 						if (
+// 							state != undefined
+// 							&& state !== MockControllerCommunicationState.Idle
+// 						) {
+// 							throw new Error(
+// 								"Received SendDataRequest while not idle",
+// 							);
+// 						}
+
+// 						// Put the controller into sending state
+// 						controller.state.set(
+// 							MockControllerStateKeys.CommunicationState,
+// 							MockControllerCommunicationState.Sending,
+// 						);
+
+// 						// Notify the host that the message was sent
+// 						const res = new SendDataResponse(host, {
+// 							wasSent: true,
+// 						});
+// 						await controller.sendToHost(res.serialize());
+
+// 						return true;
+// 					} else if (msg instanceof SendDataAbort) {
+// 						// Put the controller into idle state
+// 						controller.state.set(
+// 							MockControllerStateKeys.CommunicationState,
+// 							MockControllerCommunicationState.Idle,
+// 						);
+
+// 						return true;
+// 					}
+// 				},
+// 			};
+// 			mockController.defineBehavior(handleBrokenSendData);
+
+// 			const handleSoftReset: MockControllerBehavior = {
+// 				onHostMessage(host, controller, msg) {
+// 					// Soft reset should restore normal operation
+// 					if (msg instanceof SoftResetRequest) {
+// 						shouldTimeOut = false;
+// 						// Delegate to the default behavior
+// 						return false;
+// 					}
+// 				},
+// 			};
+// 			mockController.defineBehavior(handleSoftReset);
+// 		},
+// 		testBody: async (t, driver, node, mockController, mockNode) => {
+// 			// Circumvent the options validation so the test doesn't take forever
+// 			driver.options.timeouts.sendDataCallback = 1500;
+
+// 			shouldTimeOut = true;
+
+// 			const firstCommand = node.commandClasses.Basic.set(99);
+// 			const followupCommand = node.commandClasses.Basic.set(0);
+
+// 			await wait(2000);
+
+// 			mockController.assertReceivedHostMessage(
+// 				(msg) => msg.functionType === FunctionType.SendDataAbort,
+// 			);
+// 			mockController.clearReceivedHostMessages();
+
+// 			// The stick should have been soft-reset
+// 			await wait(1000);
+// 			mockController.assertReceivedHostMessage(
+// 				(msg) => msg.functionType === FunctionType.SoftReset,
+// 			);
+
+// 			// The ping and the followup command should eventually succeed
+// 			await firstCommand;
+// 			await followupCommand;
+
+// 			t.pass();
+// 		},
+// 	},
+// );
+
+// integrationTest(
+// 	"Missing callback recovery only kicks in for SendData commands",
+// 	{
+// 		// debug: true,
+
+// 		additionalDriverOptions: {
+// 			testingHooks: {
+// 				skipNodeInterview: true,
+// 			},
+// 		},
+
+// 		customSetup: async (driver, mockController, mockNode) => {
+// 			// This is almost a 1:1 copy of the default behavior, except that the callback never gets sent
+// 			const handleBrokenRequestNodeInfo: MockControllerBehavior = {
+// 				async onHostMessage(host, controller, msg) {
+// 					if (msg instanceof RequestNodeInfoRequest) {
+// 						// Notify the host that the message was sent
+// 						const res = new RequestNodeInfoResponse(host, {
+// 							wasSent: true,
+// 						});
+// 						await controller.sendToHost(res.serialize());
+
+// 						// And never send a callback
+// 						return true;
+// 					}
+// 				},
+// 			};
+// 			mockController.defineBehavior(handleBrokenRequestNodeInfo);
+// 		},
+// 		testBody: async (t, driver, node, mockController, mockNode) => {
+// 			// Circumvent the options validation so the test doesn't take forever
+// 			driver.options.timeouts.sendDataCallback = 1500;
+
+// 			await assertZWaveError(t, () => node.requestNodeInfo(), {
+// 				errorCode: ZWaveErrorCodes.Controller_Timeout,
+// 				context: "callback",
+// 			});
+// 		},
+// 	},
+// );

--- a/test/run.ts
+++ b/test/run.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import { wait as _wait } from "alcalzone-shared/async";
-import path from "path";
+import path from "node:path";
 import "reflect-metadata";
 import { Driver } from "zwave-js";
 
@@ -12,9 +12,12 @@ process.on("unhandledRejection", (_r) => {
 
 // const port = "tcp://Z-Net-R2v2.local:2001";
 // 500/700 series
+const port = require("node:os").platform() === "win32"
+	? "COM5"
+	: "/dev/ttyACM0";
 // const port = require("os").platform() === "win32" ? "COM5" : "/dev/ttyUSB0";
 // 800 series
-const port = require("os").platform() === "win32" ? "COM5" : "/dev/ttyACM0";
+// const port = require("node:os").platform() === "win32" ? "COM5" : "/dev/serial/by-id/usb-1a86_USB_Single_Serial_5479014030-if00";
 
 const driver = new Driver(port, {
 	// logConfig: {
@@ -24,6 +27,7 @@ const driver = new Driver(port, {
 	// testingHooks: {
 	// 	skipNodeInterview: true,
 	// },
+	enableSoftReset: false,
 	securityKeys: {
 		S0_Legacy: Buffer.from("0102030405060708090a0b0c0d0e0f10", "hex"),
 		S2_Unauthenticated: Buffer.from(
@@ -48,7 +52,15 @@ const driver = new Driver(port, {
 	.on("error", console.error)
 	.once("driver ready", async () => {
 		// Test code goes here
-		await wait(2000);
+		await wait(10000);
+		console.log("TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT");
+		console.log("TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT");
+		console.log("TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT");
+		console.log("TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT");
+
+		await driver["writeSerial"](Buffer.from("010800130201002503c1", "hex"));
+		await wait(3);
+		await driver["writeSerial"](Buffer.from("01030016ea", "hex"));
 	})
 	.once("bootloader ready", async () => {
 		// What to do when stuck in the bootloader


### PR DESCRIPTION
for https://github.com/zwave-js/node-zwave-js/issues/6402

This PR changes how timed out Send Data responses are handled. Previously, we'd retry the command up to 3 times without awaiting the end of the command cycle, which can likely put the controller in a weird state, possibly triggering the "unresponsive controller" recovery unnecessarily.

Now we abort the transmission and wait for the callback to be received (expected to be with status NoACK), then treat it like a NoACK (node marked dead/asleep).

If the callback doesn't come, the recovery will kick in, possibly restarting the controller.

Since we now actively abort, the default timeout was reduced back to 10s, as not responding to incoming commands for an extended amount of time can cause further problems. Users regularly experiencing these timeouts should fix their mesh or increase the timeout.