### PR TITLE
feat(config): added Wave devices 

### DIFF
--- a/packages/config/config/devices/0x0460/qnpl-001X12.json
+++ b/packages/config/config/devices/0x0460/qnpl-001X12.json
@@ -1,0 +1,105 @@
+{
+	"manufacturer": "Shelly Europe",
+	"manufacturerId": "0x0460",
+	"label": "QNPL-001X12",
+	"description": "Wave Plug UK",
+	"devices": [
+		{
+			"productType": "0x0002",
+			"productId": "0x0089"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"paramInformation": [
+		{
+			"#": "17",
+			"label": "O1: State After Power Failure",
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off",
+			"minValue": 0,
+			"maxValue": 1,
+			"unsigned": true
+		},
+		{
+			"#": "19",
+			"label": "O1: Auto-Off Timer",
+			"$import": "templates/wave_template.json#auto_off_timer"
+		},
+		{
+			"#": "20",
+			"label": "O1: Auto-On Timer",
+			"$import": "templates/wave_template.json#auto_on_timer"
+		},
+		{
+			"#": "25",
+			"label": "O1: Auto-On/Off Timer Unit",
+			"$import": "templates/wave_template.json#timer_unit"
+		},
+		{
+			"#": "23",
+			"label": "O1: Relay Type",
+			"$import": "templates/wave_template.json#out_relay_type"
+		},
+        {
+			"#": "36",
+			"label": "O1: Power Change Report Threshold",
+			"$import": "templates/wave_template.json#power_change_report_treshold"
+		},
+        {
+			"#": "39",
+			"label": "O1: Minimum Time Between Power Reports",
+			"$import": "templates/wave_template.json#min_time_between_reports"
+		},
+		{
+			"#": "91",
+			"label": "Alarm Configuration: Water",
+			"$import": "templates/wave_template.json#alarm_configuration"
+
+		},
+		{
+			"#": "92",
+			"label": "Alarm Configuration: Smoke",
+			"$import": "templates/wave_template.json#alarm_configuration"
+		},
+		{
+			"#": "93",
+			"label": "Alarm Configuration: CO",
+			"$import": "templates/wave_template.json#alarm_configuration"
+		},
+		{
+			"#": "94",
+			"label": "Alarm Configuration: Heat",
+			"$import": "templates/wave_template.json#alarm_configuration"
+		},
+        {
+			"#": "105",
+			"label": "Signal LED Intensity",
+			"$import": "templates/wave_template.json#led_intensity"
+		},
+		{
+			"#": "120",
+			"label": "Factory Reset",
+			"$import": "templates/wave_template.json#factory_reset"
+		},	
+		{
+			"#": "201",
+			"label": "Serial Number: Part 1",
+			"$import": "templates/wave_template.json#serial_number"
+		},
+		{
+			"#": "202",
+			"label": "Serial Number: Part 2",
+			"$import": "templates/wave_template.json#serial_number"
+		},
+		{
+			"#": "203",
+			"label": "Serial Number: Part 3",
+			"$import": "templates/wave_template.json#serial_number"
+		}
+	],
+	"metadata": {
+		"$import": "templates/wave_template.json#default_metadata"
+	}
+}

--- a/packages/config/config/devices/0x0460/qnpl-001X16.json
+++ b/packages/config/config/devices/0x0460/qnpl-001X16.json
@@ -1,0 +1,101 @@
+{
+	"manufacturer": "Shelly Europe",
+	"manufacturerId": "0x0460",
+	"label": "QPSW-0A1X16",
+	"description": "Wave Pro 1",
+	"devices": [
+		{
+			"productType": "0x0002",
+			"productId": "0x008A"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"paramInformation": [
+
+		{
+			"#": "1",
+			"label": "SW1 Switch Type",
+			"$import": "templates/wave_template.json#switch_type"	
+		},
+		{
+			"#": "2",
+			"label": "SW2 Switch Type",
+			"$import": "templates/wave_template.json#switch_type"
+		},
+		{
+			"#": "17",
+			"label": "O1: State After Power Failure",
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off",
+			"minValue": 0,
+			"maxValue": 1,
+			"unsigned": true
+		},
+		{
+			"#": "19",
+			"label": "O1: Auto-Off Timer",
+			"$import": "templates/wave_template.json#auto_off_timer"
+		},
+		{
+			"#": "20",
+			"label": "O1: Auto-On Timer",
+			"$import": "templates/wave_template.json#auto_on_timer"
+		},
+		{
+			"#": "25",
+			"label": "O1: Auto-On/Off Timer Unit",
+			"$import": "templates/wave_template.json#timer_unit"
+		},
+		{
+			"#": "23",
+			"label": "O1: Relay Type",
+			"$import": "templates/wave_template.json#out_relay_type"
+		},
+		{
+			"#": "91",
+			"label": "Alarm Configuration: Water",
+			"$import": "templates/wave_template.json#alarm_configuration"
+
+		},
+		{
+			"#": "92",
+			"label": "Alarm Configuration: Smoke",
+			"$import": "templates/wave_template.json#alarm_configuration"
+		},
+		{
+			"#": "93",
+			"label": "Alarm Configuration: CO",
+			"$import": "templates/wave_template.json#alarm_configuration"
+		},
+		{
+			"#": "94",
+			"label": "Alarm Configuration: Heat",
+			"$import": "templates/wave_template.json#alarm_configuration"
+		},
+		{
+			"#": "120",
+			"label": "Factory Reset",
+			"$import": "templates/wave_template.json#factory_reset"
+		},	
+		{
+			"#": "201",
+			"label": "Serial Number: Part 1",
+			"$import": "templates/wave_template.json#serial_number"
+		},
+		{
+			"#": "202",
+			"label": "Serial Number: Part 2",
+			"$import": "templates/wave_template.json#serial_number"
+		},
+		{
+			"#": "203",
+			"label": "Serial Number: Part 3",
+			"$import": "templates/wave_template.json#serial_number"
+		}
+	],
+	"metadata": {
+		"$import": "templates/wave_template.json#default_metadata"
+	}
+}

--- a/packages/config/config/devices/0x0460/qnsn-0A24X.json
+++ b/packages/config/config/devices/0x0460/qnsn-0A24X.json
@@ -1,0 +1,66 @@
+{
+	"manufacturer": "Shelly Europe",
+	"manufacturerId": "0x0460",
+	"label": "QNSN-0A24X",
+	"description": "Wave i4",
+	"devices": [
+		{
+			"productType": "0x0009",
+			"productId": "0x0081"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"label": "SW1 Switch Type",
+			"$import": "templates/wave_template.json#switch_type"	
+		},
+		{
+			"#": "2",
+			"label": "SW2 Switch Type",
+			"$import": "templates/wave_template.json#switch_type"
+		},
+		{
+			"#": "3",
+			"label": "SW3 Switch Type",
+			"$import": "templates/wave_template.json#switch_type"	
+		},
+		{
+			"#": "4",
+			"label": "SW4 Switch Type",
+			"$import": "templates/wave_template.json#switch_type"
+		},
+        {
+			"#": "105",
+			"label": "Signal LED Intensity",
+			"$import": "templates/wave_template.json#led_intensity"
+		},
+		{
+			"#": "120",
+			"label": "Factory Reset",
+			"$import": "templates/wave_template.json#factory_reset"
+		},	
+		{
+			"#": "201",
+			"label": "Serial Number: Part 1",
+			"$import": "templates/wave_template.json#serial_number"
+		},
+		{
+			"#": "202",
+			"label": "Serial Number: Part 2",
+			"$import": "templates/wave_template.json#serial_number"
+		},
+		{
+			"#": "203",
+			"label": "Serial Number: Part 3",
+			"$import": "templates/wave_template.json#serial_number"
+		}
+	],
+	"metadata": {
+		"$import": "templates/wave_template.json#default_metadata"
+	}
+}

--- a/packages/config/config/devices/0x0460/qnsn-0D24X.json
+++ b/packages/config/config/devices/0x0460/qnsn-0D24X.json
@@ -1,0 +1,66 @@
+{
+	"manufacturer": "Shelly Europe",
+	"manufacturerId": "0x0460",
+	"label": "QNSN-0D24X",
+	"description": "Wave i4 DC",
+	"devices": [
+		{
+			"productType": "0x0009",
+			"productId": "0x0082"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"label": "SW1 Switch Type",
+			"$import": "templates/wave_template.json#switch_type"	
+		},
+		{
+			"#": "2",
+			"label": "SW2 Switch Type",
+			"$import": "templates/wave_template.json#switch_type"
+		},
+		{
+			"#": "3",
+			"label": "SW3 Switch Type",
+			"$import": "templates/wave_template.json#switch_type"	
+		},
+		{
+			"#": "4",
+			"label": "SW4 Switch Type",
+			"$import": "templates/wave_template.json#switch_type"
+		},
+        {
+			"#": "105",
+			"label": "Signal LED Intensity",
+			"$import": "templates/wave_template.json#led_intensity"
+		},
+		{
+			"#": "120",
+			"label": "Factory Reset",
+			"$import": "templates/wave_template.json#factory_reset"
+		},	
+		{
+			"#": "201",
+			"label": "Serial Number: Part 1",
+			"$import": "templates/wave_template.json#serial_number"
+		},
+		{
+			"#": "202",
+			"label": "Serial Number: Part 2",
+			"$import": "templates/wave_template.json#serial_number"
+		},
+		{
+			"#": "203",
+			"label": "Serial Number: Part 3",
+			"$import": "templates/wave_template.json#serial_number"
+		}
+	],
+	"metadata": {
+		"$import": "templates/wave_template.json#default_metadata"
+	}
+}

--- a/packages/config/config/devices/0x0460/qpsw-0A1P16.json
+++ b/packages/config/config/devices/0x0460/qpsw-0A1P16.json
@@ -1,0 +1,101 @@
+{
+	"manufacturer": "Shelly Europe",
+	"manufacturerId": "0x0460",
+	"label": "QPSW-0A1X16",
+	"description": "Wave Pro 1",
+	"devices": [
+		{
+			"productType": "0x0002",
+			"productId": "0x008A"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"paramInformation": [
+
+		{
+			"#": "1",
+			"label": "SW1 Switch Type",
+			"$import": "templates/wave_template.json#switch_type"	
+		},
+		{
+			"#": "2",
+			"label": "SW2 Switch Type",
+			"$import": "templates/wave_template.json#switch_type"
+		},
+		{
+			"#": "17",
+			"label": "O1: State After Power Failure",
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off",
+			"minValue": 0,
+			"maxValue": 1,
+			"unsigned": true
+		},
+		{
+			"#": "19",
+			"label": "O1: Auto-Off Timer",
+			"$import": "templates/wave_template.json#auto_off_timer"
+		},
+		{
+			"#": "20",
+			"label": "O1: Auto-On Timer",
+			"$import": "templates/wave_template.json#auto_on_timer"
+		},
+		{
+			"#": "25",
+			"label": "O1: Auto-On/Off Timer Unit",
+			"$import": "templates/wave_template.json#timer_unit"
+		},
+		{
+			"#": "23",
+			"label": "O1: Relay Type",
+			"$import": "templates/wave_template.json#out_relay_type"
+		},
+		{
+			"#": "91",
+			"label": "Alarm Configuration: Water",
+			"$import": "templates/wave_template.json#alarm_configuration"
+
+		},
+		{
+			"#": "92",
+			"label": "Alarm Configuration: Smoke",
+			"$import": "templates/wave_template.json#alarm_configuration"
+		},
+		{
+			"#": "93",
+			"label": "Alarm Configuration: CO",
+			"$import": "templates/wave_template.json#alarm_configuration"
+		},
+		{
+			"#": "94",
+			"label": "Alarm Configuration: Heat",
+			"$import": "templates/wave_template.json#alarm_configuration"
+		},
+		{
+			"#": "120",
+			"label": "Factory Reset",
+			"$import": "templates/wave_template.json#factory_reset"
+		},	
+		{
+			"#": "201",
+			"label": "Serial Number: Part 1",
+			"$import": "templates/wave_template.json#serial_number"
+		},
+		{
+			"#": "202",
+			"label": "Serial Number: Part 2",
+			"$import": "templates/wave_template.json#serial_number"
+		},
+		{
+			"#": "203",
+			"label": "Serial Number: Part 3",
+			"$import": "templates/wave_template.json#serial_number"
+		}
+	],
+	"metadata": {
+		"$import": "templates/wave_template.json#default_metadata"
+	}
+}

--- a/packages/config/config/devices/0x0460/qpsw-0A1X16.json
+++ b/packages/config/config/devices/0x0460/qpsw-0A1X16.json
@@ -1,0 +1,101 @@
+{
+	"manufacturer": "Shelly Europe",
+	"manufacturerId": "0x0460",
+	"label": "QPSW-0A1X16",
+	"description": "Wave Pro 1",
+	"devices": [
+		{
+			"productType": "0x0002",
+			"productId": "0x008A"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"paramInformation": [
+
+		{
+			"#": "1",
+			"label": "SW1 Switch Type",
+			"$import": "templates/wave_template.json#switch_type"	
+		},
+		{
+			"#": "2",
+			"label": "SW2 Switch Type",
+			"$import": "templates/wave_template.json#switch_type"
+		},
+		{
+			"#": "17",
+			"label": "O1: State After Power Failure",
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off",
+			"minValue": 0,
+			"maxValue": 1,
+			"unsigned": true
+		},
+		{
+			"#": "19",
+			"label": "O1: Auto-Off Timer",
+			"$import": "templates/wave_template.json#auto_off_timer"
+		},
+		{
+			"#": "20",
+			"label": "O1: Auto-On Timer",
+			"$import": "templates/wave_template.json#auto_on_timer"
+		},
+		{
+			"#": "25",
+			"label": "O1: Auto-On/Off Timer Unit",
+			"$import": "templates/wave_template.json#timer_unit"
+		},
+		{
+			"#": "23",
+			"label": "O1: Relay Type",
+			"$import": "templates/wave_template.json#out_relay_type"
+		},
+		{
+			"#": "91",
+			"label": "Alarm Configuration: Water",
+			"$import": "templates/wave_template.json#alarm_configuration"
+
+		},
+		{
+			"#": "92",
+			"label": "Alarm Configuration: Smoke",
+			"$import": "templates/wave_template.json#alarm_configuration"
+		},
+		{
+			"#": "93",
+			"label": "Alarm Configuration: CO",
+			"$import": "templates/wave_template.json#alarm_configuration"
+		},
+		{
+			"#": "94",
+			"label": "Alarm Configuration: Heat",
+			"$import": "templates/wave_template.json#alarm_configuration"
+		},
+		{
+			"#": "120",
+			"label": "Factory Reset",
+			"$import": "templates/wave_template.json#factory_reset"
+		},	
+		{
+			"#": "201",
+			"label": "Serial Number: Part 1",
+			"$import": "templates/wave_template.json#serial_number"
+		},
+		{
+			"#": "202",
+			"label": "Serial Number: Part 2",
+			"$import": "templates/wave_template.json#serial_number"
+		},
+		{
+			"#": "203",
+			"label": "Serial Number: Part 3",
+			"$import": "templates/wave_template.json#serial_number"
+		}
+	],
+	"metadata": {
+		"$import": "templates/wave_template.json#default_metadata"
+	}
+}

--- a/packages/config/config/devices/0x0460/qpsw-0A2P16.json
+++ b/packages/config/config/devices/0x0460/qpsw-0A2P16.json
@@ -1,0 +1,153 @@
+{
+	"manufacturer": "Shelly Europe",
+	"manufacturerId": "0x0460",
+	"label": "QPSW-0A2P16",
+	"description": "Wave Pro 2PM",
+	"devices": [
+		{
+			"productType": "0x0002",
+			"productId": "0x008D"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"label": "SW1 Switch Type",
+			"$import": "templates/wave_template.json#switch_type"	
+		},
+		{
+			"#": "2",
+			"label": "SW2 Switch Type",
+			"$import": "templates/wave_template.json#switch_type"
+		},
+		{
+			"#": "16",
+			"label": "Swap Outputs",
+			"$import": "templates/wave_template.json#o1_o2_swap"
+		},
+		{
+			"#": "17",
+			"label": "O1: State After Power Failure",
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off",
+			"minValue": 0,
+			"maxValue": 1,
+			"unsigned": true
+		},
+		{
+			"#": "18",
+			"label": "O2: State After Power Failure",
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off",
+			"minValue": 0,
+			"maxValue": 1,
+			"unsigned": true
+		},
+		{
+			"#": "19",
+			"label": "O1: Auto-Off Timer",
+			"$import": "templates/wave_template.json#auto_off_timer"
+		},
+        {
+			"#": "20",
+			"label": "O1: Auto-On Timer",
+			"$import": "templates/wave_template.json#auto_on_timer"
+		},
+		{
+			"#": "25",
+			"label": "O1: Auto-On/Off Timer Unit",
+			"$import": "templates/wave_template.json#timer_unit"
+		},
+		{
+			"#": "21",
+			"label": "O2: Auto-Off Timer",
+			"$import": "templates/wave_template.json#auto_off_timer"
+		},
+		{
+			"#": "22",
+			"label": "O2: Auto-On Timer",
+			"$import": "templates/wave_template.json#auto_on_timer"
+		},
+		{
+			"#": "26",
+			"label": "O2: Auto-On/Off Timer Unit",
+			"$import": "templates/wave_template.json#timer_unit"
+		},
+		{
+			"#": "23",
+			"label": "O1: Relay Type",
+			"$import": "templates/wave_template.json#out_relay_type"
+		},
+		{
+			"#": "24",
+			"label": "O2: Relay Type",
+			"$import": "templates/wave_template.json#out_relay_type"
+		},
+        {
+			"#": "36",
+			"label": "O1: Power Change Report Threshold",
+			"$import": "templates/wave_template.json#power_change_report_treshold"
+		},
+        {
+			"#": "39",
+			"label": "O1: Minimum Time Between Power Reports",
+			"$import": "templates/wave_template.json#min_time_between_reports"
+		},
+        {
+			"#": "37",
+			"label": "O2: Power Change Report Threshold",
+			"$import": "templates/wave_template.json#power_change_report_treshold"
+		},
+        {
+			"#": "40",
+			"label": "O2: Minimum Time Between Power Reports",
+			"$import": "templates/wave_template.json#min_time_between_reports"
+		},
+		{
+			"#": "91",
+			"label": "Alarm Configuration: Water",
+			"$import": "templates/wave_template.json#alarm_configuration"
+
+		},
+		{
+			"#": "92",
+			"label": "Alarm Configuration: Smoke",
+			"$import": "templates/wave_template.json#alarm_configuration"
+		},
+		{
+			"#": "93",
+			"label": "Alarm Configuration: CO",
+			"$import": "templates/wave_template.json#alarm_configuration"
+		},
+		{
+			"#": "94",
+			"label": "Alarm Configuration: Heat",
+			"$import": "templates/wave_template.json#alarm_configuration"
+		},
+		{
+			"#": "120",
+			"label": "Factory Reset",
+			"$import": "templates/wave_template.json#factory_reset"
+		},	
+		{
+			"#": "201",
+			"label": "Serial Number: Part 1",
+			"$import": "templates/wave_template.json#serial_number"
+		},
+		{
+			"#": "202",
+			"label": "Serial Number: Part 2",
+			"$import": "templates/wave_template.json#serial_number"
+		},
+		{
+			"#": "203",
+			"label": "Serial Number: Part 3",
+			"$import": "templates/wave_template.json#serial_number"
+		}
+	],
+	"metadata": {
+		"$import": "templates/wave_template.json#default_metadata"
+	}
+}

--- a/packages/config/config/devices/0x0460/qpsw-0A2X16.json
+++ b/packages/config/config/devices/0x0460/qpsw-0A2X16.json
@@ -1,0 +1,138 @@
+{
+	"manufacturer": "Shelly Europe",
+	"manufacturerId": "0x0460",
+	"label": "QPSW-0A2X16",
+	"description": "Wave Pro 2",
+	"devices": [
+		{
+			"productType": "0x0002",
+			"productId": "0x008C"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"label": "SW1 Switch Type",
+			"$import": "templates/wave_template.json#switch_type"	
+		},
+		{
+			"#": "2",
+			"label": "SW2 Switch Type",
+			"$import": "templates/wave_template.json#switch_type"
+		},
+		{
+			"#": "6",
+			"label": "Swap Inputs",
+			"$import": "templates/wave_template.json#sw1_sw2_swap"
+		},
+		{
+			"#": "16",
+			"label": "Swap Outputs",
+			"$import": "templates/wave_template.json#o1_o2_swap"
+		},
+		{
+			"#": "17",
+			"label": "O1: State After Power Failure",
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off",
+			"minValue": 0,
+			"maxValue": 1,
+			"unsigned": true
+		},
+		{
+			"#": "18",
+			"label": "O2: State After Power Failure",
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off",
+			"minValue": 0,
+			"maxValue": 1,
+			"unsigned": true
+		},
+		{
+			"#": "19",
+			"label": "O1: Auto-Off Timer",
+			"$import": "templates/wave_template.json#auto_off_timer"
+		},
+		{
+			"#": "20",
+			"label": "O1: Auto-On Timer",
+			"$import": "templates/wave_template.json#auto_on_timer"
+		},
+		{
+			"#": "25",
+			"label": "O1: Auto-On/Off Timer Unit",
+			"$import": "templates/wave_template.json#timer_unit"
+		},
+		{
+			"#": "21",
+			"label": "O2: Auto-Off Timer",
+			"$import": "templates/wave_template.json#auto_off_timer"
+		},
+		{
+			"#": "22",
+			"label": "O2: Auto-On Timer",
+			"$import": "templates/wave_template.json#auto_on_timer"
+		},
+		{
+			"#": "26",
+			"label": "O2: Auto-On/Off Timer Unit",
+			"$import": "templates/wave_template.json#timer_unit"
+		},
+		{
+			"#": "23",
+			"label": "O1: Relay Type",
+			"$import": "templates/wave_template.json#out_relay_type"
+		},
+		{
+			"#": "24",
+			"label": "O2: Relay Type",
+			"$import": "templates/wave_template.json#out_relay_type"
+		},
+		{
+			"#": "91",
+			"label": "Alarm Configuration: Water",
+			"$import": "templates/wave_template.json#alarm_configuration"
+
+		},
+		{
+			"#": "92",
+			"label": "Alarm Configuration: Smoke",
+			"$import": "templates/wave_template.json#alarm_configuration"
+		},
+		{
+			"#": "93",
+			"label": "Alarm Configuration: CO",
+			"$import": "templates/wave_template.json#alarm_configuration"
+		},
+		{
+			"#": "94",
+			"label": "Alarm Configuration: Heat",
+			"$import": "templates/wave_template.json#alarm_configuration"
+		},
+		{
+			"#": "120",
+			"label": "Factory Reset",
+			"$import": "templates/wave_template.json#factory_reset"
+		},	
+		{
+			"#": "201",
+			"label": "Serial Number: Part 1",
+			"$import": "templates/wave_template.json#serial_number"
+		},
+		{
+			"#": "202",
+			"label": "Serial Number: Part 2",
+			"$import": "templates/wave_template.json#serial_number"
+		},
+		{
+			"#": "203",
+			"label": "Serial Number: Part 3",
+			"$import": "templates/wave_template.json#serial_number"
+		}
+	],
+	"metadata": {
+		"$import": "templates/wave_template.json#default_metadata"
+	}
+}

--- a/packages/config/config/devices/0x0460/templates/wave_template.json
+++ b/packages/config/config/devices/0x0460/templates/wave_template.json
@@ -1,0 +1,173 @@
+{
+	"switch_type": {
+		"valueSize": 1,
+		"defaultValue": 2,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Momentary switch",
+				"value": 0
+			},
+			{
+				"label": "Toggle switch (follow switch)",
+				"value": 1
+			},
+			{
+				"label": "Toggle switch (change on toggle)",
+				"value": 2
+			}
+		]
+	},
+		"sw1_sw2_swap": {
+		"label": "SW1 & SW2: Swap",
+		"description": "swaped state SW1 control O2, SW2 control O1)",
+		"valueSize": 1,
+		"defaultValue": 0,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "default",
+				"value": 0
+			},
+			{
+				"label": "swapped ",
+				"value": 1
+			}
+		]
+	},
+		"o1_o2_swap": {
+		"label": "O1 & O2: Swap",
+		"description": "swaped state O1 - close, O2 - open",
+		"valueSize": 1,
+		"defaultValue": 0,
+		"unsigned": true,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "default",
+				"value": 0
+			},
+			{
+				"label": "swapped",
+				"value": 1
+			}
+		]
+	},
+		"auto_off_timer": {
+		"description": "The timer resets to zero each time the Device receives an ON command",
+		"valueSize": 2,
+		"minValue": 0,
+		"maxValue": 32535,
+		"defaultValue": 0
+	},
+		"auto_on_timer": {
+		"description": "The timer resets to zero each time the Device receives an OFF command",
+		"valueSize": 2,
+		"minValue": 0,
+		"maxValue": 32535,
+		"defaultValue": 0
+	},
+		"timer_unit": {
+		"valueSize": 1,
+		"defaultValue": 0,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Seconds",
+				"value": 0
+			},
+			{
+				"label": "10 ms",
+				"value": 1
+			}
+		]
+	},
+		"out_relay_type": {
+		"valueSize": 1,
+		"defaultValue": 0,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "NO: normally open",
+				"value": 0
+			},
+			{
+				"label": "NC: normally closed",
+				"value": 1
+			}
+		]
+	},
+		"power_change_report_treshold": {
+		"valueSize": 1,
+		"unit": "%",
+		"minValue": 0,
+		"maxValue": 100,
+		"defaultValue": 50
+	},
+		"min_time_between_reports": {
+		"label": "O1: Minimum Time Between Power Reports",
+		"valueSize": 1,
+		"unit": "seconds",
+		"minValue": 0,
+		"maxValue": 120,
+		"defaultValue": 30
+	},
+		"alarm_configuration": {
+		"description": "This parameter determines which alarm frames the Device should respond to and how.",
+		"valueSize": 4,
+		"defaultValue": 0,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "No action",
+				"value": 0
+			},
+			{
+				"label": "Open relay",
+				"value": 1
+			},
+			{
+				"label": "Close relay",
+				"value": 2
+			}
+		]
+	},
+		"led_intensity": {
+		"valueSize": 1,
+		"unit": "%",
+		"minValue": 0,
+		"maxValue": 100,
+		"defaultValue": 100
+	},
+	
+		"factory_reset": {
+		"label": "Factory Reset",
+		"description": "Reset to factory default settings and remove from the Z-Wave network.",
+		"valueSize": 4,
+		"defaultValue": 0,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Idle",
+				"value": 0
+			},
+			{
+				"label": "Factory reset",
+				"value": 1431655765
+			}
+		]
+	},
+		"serial_number": {
+		"description": "This parameter contains a part of devices serial number.",
+		"valueSize": 4,
+		"minValue": 0,
+		"maxValue": 2147483647,
+		"readOnly": true
+	},
+		"default_metadata": {
+			"inclusion": "6.1 Adding the Device to a Z-Wave™ network (inclusion)\nNote! All Device outputs (O, O1, O2, etc. - depending on the Device type) will turn the load 1s on/1s off /1s on/1s off if the Device is successfully added to/removed from a Z-Wave™ network.\n\n6.1.1 SmartStart adding (inclusion)\nSmartStart enabled products can be added into a Z-Wave™ network by scanning the Z-Wave™ QR Code present on the Device with a gateway providing SmartStart inclusion. No further action is required, and the SmartStart device will be added automatically within 10 minutes of being switched on in the network vicinity.\n1. With the gateway application scan the QR code on the Device label and add the Security 2 (S2) Device Specific Key (DSK) to the provisioning list in the gateway.\n2. Connect the Device to a power supply.\n3. Check if the blue LED is blinking in Mode 1. If so, the Device is not added to a Z-Wave™ network.\n4. Adding will be initiated automatically within a few seconds after connecting the Device to a power supply, and the Device will be added to a Z-Wave™ network automatically.\n5. The blue LED will be blinking in Mode 2 during the adding process.\n6. The green LED will be blinking in Mode 1 if the Device is successfully added to a Z-Wave™ network.\n\n6.1.2 Adding (inclusion) with a switch/push-button\n1. Connect the Device to a power supply.\n2. Check if the blue LED is blinking in Mode 1. If so, the Device is not added to a Z-Wave™ network.\n3. Enable add/remove mode on the gateway.\n4. Toggle the switch/push-button connected to any of the SW terminals (SW, SW1, SW2, etc.) 3 times within 3 seconds (this procedure puts the Device in Learn mode*). The Device must receive on/off signal 3 times, which means pressing the momentary switch 3 times, or toggling the switch on and off 3 times.\n5. The blue LED will be blinking in Mode 2 during the adding process.\n6. The green LED will be blinking in Mode 1 if the Device is successfully added to a Z-Wave™ network.\n*Learn mode - a state that allows the Device to receive network information from the gateway.\n\n6.1.3 Adding (inclusion) with the S button\n1. Connect the Device to a power supply.\n2. Check if the blue LED is blinking in Mode 1. If so, the Device is not added to a Z-Wave™ network.\n3. Enable add/remove mode on the gateway.\n4. To enter the Setting mode, quickly press and hold the S button on the Device until the LED turns solid blue.\n5. Quickly release and then press and hold (> 2s) the S button on the Device until the blue LED starts blinking in Mode 3. Releasing the S button will start the Learn mode.\n6. The blue LED will be blinking in Mode 2 during the adding process.\n7. The green LED will be blinking in Mode 1 if the Device is successfully added to a Z-Wave™ network.\nNote! In Setting mode, the Device has a timeout of 10s before entering again into Normal mode",
+			"exclusion": "Removing the Device from a Z-Wave™ network (exclusion)\nNote! The Device will be removed from your Z-wave™ network, but any custom configuration parameters will not be erased.\nNote! All Device outputs (O, O1, O2, etc. - depending on the Device type) will turn the load 1s on/1s off /1s on/1s off if the Device is successfully added to/removed from a Z-Wave™ network.\n\n6.2.1 Removing (exclusion) with a switch/push-button\n1. Connect the Device to a power supply.\n2. Check if the green LED is blinking in Mode 1. If so, the Device is added to a Z-Wave™ network.\n3. Enable add/remove mode on the gateway.\n4. Toggle the switch/push-button connected to any of the SW terminals (SW, SW1, SW2,…) 3 times within 3 seconds (this procedure puts the Device in Learn mode). The Device must receive on/off signal 3 times, which means pressing the momentary switch 3 times, or toggling the switch on and off 3 times.\n5. The blue LED will be blinking in Mode 2 during the removing process.\n6. The blue LED will be blinking in Mode 1 if the Device is successfully removed from a Z-Wave™ network.\n\n6.2.2 Removing (exclusion) with the S button\n1. Connect the Device to a power supply.\n2. Check if the green LED is blinking in Mode 1. If so, the Device is added to a Z-Wave™ network.\n3. Enable add/remove mode on the gateway.\n4. To enter the Setting mode, quickly press and hold the S button on the Device until the LED turns solid blue.\n5. Quickly release and then press and hold (> 2s) the S button on the Device until the blue LED starts blinking in Mode 3. Releasing the S button will start the Learn mode.\n6. The blue LED will be blinking in Mode 2 during the removing process.\n7. The blue LED will be blinking in Mode 1 if the Device is successfully removed from a Z-Wave™ network.\nNote! In Setting mode, the Device has a timeout of 10s before entering again into Normal mode",
+			"reset": "6.3 Factory reset\n6.3.1 Factory reset general\nAfter Factory reset, all custom parameters and stored values (kWh, associations, routings, etc.) will return to their default state. HOME ID and NODE ID assigned to the Device will be deleted. Use this reset procedure only when the gateway is missing or otherwise inoperable.\n\n6.3.2 Factory reset with a switch/push-button\nNote! Factory reset with a switch/push-button is only possible within the first minute after the Device is connected to a power supply.\n1. Connect the Device to a power supply.\n2. Toggle the switch/push-button connected to any of the SW terminals (SW, SW1, SW2,…) 5 times within 3 seconds. The Device must receive on/off signal 5 times, which means pressing the push-button 5 times, or toggling the switch on and off 5 times.\n3. During factory reset, the LED will turn solid green for about 1s, then the blue and red LED will start blinking in Mode 3 for approx. 2s.\n4. The blue LED will be blinking in Mode 1 if the Factory reset is successful.\n\n6.3.3 Factory reset with the S button\nNote! Factory reset with the S button is possible anytime.\n1. To enter the Setting mode, quickly press and hold the S button on the Device until the LED turns solid blue.\n2. Press the S button multiple times until the LED turns solid red.\n3. Press and hold (> 2s) S button on the Device until the red LED starts blinking in Mode 3. Releasing the S button will start the factory reset.\n4. During factory reset, the LED will turn solid green for about 1s, then the blue and red LED will start blinking in Mode 3 for approx. 2s.\n5. The blue LED will be blinking in Mode 1 if the Factory reset is successful.\n\n6.3.4 Remote factory reset with parameter with the gateway\nFactory reset can be done remotely with the settings in Parameter No. 120",
+			"manual": "https://kb.shelly.cloud/knowledge-base/shelly-qubino-wave-devices"
+		}
+	}


### PR DESCRIPTION
added Wave devices i4, i4DC, Plug UK, Plug US, PRO 1, PRO 2, PRO 2, PRO 2PM
added wave_template

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->


