### PR TITLE
feat: expose rebuild routes progress as a controller property

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -1233,6 +1233,14 @@ readonly isRebuildingRoutes: boolean;
 
 Returns whether the routes are currently being rebuilt for one or more nodes.
 
+### `rebuildRoutesProgress`
+
+```ts
+readonly rebuildRoutesProgress: ReadonlyMap<number, RebuildRoutesStatus> | undefined;
+```
+
+If routes are currently being rebuilt for the entire network, this returns the current progress as a map of each node's ID and its status.
+
 ### `inclusionState`
 
 ```ts

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -3890,6 +3890,20 @@ supported CCs: ${
 	}
 
 	private _rebuildRoutesProgress = new Map<number, RebuildRoutesStatus>();
+	/**
+	 * If routes are currently being rebuilt for the entire network, this returns the current progress.
+	 * The information is the same as in the `"rebuild routes progress"` event.
+	 */
+	public get rebuildRoutesProgress():
+		| ReadonlyMap<
+			number,
+			RebuildRoutesStatus
+		>
+		| undefined
+	{
+		if (!this._isRebuildingRoutes) return undefined;
+		return new Map(this._rebuildRoutesProgress);
+	}
 
 	/**
 	 * Starts the process of rebuilding routes for all alive nodes in the network,
@@ -4053,6 +4067,7 @@ supported CCs: ${
 		}
 		// We're done!
 		this._isRebuildingRoutes = false;
+		this._rebuildRoutesProgress.clear();
 	}
 
 	/**
@@ -4072,6 +4087,8 @@ supported CCs: ${
 				|| t.message instanceof DeleteReturnRouteRequest
 				|| t.message instanceof AssignReturnRouteRequest,
 		);
+
+		this._rebuildRoutesProgress.clear();
 
 		return true;
 	}


### PR DESCRIPTION
For some reason we were storing the progress but not exposing it before.