### PR TITLE
fix(config): correct group 3 label for GE/Enbrighten 26931/ZW4006

### DIFF
--- a/packages/config/config/devices/0x0063/26931_zw4006.json
+++ b/packages/config/config/devices/0x0063/26931_zw4006.json
@@ -24,9 +24,8 @@
 			"maxNodes": 5
 		},
 		"3": {
-			"label": "Double Tap",
-			"maxNodes": 5,
-			"isLifeline": true
+			"label": "Local Load",
+			"maxNodes": 5
 		}
 	},
 	"paramInformation": [


### PR DESCRIPTION
Unlike other GE/Enbrighten switches, this one does not actually support double-tap. Both groups 2 and 3 behave identically (Basic Set for single tap). 😞 

The manual says as much, and confirmed through testing with my device:
![image](https://github.com/zwave-js/node-zwave-js/assets/15070192/94fad761-101a-4db6-81d0-8f9af33c8b53)

I just set the labels to be the same; not sure if there might be a better alternative?

