### PR TITLE
feat: add compat flag to treat `Set` commands as `Report`, enable for SRT321 HRT4-ZW

### DIFF
--- a/.vscode/deviceSnippets.code-snippets
+++ b/.vscode/deviceSnippets.code-snippets
@@ -135,7 +135,7 @@
 		"body": [
 			"\"compat\": {",
 			"\t$LINE_COMMENT This device incorrectly ${1:[problem]}",
-			"\t\"${2|disableBasicMapping,disableStrictEntryControlDataValidation,disableStrictMeasurementValidation,enableBasicSetMapping,forceNotificationIdleReset,mapRootReportsToEndpoint,preserveRootApplicationCCValueIDs,skipConfigurationNameQuery,skipConfigurationInfoQuery,treatBasicSetAsEvent,treatMultilevelSwitchSetAsEvent,treatDestinationEndpointAsSource|}\": true",
+			"\t\"${2|disableBasicMapping,disableStrictEntryControlDataValidation,disableStrictMeasurementValidation,enableBasicSetMapping,forceNotificationIdleReset,mapRootReportsToEndpoint,preserveRootApplicationCCValueIDs,skipConfigurationNameQuery,skipConfigurationInfoQuery,treatBasicSetAsEvent,treatMultilevelSwitchSetAsEvent,treatSetAsReport,treatDestinationEndpointAsSource|}\": true",
 			"},"
 		],
 		"description": "Insert parameter condition"

--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -505,7 +505,10 @@ By default, `Multilevel Switch CC::Set` commands are ignored, because they are m
 
 ### `treatSetAsReport`
 
-By default, `all CC::Set` commands are ignored, because they are meant to control end devices. This flag causes the driver to emit a `value report`, so applications can react to these commands, e.g. for BinarySwitchCCSet and ThermostatModeCCSet.
+By default, many `Set` CC commands are ignored, because they are meant to control end devices. For some devices, those commands are the only way to receive updates about some values though.
+This flag causes the driver treat the listed commands as a report instead and issue a `value report`, so applications can react to them.
+
+> [!NOTE] This mapping is CC specific and must be implemented for every CC that needs it. Currently, only `BinarySwitchCCSet` and `ThermostatModeCCSet` are supported.
 
 ### `treatDestinationEndpointAsSource`
 

--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -503,6 +503,10 @@ By default, `Basic CC::Set` commands are interpreted as status updates. This fla
 
 By default, `Multilevel Switch CC::Set` commands are ignored, because they are meant to control end devices. This flag causes the driver to emit a `value event` for the `"event"` property instead, so applications can react to these commands, e.g. for remotes.
 
+### `treatSetAsReport`
+
+By default, `all CC::Set` commands are ignored, because they are meant to control end devices. This flag causes the driver to emit a `value report`, so applications can react to these commands, e.g. for BinarySwitchCCSet and ThermostatModeCCSet.
+
 ### `treatDestinationEndpointAsSource`
 
 Some devices incorrectly use the multi channel **destination** endpoint in reports to indicate the **source** endpoint the report originated from. When this flag is `true`, the destination endpoint is instead interpreted to be the source and the original source endpoint gets ignored.

--- a/maintenance/schemas/device-config.json
+++ b/maintenance/schemas/device-config.json
@@ -704,12 +704,12 @@
 				},
 				"treatSetAsReport": {
 					"type": "array",
-						"minItems": 1,
-						"items": {
-							"type": "string",
-							"minimum": 1
-						}
-				}
+					"minItems": 1,
+					"items": {
+						"type": "string",
+						"minLength": 1
+					}
+				},
 				"treatDestinationEndpointAsSource": {
 					"const": true
 				},

--- a/maintenance/schemas/device-config.json
+++ b/maintenance/schemas/device-config.json
@@ -702,6 +702,14 @@
 				"treatMultilevelSwitchSetAsEvent": {
 					"const": true
 				},
+				"treatSetAsReport": {
+					"type": "array",
+						"minItems": 1,
+						"items": {
+							"type": "string",
+							"minimum": 1
+						}
+				}
 				"treatDestinationEndpointAsSource": {
 					"const": true
 				},

--- a/packages/config/api.md
+++ b/packages/config/api.md
@@ -195,7 +195,7 @@ export class ConditionalCompatConfig implements ConditionalItem<CompatConfig> {
     // (undocumented)
     readonly treatMultilevelSwitchSetAsEvent?: boolean;
     // (undocumented)
-    readonly treatSetAsReport?: undefined | readonly string[];
+    readonly treatSetAsReport?: readonly string[];
     // (undocumented)
     readonly useUTCInTimeParametersCC?: boolean;
 }

--- a/packages/config/api.md
+++ b/packages/config/api.md
@@ -195,8 +195,6 @@ export class ConditionalCompatConfig implements ConditionalItem<CompatConfig> {
     // (undocumented)
     readonly treatMultilevelSwitchSetAsEvent?: boolean;
     // (undocumented)
-    readonly treatSetAsReport?: readonly string[];
-    // (undocumented)
     readonly useUTCInTimeParametersCC?: boolean;
 }
 

