### PR TITLE
fix(config): change MH9-CO2 Temperature Reporting Threshold step size to 0.1

### DIFF
--- a/packages/config/config/devices/0x015f/mh9-co2.json
+++ b/packages/config/config/devices/0x015f/mh9-co2.json
@@ -80,7 +80,7 @@
 			"$if": "firmwareVersion >= 2.4",
 			"label": "Temperature Reporting Threshold",
 			"valueSize": 1,
-			"unit": "0.5 °C",
+			"unit": "0.1 °C",
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 1,


### PR DESCRIPTION
Device supports a temperature unit of 0.1. This change reflects that.

This change has been deployed on a Home Assistant Yellow by manually editing the json and works as expected.

For reference this was discussed here: https://github.com/home-assistant/core/issues/106807