### PR TITLE
fix(config): correct parameter 5 size for Zooz ZEN34

### DIFF
--- a/packages/config/config/devices/0x027a/zen34.json
+++ b/packages/config/config/devices/0x027a/zen34.json
@@ -156,7 +156,7 @@
 			"#": "5",
 			"$if": "firmwareVersion >= 1.40",
 			"label": "Dimmer Control Group: Dimming Duration",
-			"valueSize": 2,
+			"valueSize": 1,
 			"unit": "seconds",
 			"minValue": 1,
 			"maxValue": 99,


### PR DESCRIPTION
I have tested this change by replacing this file via the Z-Wave JS UI store section and restarting.