### PR TITLE
fix: export all option types for `Configuration CC`

### DIFF
--- a/packages/cc/src/cc/ConfigurationCC.ts
+++ b/packages/cc/src/cc/ConfigurationCC.ts
@@ -103,6 +103,7 @@ export const ConfigurationCCValues = Object.freeze({
 	}),
 });
 
+/** @publicAPI */
 export type ConfigurationCCAPISetOptions =
 	& {
 		parameter: number;
@@ -1580,6 +1581,7 @@ alters capabilities: ${!!properties.altersCapabilities}`;
 	}
 }
 
+/** @publicAPI */
 export interface ConfigurationCCReportOptions extends CCCommandOptions {
 	parameter: number;
 	value: ConfigValue;
@@ -2282,6 +2284,7 @@ export class ConfigurationCCBulkGet extends ConfigurationCC {
 	}
 }
 
+/** @publicAPI */
 export interface ConfigurationCCNameReportOptions extends CCCommandOptions {
 	parameter: number;
 	name: string;
@@ -2428,6 +2431,7 @@ export class ConfigurationCCNameGet extends ConfigurationCC {
 	}
 }
 
+/** @publicAPI */
 export interface ConfigurationCCInfoReportOptions extends CCCommandOptions {
 	parameter: number;
 	info: string;
@@ -2587,6 +2591,7 @@ export class ConfigurationCCInfoGet extends ConfigurationCC {
 	}
 }
 
+/** @publicAPI */
 export interface ConfigurationCCPropertiesReportOptions
 	extends CCCommandOptions
 {

--- a/packages/cc/src/cc/index.ts
+++ b/packages/cc/src/cc/index.ts
@@ -106,7 +106,13 @@ export {
 	ColorSwitchCCSupportedReport,
 	ColorSwitchCCValues,
 } from "./ColorSwitchCC";
-export type { ConfigurationCCAPISetOptions } from "./ConfigurationCC";
+export type {
+	ConfigurationCCAPISetOptions,
+	ConfigurationCCInfoReportOptions,
+	ConfigurationCCNameReportOptions,
+	ConfigurationCCPropertiesReportOptions,
+	ConfigurationCCReportOptions,
+} from "./ConfigurationCC";
 export {
 	ConfigurationCC,
 	ConfigurationCCBulkGet,


### PR DESCRIPTION
Followup to https://github.com/zwave-js/node-zwave-js/pull/6400, this is the correct fix, the other won't stick due to the file being auto-generated.