### PR TITLE
fix(config): override user code count for Yale ZW2 locks to expose admin code

### DIFF
--- a/packages/config/config/devices/0x0129/yrc_yrd_226_246_256_446-zw2.json
+++ b/packages/config/config/devices/0x0129/yrc_yrd_226_246_256_446-zw2.json
@@ -111,7 +111,7 @@
 		],
 		"overrideQueries": {
 			// The lock reports support for 250 lock codes, but slot 251 is
-			// the master code which isn't available otherwise in CC version 1.
+			// the admin code which isn't available otherwise in CC version 1.
 			"User Code": [
 				{
 					"method": "getUsersCount",

--- a/packages/config/config/devices/0x0129/yrc_yrd_226_246_256_446-zw2.json
+++ b/packages/config/config/devices/0x0129/yrc_yrd_226_246_256_446-zw2.json
@@ -108,7 +108,17 @@
 			{
 				"$import": "templates/yale_template.json#alarm_map_auto_relock"
 			}
-		]
+		],
+		"overrideQueries": {
+			// The lock reports support for 250 lock codes, but slot 251 is
+			// the master code which isn't available otherwise in CC version 1.
+			"User Code": [
+				{
+					"method": "getUsersCount",
+					"result": 251
+				}
+			]
+		}
 	},
 	"metadata": {
 		"inclusion": "Enter the 4-8 master Pin code followed by the gear key.\nPress the 7 key followed by the gear key\nPress the 1 key followed by the gear key",


### PR DESCRIPTION
for https://github.com/zwave-js/node-zwave-js/discussions/6527

waiting on confirmation