### PR TITLE
fix(config): correct device label for Airzone Aidoo Control HVAC unit

### DIFF
--- a/packages/config/config/devices/0x044e/AZAI6ZWEFU2.json
+++ b/packages/config/config/devices/0x044e/AZAI6ZWEFU2.json
@@ -1,7 +1,7 @@
 {
 	"manufacturer": "Airzone",
 	"manufacturerId": "0x044e",
-	"label": "AZAI6WSPFU2",
+	"label": "AZAI6ZWEFU2",
 	"description": "Aidoo Control HVAC Unit",
 	"devices": [
 		{


### PR DESCRIPTION
Fix device name & label for Airzone Aidoo Control HVAC unit