### PR TITLE
fix: make `RouteStatistics.protocolDataRate` optional

### DIFF
--- a/packages/zwave-js/src/lib/node/NodeStatistics.ts
+++ b/packages/zwave-js/src/lib/node/NodeStatistics.ts
@@ -55,7 +55,7 @@ export interface NodeStatistics {
 
 export interface RouteStatistics {
 	/** The protocol and used data rate for this route */
-	protocolDataRate: ProtocolDataRate;
+	protocolDataRate?: ProtocolDataRate;
 	/** Which nodes are repeaters for this route */
 	repeaters: number[];
 


### PR DESCRIPTION
Older SDKs don't include this byte, so it can be `undefined`. This PR updates the type definitions to match.

fixes: #6616