### PR TITLE
fix(config): tweak z-trm6 options

### DIFF
--- a/packages/config/config/devices/0x019b/z-trm6.json
+++ b/packages/config/config/devices/0x019b/z-trm6.json
@@ -47,6 +47,7 @@
 			"minValue": 0,
 			"maxValue": 5,
 			"defaultValue": 1,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Floor",
@@ -82,6 +83,7 @@
 			"minValue": 0,
 			"maxValue": 7,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "10",
@@ -208,6 +210,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Hysteresis",
@@ -235,6 +238,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Setpoint",
@@ -368,6 +372,7 @@
 			"minValue": 0,
 			"maxValue": 3,
 			"defaultValue": 1,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Off",
@@ -394,6 +399,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disabled",

--- a/packages/config/config/devices/0x019b/z-trm6.json
+++ b/packages/config/config/devices/0x019b/z-trm6.json
@@ -44,8 +44,6 @@
 			"#": "2",
 			"label": "Sensor Mode",
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 5,
 			"defaultValue": 1,
 			"allowManualEntry": false,
 			"options": [
@@ -80,8 +78,6 @@
 			"label": "External Sensor Resistance",
 			"valueSize": 1,
 			"unit": "kΩ",
-			"minValue": 0,
-			"maxValue": 7,
 			"defaultValue": 0,
 			"allowManualEntry": false,
 			"options": [
@@ -207,8 +203,6 @@
 			"#": "13",
 			"label": "Regulation Mode",
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
 			"defaultValue": 0,
 			"allowManualEntry": false,
 			"options": [
@@ -235,8 +229,6 @@
 			"#": "15",
 			"label": "Temperature Display",
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
 			"defaultValue": 0,
 			"allowManualEntry": false,
 			"options": [
@@ -369,8 +361,6 @@
 			"#": "27",
 			"label": "Operating Mode",
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 3,
 			"defaultValue": 1,
 			"allowManualEntry": false,
 			"options": [
@@ -396,8 +386,6 @@
 			"#": "28",
 			"label": "Open Window Detection",
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
 			"defaultValue": 0,
 			"allowManualEntry": false,
 			"options": [


### PR DESCRIPTION
This is mainly a cosmetic fix for HA.
These predefined options, but since we allow manual entry Home-Assistant doesn´t list the options.
