### PR TITLE
fix: add workaround for devices that omit notification parameters instead of sending "no data"

### DIFF
--- a/packages/cc/src/cc/NotificationCC.ts
+++ b/packages/cc/src/cc/NotificationCC.ts
@@ -1191,7 +1191,7 @@ export class NotificationCCReport extends NotificationCC {
 				valueConfig.parameter.default,
 			);
 			if (label) {
-				message["state parameters"] = label;
+				message["state parameters"] = `${label} (omitted)`;
 			}
 		}
 		return {

--- a/packages/config/config/notifications.json
+++ b/packages/config/config/notifications.json
@@ -303,7 +303,7 @@
 								"0x04": "Max"
 							},
 							// Translate missing event parameter to "no data"
-							"default": 1
+							"default": "0x01"
 						}
 					}
 				}
@@ -322,7 +322,7 @@
 								"0x04": "Max"
 							},
 							// Translate missing event parameter to "no data"
-							"default": 1
+							"default": "0x01"
 						}
 					}
 				}
@@ -340,7 +340,7 @@
 								"0x03": "Above high threshold"
 							},
 							// Translate missing event parameter to "no data"
-							"default": 1
+							"default": "0x01"
 						}
 					}
 				}
@@ -358,7 +358,7 @@
 								"0x03": "Above high threshold"
 							},
 							// Translate missing event parameter to "no data"
-							"default": 1
+							"default": "0x01"
 						}
 					}
 				}
@@ -1259,7 +1259,7 @@
 								"0x04": "Max"
 							},
 							// Translate missing event parameter to "no data"
-							"default": 1
+							"default": "0x01"
 						}
 					}
 				}
@@ -1278,7 +1278,7 @@
 								"0x04": "Max"
 							},
 							// Translate missing event parameter to "no data"
-							"default": 1
+							"default": "0x01"
 						}
 					}
 				}

--- a/packages/config/config/notifications.json
+++ b/packages/config/config/notifications.json
@@ -301,7 +301,9 @@
 								"0x02": "Below low threshold",
 								"0x03": "Above high threshold",
 								"0x04": "Max"
-							}
+							},
+							// Translate missing event parameter to "no data"
+							"default": 1
 						}
 					}
 				}
@@ -318,7 +320,9 @@
 								"0x02": "Below low threshold",
 								"0x03": "Above high threshold",
 								"0x04": "Max"
-							}
+							},
+							// Translate missing event parameter to "no data"
+							"default": 1
 						}
 					}
 				}
@@ -334,7 +338,9 @@
 								"0x01": "No data",
 								"0x02": "Below low threshold",
 								"0x03": "Above high threshold"
-							}
+							},
+							// Translate missing event parameter to "no data"
+							"default": 1
 						}
 					}
 				}
@@ -350,7 +356,9 @@
 								"0x01": "No data",
 								"0x02": "Below low threshold",
 								"0x03": "Above high threshold"
-							}
+							},
+							// Translate missing event parameter to "no data"
+							"default": 1
 						}
 					}
 				}
@@ -1249,7 +1257,9 @@
 								"0x02": "Below low threshold",
 								"0x03": "Above high threshold",
 								"0x04": "Max"
-							}
+							},
+							// Translate missing event parameter to "no data"
+							"default": 1
 						}
 					}
 				}
@@ -1266,7 +1276,9 @@
 								"0x02": "Below low threshold",
 								"0x03": "Above high threshold",
 								"0x04": "Max"
-							}
+							},
+							// Translate missing event parameter to "no data"
+							"default": 1
 						}
 					}
 				}

--- a/packages/config/src/Notifications.ts
+++ b/packages/config/src/Notifications.ts
@@ -331,7 +331,34 @@ export class NotificationParameterWithEnum {
 		}
 
 		this.values = values;
+
+		if (definition.default != undefined) {
+			let defaultVal: number;
+			if (typeof definition.default === "number") {
+				defaultVal = definition.default;
+			} else if (
+				typeof definition.default === "string"
+				&& hexKeyRegexNDigits.test(definition.default)
+			) {
+				defaultVal = parseInt(definition.default, 16);
+			} else {
+				throwInvalidConfig(
+					"notifications",
+					`The default value for an event parameter enum must be a number or a string in hexadecimal format`,
+				);
+			}
+
+			if (!values.has(defaultVal)) {
+				throwInvalidConfig(
+					"notifications",
+					`The default value for an event parameter enum must be one of the defined values`,
+				);
+			}
+
+			this.default = defaultVal;
+		}
 	}
 
 	public readonly values: ReadonlyMap<number, string>;
+	public readonly default?: number;
 }

--- a/packages/zwave-js/src/lib/test/cc-specific/notificationEnums.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/notificationEnums.test.ts
@@ -314,10 +314,10 @@ integrationTest("The 'simple' Door state value works correctly", {
 	},
 });
 
-integrationTest.only(
+integrationTest(
 	"Notification types with 'replace'-type enums fall back to the default value if the event parameter is not contained in the CC",
 	{
-		debug: true,
+		// debug: true,
 
 		nodeCapabilities: {
 			commandClasses: [


### PR DESCRIPTION
fixes: #6584
closes: https://github.com/zwave-js/node-zwave-js/pull/6606