### PR TITLE
fix(config): label and parameter definitions for Sensative Drip 700

### DIFF
--- a/packages/config/config/devices/0x019a/11_04_21_22_28.json
+++ b/packages/config/config/devices/0x019a/11_04_21_22_28.json
@@ -29,7 +29,7 @@
 		},
 		{
 			"#": "4",
-			"label": "Temperature reporting type",
+			"label": "Temperature Reporting",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 3,

--- a/packages/config/config/devices/0x019a/11_04_21_22_28.json
+++ b/packages/config/config/devices/0x019a/11_04_21_22_28.json
@@ -29,11 +29,11 @@
 		},
 		{
 			"#": "4",
-			"label": "Temperature & Humidity Reporting",
+			"label": "Temperature reporting type",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 3,
-			"defaultValue": 2,
+			"defaultValue": 0,
 			"options": [
 				{
 					"label": "Disable",
@@ -65,7 +65,7 @@
 		{
 			"#": "7",
 			"label": "High Temperature Threshold",
-			"valueSize": 2,
+			"valueSize": 1,
 			"unit": "°C",
 			"minValue": -20,
 			"maxValue": 80,
@@ -74,7 +74,7 @@
 		{
 			"#": "8",
 			"label": "Low Temperature Threshold",
-			"valueSize": 2,
+			"valueSize": 1,
 			"unit": "°C",
 			"minValue": -20,
 			"maxValue": 60,


### PR DESCRIPTION
fix for issue 6509.

Following discrepancies have been corrected:
1. Label for config parameter 4
2. Corrected 'defaultValue' for config parameter 4
3. Config parameter size for parameters 7 & 8

Affects:

**Device information**
Manufacturer: Sensative (0x019A)
Model name: "11 04 021/022/028"