### PR TITLE
feat: driver option presets

### DIFF
--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -5,12 +5,29 @@ The driver is the core of this library. It controls the serial interface, handle
 ## Constructor
 
 ```ts
-new (port: string, options?: PartialZWaveOptions) => Driver
+new (
+	port: string,
+	...optionsAndPresets: PartialZWaveOptions[]
+) => Driver
 ```
 
 The first constructor argument is the address of the serial port. On Windows, this is similar to `"COM3"`. On Linux this has the form `/dev/ttyAMA0` (or similar). Alternatively, you can connect to a serial port that is hosted over TCP (for example with the `ser2net` utility), see [Remote serial port over TCP](usage/tcp-connection.md).
 
-For more control, the constructor accepts an optional options object as the second argument. `PartialZWaveOptions` are a subset of [`ZWaveOptions`](#ZWaveOptions), allowing you to specify just what's necessary.
+For most scenarios the default configuration should be sufficient. For more control, the constructor optionally accepts a list of options objects or presets. Multiple sets of options are deep-merged where the later ones have higher priority. `PartialZWaveOptions` are a subset of [`ZWaveOptions`](#ZWaveOptions), allowing you to specify just what's necessary.
+
+Some curated presets are included in the library:
+| Preset | Description |
+| --- | --- |
+| `SAFE_MODE` | Increases several timeouts to be able to deal with controllers and/or nodes that have severe trouble communicating. This should not be enabled permanently, as it can decrease the performance of the network significantly |
+| `BATTERY_SAVE` | Sends battery powered nodes to sleep more quickly in order to save battery. |
+| `AWAKE_LONGER` | Sends battery powered nodes to sleep less quickly to give applications more time between interactions. |
+
+These can be used like this:
+
+```ts
+import { Driver, driverPresets } from "zwave-js"; // Or from "zwave-js/Utils"
+const driver = new Driver("/path/to/serial", driverPresets.BATTERY_SAVE);
+```
 
 ## Driver methods
 

--- a/packages/zwave-js/src/Utils.ts
+++ b/packages/zwave-js/src/Utils.ts
@@ -23,6 +23,7 @@ export {
 	num2hex,
 } from "@zwave-js/shared/safe";
 export { createDefaultBehaviors as createDefaultMockControllerBehaviors } from "./lib/controller/MockControllerBehaviors";
+export { driverPresets } from "./lib/driver/ZWaveOptions";
 export {
 	formatLifelineHealthCheckRound,
 	formatLifelineHealthCheckSummary,

--- a/packages/zwave-js/src/Utils_safe.ts
+++ b/packages/zwave-js/src/Utils_safe.ts
@@ -14,6 +14,7 @@ export {
 	getEnumMemberName,
 	num2hex,
 } from "@zwave-js/shared/safe";
+export { driverPresets } from "./lib/driver/ZWaveOptions";
 export {
 	formatLifelineHealthCheckRound,
 	formatLifelineHealthCheckSummary,

--- a/packages/zwave-js/src/lib/driver/Driver.unit.test.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.unit.test.ts
@@ -1,10 +1,12 @@
 import { ZWaveErrorCodes, assertZWaveError } from "@zwave-js/core";
 // import { Message, MessageType, messageTypes } from "@zwave-js/serial";
 import { MockSerialPort } from "@zwave-js/serial/mock";
+import { mergeDeep } from "@zwave-js/shared";
 import test from "ava";
 import proxyquire from "proxyquire";
 import sinon from "sinon";
 import { PORT_ADDRESS, createAndStartDriver } from "../test/utils";
+import { type PartialZWaveOptions, driverPresets } from "./ZWaveOptions";
 
 // @messageTypes(MessageType.Request, 0xff)
 // class TestMessage extends Message {}
@@ -195,6 +197,83 @@ test.serial("the constructor should throw on duplicate security keys", (t) => {
 			errorCode: ZWaveErrorCodes.Driver_InvalidOptions,
 		},
 	);
+});
+
+test("merging multiple sets of options should work", (t) => {
+	const preset1: PartialZWaveOptions = {
+		attempts: {
+			sendDataJammed: 1,
+		},
+		timeouts: {
+			sendDataAbort: 22000,
+			sendDataCallback: 33000,
+		},
+	};
+
+	const preset2: PartialZWaveOptions = {
+		attempts: {
+			sendDataJammed: 2,
+			sendData: 3,
+		},
+		timeouts: {
+			sendDataAbort: 25000,
+		},
+	};
+
+	const driver = new Driver("/dev/test", preset1, preset2);
+
+	t.like(driver.options, {
+		attempts: {
+			sendDataJammed: 2,
+			sendData: 3,
+		},
+		timeouts: {
+			sendDataAbort: 25000,
+			sendDataCallback: 33000,
+		},
+		// This comes from the defaults:
+		enableSoftReset: true,
+	});
+});
+
+test("The result of merging multiple sets of options is still checked", (t) => {
+	const preset1: PartialZWaveOptions = {
+		attempts: {
+			sendDataJammed: 1,
+		},
+		timeouts: {
+			sendDataAbort: 22000,
+			sendDataCallback: 33000,
+		},
+	};
+
+	const preset2: PartialZWaveOptions = {
+		attempts: {
+			sendDataJammed: 2,
+			sendData: 3,
+		},
+		timeouts: {
+			sendDataAbort: 1,
+		},
+	};
+
+	assertZWaveError(t, () => new Driver("/dev/test", preset1, preset2), {
+		errorCode: ZWaveErrorCodes.Driver_InvalidOptions,
+		messageMatches: /Abort/,
+	});
+});
+
+test("The exported driver presets work", (t) => {
+	const driver = new Driver(
+		"/dev/test",
+		driverPresets.SAFE_MODE,
+		driverPresets.AWAKE_LONGER,
+	);
+
+	let expected = mergeDeep({}, driverPresets.SAFE_MODE, true);
+	expected = mergeDeep(expected, driverPresets.AWAKE_LONGER, true);
+
+	t.like(driver.options, expected);
 });
 
 // describe.skip("sending messages", () => {

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -327,3 +327,49 @@ export type EditableZWaveOptions = Expand<
 		userAgent?: Record<string, string | null | undefined>;
 	}
 >;
+
+export const driverPresets = Object.freeze(
+	{
+		/**
+		 * Increases several timeouts to be able to deal with controllers
+		 * and/or nodes that have severe trouble communicating.
+		 */
+		SAFE_MODE: {
+			timeouts: {
+				// 500 series controllers that take long to respond instead of delaying the callback
+				response: 60000,
+				// Any controller having trouble reaching a node
+				sendDataAbort: 60000,
+				sendDataCallback: 65000,
+				// Slow nodes taking long to respond
+				report: 10000,
+				nonce: 20000,
+			},
+			attempts: {
+				// Increase communication attempts with nodes to their maximum
+				sendData: 5,
+				sendDataJammed: 10,
+				nodeInterview: 10,
+			},
+		},
+
+		/**
+		 * Sends battery powered nodes to sleep more quickly in order to save battery.
+		 */
+		BATTERY_SAVE: {
+			timeouts: {
+				sendToSleep: 100,
+			},
+		},
+
+		/**
+		 * Sends battery powered nodes to sleep less quickly to give applications
+		 * more time between interactions.
+		 */
+		AWAKE_LONGER: {
+			timeouts: {
+				sendToSleep: 1000,
+			},
+		},
+	} as const satisfies Record<string, PartialZWaveOptions>,
+);


### PR DESCRIPTION
This PR adds support for driver option presets, allowing us to curate a set of useful option presets, starting with:
| Preset | Description |
| --- | --- |
| `SAFE_MODE` | Increases several timeouts to be able to deal with controllers and/or nodes that have severe trouble communicating. This should not be enabled permanently, as it can decrease the performance of the network significantly |
| `BATTERY_SAVE` | Sends battery powered nodes to sleep more quickly in order to save battery. |
| `AWAKE_LONGER` | Sends battery powered nodes to sleep less quickly to give applications more time between interactions. |