### PR TITLE
feat(config): add a new productId and add parameters to 14297/ZW1002 outlet

### DIFF
--- a/packages/config/config/devices/0x0063/14297_zw1002.json
+++ b/packages/config/config/devices/0x0063/14297_zw1002.json
@@ -7,10 +7,26 @@
 		{
 			"productType": "0x4952",
 			"productId": "0x3233"
+		},
+		{
+			"productType": "0x4952",
+			"productId": "0x3236"
 		}
 	],
 	"firmwareVersion": {
 		"min": "0.0",
 		"max": "255.255"
+	},
+	"paramInformation": [
+		{
+			"#": "3",
+			"$import": "~/templates/master_template.json#led_indicator_three_options"
+		}
+	],
+	"metadata": {
+		"inclusion": "Follow the instructions for your Z-Wave certified\ncontroller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and\nrelease the Program Button to add it in the network",
+		"exclusion": "1. Follow the instructions for your Z-Wave certified controller to\nremove a device from the Z-Wave network.\n2. Once the controller is ready to remove your device, press and\nrelease the manual/program button to remove it from the\nnetwork",
+		"reset": "Press the button 3 times, then press and hold the button for at least 3\nseconds. The LED will blink 5 times to confirm.\nNOTE: This should only be used in the event your network’s primary\ncontroller is missing or otherwise inoperable",
+		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/2236/14288%20QSG%20v1.pdf"
 	}
 }


### PR DESCRIPTION
Label is the same but I got one with a newer product Id.

Also added the parameters/metadata from the other zw1002 entry as the configuration parameters are the same. (as written on the manual in the box)