### PR TITLE
fix: allow State as a valid HA option for 6 States with No Data State Parameter options

### DIFF
--- a/packages/config/config/notifications.json
+++ b/packages/config/config/notifications.json
@@ -300,7 +300,8 @@
 								"0x01": "No data",
 								"0x02": "Below low threshold",
 								"0x03": "Above high threshold",
-								"0x04": "Max"
+								"0x04": "Max",
+								"0x06": "No data"
 							}
 						}
 					}
@@ -317,7 +318,8 @@
 								"0x01": "No data",
 								"0x02": "Below low threshold",
 								"0x03": "Above high threshold",
-								"0x04": "Max"
+								"0x04": "Max",
+								"0x07": "No data"
 							}
 						}
 					}
@@ -333,7 +335,8 @@
 							"values": {
 								"0x01": "No data",
 								"0x02": "Below low threshold",
-								"0x03": "Above high threshold"
+								"0x03": "Above high threshold",
+								"0x08": "No data"
 							}
 						}
 					}
@@ -349,7 +352,8 @@
 							"values": {
 								"0x01": "No data",
 								"0x02": "Below low threshold",
-								"0x03": "Above high threshold"
+								"0x03": "Above high threshold",
+								"0x09": "No data"
 							}
 						}
 					}
@@ -1248,7 +1252,8 @@
 								"0x01": "No data",
 								"0x02": "Below low threshold",
 								"0x03": "Above high threshold",
-								"0x04": "Max"
+								"0x04": "Max",
+								"0x05": "No data"
 							}
 						}
 					}
@@ -1265,7 +1270,8 @@
 								"0x01": "No data",
 								"0x02": "Below low threshold",
 								"0x03": "Above high threshold",
-								"0x04": "Max"
+								"0x04": "Max",
+								"0x06": "No data"
 							}
 						}
 					}


### PR DESCRIPTION
PR description here

Not being a HA user and a beginner in ZWave JS, this is highly likely not correct, but I can handle that.

This is a potential hack to address #6584.  For the 6 states that allow the "No Data" option as state parameters, the device mfr might not provide a state parameter (optional per the ZW spec) and in this case ZWave JS sends the state, not the state parameter.  This throws an HA validation error.  The intent of this PR is to add the "state" to the "state parameter" list so that validation will succeed. Conveniently all the "states" are higher than any Zwave "state parameter" options, so the device will never send that "state parameter".  It is only to inform HA that the value is allowed and means no data was provided.

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->


