### PR TITLE
fix(config): correct product id for Fakro ZWS12

### DIFF
--- a/packages/config/config/devices/0x0085/zws12.json
+++ b/packages/config/config/devices/0x0085/zws12.json
@@ -6,7 +6,7 @@
 	"devices": [
 		{
 			"productType": "0x0002",
-			"productId": "0x0001"
+			"productId": "0x0010"
 		},
 		{
 			"productType": "0x0011",


### PR DESCRIPTION
fix(config): Correct Product ID for Fakro ZWS12 from 0x0001 to 0x0010 

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

[per page 6 of product manual downloadable at [https://docs.gofakro.com/files/DWT/programming_manual/gb/Programming_instruction_NC_814-GB_ZWS12_mobileJPG.pdf](https://docs.gofakro.com/files/DWT/programming_manual/gb/Programming_instruction_NC_814-GB_ZWS12_mobileJPG.pdf)]
