### PR TITLE
fix: update DB library to reduce idle load

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@actions/core": "^1.9.1",
     "@actions/exec": "^1.1.1",
     "@actions/github": "^5.0.3",
-    "@alcalzone/jsonl-db": "^3.1.0",
+    "@alcalzone/jsonl-db": "^3.1.1",
     "@alcalzone/monopack": "^1.2.2",
     "@alcalzone/release-script": "~3.7.0",
     "@commitlint/cli": "^17.7.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
     "test:dirty": "node -r ../../maintenance/esbuild-register.js ../maintenance/src/resolveDirtyTests.ts --run"
   },
   "dependencies": {
-    "@alcalzone/jsonl-db": "^3.1.0",
+    "@alcalzone/jsonl-db": "^3.1.1",
     "@zwave-js/shared": "workspace:*",
     "alcalzone-shared": "^4.0.8",
     "ansi-colors": "^4.1.3",

--- a/packages/zwave-js/package.json
+++ b/packages/zwave-js/package.json
@@ -81,7 +81,7 @@
     "test:dirty": "node -r ../../maintenance/esbuild-register.js ../maintenance/src/resolveDirtyTests.ts --run"
   },
   "dependencies": {
-    "@alcalzone/jsonl-db": "^3.1.0",
+    "@alcalzone/jsonl-db": "^3.1.1",
     "@alcalzone/pak": "^0.10.1",
     "@zwave-js/cc": "workspace:*",
     "@zwave-js/config": "workspace:*",

--- a/test/run.ts
+++ b/test/run.ts
@@ -52,15 +52,6 @@ const driver = new Driver(port, {
 	.on("error", console.error)
 	.once("driver ready", async () => {
 		// Test code goes here
-		await wait(10000);
-		console.log("TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT");
-		console.log("TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT");
-		console.log("TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT");
-		console.log("TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT");
-
-		await driver["writeSerial"](Buffer.from("010800130201002503c1", "hex"));
-		await wait(3);
-		await driver["writeSerial"](Buffer.from("01030016ea", "hex"));
 	})
 	.once("bootloader ready", async () => {
 		// What to do when stuck in the bootloader

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,14 +59,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@alcalzone/jsonl-db@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "@alcalzone/jsonl-db@npm:3.1.0"
+"@alcalzone/jsonl-db@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@alcalzone/jsonl-db@npm:3.1.1"
   dependencies:
     "@alcalzone/proper-lockfile": ^4.1.3-0
     alcalzone-shared: ^4.0.8
     fs-extra: ^10.1.0
-  checksum: 7ca8b6ba7ba92abc59e2ef6affecaeeb0797d20756904f08e906882e15173b6a2c975fc170355ac9b2ac57c07fd1e37a09c70c4a1a1c35249ab51b425514a04d
+  checksum: 377a1bcb4f5d00d9ae7ebaabd066e077eb8cf790311cbe44878fbcd8da5ae912630b2d2a505c57c8e6aa0d116b57ccbd6c798ace2a2d5341215b40b53e87ee30
   languageName: node
   linkType: hard
 
@@ -1973,7 +1973,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@zwave-js/core@workspace:packages/core"
   dependencies:
-    "@alcalzone/jsonl-db": ^3.1.0
+    "@alcalzone/jsonl-db": ^3.1.1
     "@microsoft/api-extractor": ^7.37.3
     "@types/node": ^18.17.14
     "@types/sinon": ^10.0.16
@@ -2122,7 +2122,7 @@ __metadata:
     "@actions/core": ^1.9.1
     "@actions/exec": ^1.1.1
     "@actions/github": ^5.0.3
-    "@alcalzone/jsonl-db": ^3.1.0
+    "@alcalzone/jsonl-db": ^3.1.1
     "@alcalzone/monopack": ^1.2.2
     "@alcalzone/release-script": ~3.7.0
     "@commitlint/cli": ^17.7.1
@@ -9235,7 +9235,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "zwave-js@workspace:packages/zwave-js"
   dependencies:
-    "@alcalzone/jsonl-db": ^3.1.0
+    "@alcalzone/jsonl-db": ^3.1.1
     "@alcalzone/pak": ^0.10.1
     "@microsoft/api-extractor": ^7.37.3
     "@types/fs-extra": ^11.0.1


### PR DESCRIPTION
`@alcalzone/jsonl-db` `v3.1.1` has an internal optimization which reduces the idle CPU load from ~3-5% on my system to 0%

fixes: https://github.com/zwave-js/node-zwave-js/issues/6612 (I hope)