### PR TITLE
feat(config): add ZVIDAR Z-TRV-V01 thermostatic valve

### DIFF
--- a/packages/config/config/devices/0x045a/Z-TRV-V01.json
+++ b/packages/config/config/devices/0x045a/Z-TRV-V01.json
@@ -2,7 +2,7 @@
 	"manufacturer": "ZVIDAR",
 	"manufacturerId": "0x045a",
 	"label": "Z-TRV-V01",
-	"description": "Thermostatic radiator valve",
+	"description": "Thermostatic Radiator Valve",
 	"devices": [
 		{
 			"productType": "0x0000",
@@ -16,19 +16,19 @@
 	"paramInformation": [
 		{
 			"#": "1",
-			"label": "Open window detect function",
-			"description": "When use radiator to heating, the window is opened, when room temperature drop 6°c in 4 minutes, TRV will close valve automatic, display will show ”OP”. When window is closed, meanwhile room temperature increase 2°c, TRV will open valve automatic, back to operation mode",
-			"$import": "~/templates/master_template.json#base_enable_disable"
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Open Window Detect Function",
+			"description": "When use radiator to heating, the window is opened, when room temperature drop 6°c in 4 minutes, TRV will close valve automatic, display will show 'OP'. When window is closed, meanwhile room temperature increase 2°c, TRV will open valve automatic, back to operation mode"
 		},
 		{
 			"#": "2",
-			"label": "Anti-freezing function",
-			"description": "The TRV is at “off” state, the screen show. Anti-freezing function: the valve will be opened when the temperature is below 5°c, when the temperature risees to 8°c, the valve will be closed.",
-			"$import": "~/templates/master_template.json#base_enable_disable"
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Anti-Freezing Function",
+			"description": "The TRV is at 'off' state, the screen show. Anti-freezing function:  the valve will be opened when the temperature is below 5°c, when the temperature risees to 8°c, the valve will be closed."
 		},
 		{
 			"#": "3",
-			"label": "Mesured temperature offset",
+			"label": "Mesured Temperature Offset",
 			"description": "Offsets the measured temperature by -6.0°c – 6.0°c.",
 			"valueSize": 1,
 			"minValue": -6,
@@ -37,11 +37,9 @@
 		},
 		{
 			"#": "4",
-			"label": "Set away home mode",
-			"description": "Set away home mode",
+			"label": "Set Away Home Mode",
 			"valueSize": 1,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
@@ -56,14 +54,13 @@
 		},
 		{
 			"#": "5",
-			"label": "Anti-scale function",
-			"description": "If radiator not open within two weeks or long time not open will let valve clogged as scale, radiator will be damaged. In order to let radiator to use normally, TRV will open valave running 30 seconds every two weeks, display will show “AS”, when run finished will recovery running condition.",
-			"$import": "~/templates/master_template.json#base_enable_disable"
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Anti-Scale Function",
+			"description": "If radiator not open within two weeks or long time not open will let valve clogged as scale, radiator will be damaged. In order to let radiator to use normally, TRV will open valave running 30 seconds every two weeks, display will show 'AS', when run finished will recovery running condition."
 		},
 		{
 			"#": "6",
-			"label": "Valve openning level report threshold",
-			"description": "Valve opening level change threshold.",
+			"label": "Valve Openning Level Report Threshold",
 			"valueSize": 1,
 			"unit": "%",
 			"minValue": 0,
@@ -72,10 +69,10 @@
 		},
 		{
 			"#": "7",
-			"label": "Temperature auto report interval time",
+			"label": "Temperature Auto Report Interval Time",
 			"description": "The time interval when to send the temperature report.",
 			"valueSize": 4,
-			"unit": "second",
+			"unit": "seconds",
 			"minValue": 0,
 			"maxValue": 267840,
 			"defaultValue": 0,
@@ -88,8 +85,7 @@
 		},
 		{
 			"#": "8",
-			"label": "Temperature change report threshold",
-			"description": "Temperature change threshold.",
+			"label": "Temperature Change Report Threshold",
 			"valueSize": 1,
 			"unit": "0.1°c",
 			"minValue": 0,
@@ -98,10 +94,10 @@
 		},
 		{
 			"#": "9",
-			"label": "Battery auto report interval time",
+			"label": "Battery Auto Report Interval Time",
 			"description": "The time interval when to send the battery report.",
 			"valueSize": 4,
-			"unit": "second",
+			"unit": "seconds",
 			"minValue": 0,
 			"maxValue": 267840,
 			"defaultValue": 0,
@@ -114,8 +110,7 @@
 		},
 		{
 			"#": "10",
-			"label": "Battery change report threshold",
-			"description": "Battery power change threshold.",
+			"label": "Battery Change Report Threshold",
 			"valueSize": 1,
 			"unit": "%",
 			"minValue": 0,
@@ -130,35 +125,34 @@
 		},
 		{
 			"#": "11",
-			"label": "Enable child lock",
-			"description": "Enable or disable child lock.",
-			"$import": "~/templates/master_template.json#base_enable_disable"
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Child Lock"
 		},
 		{
 			"#": "12",
-			"label": "Enable or disable external temperature sensor",
-			"description": "Enable or disable TRV to use external temperature sensor's value as reference to control the  valve accordingly.",
-			"$import": "~/templates/master_template.json#base_enable_disable"
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "External Temperature Sensor",
+			"description": "Enable or disable TRV to use external temperature sensor's value as reference to control the  valve accordingly."
 		},
 		{
 			"#": "13",
-			"label": "External temperature value",
+			"label": "External Temperature Value",
 			"description": "Use this parameter to send an external temperature value to TRV.",
 			"valueSize": 2,
 			"unit": "0.1°c",
-			"defaultValue": 0,
 			"minValue": -500,
-			"maxValue": 500
+			"maxValue": 500,
+			"defaultValue": 0
 		},
 		{
 			"#": "14",
-			"label": "External temperature value timeout setting",
+			"label": "External Temperature Value Timeout Setting",
 			"description": "Timeout interval for TRV to receive temperature value from other devices of gateway. TRV will use this temperature value to act accordingly if the value is received befire this timeout. Otherwise, TRV will refer to its own internal temperature value.",
 			"valueSize": 2,
-			"unit": "minute",
-			"defaultValue": 30,
+			"unit": "minutes",
 			"minValue": 0,
 			"maxValue": 300,
+			"defaultValue": 30,
 			"options": [
 				{
 					"label": "No timeout",
@@ -168,8 +162,8 @@
 		}
 	],
 	"metadata": {
-		"inclusion": "1. Power on your TRV. \n2. Set your Z-Wave controller into add/inclusion mode.\n3. In ”OF” state, short press rotary plate three times unit this screen shows ”--”.\n4. The screen will show ”PA” after few seconds, whick meant the inclusion is successful. And the signal icon will light on. Otherwise, the inclusion is failed, which you will need to repeat the process.",
-		"exclusion": "1. Power on your TRV. \n2. Put your Z-Wave controller into exclusion mode by following the instructions provided by the controller manufacturer. \n3. In ”OF” state, short press rotary plate three times unit this screen shows ”--”.\n4. The screen will turn back to ”OF” after few seconds. which meant the exclusion is successful. The signal light turn off.",
-		"reset": "Use this procedure only in the event that the primary controller is lost or otherwise inoperable. \n1. In ”OF” state, hold rotary plate for at least 5 seconds and release when screen will blink ”OF”. When successful, the screen will show ”OF” in solid for 2 seconds then turn off."
+		"inclusion": "1. Power on your TRV. \n2. Set your Z-Wave controller into add/inclusion mode.\n3. In 'OF' state, short press rotary plate three times unit this screen shows '--'.\n4. The screen will show 'PA' after few seconds, whick meant the inclusion is successful. And the signal icon will light on. Otherwise, the inclusion is failed, which you will need to repeat the process.",
+		"exclusion": "1. Power on your TRV. \n2. Put your Z-Wave controller into exclusion mode by following the instructions provided by the controller manufacturer. \n3. In 'OF' state, short press rotary plate three times unit this screen shows '--'.\n4. The screen will turn back to 'OF' after few seconds. which meant the exclusion is successful. The signal light turn off.",
+		"reset": "Use this procedure only in the event that the primary controller is lost or otherwise inoperable. \n1. In 'OF' state, hold rotary plate for at least 5 seconds and release when screen will blink 'OF'. When successful, the screen will show 'OF' in solid for 2 seconds then turn off."
 	}
 }

--- a/packages/config/config/devices/0x045a/Z-TRV-V01.json
+++ b/packages/config/config/devices/0x045a/Z-TRV-V01.json
@@ -1,0 +1,171 @@
+{
+	"manufacturer": "ZVIDAR",
+	"manufacturerId": "0x045a",
+	"label": "Z-TRV-V01",
+	"description": "Thermostatic radiator valve",
+	"devices": [
+		{
+			"productType": "0x0000",
+			"productId": "0x0400"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"label": "Open window detect function",
+			"description": "When use radiator to heating, the window is opened, when room temperature drop 6°c in 4 minutes, TRV will close valve automatic, display will show ”OP”. When window is closed, meanwhile room temperature increase 2°c, TRV will open valve automatic, back to operation mode",
+			"$import": "~/templates/master_template.json#base_enable_disable"
+		},
+		{
+			"#": "2",
+			"label": "Anti-freezing function",
+			"description": "The TRV is at “off” state, the screen show. Anti-freezing function: the valve will be opened when the temperature is below 5°c, when the temperature risees to 8°c, the valve will be closed.",
+			"$import": "~/templates/master_template.json#base_enable_disable"
+		},
+		{
+			"#": "3",
+			"label": "Mesured temperature offset",
+			"description": "Offsets the measured temperature by -6.0°c – 6.0°c.",
+			"valueSize": 1,
+			"minValue": -6,
+			"maxValue": 6,
+			"defaultValue": 0
+		},
+		{
+			"#": "4",
+			"label": "Set away home mode",
+			"description": "Set away home mode",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "No",
+					"value": 0
+				},
+				{
+					"label": "Yes",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "5",
+			"label": "Anti-scale function",
+			"description": "If radiator not open within two weeks or long time not open will let valve clogged as scale, radiator will be damaged. In order to let radiator to use normally, TRV will open valave running 30 seconds every two weeks, display will show “AS”, when run finished will recovery running condition.",
+			"$import": "~/templates/master_template.json#base_enable_disable"
+		},
+		{
+			"#": "6",
+			"label": "Valve openning level report threshold",
+			"description": "Valve opening level change threshold.",
+			"valueSize": 1,
+			"unit": "%",
+			"minValue": 0,
+			"maxValue": 100,
+			"defaultValue": 1
+		},
+		{
+			"#": "7",
+			"label": "Temperature auto report interval time",
+			"description": "The time interval when to send the temperature report.",
+			"valueSize": 4,
+			"unit": "second",
+			"minValue": 0,
+			"maxValue": 267840,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
+		},
+		{
+			"#": "8",
+			"label": "Temperature change report threshold",
+			"description": "Temperature change threshold.",
+			"valueSize": 1,
+			"unit": "0.1°c",
+			"minValue": 0,
+			"maxValue": 100,
+			"defaultValue": 5
+		},
+		{
+			"#": "9",
+			"label": "Battery auto report interval time",
+			"description": "The time interval when to send the battery report.",
+			"valueSize": 4,
+			"unit": "second",
+			"minValue": 0,
+			"maxValue": 267840,
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
+		},
+		{
+			"#": "10",
+			"label": "Battery change report threshold",
+			"description": "Battery power change threshold.",
+			"valueSize": 1,
+			"unit": "%",
+			"minValue": 0,
+			"maxValue": 100,
+			"defaultValue": 5,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
+		},
+		{
+			"#": "11",
+			"label": "Enable child lock",
+			"description": "Enable or disable child lock.",
+			"$import": "~/templates/master_template.json#base_enable_disable"
+		},
+		{
+			"#": "12",
+			"label": "Enable or disable external temperature sensor",
+			"description": "Enable or disable TRV to use external temperature sensor's value as reference to control the  valve accordingly.",
+			"$import": "~/templates/master_template.json#base_enable_disable"
+		},
+		{
+			"#": "13",
+			"label": "External temperature value",
+			"description": "Use this parameter to send an external temperature value to TRV.",
+			"valueSize": 2,
+			"unit": "0.1°c",
+			"minValue": -500,
+			"maxValue": 500
+		},
+		{
+			"#": "14",
+			"label": "External temperature value timeout setting",
+			"description": "Timeout interval for TRV to receive temperature value from other devices of gateway. TRV will use this temperature value to act accordingly if the value is received befire this timeout. Otherwise, TRV will refer to its own internal temperature value.",
+			"valueSize": 2,
+			"unit": "minute",
+			"minValue": 0,
+			"maxValue": 300,
+			"options": [
+				{
+					"label": "No timeout",
+					"value": 0
+				}
+			]
+		}
+	],
+	"metadata": {
+		"inclusion": "1. Power on your TRV. \n2. Set your Z-Wave controller into add/inclusion mode.\n3. In ”OF” state, short press rotary plate three times unit this screen shows ”--”.\n4. The screen will show ”PA” after few seconds, whick meant the inclusion is successful. And the signal icon will light on. Otherwise, the inclusion is failed, which you will need to repeat the process.",
+		"exclusion": "1. Power on your TRV. \n2. Put your Z-Wave controller into exclusion mode by following the instructions provided by the controller manufacturer. \n3. In ”OF” state, short press rotary plate three times unit this screen shows ”--”.\n4. The screen will turn back to ”OF” after few seconds. which meant the exclusion is successful. The signal light turn off.",
+		"reset": "Use this procedure only in the event that the primary controller is lost or otherwise inoperable. \n1. In ”OF” state, hold rotary plate for at least 5 seconds and release when screen will blink ”OF”. When successful, the screen will show ”OF” in solid for 2 seconds then turn off."
+	}
+}

--- a/packages/config/config/devices/0x045a/Z-TRV-V01.json
+++ b/packages/config/config/devices/0x045a/Z-TRV-V01.json
@@ -41,6 +41,8 @@
 			"description": "Set away home mode",
 			"valueSize": 1,
 			"defaultValue": 0,
+			"unsigned": true,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "No",
@@ -144,6 +146,7 @@
 			"description": "Use this parameter to send an external temperature value to TRV.",
 			"valueSize": 2,
 			"unit": "0.1°c",
+			"defaultValue": 0,
 			"minValue": -500,
 			"maxValue": 500
 		},
@@ -153,6 +156,7 @@
 			"description": "Timeout interval for TRV to receive temperature value from other devices of gateway. TRV will use this temperature value to act accordingly if the value is received befire this timeout. Otherwise, TRV will refer to its own internal temperature value.",
 			"valueSize": 2,
 			"unit": "minute",
+			"defaultValue": 30,
 			"minValue": 0,
 			"maxValue": 300,
 			"options": [

--- a/packages/config/config/devices/0x045a/Z-TRV-V01.json
+++ b/packages/config/config/devices/0x045a/Z-TRV-V01.json
@@ -17,50 +17,38 @@
 		{
 			"#": "1",
 			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Open Window Detect Function",
-			"description": "When use radiator to heating, the window is opened, when room temperature drop 6°c in 4 minutes, TRV will close valve automatic, display will show 'OP'. When window is closed, meanwhile room temperature increase 2°c, TRV will open valve automatic, back to operation mode"
+			"label": "Open Window Detection",
+			"description": "When the room temperature drops by 6 °C in 4 minutes while heating, TRV will automatically close the valve and display 'OP'. When the room temperature increases by 2 °C again, normal operation resumes."
 		},
 		{
 			"#": "2",
 			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Anti-Freezing Function",
-			"description": "The TRV is at 'off' state, the screen show. Anti-freezing function:  the valve will be opened when the temperature is below 5°c, when the temperature risees to 8°c, the valve will be closed."
+			"description": "When the room temperature drops below 5 °C while, the thermostat automatically turns on until the temperature rises to 8 °C"
 		},
 		{
 			"#": "3",
-			"label": "Mesured Temperature Offset",
-			"description": "Offsets the measured temperature by -6.0°c – 6.0°c.",
+			"label": "Temperature Calibration",
 			"valueSize": 1,
+			"unit": "°C",
 			"minValue": -6,
 			"maxValue": 6,
 			"defaultValue": 0
 		},
 		{
 			"#": "4",
-			"label": "Set Away Home Mode",
-			"valueSize": 1,
-			"defaultValue": 0,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "No",
-					"value": 0
-				},
-				{
-					"label": "Yes",
-					"value": 1
-				}
-			]
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Away Mode"
 		},
 		{
 			"#": "5",
 			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Anti-Scale Function",
-			"description": "If radiator not open within two weeks or long time not open will let valve clogged as scale, radiator will be damaged. In order to let radiator to use normally, TRV will open valave running 30 seconds every two weeks, display will show 'AS', when run finished will recovery running condition."
+			"description": "Operate the valve for 30 seconds every two weeks to keep it operational. The display will show 'AS' and return to normal operation afterwards."
 		},
 		{
 			"#": "6",
-			"label": "Valve Openning Level Report Threshold",
+			"label": "Valve Opening Level Report Threshold",
 			"valueSize": 1,
 			"unit": "%",
 			"minValue": 0,
@@ -69,8 +57,7 @@
 		},
 		{
 			"#": "7",
-			"label": "Temperature Auto Report Interval Time",
-			"description": "The time interval when to send the temperature report.",
+			"label": "Temperature Report Interval",
 			"valueSize": 4,
 			"unit": "seconds",
 			"minValue": 0,
@@ -87,15 +74,14 @@
 			"#": "8",
 			"label": "Temperature Change Report Threshold",
 			"valueSize": 1,
-			"unit": "0.1°c",
+			"unit": "0.1 °C",
 			"minValue": 0,
 			"maxValue": 100,
 			"defaultValue": 5
 		},
 		{
 			"#": "9",
-			"label": "Battery Auto Report Interval Time",
-			"description": "The time interval when to send the battery report.",
+			"label": "Battery Report Interval",
 			"valueSize": 4,
 			"unit": "seconds",
 			"minValue": 0,
@@ -132,22 +118,22 @@
 			"#": "12",
 			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "External Temperature Sensor",
-			"description": "Enable or disable TRV to use external temperature sensor's value as reference to control the  valve accordingly."
+			"description": "Use an external temperature sensor's value (parameter 13) instead of the internal sensor."
 		},
 		{
 			"#": "13",
 			"label": "External Temperature Value",
-			"description": "Use this parameter to send an external temperature value to TRV.",
+			"description": "Use this parameter to send an external temperature value to the TRV.",
 			"valueSize": 2,
-			"unit": "0.1°c",
+			"unit": "0.1 °C",
 			"minValue": -500,
 			"maxValue": 500,
 			"defaultValue": 0
 		},
 		{
 			"#": "14",
-			"label": "External Temperature Value Timeout Setting",
-			"description": "Timeout interval for TRV to receive temperature value from other devices of gateway. TRV will use this temperature value to act accordingly if the value is received befire this timeout. Otherwise, TRV will refer to its own internal temperature value.",
+			"label": "External Temperature Value Timeout",
+			"description": "How long to wait for an update from the external temperature sensor before reverting to the internal sensor.",
 			"valueSize": 2,
 			"unit": "minutes",
 			"minValue": 0,


### PR DESCRIPTION
I add support for thermostatic valve from ZVIDAR. I found manufacturer ID 0x045a from zwavejs server logs, productId from zwave alliance listing https://products.z-wavealliance.org/products/4819. I'm not sure which product type it is.

Parameters come from product documentation.