### PR TITLE
fix(config): correct config parameters for Minoston MP21ZD Dimmer Plug

### DIFF
--- a/packages/config/config/devices/0x0312/mp21zd.json
+++ b/packages/config/config/devices/0x0312/mp21zd.json
@@ -57,7 +57,6 @@
 		{
 			"#": "12",
 			"$import": "~/templates/master_template.json#maximum_dim_level_0-99",
-			"defaultValue": 99,
 			"options": [
 				{
 					"label": "Disable",

--- a/packages/config/config/devices/0x0312/mp21zd.json
+++ b/packages/config/config/devices/0x0312/mp21zd.json
@@ -2,7 +2,7 @@
 	"manufacturer": "Minoston",
 	"manufacturerId": "0x0312",
 	"label": "MP21ZD",
-	"description": "Smart Plug Dimmer",
+	"description": "Smart Plug Dimmer (800S)",
 	"devices": [
 		{
 			"productType": "0xff00",
@@ -24,24 +24,29 @@
 			"$import": "templates/minoston_template.json#auto_off_timer"
 		},
 		{
-			"#": "5",
+			"#": "6",
 			"$import": "templates/minoston_template.json#auto_on_timer"
 		},
 		{
+			"#": "7",
+			"$import": "templates/minoston_template.json#night_light_set"
+		},
+		{
 			"#": "8",
-			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off_on"
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
 		{
 			"#": "9",
-			"$import": "~/templates/master_template.json#dim_rate"
+			"$import": "templates/minoston_template.json#dim_speed_on_off"
 		},
 		{
 			"#": "10",
-			"$import": "~/templates/master_template.json#minimum_dim_level_0-99"
+			"$import": "templates/minoston_template.json#dim_speed_dimmer"
 		},
 		{
 			"#": "11",
-			"$import": "~/templates/master_template.json#maximum_dim_level_0-99",
+			"$import": "~/templates/master_template.json#minimum_dim_level_0-99",
+			"defaultValue": 10,
 			"options": [
 				{
 					"label": "Disable",
@@ -51,41 +56,20 @@
 		},
 		{
 			"#": "12",
-			"$import": "templates/minoston_template.json#double_tap_function"
-		},
-		{
-			"#": "15",
-			"$import": "~/templates/master_template.json#smart_switch_mode_0-2"
-		},
-		{
-			"#": "21",
-			"$import": "templates/minoston_template.json#report_state_when_local_control_disabled"
-		},
-		{
-			"#": "16",
-			"$import": "~/templates/master_template.json#dimming_speed_1-99_seconds"
-		},
-		{
-			"#": "20",
-			"$import": "templates/minoston_template.json#association_reports_basic_multilevel"
-		},
-		{
-			"#": "22",
-			"$import": "templates/minoston_template.json#night_mode_brightness"
-		},
-		{
-			"#": "23",
-			"$import": "templates/minoston_template.json#led_indicator_color"
-		},
-		{
-			"#": "26",
-			"$import": "templates/minoston_template.json#led_indicator_brightness"
+			"$import": "~/templates/master_template.json#maximum_dim_level_0-99",
+			"defaultValue": 99,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
 		}
 	],
 	"metadata": {
 		"inclusion": "1. Refer to your primary controller instructions to process the inclusion / exclusion setup procedure.\n2. When prompted by your primary controller, click the button three times in one second",
 		"exclusion": "1. Refer to your primary controller instructions to process the inclusion / exclusion setup procedure.\n2. When prompted by your primary controller, click the button three times in one second",
 		"reset": "Press click Z-Wave button 3 times quickly, and hold for at least 10 seconds at the third time to restore the device to the factory\n(Node:Please use this procedure only when the network primary controller is missing or otherwise inoperable.)",
-		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=product_documents/4137/MP21ZD%20Manual-20210322.pdf"
+		"manual": "https://cdn-files.myshopline.com/file/store/1701829637050/MP21ZD(800-Series)-Manual.pdf"
 	}
 }

--- a/packages/config/config/devices/0x0312/mp21zd.json
+++ b/packages/config/config/devices/0x0312/mp21zd.json
@@ -2,7 +2,7 @@
 	"manufacturer": "Minoston",
 	"manufacturerId": "0x0312",
 	"label": "MP21ZD",
-	"description": "Smart Plug Dimmer (800S)",
+	"description": "Smart Plug Dimmer",
 	"devices": [
 		{
 			"productType": "0xff00",

--- a/packages/config/config/devices/0x0312/templates/minoston_template.json
+++ b/packages/config/config/devices/0x0312/templates/minoston_template.json
@@ -376,6 +376,57 @@
 		"defaultValue": 20,
 		"unsigned": true
 	},
+	"night_light_set": {
+		"label": "Night Light Brightness Level",
+		"description": "Sets a specific brightness for the light when you want to make it as a night light",
+		"valueSize": 1,
+		"minValue": 1,
+		"maxValue": 10,
+		"defaultValue": 2,
+		"unsigned": true,
+		"options": [
+			{
+				"label": "10%",
+				"value": 1
+			},
+			{
+				"label": "20%",
+				"value": 2
+			},
+			{
+				"label": "30%",
+				"value": 3
+			},
+			{
+				"label": "40%",
+				"value": 4
+			},
+			{
+				"label": "50%",
+				"value": 5
+			},
+			{
+				"label": "60%",
+				"value": 6
+			},
+			{
+				"label": "70%",
+				"value": 7
+			},
+			{
+				"label": "80%",
+				"value": 8
+			},
+			{
+				"label": "90%",
+				"value": 9
+			},
+			{
+				"label": "100%",
+				"value": 10
+			}
+		]
+	},
 	"external_switch_type_two_options": {
 		"label": "External Switch Type",
 		"valueSize": 1,
@@ -533,5 +584,31 @@
 				"value": 0
 			}
 		]
+	},
+	"dim_speed_on_off": {
+		"label": "Dimmer Speed (On/Off Control)",
+		"description": "Sets the time (seconds) from maximum brightness to minimum brightness or minimum brightness to maximum brightness",
+		"valueSize": 1,
+		"unit": "seconds",
+		"minValue": 0,
+		"maxValue": 10,
+		"defaultValue": 2,
+		"unsigned": true,
+		"options": [
+			{
+				"label": "Instant on/off",
+				"value": 0
+			}
+		]
+	},
+	"dim_speed_dimmer": {
+		"label": "Dimmer Speed (Dimmer Control)",
+		"description": "Sets the time (seconds) from maximum brightness to minimum brightness or minimum brightness to maximum brightness",
+		"valueSize": 1,
+		"unit": "seconds",
+		"minValue": 1,
+		"maxValue": 10,
+		"defaultValue": 4,
+		"unsigned": true
 	}
 }

--- a/packages/config/config/devices/0x0312/templates/minoston_template.json
+++ b/packages/config/config/devices/0x0312/templates/minoston_template.json
@@ -378,12 +378,10 @@
 	},
 	"night_light_set": {
 		"label": "Night Light Brightness Level",
-		"description": "Sets a specific brightness for the light when you want to make it as a night light",
 		"valueSize": 1,
-		"minValue": 1,
-		"maxValue": 10,
 		"defaultValue": 2,
 		"unsigned": true,
+		"allowManualEntry": false,
 		"options": [
 			{
 				"label": "10%",
@@ -587,7 +585,7 @@
 	},
 	"dim_speed_on_off": {
 		"label": "Dimmer Speed (On/Off Control)",
-		"description": "Sets the time (seconds) from maximum brightness to minimum brightness or minimum brightness to maximum brightness",
+		"description": "Time from minimum to maximum brightness or vice-versa",
 		"valueSize": 1,
 		"unit": "seconds",
 		"minValue": 0,
@@ -603,7 +601,7 @@
 	},
 	"dim_speed_dimmer": {
 		"label": "Dimmer Speed (Dimmer Control)",
-		"description": "Sets the time (seconds) from maximum brightness to minimum brightness or minimum brightness to maximum brightness",
+		"description": "Time from minimum to maximum brightness or vice-versa",
 		"valueSize": 1,
 		"unit": "seconds",
 		"minValue": 1,


### PR DESCRIPTION
The existing configuration parameters for the MP21ZD were pulled from a similar, but different, Minoston dimmer plug and are mostly incorrect.

This PR corrects the configuration parameters for the MP21ZD, based on the parameters available in the user manual from Minoston: https://cdn-files.myshopline.com/file/store/1701829637050/MP21ZD(800-Series)-Manual.pdf

This required a few additions to the template config, for new parameters that appear to not have any prior work in existing template files. 

I believe I followed all the style guide rules, to the best of my ability, but always open for feedback.

Thanks!

Fixes: https://github.com/zwave-js/node-zwave-js/issues/6902