--- a/packages/config/api.md
+++ b/packages/config/api.md
@@ -195,6 +195,8 @@ export class ConditionalCompatConfig implements ConditionalItem<CompatConfig> {
     // (undocumented)
     readonly treatMultilevelSwitchSetAsEvent?: boolean;
     // (undocumented)
+    readonly treatSetAsReport?: undefined | readonly string[];
+    // (undocumented)
     readonly useUTCInTimeParametersCC?: boolean;
 }
 

--- a/packages/config/config/devices/0x0059/hrt4-zw.json
+++ b/packages/config/config/devices/0x0059/hrt4-zw.json
@@ -92,6 +92,7 @@
 		}
 	],
 	"compat": {
+		// The device "reports" some of its state with Set commands
 		"treatSetAsReport": ["BinarySwitchCCSet", "ThermostatModeCCSet"]
 	}
 }

--- a/packages/config/config/devices/0x0059/hrt4-zw.json
+++ b/packages/config/config/devices/0x0059/hrt4-zw.json
@@ -90,5 +90,8 @@
 			"defaultValue": 10,
 			"unsigned": true
 		}
-	]
+	],
+	"compat": {
+		"treatSetAsReport": ["BinarySwitchCCSet", "ThermostatModeCCSet"]
+	}
 }

--- a/packages/config/src/devices/CompatConfig.ts
+++ b/packages/config/src/devices/CompatConfig.ts
@@ -286,6 +286,22 @@ error in compat option treatMultilevelSwitchSetAsEvent`,
 				definition.treatMultilevelSwitchSetAsEvent;
 		}
 
+		if (definition.treatSetAsReport != undefined) {
+			if (!(isArray(definition.treatSetAsReport)
+					&& definition.treatSetAsReport.every(
+						(s) => typeof s === "string",
+					))) {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+error in compat option treatSetAsReport must be array of string`,
+				);
+			}
+
+			this.treatSetAsReport =
+				definition.treatSetAsReport;
+		}
+
 		if (definition.treatDestinationEndpointAsSource != undefined) {
 			if (definition.treatDestinationEndpointAsSource !== true) {
 				throwInvalidConfig(
@@ -616,6 +632,7 @@ compat option overrideQueries must be an object!`,
 	public readonly skipConfigurationInfoQuery?: boolean;
 	public readonly treatBasicSetAsEvent?: boolean;
 	public readonly treatMultilevelSwitchSetAsEvent?: boolean;
+	public readonly treatSetAsReport?: readonly string[];;
 	public readonly treatDestinationEndpointAsSource?: boolean;
 	public readonly useUTCInTimeParametersCC?: boolean;
 	public readonly queryOnWakeup?: readonly [
@@ -657,6 +674,7 @@ compat option overrideQueries must be an object!`,
 			"skipConfigurationInfoQuery",
 			"treatBasicSetAsEvent",
 			"treatMultilevelSwitchSetAsEvent",
+			"treatSetAsReport",
 			"treatDestinationEndpointAsSource",
 			"useUTCInTimeParametersCC",
 			"queryOnWakeup",

--- a/packages/config/src/devices/CompatConfig.ts
+++ b/packages/config/src/devices/CompatConfig.ts
@@ -289,7 +289,7 @@ error in compat option treatMultilevelSwitchSetAsEvent`,
 		if (definition.treatSetAsReport != undefined) {
 			if (!(isArray(definition.treatSetAsReport)
 					&& definition.treatSetAsReport.every(
-						(s) => typeof s === "string",
+						(stp: any) => typeof stp === "string",
 					))) {
 				throwInvalidConfig(
 					"devices",

--- a/packages/config/src/devices/CompatConfig.ts
+++ b/packages/config/src/devices/CompatConfig.ts
@@ -287,19 +287,20 @@ error in compat option treatMultilevelSwitchSetAsEvent`,
 		}
 
 		if (definition.treatSetAsReport != undefined) {
-			if (!(isArray(definition.treatSetAsReport)
+			if (
+				!(isArray(definition.treatSetAsReport)
 					&& definition.treatSetAsReport.every(
-						(stp: any) => typeof stp === "string",
-					))) {
+						(d: any) => typeof d === "string",
+					))
+			) {
 				throwInvalidConfig(
 					"devices",
 					`config/devices/${filename}:
-error in compat option treatSetAsReport must be array of string`,
+compat option treatSetAsReport must be an array of strings`,
 				);
 			}
 
-			this.treatSetAsReport =
-				definition.treatSetAsReport;
+			this.treatSetAsReport = new Set(definition.treatSetAsReport);
 		}
 
 		if (definition.treatDestinationEndpointAsSource != undefined) {
@@ -632,7 +633,7 @@ compat option overrideQueries must be an object!`,
 	public readonly skipConfigurationInfoQuery?: boolean;
 	public readonly treatBasicSetAsEvent?: boolean;
 	public readonly treatMultilevelSwitchSetAsEvent?: boolean;
-	public readonly treatSetAsReport?: readonly string[];;
+	public readonly treatSetAsReport?: ReadonlySet<string>;
 	public readonly treatDestinationEndpointAsSource?: boolean;
 	public readonly useUTCInTimeParametersCC?: boolean;
 	public readonly queryOnWakeup?: readonly [

--- a/packages/config/src/devices/DeviceConfig.ts
+++ b/packages/config/src/devices/DeviceConfig.ts
@@ -866,6 +866,7 @@ export class DeviceConfig {
 					"removeEndpoints",
 					"treatBasicSetAsEvent",
 					"treatMultilevelSwitchSetAsEvent",
+					"treatSetAsReport",
 				] as const
 			) {
 				if (this.compat[prop] != undefined) {

--- a/packages/config/src/devices/DeviceConfig.ts
+++ b/packages/config/src/devices/DeviceConfig.ts
@@ -866,7 +866,6 @@ export class DeviceConfig {
 					"removeEndpoints",
 					"treatBasicSetAsEvent",
 					"treatMultilevelSwitchSetAsEvent",
-					"treatSetAsReport",
 				] as const
 			) {
 				if (this.compat[prop] != undefined) {
@@ -890,6 +889,9 @@ export class DeviceConfig {
 			}
 			if (this.compat.removeCCs) {
 				c.removeCCs = Object.fromEntries(this.compat.removeCCs);
+			}
+			if (this.compat.treatSetAsReport) {
+				c.treatSetAsReport = [...this.compat.treatSetAsReport].sort();
 			}
 
 			c = sortObject(c);

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -61,6 +61,16 @@ import {
 	BasicCCValues,
 } from "@zwave-js/cc/BasicCC";
 import {
+	BinarySwitchCC,
+	BinarySwitchCCSet,
+	BinarySwitchCCValues,
+} from "@zwave-js/cc/BinarySwitchCC";
+import {
+	ThermostatModeCC,
+	ThermostatModeCCSet,
+	ThermostatModeCCValues,
+} from "@zwave-js/cc/ThermostatModeCC";
+import {
 	CentralSceneCCNotification,
 	CentralSceneCCValues,
 } from "@zwave-js/cc/CentralSceneCC";
@@ -3008,6 +3018,10 @@ protocol version:      ${this.protocolVersion}`;
 			return this.handleBasicCommand(command);
 		} else if (command instanceof MultilevelSwitchCC) {
 			return this.handleMultilevelSwitchCommand(command);
+		} else if (command instanceof BinarySwitchCCSet) {
+			return this.handleBinarySwitchSetCommand(command);
+		} else if (command instanceof ThermostatModeCCSet) {
+			return this.handleThermostatModeSetCommand(command);
 		} else if (command instanceof CentralSceneCCNotification) {
 			return this.handleCentralSceneNotification(command);
 		} else if (command instanceof WakeUpCCWakeUpNotification) {
@@ -3730,6 +3744,32 @@ protocol version:      ${this.protocolVersion}`;
 		}
 	}
 
+	private handleBinarySwitchSetCommand(command: BinarySwitchCC) : void {
+		if (command instanceof BinarySwitchCCSet && isArray(this._deviceConfig?.compat?.treatSetAsReport)) {
+			// Treat BinarySwitchCCSet as value report if desired
+			if (this._deviceConfig?.compat?.treatSetAsReport.indexOf("BinarySwitchCCSet")!=-1) {
+				this.driver.controllerLog.logNode(this.id, {
+					endpoint: command.endpointIndex,
+					message: "treating BinarySwitchCC::Set as a report",
+				});
+				this._valueDB.setValue(BinarySwitchCCValues.currentValue.endpoint(command.endpointIndex), command.targetValue);
+			}
+		}
+	}
+	
+	private handleThermostatModeSetCommand(command: ThermostatModeCC) : void {
+		if (command instanceof ThermostatModeCCSet && isArray(this._deviceConfig?.compat?.treatSetAsReport)) {
+			// Treat ThermostatModeCCSet as value report if desired
+			if (this._deviceConfig?.compat?.treatSetAsReport.indexOf("ThermostatModeCCSet")!=-1) {
+				this.driver.controllerLog.logNode(this.id, {
+					endpoint: command.endpointIndex,
+					message: "treating ThermostatModeCC::Set as a report",
+				});
+				this._valueDB.setValue(ThermostatModeCCValues.thermostatMode.endpoint(command.endpointIndex), command.mode);
+			}
+		}
+	}
+	
 	private async handleZWavePlusGet(command: ZWavePlusCCGet): Promise<void> {
 		const endpoint = this.getEndpoint(command.endpointIndex) ?? this;
 


### PR DESCRIPTION
Hello @AlCalzone,

i think i've understand that you mean in : https://github.com/zwave-js/node-zwave-js/pull/6415
Here is v2 :-)

I've test for BinarySwitchSet and ThermostatModeSet command as a report. It's ok
(for SRT321 HRT4-ZW)

Thank you for your advice

fixes: https://github.com/zwave-js/node-zwave-js/issues/5937