### PR TITLE
docs: fixed multiple typos

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -332,7 +332,7 @@ To get around this:
 
 ### `getKnownLifelineRoutes`
 
-The routing table of the controller is stored in its memory and not easily accessible during normal operation. Z-Wave JS gets around this by keeping statistics for each node that include the last used routes, the used repeaters, procotol and speed, as well as RSSI readings. This information can be read using
+The routing table of the controller is stored in its memory and not easily accessible during normal operation. Z-Wave JS gets around this by keeping statistics for each node that include the last used routes, the used repeaters, protocol and speed, as well as RSSI readings. This information can be read using
 
 ```ts
 getKnownLifelineRoutes(): ReadonlyMap<number, LifelineRoutes>
@@ -635,7 +635,7 @@ interface Route {
 
 #### Manually assign custom return routes (nodes → controller or nodes → other nodes)
 
-As a last resort, the routes uses by a node can entirely be assigned manually. This uses the `Z-Wave Protocol` command class, which is used internally by the controller and Z-Wave protocol, so this should at least be considered an inofficial way to set return routes.
+As a last resort, the routes uses by a node can entirely be assigned manually. This uses the `Z-Wave Protocol` command class, which is used internally by the controller and Z-Wave protocol, so this should at least be considered an unofficial way to set return routes.
 
 Up to 4 routes for each combination of source and destination node can be set. If less routes are given, the remaining ones will be cleared. Optionally, a priority route can be set, which will always be used for the first transmission attempt. Up to 3 of the other routes will then be used as fallbacks, but no automatically determined routes will be used.
 
@@ -1554,4 +1554,4 @@ This is emitted when another node instructs Z-Wave JS to identify itself using t
 > [!NOTE] Although support for this seems to be a certification requirement, it is currently unclear how this requirement must be fulfilled for controllers. The specification only refers to nodes:
 > The node is RECOMMENDED to use a visible LED for an identify function if it has an LED. If the node is itself a light source, e.g. a light bulb, this MAY be used in place of a dedicated LED.
 >
-> The event signature may be extended to accomodate this after clarification.
+> The event signature may be extended to accommodate this after clarification.

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -1108,7 +1108,7 @@ readonly deviceConfig: DeviceConfig | undefined
 
 Contains additional information about this node, loaded from a [config file](/development/config-files.md#device-configuration-files).
 
-This information may change after an update of the config files. To check whether a change occured that requires a re-interview, use the [`hasDeviceConfigChanged`](#hasdeviceconfigchanged) method.
+This information may change after an update of the config files. To check whether a change occurred that requires a re-interview, use the [`hasDeviceConfigChanged`](#hasdeviceconfigchanged) method.
 
 ### `deviceDatabaseUrl`
 

--- a/docs/getting-started/migrating-to-v11.md
+++ b/docs/getting-started/migrating-to-v11.md
@@ -77,7 +77,7 @@ However, the type `ConfigValue` has been changed to just `number`, so we treat t
 
 ## Changed `Node.setValue` and `VirtualNode.setValue` to return a `SetValueResult`
 
-Historically, these methods returned a `boolean` indicating whether the value was successfully set or not. While convenient, simply returning `true` or `false` isn't very helpful, especially since Z-Wave JS started using Supervision whereever possible in v10.
+Historically, these methods returned a `boolean` indicating whether the value was successfully set or not. While convenient, simply returning `true` or `false` isn't very helpful, especially since Z-Wave JS started using Supervision wherever possible in v10.
 
 For example, it is not possible to know from a simple `true` whether the command was actually executed by the device or whether it just acknowledged an unsupervised command but didn't actually do anything.
 Likewise, returning `false` seems too generic when there are a multitude of possible reasons for this:

--- a/docs/getting-started/migrating-to-v12.md
+++ b/docs/getting-started/migrating-to-v12.md
@@ -6,7 +6,7 @@ A bit earlier than expected, but there were some necessary breaking changes queu
 
 Node.js 16 will reach its end-of-life on [September 11th, 2023](https://nodejs.org/en/blog/announcements/nodejs16-eol) due to OpenSSL 1.1.1's end-of-life. Due to the security implications, we've decided to drop support and require Node.js 18 from now on.
 
-Aside from the runtime changes, this has implications for applications using TypeScript or it's type-checking capabilities. The new module resolution strategy `node16` is now used, which better mimicks what Node.js actually does, including evaluating the `exports` field in `package.json`, which Z-Wave JS now also uses.
+Aside from the runtime changes, this has implications for applications using TypeScript or it's type-checking capabilities. The new module resolution strategy `node16` is now used, which better mimics what Node.js actually does, including evaluating the `exports` field in `package.json`, which Z-Wave JS now also uses.
 
 This means applications have to switch to `moduleResolution: "node16"` too, which can cause issues with other dependencies if their `exports` aren't set up correctly, e.g. hybrid CJS/ESM packages with a single `.d.ts` file for both. As described in [the TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing), hybrid packages need a separate `.d.ts` file for the `ESM` and `CommonJS` entry points, even if their content is identical.\
 Unfortunately, affected dependencies have to be fixed, like [in this example](https://github.com/express-rate-limit/express-rate-limit/issues/355). Short-term workarounds can be enabled by `yarn`'s [patch feature](https://yarnpkg.com/cli/patch).

--- a/docs/getting-started/migrating-to-v8.md
+++ b/docs/getting-started/migrating-to-v8.md
@@ -75,7 +75,7 @@ It is recommended to only query the necessary user codes on demand instead after
 
 Using the new `interview.queryAllUserCodes` property of `ZWaveOptions`, the interview behavior can be toggled back to query all codes if you wish to do so.
 
-## Restructing of the Driver's `ZWaveOptions` object
+## Restructuring of the Driver's `ZWaveOptions` object
 
 We have unified all interview behavior options under a single key (`interview`). This likely does not affect you, unless you were previously using the internal `skipInterview` property.
 The new structure simply wraps the prior key inside `interview` and adds additional options as seen below:

--- a/docs/usage/log-transports.md
+++ b/docs/usage/log-transports.md
@@ -41,7 +41,7 @@ The transport format is responsible for formatting the log output and **MUST** b
 - `colorize`: Whether log outputs should be colorized using ANSI escape codes. This can be useful if you log to a terminal.
 - `shortTimestamps`: Whether the timestamps should include only the time (`true`) or also the date (`false`).
 
-The [`log-transports` repository](https://github.com/zwave-js/log-transports) cotnains a few predefined transports that you can use.
+The [`log-transports` repository](https://github.com/zwave-js/log-transports) contains a few predefined transports that you can use.
 
 ## `JSONTransport`
 


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

PR description here

Fixed multiple typos from files:
docs/api/controller.md, docs/api/node.md, docs/getting-started/migrating-to-v11.md, docs/getting-started/migrating-to v12.md, docs/getting-started/migrating-to-v8.md, docs/usage/log-transports.md

procotol -> protocol 
inofficial -> unofficial 
accomodate -> accommodate 
occured -> occurred 
whereever -> wherever 
mimicks -> mimics 
Restructing -> Restructuring 
cotnains -> contains 