### PR TITLE
fix: make Central Scene CC scene property stateless

### DIFF
--- a/packages/cc/src/cc/CentralSceneCC.ts
+++ b/packages/cc/src/cc/CentralSceneCC.ts
@@ -82,6 +82,7 @@ export const CentralSceneCCValues = Object.freeze({
 			(sceneNumber: number) => ({
 				...ValueMetadata.ReadOnlyUInt8,
 				label: `Scene ${padStart(sceneNumber.toString(), 3, "0")}`,
+				stateful: false,
 			} as const),
 		),
 	}),


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

This value should be stateless right?
