### PR TITLE
feat(config): add new product ID to Fibaro FGS-213

### DIFF
--- a/packages/config/config/devices/0x010f/fgs213.json
+++ b/packages/config/config/devices/0x010f/fgs213.json
@@ -18,6 +18,10 @@
 		},
 		{
 			"productType": "0x0403",
+			"productId": "0x4000"
+		},
+		{
+			"productType": "0x0403",
 			"productId": "0x6000"
 		}
 	],


### PR DESCRIPTION
Added new product id 0x4000 in accordance to technical data https://manual.zwave.eu/backend/make.php?lang=en&sku=FGS-213&cert=ZC10-19076667&type=mini
