### PR TITLE
fix(config): correct overridden `thermostatMode` metadata for ZME_FT

### DIFF
--- a/packages/config/config/devices/0x0115/zme_ft.json
+++ b/packages/config/config/devices/0x0115/zme_ft.json
@@ -130,10 +130,10 @@
 					"extendMetadata": {
 						"thermostatMode": {
 							"states": {
-								"Off": 0,
-								"Heat": 1,
-								"Furnace": 7,
-								"Energy heat": 11
+								"0": "Off",
+								"1": "Heat",
+								"7": "Furnace",
+								"11": "Energy heat"
 							}
 						}
 					}


### PR DESCRIPTION
reported in https://github.com/zwave-js/node-zwave-js/issues/6405