### PR TITLE
fix: use separate S2 keys for ZWLR

### DIFF
--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -828,13 +828,21 @@ interface ZWaveOptions extends ZWaveHostOptions {
 	};
 
 	/**
-	 * Specify the security keys to use for encryption. Each one must be a Buffer of exactly 16 bytes.
+	 * Specify the security keys to use for encryption (Z-Wave Classic). Each one must be a Buffer of exactly 16 bytes.
 	 */
 	securityKeys?: {
-		S2_Unauthenticated?: Buffer;
-		S2_Authenticated?: Buffer;
 		S2_AccessControl?: Buffer;
+		S2_Authenticated?: Buffer;
+		S2_Unauthenticated?: Buffer;
 		S0_Legacy?: Buffer;
+	};
+
+	/**
+	 * Specify the security keys to use for encryption (Z-Wave Long Range). Each one must be a Buffer of exactly 16 bytes.
+	 */
+	securityKeysLongRange?: {
+		S2_AccessControl?: Buffer;
+		S2_Authenticated?: Buffer;
 	};
 
 	/**

--- a/docs/getting-started/long-range.md
+++ b/docs/getting-started/long-range.md
@@ -5,7 +5,8 @@ Z-Wave Long Range (ZWLR) is an addition to Z-Wave, that allows for a massively i
 There are a few things applications need to be aware of to support Long Range using Z-Wave JS.
 
 1. ZWLR node IDs start at 256. This can be used to distinguish between ZWLR and classic Z-Wave nodes.
-2. ZWLR inclusion works exclusively through [Smart Start](getting-started/security-s2#smartstart).
+1. ZWLR has only two security classes, S2 Access Control and S2 Authenticated. Both must use a different security key than their Z-Wave Classic counterparts. To configure them, use the `securityKeysLongRange` property of the [`ZWaveOptions`](../api/driver#zwaveoptions)
+1. ZWLR inclusion works exclusively through [Smart Start](../getting-started/security-s2#smartstart).
    \
-   ZWLR nodes advertise support for Long Range in the `supportedProtocols` field of the `QRProvisioningInformation` object (see [here](api/utils#other-qr-codes)). When this field is present, the user **MUST** have the choice between the advertised protocols. Currently this means deciding between including the node via Z-Wave Classic (mesh) or Z-Wave Long Range (no mesh).\
-   To include a node via ZWLR, set the `protocol` field of the `PlannedProvisioningEntry` to `Protocols.ZWaveLongRange` when [provisioning the node](api/controller#provisionsmartstartnode).
+   ZWLR nodes advertise support for Long Range in the `supportedProtocols` field of the `QRProvisioningInformation` object (see [here](../api/utils#other-qr-codes)). When this field is present, the user **MUST** have the choice between the advertised protocols. Currently this means deciding between including the node via Z-Wave Classic (mesh) or Z-Wave Long Range (no mesh).\
+   To include a node via ZWLR, set the `protocol` field of the `PlannedProvisioningEntry` to `Protocols.ZWaveLongRange` when [provisioning the node](../api/controller#provisionsmartstartnode).

--- a/packages/cc/src/cc/Security2CC.ts
+++ b/packages/cc/src/cc/Security2CC.ts
@@ -4,6 +4,7 @@ import {
 	type MessageOrCCLogEntry,
 	MessagePriority,
 	type MessageRecord,
+	type MulticastDestination,
 	type S2SecurityClass,
 	SECURITY_S2_AUTH_TAG_LENGTH,
 	SPANState,
@@ -41,6 +42,7 @@ import {
 	pick,
 } from "@zwave-js/shared/safe";
 import { wait } from "alcalzone-shared/async";
+import { isArray } from "alcalzone-shared/typeguards";
 import { CCAPI } from "../lib/API";
 import {
 	type CCCommandOptions,
@@ -116,21 +118,35 @@ function getAuthenticationData(
 	return ret;
 }
 
+function getSecurityManager(
+	host: ZWaveHost,
+	destination: MulticastDestination | number,
+): SecurityManager2 | undefined {
+	const longRange = isLongRangeNodeId(
+		isArray(destination) ? destination[0]! : destination,
+	);
+	return longRange
+		? host.securityManagerLR
+		: host.securityManager2;
+}
+
 /** Validates that a sequence number is not a duplicate and updates the SPAN table if it is accepted. Returns the previous sequence number if there is one. */
 function validateSequenceNumber(
 	this: Security2CC,
 	sequenceNumber: number,
 ): number | undefined {
+	const securityManager = getSecurityManager(this.host, this.nodeId);
+
 	validatePayload.withReason(
 		`Duplicate command (sequence number ${sequenceNumber})`,
 	)(
-		!this.host.securityManager2!.isDuplicateSinglecast(
+		!securityManager!.isDuplicateSinglecast(
 			this.nodeId as number,
 			sequenceNumber,
 		),
 	);
 	// Not a duplicate, store it
-	return this.host.securityManager2!.storeSequenceNumber(
+	return securityManager!.storeSequenceNumber(
 		this.nodeId as number,
 		sequenceNumber,
 	);
@@ -143,7 +159,7 @@ function assertSecurity(this: Security2CC, options: CommandClassOptions): void {
 			`Secure commands (S2) can only be ${verb} when the controller's node id is known!`,
 			ZWaveErrorCodes.Driver_NotReady,
 		);
-	} else if (!this.host.securityManager2) {
+	} else if (!getSecurityManager(this.host, this.nodeId)) {
 		throw new ZWaveError(
 			`Secure commands (S2) can only be ${verb} when the network keys are configured!`,
 			ZWaveErrorCodes.Driver_NoSecurity,
@@ -185,14 +201,19 @@ export class Security2CCAPI extends CCAPI {
 
 		this.assertPhysicalEndpoint(this.endpoint);
 
-		if (!this.applHost.securityManager2) {
+		const securityManager = getSecurityManager(
+			this.applHost,
+			this.endpoint.nodeId,
+		);
+
+		if (!securityManager) {
 			throw new ZWaveError(
 				`Nonces can only be sent if secure communication is set up!`,
 				ZWaveErrorCodes.Driver_NoSecurity,
 			);
 		}
 
-		const receiverEI = this.applHost.securityManager2.generateNonce(
+		const receiverEI = securityManager.generateNonce(
 			this.endpoint.nodeId,
 		);
 
@@ -221,7 +242,7 @@ export class Security2CCAPI extends CCAPI {
 		} catch (e) {
 			if (isTransmissionError(e)) {
 				// The nonce could not be sent, invalidate it
-				this.applHost.securityManager2.deleteNonce(
+				securityManager.deleteNonce(
 					this.endpoint.nodeId,
 				);
 				return false;
@@ -515,6 +536,7 @@ export class Security2CC extends CommandClass {
 		).withOptions({
 			priority: MessagePriority.NodeQuery,
 		});
+		const securityManager = getSecurityManager(applHost, node.id);
 
 		// Only on the highest security class the response includes the supported commands
 		const secClass = node.getHighestSecurityClass();
@@ -556,7 +578,7 @@ export class Security2CC extends CommandClass {
 
 			// If no key is configured for this security class, skip it
 			if (
-				!this.host.securityManager2?.hasKeysForSecurityClass(secClass)
+				!securityManager?.hasKeysForSecurityClass(secClass)
 			) {
 				applHost.controllerLog.logNode(node.id, {
 					endpoint: endpoint.index,
@@ -883,12 +905,6 @@ export type MulticastContext =
 	testCCResponseForMessageEncapsulation,
 )
 export class Security2CCMessageEncapsulation extends Security2CC {
-	// Define the securityManager as existing
-	// We check it in the constructor
-	declare host: ZWaveHost & {
-		securityManager2: SecurityManager2;
-	};
-
 	public constructor(
 		host: ZWaveHost,
 		options:
@@ -899,6 +915,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 
 		// Make sure that we can send/receive secure commands
 		assertSecurity.call(this, options);
+		this.securityManager = getSecurityManager(host, this.nodeId)!;
 
 		if (gotDeserializationOptions(options)) {
 			validatePayload(this.payload.length >= 2);
@@ -973,7 +990,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 				| ReturnType<SecurityManager2["getPeerMPAN"]>
 				| undefined;
 			if (ctx.isMulticast) {
-				mpanState = this.host.securityManager2.getPeerMPAN(
+				mpanState = this.securityManager.getPeerMPAN(
 					sendingNodeId,
 					ctx.groupId,
 				);
@@ -987,7 +1004,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 				// When a node receives a singlecast message after a multicast group was marked out of sync,
 				// it must forget about the group.
 				if (ctx.groupId == undefined) {
-					this.host.securityManager2.resetOutOfSyncMPANs(
+					this.securityManager.resetOutOfSyncMPANs(
 						sendingNodeId,
 					);
 				}
@@ -1017,7 +1034,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 				// For incoming multicast commands, make sure we have an MPAN
 				if (mpanState?.type !== MPANState.MPAN) {
 					// If we don't, mark the MPAN as out of sync, so we can respond accordingly on the singlecast followup
-					this.host.securityManager2.storePeerMPAN(
+					this.securityManager.storePeerMPAN(
 						sendingNodeId,
 						ctx.groupId,
 						{ type: MPANState.OutOfSync },
@@ -1035,7 +1052,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 					);
 			} else {
 				// Decrypt payload and verify integrity
-				const spanState = this.host.securityManager2.getSPANState(
+				const spanState = this.securityManager.getSPANState(
 					sendingNodeId,
 				);
 
@@ -1086,7 +1103,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 			if (!authOK || !plaintext) {
 				if (ctx.isMulticast) {
 					// Mark the MPAN as out of sync
-					this.host.securityManager2.storePeerMPAN(
+					this.securityManager.storePeerMPAN(
 						sendingNodeId,
 						ctx.groupId,
 						{ type: MPANState.OutOfSync },
@@ -1101,7 +1118,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 				}
 			} else if (!ctx.isMulticast && ctx.groupId != undefined) {
 				// After reception of a singlecast followup, the MPAN state must be increased
-				this.host.securityManager2.tryIncrementPeerMPAN(
+				this.securityManager.tryIncrementPeerMPAN(
 					sendingNodeId,
 					ctx.groupId,
 				);
@@ -1117,7 +1134,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 			if (!ctx.isMulticast) {
 				const mpanExtension = this.getMPANExtension();
 				if (mpanExtension) {
-					this.host.securityManager2.storePeerMPAN(
+					this.securityManager.storePeerMPAN(
 						sendingNodeId,
 						mpanExtension.groupId,
 						{
@@ -1173,6 +1190,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 		}
 	}
 
+	private securityManager: SecurityManager2;
 	public readonly securityClass?: SecurityClass;
 
 	// Only used for testing/debugging purposes
@@ -1195,11 +1213,11 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 	public get sequenceNumber(): number {
 		if (this._sequenceNumber == undefined) {
 			if (this.isSinglecast()) {
-				this._sequenceNumber = this.host.securityManager2
+				this._sequenceNumber = this.securityManager
 					.nextSequenceNumber(this.nodeId);
 			} else {
 				const groupId = this.getDestinationIDTX();
-				return this.host.securityManager2.nextMulticastSequenceNumber(
+				return this.securityManager.nextMulticastSequenceNumber(
 					groupId,
 				);
 			}
@@ -1274,7 +1292,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 		if (!this.isSinglecast()) return;
 
 		const receiverNodeId: number = this.nodeId;
-		const spanState = this.host.securityManager2.getSPANState(
+		const spanState = this.securityManager.getSPANState(
 			receiverNodeId,
 		);
 		if (
@@ -1289,15 +1307,15 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 		} else if (spanState.type === SPANState.RemoteEI) {
 			// We have the receiver's EI, generate our input and send it over
 			// With both, we can create an SPAN
-			const senderEI = this.host.securityManager2.generateNonce(
+			const senderEI = this.securityManager.generateNonce(
 				undefined,
 			);
 			const receiverEI = spanState.receiverEI;
 
 			// While bootstrapping a node, the controller only sends commands encrypted
 			// with the temporary key
-			if (this.host.securityManager2.tempKeys.has(receiverNodeId)) {
-				this.host.securityManager2.initializeTempSPAN(
+			if (this.securityManager.tempKeys.has(receiverNodeId)) {
+				this.securityManager.initializeTempSPAN(
 					receiverNodeId,
 					senderEI,
 					receiverEI,
@@ -1312,7 +1330,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 						ZWaveErrorCodes.Security2CC_NoSPAN,
 					);
 				}
-				this.host.securityManager2.initializeSPAN(
+				this.securityManager.initializeSPAN(
 					receiverNodeId,
 					securityClass,
 					senderEI,
@@ -1381,18 +1399,18 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 			// Singlecast:
 			// Generate a nonce for encryption, and remember it to attempt decryption
 			// of potential in-flight messages from the target node.
-			iv = this.host.securityManager2.nextNonce(this.nodeId, true);
+			iv = this.securityManager.nextNonce(this.nodeId, true);
 			const { keyCCM } =
 				// Prefer the overridden security class if it was given
 				this.securityClass != undefined
-					? this.host.securityManager2.getKeysForSecurityClass(
+					? this.securityManager.getKeysForSecurityClass(
 						this.securityClass,
 					)
-					: this.host.securityManager2.getKeysForNode(this.nodeId);
+					: this.securityManager.getKeysForNode(this.nodeId);
 			key = keyCCM;
 		} else {
 			// Multicast:
-			const keyAndIV = this.host.securityManager2.getMulticastKeyAndIV(
+			const keyAndIV = this.securityManager.getMulticastKeyAndIV(
 				destinationTag,
 			);
 			key = keyAndIV.key;
@@ -1477,7 +1495,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 			// TODO: This is ugly, we should probably do this in the constructor or so
 			let securityClass = this.securityClass;
 			if (securityClass == undefined) {
-				const spanState = this.host.securityManager2.getSPANState(
+				const spanState = this.securityManager.getSPANState(
 					this.nodeId,
 				);
 				if (spanState.type === SPANState.SPAN) {
@@ -1510,7 +1528,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 		},
 	): DecryptionResult {
 		const decryptWithNonce = (nonce: Buffer) => {
-			const { keyCCM: key } = this.host.securityManager2.getKeysForNode(
+			const { keyCCM: key } = this.securityManager.getKeysForNode(
 				sendingNodeId,
 			);
 
@@ -1522,7 +1540,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 			};
 		};
 		const getNonceAndDecrypt = () => {
-			const iv = this.host.securityManager2.nextNonce(sendingNodeId);
+			const iv = this.securityManager.nextNonce(sendingNodeId);
 			return decryptWithNonce(iv);
 		};
 
@@ -1566,12 +1584,12 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 			const receiverEI = spanState.receiverEI;
 
 			// How we do this depends on whether we know the security class of the other node
-			const isBootstrappingNode = this.host.securityManager2.tempKeys.has(
+			const isBootstrappingNode = this.securityManager.tempKeys.has(
 				sendingNodeId,
 			);
 			if (isBootstrappingNode) {
 				// We're currently bootstrapping the node, it might be using a temporary key
-				this.host.securityManager2.initializeTempSPAN(
+				this.securityManager.initializeTempSPAN(
 					sendingNodeId,
 					senderEI,
 					receiverEI,
@@ -1587,7 +1605,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 				}
 
 				// Reset the SPAN state and try with the recently granted security class
-				this.host.securityManager2.setSPANState(
+				this.securityManager.setSPANState(
 					sendingNodeId,
 					spanState,
 				);
@@ -1614,7 +1632,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 			for (const secClass of possibleSecurityClasses) {
 				// Skip security classes we don't have keys for
 				if (
-					!this.host.securityManager2.hasKeysForSecurityClass(
+					!this.securityManager.hasKeysForSecurityClass(
 						secClass,
 					)
 				) {
@@ -1622,7 +1640,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 				}
 
 				// Initialize an SPAN with that security class
-				this.host.securityManager2.initializeSPAN(
+				this.securityManager.initializeSPAN(
 					sendingNodeId,
 					secClass,
 					senderEI,
@@ -1649,7 +1667,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 					};
 				} else {
 					// Reset the SPAN state and try with the next security class
-					this.host.securityManager2.setSPANState(
+					this.securityManager.setSPANState(
 						sendingNodeId,
 						spanState,
 					);
@@ -1672,11 +1690,11 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 		authData: Buffer,
 		authTag: Buffer,
 	): DecryptionResult {
-		const iv = this.host.securityManager2.nextPeerMPAN(
+		const iv = this.securityManager.nextPeerMPAN(
 			sendingNodeId,
 			groupId,
 		);
-		const { keyCCM: key } = this.host.securityManager2.getKeysForNode(
+		const { keyCCM: key } = this.securityManager.getKeysForNode(
 			sendingNodeId,
 		);
 		return {
@@ -1704,12 +1722,6 @@ export type Security2CCNonceReportOptions =
 
 @CCCommand(Security2Command.NonceReport)
 export class Security2CCNonceReport extends Security2CC {
-	// Define the securityManager as existing
-	// We check it in the constructor
-	declare host: ZWaveHost & {
-		securityManager2: SecurityManager2;
-	};
-
 	public constructor(
 		host: ZWaveHost,
 		options:
@@ -1720,6 +1732,7 @@ export class Security2CCNonceReport extends Security2CC {
 
 		// Make sure that we can send/receive secure commands
 		assertSecurity.call(this, options);
+		this.securityManager = getSecurityManager(host, this.nodeId)!;
 
 		if (gotDeserializationOptions(options)) {
 			validatePayload(this.payload.length >= 2);
@@ -1738,7 +1751,7 @@ export class Security2CCNonceReport extends Security2CC {
 
 				// In that case we also need to store it, so the next sent command
 				// can use it for encryption
-				this.host.securityManager2.storeRemoteEI(
+				this.securityManager.storeRemoteEI(
 					this.nodeId as number,
 					this.receiverEI,
 				);
@@ -1750,6 +1763,7 @@ export class Security2CCNonceReport extends Security2CC {
 		}
 	}
 
+	private securityManager: SecurityManager2;
 	private _sequenceNumber: number | undefined;
 	/**
 	 * Return the sequence number of this command.
@@ -1759,7 +1773,7 @@ export class Security2CCNonceReport extends Security2CC {
 	 */
 	public get sequenceNumber(): number {
 		if (this._sequenceNumber == undefined) {
-			this._sequenceNumber = this.host.securityManager2
+			this._sequenceNumber = this.securityManager
 				.nextSequenceNumber(
 					this.nodeId as number,
 				);
@@ -1804,17 +1818,12 @@ export class Security2CCNonceGet extends Security2CC {
 	// TODO: A node sending this command MUST accept a delay up to <Previous Round-trip-time to peer node> +
 	// 250 ms before receiving the Security 2 Nonce Report Command.
 
-	// Define the securityManager as existing
-	// We check it in the constructor
-	declare host: ZWaveHost & {
-		securityManager2: SecurityManager2;
-	};
-
 	public constructor(host: ZWaveHost, options: CCCommandOptions) {
 		super(host, options);
 
 		// Make sure that we can send/receive secure commands
 		assertSecurity.call(this, options);
+		this.securityManager = getSecurityManager(host, this.nodeId)!;
 
 		if (gotDeserializationOptions(options)) {
 			validatePayload(this.payload.length >= 1);
@@ -1826,6 +1835,7 @@ export class Security2CCNonceGet extends Security2CC {
 		}
 	}
 
+	private securityManager: SecurityManager2;
 	private _sequenceNumber: number | undefined;
 	/**
 	 * Return the sequence number of this command.
@@ -1835,7 +1845,7 @@ export class Security2CCNonceGet extends Security2CC {
 	 */
 	public get sequenceNumber(): number {
 		if (this._sequenceNumber == undefined) {
-			this._sequenceNumber = this.host.securityManager2
+			this._sequenceNumber = this.securityManager
 				.nextSequenceNumber(
 					this.nodeId as number,
 				);

--- a/packages/host/src/ZWaveHost.ts
+++ b/packages/host/src/ZWaveHost.ts
@@ -29,8 +29,10 @@ export interface ZWaveHost {
 
 	/** Management of Security S0 keys and nonces */
 	securityManager: SecurityManager | undefined;
-	/** Management of Security S2 keys and nonces */
+	/** Management of Security S2 keys and nonces (Z-Wave Classic) */
 	securityManager2: SecurityManager2 | undefined;
+	/** Management of Security S2 keys and nonces (Z-Wave Long Range) */
+	securityManagerLR: SecurityManager2 | undefined;
 
 	/**
 	 * Retrieves the maximum version of a command class that can be used to communicate with a node.

--- a/packages/host/src/mocks.ts
+++ b/packages/host/src/mocks.ts
@@ -44,6 +44,7 @@ export function createTestingHost(
 		isControllerNode: (nodeId) => nodeId === ret.ownNodeId,
 		securityManager: undefined,
 		securityManager2: undefined,
+		securityManagerLR: undefined,
 		getDeviceConfig: undefined,
 		controllerLog: new Proxy({} as any, {
 			get() {

--- a/packages/testing/src/MockController.ts
+++ b/packages/testing/src/MockController.ts
@@ -56,6 +56,7 @@ export class MockController {
 			homeId: options.homeId ?? 0x7e571000,
 			securityManager: undefined,
 			securityManager2: undefined,
+			securityManagerLR: undefined,
 			// nodes: this.nodes as any,
 			getNextCallbackId: () => 1,
 			getNextSupervisionSessionId: (nodeId) => {

--- a/packages/zwave-js/src/lib/driver/MessageGenerators.ts
+++ b/packages/zwave-js/src/lib/driver/MessageGenerators.ts
@@ -568,8 +568,8 @@ export const secureMessageGeneratorS2: MessageGeneratorImplementation =
 			);
 		}
 
-		const secMan = driver.securityManager2!;
 		const nodeId = msg.command.nodeId;
+		const secMan = driver.getSecurityManager2(nodeId)!;
 		const spanState = secMan.getSPANState(nodeId);
 		let additionalTimeoutMs: number | undefined;
 
@@ -742,7 +742,7 @@ export const secureMessageGeneratorS2Multicast: MessageGeneratorImplementation =
 			);
 		}
 
-		const secMan = driver.securityManager2!;
+		const secMan = driver.getSecurityManager2(msg.command.nodeId)!;
 		const group = secMan.getMulticastGroup(groupId);
 		if (!group) {
 			throw new ZWaveError(

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -146,13 +146,21 @@ export interface ZWaveOptions extends ZWaveHostOptions {
 	};
 
 	/**
-	 * Specify the security keys to use for encryption. Each one must be a Buffer of exactly 16 bytes.
+	 * Specify the security keys to use for encryption (Z-Wave Classic). Each one must be a Buffer of exactly 16 bytes.
 	 */
 	securityKeys?: {
-		S2_Unauthenticated?: Buffer;
-		S2_Authenticated?: Buffer;
 		S2_AccessControl?: Buffer;
+		S2_Authenticated?: Buffer;
+		S2_Unauthenticated?: Buffer;
 		S0_Legacy?: Buffer;
+	};
+
+	/**
+	 * Specify the security keys to use for encryption (Z-Wave Long Range). Each one must be a Buffer of exactly 16 bytes.
+	 */
+	securityKeysLongRange?: {
+		S2_AccessControl?: Buffer;
+		S2_Authenticated?: Buffer;
 	};
 
 	/**


### PR DESCRIPTION
The specification requires to use separate S2 keys for Z-Wave Long Range, so this is what we do now. They can be specified using the new `securityKeysLongRange` property of the `ZWaveOptions`.