### PR TITLE
fix: allow setting `Sound Switch CC` volume

### DIFF
--- a/packages/cc/src/cc/SoundSwitchCC.ts
+++ b/packages/cc/src/cc/SoundSwitchCC.ts
@@ -286,6 +286,23 @@ export class SoundSwitchCCAPI extends CCAPI {
 					0x00, /* keep current tone */
 					value,
 				);
+			} else if (property === "volume") {
+				if (typeof value !== "number") {
+					throwWrongValueType(
+						this.ccId,
+						property,
+						"number",
+						typeof value,
+					);
+				}
+				// Allow playing a tone by first setting the volume, then the tone ID
+				this.tryGetValueDB()?.setValue(
+					SoundSwitchCCValues.volume.endpoint(
+						this.endpoint.index,
+					),
+					value,
+					{ source: "driver", updateTimestamp: false },
+				);
 			} else if (property === "toneId") {
 				if (typeof value !== "number") {
 					throwWrongValueType(


### PR DESCRIPTION
fixes: https://github.com/zwave-js/node-zwave-js/issues/6320

Setting this property doesn't do anything immediately, it just pre-sets the volume for following play commands, e.g. by setting the `toneId`