### PR TITLE
fix(config): disable Supervision for Alfred DB1 Digital Deadbolt Lock

### DIFF
--- a/packages/config/config/devices/0x021d/db1.json
+++ b/packages/config/config/devices/0x021d/db1.json
@@ -19,5 +19,16 @@
 		"exclusion": "-Follow the user guide of hub to enter exclusion mode.\n-Operate on lock following guide below:\n1.Enter master mode(refer to programming instruction)\n2.Input “8” to enter “function extension settings”\n3.Input “2” to log off a network",
 		"reset": "※Please use this procedure only when the network primary controller is missing or inoperable.\n-Operations on lock\n1.Open the door and keep the lock in \"unlock\" status\n2.Open battery box and find the reset button. \n3.Use a sharp thing to press and hold the reset button.\n4.Keep holding the reset button and remove a battery from battery box then replace it.\n5.Keep holding the reset button until hearing voice guide",
 		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/3373/Alfred%20Z-Wave%20Plus%20System%20Integrators%20Guide(DB1)%20V1.2.pdf"
+	},
+	"compat": {
+		"commandClasses": {
+			"remove": {
+				// The device has a bug where it stays awake after receiving a Supervision Get command
+				// with "request updates" set to true, which quickly drains the battery.
+				"Supervision": {
+					"endpoints": "*"
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
The manufacturer has identified a bug where it stays awake after receiving a Supervision Get command with "request updates" set to true, which quickly drains the battery.