### PR TITLE
fix: reopen serial port if controller is missing ACKs after soft-reset

### DIFF
--- a/packages/serial/src/SerialPortBindingMock.ts
+++ b/packages/serial/src/SerialPortBindingMock.ts
@@ -151,6 +151,7 @@ export const MockBinding: MockBindingInterface = {
 
 interface MockPortBindingEvents {
 	write: (data: Buffer) => void;
+	close: () => void;
 }
 
 /**
@@ -221,6 +222,8 @@ export class MockPortBinding extends TypedEventEmitter<MockPortBindingEvents>
 		if (this.pendingRead) {
 			this.pendingRead(new CanceledError("port is closed"));
 		}
+
+		this.emit("close");
 	}
 
 	async read(

--- a/packages/zwave-js/src/lib/test/driver/unresponsiveStick.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/unresponsiveStick.test.ts
@@ -63,6 +63,10 @@ integrationTest(
 			testingHooks: {
 				skipNodeInterview: true,
 			},
+			attempts: {
+				// Spend less time waiting
+				controller: 1,
+			},
 		},
 
 		async customSetup(driver, mockController, mockNode) {


### PR DESCRIPTION
With this PR, we no longer restart the driver when the controller does not ACK our commands.
Instead, we now reopen the serial port, hoping that this restarts the controller (at least it should for some 500 series ones). If it doesn't help, we just carry on and hope that the controller recovers itself at some point.

for https://github.com/zwave-js/node-zwave-js/issues/6402