### PR TITLE
chore: set up root tsconfig as "solution"

### DIFF
--- a/packages/cc/tsconfig.json
+++ b/packages/cc/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"plugins": [
 			{

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {},
 	"references": [
 		{

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {},
 	"references": [
 		{

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"types": ["node", "@typescript-eslint/utils"]
 	},

--- a/packages/flash/tsconfig.json
+++ b/packages/flash/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {},
 	"references": [
 		{

--- a/packages/host/tsconfig.json
+++ b/packages/host/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {},
 	"references": [
 		{

--- a/packages/maintenance/tsconfig.json
+++ b/packages/maintenance/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"newLine": "lf",
 		"resolveJsonModule": true

--- a/packages/nvmedit/tsconfig.json
+++ b/packages/nvmedit/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {},
 	"references": [
 		{

--- a/packages/serial/tsconfig.json
+++ b/packages/serial/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {},
 	"references": [
 		{

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {},
 	"references": [],
 	"include": ["src/**/*.ts"],

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {},
 	"references": [
 		{

--- a/packages/transformers/tsconfig.json
+++ b/packages/transformers/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"newLine": "lf",
 		"experimentalDecorators": true,

--- a/packages/zwave-js/tsconfig.json
+++ b/packages/zwave-js/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"plugins": [
 			{

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,26 @@
+{
+	"extends": "@tsconfig/node18/tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"incremental": true,
+		"declaration": true,
+		"declarationMap": true,
+
+		"noEmitOnError": true,
+		"removeComments": false,
+		"experimentalDecorators": true,
+		"emitDecoratorMetadata": false,
+		"sourceMap": true,
+		"inlineSourceMap": false,
+		"stripInternal": true,
+
+		"pretty": true,
+		"types": ["node"],
+		"noErrorTruncation": true
+	}
+	// "include": [
+	// 	"maintenance/**/*.ts",
+	// 	"test/**/*.ts"
+	// ],
+	// "exclude": ["**/build/**", "node_modules/**", "./packages/**/node_modules"]
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,5 +1,5 @@
 {
-	"extends": "./tsconfig.json",
+	"extends": "./tsconfig.base.json",
 	"include": ["**/*.ts"],
 	"exclude": ["**/build/**", "**/node_modules/**"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,28 +1,45 @@
 {
-	"extends": "@tsconfig/node18/tsconfig.json",
-	"compilerOptions": {
-		"composite": true,
-		"incremental": true,
-		"declaration": true,
-		"declarationMap": true,
-
-		"noEmitOnError": true,
-		"removeComments": false,
-		"experimentalDecorators": true,
-		"emitDecoratorMetadata": false,
-		"sourceMap": true,
-		"inlineSourceMap": false,
-		"stripInternal": true,
-
-		"pretty": true,
-		"types": ["node"],
-		"noErrorTruncation": true
-	},
-	"include": [
-		"packages/**/src/**/*.ts",
-		"packages/**/maintenance/**/*.ts",
-		"maintenance/**/*.ts",
-		"test/**/*.ts"
-	],
-	"exclude": ["**/build/**", "node_modules/**", "packages/**/node_modules"]
+	"files": [],
+	"include": [],
+	"references": [
+		{
+			"path": "./packages/cc"
+		},
+		{
+			"path": "./packages/config"
+		},
+		{
+			"path": "./packages/core"
+		},
+		{
+			"path": "./packages/eslint-plugin"
+		},
+		{
+			"path": "./packages/flash"
+		},
+		{
+			"path": "./packages/host"
+		},
+		{
+			"path": "./packages/maintenance"
+		},
+		{
+			"path": "./packages/nvmedit"
+		},
+		{
+			"path": "./packages/serial"
+		},
+		{
+			"path": "./packages/shared"
+		},
+		{
+			"path": "./packages/testing"
+		},
+		{
+			"path": "./packages/transformers"
+		},
+		{
+			"path": "./packages/zwave-js"
+		}
+	]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -91,6 +91,7 @@
 		"yarn.lock",
 		// Build fresh when TS related stuff changes
 		"tsconfig.json",
+		"tsconfig.base.json",
 		"tsconfig.build.json"
 	]
 }


### PR DESCRIPTION
This follows the official handbook for monorepos:
https://www.typescriptlang.org/docs/handbook/project-references.html#overall-structure

Hopefully this will improve the goto references functionality.