### PR TITLE
fix(config): add fingerprint for Ring Glass Break Sensor EU

### DIFF
--- a/packages/config/config/devices/0x0346/glass_break_sensor.json
+++ b/packages/config/config/devices/0x0346/glass_break_sensor.json
@@ -8,6 +8,11 @@
 			"productType": "0x0a01",
 			"productId": "0x0301",
 			"zwaveAllianceId": 4554
+		},
+		{
+			"productType": "0x0a01",
+			"productId": "0x0401",
+			"zwaveAllianceId": 4560
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
Additional fingerprint of Ring Glass Break Sensor device for the UE version (0x0346 0x0a01-0x0401)

fixes: #6635
