### PR TITLE
fix(config): add missing units and firmware condition for Heatit Z-Temp2

### DIFF
--- a/packages/config/config/devices/0x019b/z-temp2.json
+++ b/packages/config/config/devices/0x019b/z-temp2.json
@@ -161,6 +161,7 @@
 		},
 		{
 			"#": "15",
+			"$if": "firmwareVersion >= 1.2",
 			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Invert Output",
 			"valueSize": 2

--- a/packages/config/config/devices/0x019b/z-temp2.json
+++ b/packages/config/config/devices/0x019b/z-temp2.json
@@ -142,6 +142,7 @@
 			"label": "External Relay and Operating State Update Interval",
 			"description": "How often the devices sends Binary Switch State and Thermostat Mode in addition to change reports",
 			"valueSize": 2,
+			"unit": "minutes",
 			"minValue": 0,
 			"maxValue": 240,
 			"defaultValue": 0,


### PR DESCRIPTION
Firmware version 1.2 is required for parameter 15 (ref manuals here: https://heatit.com/produkt/9437/heatit-z-temp2-white-ral-9003).

Also added missing "minutes" unit on parameter 13