### PR TITLE
feat(config): update parameter addition for ZEN52 Firmware 1.70 - external switch delay

### DIFF
--- a/packages/config/config/devices/0x027a/zen52.json
+++ b/packages/config/config/devices/0x027a/zen52.json
@@ -129,6 +129,10 @@
 		{
 			"#": "24",
 			"$import": "templates/zooz_template.json#association_reports_binary"
+		},
+		{
+			"#": "27",
+			"$import": "templates/zooz_template.json#zen5x_external_switch_multiple_click"
 		}
 	],
 	"metadata": {


### PR DESCRIPTION
Update configuration for firmware 1.70 released 8/2023. New parameter 27- external switch multiple click. 

From patch notes:
"Removed the delay when controlling the ZEN52 from the external mechanical switch when parameter 27 is set to value 0 (disable external switch multiple click detection)"

