### PR TITLE
fix(config): use Color Switch V2 for Inovelli LZW42

### DIFF
--- a/packages/config/config/devices/0x031e/lzw42.json
+++ b/packages/config/config/devices/0x031e/lzw42.json
@@ -68,7 +68,7 @@
 		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=product_documents/3613/LZW42%20Manual.pdf"
 	},
 	"compat": {
-		// The device supports Color Switch V2, despite the Version query saying
+		// The device supports Color Switch V2, despite only reporting support for V1
 		"commandClasses": {
 			"add": {
 				"Color Switch": {

--- a/packages/config/config/devices/0x031e/lzw42.json
+++ b/packages/config/config/devices/0x031e/lzw42.json
@@ -66,5 +66,16 @@
 		"exclusion": "Put your hub in exclusion mode and turn the power to the bulb on.  Your bulb will blink twice (2x) indicating it's in exclusion mode.  When exclusion is successful, it will blink one more time (1x) to confirm.  Your hub should say that the device is excluded.",
 		"reset": "You may power on/off the bulb 6x (between 0.5-2 seconds each time) or use a certified controller to remove the device from your network to factory default.  Only use this procedure in the event that the network primary controller is missing or otherwise inoperable.  Your bulb will flash twice to confirm factory reset.",
 		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=product_documents/3613/LZW42%20Manual.pdf"
+	},
+	"compat": {
+		// The device supports Color Switch V2, despite the Version query saying
+		"commandClasses": {
+			"add": {
+				"Color Switch": {
+					"isSupported": true,
+					"version": 2
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
In the Inovelli Official Hubitat driver for the LZW42, they use Color Switch V2 commands ([source](https://github.com/InovelliUSA/Hubitat/blob/master/Drivers/inovelli-bulb-multi-color-lzw42.src/inovelli-bulb-multi-color-lzw42.groovy#L338)).
I also own these lightbulbs, and I can confirm they do indeed respond to the V2 version of set, which takes a dimming duration.

I am not super familiar with how to write these config files, so if this is the wrong way to force it to use Color Switch V2, please point me in the correct direction, so that I can fix it.