### PR TITLE
feat(config): add PM-B400ZW-N

### DIFF
--- a/packages/config/config/devices/0x018c/pm-b400zw-n.json
+++ b/packages/config/config/devices/0x018c/pm-b400zw-n.json
@@ -2,7 +2,7 @@
 	"manufacturer": "Dawon DNS",
 	"manufacturerId": "0x018c",
 	"label": "PM-B400ZW-N",
-	"description": "Power Manager",
+	"description": "Smart Plug with Power Meter",
 	"devices": [
 		{
 			"productType": "0x0042",
@@ -18,18 +18,10 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
-	"associations": {
-		"1": {
-			"label": "Group 1",
-			"maxNodes": 5,
-			"isLifeline": true
-		}
-	},
 	"paramInformation": [
 		{
-			"#": "1",
+			"#": "1[0xffffff00]",
 			"label": "Standy Power Setting Value",
-			"description": "If 300, standby power is 3.00w and standby power is enabled. default : 0, disabled",
 			"valueSize": 4,
 			"unit": "0.01 W",
 			"minValue": 0,
@@ -37,25 +29,31 @@
 			"defaultValue": 0
 		},
 		{
+			"#": "1[0x01]",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Standy Power Enable",
+			"valueSize": 4
+		},
+		{
 			"#": "2",
 			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Periodic kWh Reporting",
+			"label": "Energy (kWh) Reporting",
 			"defaultValue": 1
 		},
 		{
 			"#": "3",
 			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Accumulation of kWh Values Stop (0) /Start (1)",
+			"label": "Accumulation of kWh Values",
 			"defaultValue": 1
 		},
 		{
 			"#": "4",
 			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Connected Device in Use (1) /Not in Use (0)"
+			"label": "Connected Device in Use"
 		},
 		{
 			"#": "5",
-			"label": "Periodic kWh Reporting Time",
+			"label": "Energy (kWh) Report Interval",
 			"valueSize": 1,
 			"unit": "10 minutes",
 			"minValue": 0,

--- a/packages/config/config/devices/0x018c/pm-b400zw-n.json
+++ b/packages/config/config/devices/0x018c/pm-b400zw-n.json
@@ -20,7 +20,7 @@
 	},
 	"paramInformation": [
 		{
-			"#": "1[0x01]",
+			"#": "1[0xff]",
 			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Standby Power Cutoff",
 			"valueSize": 4

--- a/packages/config/config/devices/0x018c/pm-b400zw-n.json
+++ b/packages/config/config/devices/0x018c/pm-b400zw-n.json
@@ -20,19 +20,19 @@
 	},
 	"paramInformation": [
 		{
+			"#": "1[0x01]",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Standby Power Cutoff",
+			"valueSize": 4
+		},
+		{
 			"#": "1[0xffffff00]",
-			"label": "Standy Power Setting Value",
+			"label": "Standby Power Cutoff Threshold",
 			"valueSize": 4,
 			"unit": "0.01 W",
 			"minValue": 0,
 			"maxValue": 60000,
 			"defaultValue": 0
-		},
-		{
-			"#": "1[0x01]",
-			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Standy Power Enable",
-			"valueSize": 4
 		},
 		{
 			"#": "2",

--- a/packages/config/config/devices/0x018c/pm-b400zw-n.json
+++ b/packages/config/config/devices/0x018c/pm-b400zw-n.json
@@ -1,0 +1,73 @@
+{
+	"manufacturer": "Dawon DNS",
+	"manufacturerId": "0x018c",
+	"label": "PM-B400ZW-N",
+	"description": "Power Manager",
+	"devices": [
+		{
+			"productType": "0x0042",
+			"productId": "0x0006",
+			"zwaveAllianceId": 1870
+		},
+		{
+			"productType": "0x0042",
+			"productId": "0x0005"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Group 1",
+			"maxNodes": 5,
+			"isLifeline": true
+		}
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"label": "Standy Power Setting Value",
+			"description": "If 300, standby power is 3.00w and standby power is enabled. default : 0, disabled",
+			"valueSize": 4,
+			"unit": "0.01 W",
+			"minValue": 0,
+			"maxValue": 60000,
+			"defaultValue": 0
+		},
+		{
+			"#": "2",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Periodic kWh Reporting",
+			"defaultValue": 1
+		},
+		{
+			"#": "3",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Accumulation of kWh Values Stop (0) /Start (1)",
+			"defaultValue": 1
+		},
+		{
+			"#": "4",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Connected Device in Use (1) /Not in Use (0)"
+		},
+		{
+			"#": "5",
+			"label": "Periodic kWh Reporting Time",
+			"valueSize": 1,
+			"unit": "10 minutes",
+			"minValue": 0,
+			"maxValue": 144,
+			"defaultValue": 6,
+			"unsigned": true
+		}
+	],
+	"metadata": {
+		"inclusion": "After mounting the UZB controller to your PC and running the PC Controller program, click the Add button in the PC Controller program. Press the button on the Smart Plug for more than five seconds after you plug the Smart Plug into a power outlet and it will include to the network controller, while flashing the red button on the LED Smart Plug",
+		"exclusion": "After mounting the UZB controller to your PC and run the PC Controller program you can click the Remove button in the PC Controller program. Press the button on the Smart Plug for more than five seconds after you plug the Smart Plug into a power outlet will Exclusion in the network controller, while the flashing red button LED Smart Plug",
+		"reset": "Press the button on the Smart Plug for more than 10 seconds after you plug the Smart Plug into a power outlet will make a Exclusion in the network controller, while the flashing red button LED Smart Plug. And all the variables are initialized.\n\n※ Please use this procedure only in the event that the network primary \n controller is missing or otherwise inoperable",
+		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/1870/PB-B400ZWN_Manual.pdf"
+	}
+}


### PR DESCRIPTION
First extract attempt from ZWA to close #5849 (help wanted issue). Tried to pick up the bot import #5871, but had unexpected message (separate repository?), so started from fresh. Only real area of concern for me is param 1. It appears from the manual that once a value over 0 is added, the device enables the 4th byte (0x01). I do not see how to do that separately with masking. It seems the function of the parameter is to turn off the switch if the value falls below the setting value. Other than that, I used the 'label' to explain the enable_disable for params 3 & 4 rather than add new labels with options to simplify a bit.

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

PR description here
Manual 
[PB-B400ZWN_Manual (1).pdf](https://github.com/zwave-js/node-zwave-js/files/13024822/PB-B400ZWN_Manual.1.pdf)

