### PR TITLE
feat(config): remove Association Groups 2 & 3 from AEON Labs DSB09

### DIFF
--- a/packages/config/config/devices/0x0086/dsb09.json
+++ b/packages/config/config/devices/0x0086/dsb09.json
@@ -19,16 +19,6 @@
 			"label": "Lifeline",
 			"maxNodes": 5,
 			"isLifeline": true
-		},
-		"2": {
-			"label": "Group 2",
-			"maxNodes": 5,
-			"isLifeline": true
-		},
-		"3": {
-			"label": "Group 3",
-			"maxNodes": 5,
-			"isLifeline": true
 		}
 	},
 	"paramInformation": [


### PR DESCRIPTION
Closes #6684 Note: I do not see Association groups 2 and 3 in the ZW095 json.

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

PR description here
