### PR TITLE
fix(lint): compatibility of ESLint plugin with Node.js 18

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-device-config-property-order.ts
+++ b/packages/eslint-plugin/src/rules/consistent-device-config-property-order.ts
@@ -80,8 +80,8 @@ export const consistentDeviceConfigPropertyOrder: JSONCRule.RuleModule = {
 							0,
 							withRanges[0].property.loc.start.column,
 						);
-
-					const desiredOrder = propsWithComments.toSorted((a, b) =>
+						// TODO: Change to .toSorted() once on node 20.
+						const desiredOrder = [...propsWithComments].sort((a, b) =>
 						a.index - b.index
 					).map((prop) => {
 						const start = Math.min(

--- a/packages/eslint-plugin/src/rules/consistent-device-config-property-order.ts
+++ b/packages/eslint-plugin/src/rules/consistent-device-config-property-order.ts
@@ -48,7 +48,7 @@ export const consistentDeviceConfigPropertyOrder: JSONCRule.RuleModule = {
 							.filter(
 								(c) =>
 									c.loc?.start.line
-										=== prev.property.loc.end.line,
+									=== prev.property.loc.end.line,
 							);
 						prev.comments.trailing.push(
 							...wronglyAttributedComments,
@@ -80,8 +80,8 @@ export const consistentDeviceConfigPropertyOrder: JSONCRule.RuleModule = {
 							0,
 							withRanges[0].property.loc.start.column,
 						);
-						// TODO: Change to .toSorted() once on node 20.
-						const desiredOrder = [...propsWithComments].sort((a, b) =>
+					// TODO: Change to .toSorted() once on node 20.
+					const desiredOrder = [...propsWithComments].sort((a, b) =>
 						a.index - b.index
 					).map((prop) => {
 						const start = Math.min(
@@ -161,8 +161,7 @@ export const consistentDeviceConfigPropertyOrder: JSONCRule.RuleModule = {
 		schema: [],
 		messages: {
 			"parameter-ordering":
-				`For consistency, config param properties should follow the order ${
-					paramInfoPropertyOrder.map((p) => `"${p}"`).join(", ")
+				`For consistency, config param properties should follow the order ${paramInfoPropertyOrder.map((p) => `"${p}"`).join(", ")
 				}.`,
 		},
 		type: "problem",

--- a/packages/eslint-plugin/src/rules/consistent-device-config-property-order.ts
+++ b/packages/eslint-plugin/src/rules/consistent-device-config-property-order.ts
@@ -80,8 +80,8 @@ export const consistentDeviceConfigPropertyOrder: JSONCRule.RuleModule = {
 							0,
 							withRanges[0].property.loc.start.column,
 						);
-						// TODO: Change to .toSorted() once on node 20.
-						const desiredOrder = [...propsWithComments].sort((a, b) =>
+					// TODO: Change to .toSorted() once on node 20.
+					const desiredOrder = [...propsWithComments].sort((a, b) =>
 						a.index - b.index
 					).map((prop) => {
 						const start = Math.min(

--- a/packages/eslint-plugin/src/rules/consistent-device-config-property-order.ts
+++ b/packages/eslint-plugin/src/rules/consistent-device-config-property-order.ts
@@ -48,7 +48,7 @@ export const consistentDeviceConfigPropertyOrder: JSONCRule.RuleModule = {
 							.filter(
 								(c) =>
 									c.loc?.start.line
-									=== prev.property.loc.end.line,
+										=== prev.property.loc.end.line,
 							);
 						prev.comments.trailing.push(
 							...wronglyAttributedComments,
@@ -80,8 +80,8 @@ export const consistentDeviceConfigPropertyOrder: JSONCRule.RuleModule = {
 							0,
 							withRanges[0].property.loc.start.column,
 						);
-					// TODO: Change to .toSorted() once on node 20.
-					const desiredOrder = [...propsWithComments].sort((a, b) =>
+						// TODO: Change to .toSorted() once on node 20.
+						const desiredOrder = [...propsWithComments].sort((a, b) =>
 						a.index - b.index
 					).map((prop) => {
 						const start = Math.min(
@@ -161,7 +161,8 @@ export const consistentDeviceConfigPropertyOrder: JSONCRule.RuleModule = {
 		schema: [],
 		messages: {
 			"parameter-ordering":
-				`For consistency, config param properties should follow the order ${paramInfoPropertyOrder.map((p) => `"${p}"`).join(", ")
+				`For consistency, config param properties should follow the order ${
+					paramInfoPropertyOrder.map((p) => `"${p}"`).join(", ")
 				}.`,
 		},
 		type: "problem",


### PR DESCRIPTION
Fixes issue #6579 with node 18 compat in dev container when running `yarn run lint:zwave`

**Before:**
```bash
@zwave-js/config:lint:zwave: Oops! Something went wrong! :(
@zwave-js/config:lint:zwave: 
@zwave-js/config:lint:zwave: ESLint: 8.48.0
@zwave-js/config:lint:zwave: 
@zwave-js/config:lint:zwave: TypeError: propsWithComments.toSorted is not a function
@zwave-js/config:lint:zwave: Occurred while linting /workspaces/node-zwave-js/packages/config/config/devices/0x027a/zen37.json:64
@zwave-js/config:lint:zwave: Rule: "@zwave-js/consistent-device-config-property-order"
@zwave-js/config:lint:zwave:     at JSONProperty[key.value='paramInformation'] > JSONArrayExpression > JSONObjectExpression (/workspaces/node-zwave-js/packages/eslint-plugin/build/rules/consistent-device-config-property-order.js:58:60)
@zwave-js/config:lint:zwave:     at ruleErrorHandler (/workspaces/node-zwave-js/node_modules/.store/eslint-npm-8.48.0-0dd1c36629/node_modules/eslint/lib/linter/linter.js:1050:28)
@zwave-js/config:lint:zwave:     at /workspaces/node-zwave-js/node_modules/.store/eslint-npm-8.48.0-0dd1c36629/node_modules/eslint/lib/linter/safe-emitter.js:45:58
@zwave-js/config:lint:zwave:     at Array.forEach (<anonymous>)
@zwave-js/config:lint:zwave:     at Object.emit (/workspaces/node-zwave-js/node_modules/.store/eslint-npm-8.48.0-0dd1c36629/node_modules/eslint/lib/linter/safe-emitter.js:45:38)
@zwave-js/config:lint:zwave:     at NodeEventGenerator.applySelector (/workspaces/node-zwave-js/node_modules/.store/eslint-npm-8.48.0-0dd1c36629/node_modules/eslint/lib/linter/node-event-generator.js:297:26)
@zwave-js/config:lint:zwave:     at NodeEventGenerator.applySelectors (/workspaces/node-zwave-js/node_modules/.store/eslint-npm-8.48.0-0dd1c36629/node_modules/eslint/lib/linter/node-event-generator.js:326:22)
@zwave-js/config:lint:zwave:     at NodeEventGenerator.enterNode (/workspaces/node-zwave-js/node_modules/.store/eslint-npm-8.48.0-0dd1c36629/node_modules/eslint/lib/linter/node-event-generator.js:340:14)
@zwave-js/config:lint:zwave:     at CodePathAnalyzer.enterNode (/workspaces/node-zwave-js/node_modules/.store/eslint-npm-8.48.0-0dd1c36629/node_modules/eslint/lib/linter/code-path-analysis/code-path-analyzer.js:795:23)
@zwave-js/config:lint:zwave:     at /workspaces/node-zwave-js/node_modules/.store/eslint-npm-8.48.0-0dd1c36629/node_modules/eslint/lib/linter/linter.js:1085:32
@zwave-js/config:lint:zwave: ERROR: command finished with error: command (/workspaces/node-zwave-js/packages/config) yarn run lint:zwave exited (1)
command (/workspaces/node-zwave-js/packages/config) yarn run lint:zwave exited (1)
```
**After:**
```bash
@zwave-js/config:lint:zwave: The config files are valid!
@zwave-js/config:lint:zwave: 
@zwave-js/config:lint:zwave:  
@zwave-js/config:lint:zwave: 
@zwave-js/config:lint:zwave: /workspaces/node-zwave-js/packages/config/config/devices/0x027a/zen37.json
@zwave-js/config:lint:zwave:   65:3  error  For consistency, config param properties should follow the order "#", "$if", "$import", "label", "description", "valueSize", "unit", "minValue", "maxValue", "defaultValue", "unsigned", "readOnly", "writeOnly", "allowManualEntry", "options"  @zwave-js/consistent-device-config-property-order
@zwave-js/config:lint:zwave: 
@zwave-js/config:lint:zwave: ✖ 1 problem (1 error, 0 warnings)
@zwave-js/config:lint:zwave:   1 error and 0 warnings potentially fixable with the `--fix` option.
@zwave-js/config:lint:zwave: 
@zwave-js/config:lint:zwave: ERROR: command finished with error: command (/workspaces/node-zwave-js/packages/config) yarn run lint:zwave exited (1)
command (/workspaces/node-zwave-js/packages/config) yarn run lint:zwave exited (1)
```