### PR TITLE
fix: preserve `stateful` and `secret` flags for dynamic CC values

### DIFF
--- a/packages/cc/src/index.ts
+++ b/packages/cc/src/index.ts
@@ -20,11 +20,6 @@ export {
 export * from "./lib/Security2/shared";
 export * from "./lib/SetValueResult";
 export { defaultCCValueOptions } from "./lib/Values";
-export type {
-	CCValue,
-	CCValueOptions,
-	DynamicCCValue,
-	StaticCCValue,
-} from "./lib/Values";
+export type { CCValueOptions } from "./lib/Values";
 export * from "./lib/_Types";
 export { utils };

--- a/packages/cc/src/index.ts
+++ b/packages/cc/src/index.ts
@@ -20,6 +20,11 @@ export {
 export * from "./lib/Security2/shared";
 export * from "./lib/SetValueResult";
 export { defaultCCValueOptions } from "./lib/Values";
-export type { CCValueOptions } from "./lib/Values";
+export type {
+	CCValue,
+	CCValueOptions,
+	DynamicCCValue,
+	StaticCCValue,
+} from "./lib/Values";
 export * from "./lib/_Types";
 export { utils };

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -7,7 +7,6 @@ import {
 	CommandClass,
 	DeviceResetLocallyCommand,
 	DoorLockMode,
-	type DynamicCCValue,
 	EntryControlDataTypes,
 	type FirmwareUpdateCapabilities,
 	type FirmwareUpdateMetaData,
@@ -27,7 +26,6 @@ import {
 	ScheduleEntryLockCommand,
 	Security2Command,
 	type SetValueAPIOptions,
-	type StaticCCValue,
 	TimeCCDateGet,
 	TimeCCTimeGet,
 	TimeCCTimeOffsetGet,
@@ -1030,17 +1028,16 @@ export class ZWaveNode extends Endpoint
 		// Check if a corresponding CC value is defined for this value ID
 		// so we can extend the returned metadata
 		const definedCCValues = getCCValues(valueId.commandClass);
-		let valueDefinition: StaticCCValue | DynamicCCValue | undefined;
 		let valueOptions: Required<CCValueOptions> | undefined;
 		let meta: ValueMetadata | undefined;
 		if (definedCCValues) {
-			valueDefinition = Object.values(definedCCValues)
+			const value = Object.values(definedCCValues)
 				.find((v) => v?.is(valueId));
-			if (valueDefinition) {
-				if (typeof valueDefinition !== "function") {
-					meta = valueDefinition.meta;
+			if (value) {
+				if (typeof value !== "function") {
+					meta = value.meta;
 				}
-				valueOptions = valueDefinition.options;
+				valueOptions = value.options;
 			}
 		}
 
@@ -1048,7 +1045,7 @@ export class ZWaveNode extends Endpoint
 		return {
 			// The priority for returned metadata is valueDB > defined value > Any (default)
 			...(existingMetadata ?? meta ?? ValueMetadata.Any),
-			// Don't allow overriding these flags:
+			// ...except for these flags, which are taken from defined values:
 			stateful: valueOptions?.stateful ?? defaultCCValueOptions.stateful,
 			secret: valueOptions?.secret ?? defaultCCValueOptions.secret,
 		};

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1034,11 +1034,12 @@ export class ZWaveNode extends Endpoint
 		let valueOptions: Required<CCValueOptions> | undefined;
 		let meta: ValueMetadata | undefined;
 		if (definedCCValues) {
-			valueDefinition = Object.values(definedCCValues).find((v) =>
-				v?.is(valueId)
-			);
-			if (valueDefinition && typeof valueDefinition !== "function") {
-				meta = valueDefinition.meta;
+			valueDefinition = Object.values(definedCCValues)
+				.find((v) => v?.is(valueId));
+			if (valueDefinition) {
+				if (typeof valueDefinition !== "function") {
+					meta = valueDefinition.meta;
+				}
 				valueOptions = valueDefinition.options;
 			}
 		}
@@ -1047,15 +1048,9 @@ export class ZWaveNode extends Endpoint
 		return {
 			// The priority for returned metadata is valueDB > defined value > Any (default)
 			...(existingMetadata ?? meta ?? ValueMetadata.Any),
-			// For static values, don't allow overriding these flags with dynamic metadata
-			stateful: (typeof valueDefinition === "function"
-				? existingMetadata?.stateful
-				: valueOptions?.stateful)
-				?? defaultCCValueOptions.stateful,
-			secret: (typeof valueDefinition === "function"
-				? existingMetadata?.secret
-				: valueOptions?.secret)
-				?? defaultCCValueOptions.secret,
+			// Don't allow overriding these flags:
+			stateful: valueOptions?.stateful ?? defaultCCValueOptions.stateful,
+			secret: valueOptions?.secret ?? defaultCCValueOptions.secret,
 		};
 	}
 


### PR DESCRIPTION
https://github.com/zwave-js/node-zwave-js/pull/5467 added support for these flags, and made it so they couldn't be overridden by dynamic metadata. However the logic didn't consider that `.options` is always static, even on dynamic values, while `.meta` isn't - leading to the `stateful` and `secret` flags being ignored for dynamic CC values.