### PR TITLE
chore: set up root tsconfig as "solution", avoid compilation for lints and tests

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -125,9 +125,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Restore Turbo Cache from previous jobs
-      uses: ./.github/actions/build-cache-download
-
     - name: Prepare testing environment
       uses: ./.github/actions/prepare-env
       with:
@@ -179,9 +176,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Restore Turbo Cache from previous jobs
-      uses: ./.github/actions/build-cache-download
-
     - name: Prepare testing environment
       uses: ./.github/actions/prepare-env
       with:
@@ -203,9 +197,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-
-    - name: Restore Turbo Cache from previous jobs
-      uses: ./.github/actions/build-cache-download
 
     - name: Prepare testing environment
       uses: ./.github/actions/prepare-env
@@ -292,9 +283,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Restore Turbo Cache from previous jobs
-      uses: ./.github/actions/build-cache-download
-
     - name: Prepare testing environment
       uses: ./.github/actions/prepare-env
       with:
@@ -329,9 +317,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-
-    - name: Restore Turbo Cache from previous jobs
-      uses: ./.github/actions/build-cache-download
 
     - name: Prepare testing environment
       uses: ./.github/actions/prepare-env

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -47,9 +47,7 @@ jobs:
         githubToken: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Compile TypeScript code
-      run: |
-        # yarn clean $TURBO_FLAGS
-        yarn build $TURBO_FLAGS
+      run: yarn build $TURBO_FLAGS
 
     - name: Save Turbo Cache between jobs
       uses: ./.github/actions/build-cache-upload
@@ -118,8 +116,6 @@ jobs:
   # ===================
 
   lint:
-    needs: [build]
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -137,11 +133,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         githubToken: ${{ secrets.GITHUB_TOKEN }}
-
-    # For linting to succeed, we need to build the eslint plugin first.
-    # Thanks to caching from the previous job, this should be almost a no-op
-    - name: Compile TypeScript code
-      run: yarn build $TURBO_FLAGS
 
     - name: Run linters
       run: yarn run lint $TURBO_FLAGS
@@ -179,8 +170,6 @@ jobs:
   # ===================
 
   lint-zwave:
-    needs: [build]
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -205,8 +194,6 @@ jobs:
   # ===================
   # Runs unit tests on all supported node versions and OSes
   unit-tests:
-    needs: [build]
-
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -225,11 +212,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         githubToken: ${{ secrets.GITHUB_TOKEN }}
-
-    # For the partial tests to succeed, we need to build the packages first.
-    # Thanks to caching from the previous job, this should be almost a no-op
-    - name: Compile TypeScript code
-      run: yarn build $TURBO_FLAGS
 
     # For pull requests, only run tests for changed files
     - name: Run component tests (changes)
@@ -300,8 +282,6 @@ jobs:
       github.ref == 'refs/heads/master' &&
       github.event_name == 'push'
 
-    needs: [build]
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -320,9 +300,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         githubToken: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Compile TypeScript code
-      run: yarn build $TURBO_FLAGS
 
     - name: Update CC table # (maybe)
       uses: actions/github-script@v7
@@ -343,8 +320,6 @@ jobs:
       github.ref == 'refs/heads/master' &&
       github.event_name == 'push'
 
-    needs: [build]
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -363,9 +338,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         githubToken: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Compile TypeScript code
-      run: yarn build $TURBO_FLAGS
 
     - name: Update overview
       uses: actions/github-script@v7
@@ -386,7 +358,7 @@ jobs:
       github.event_name == 'push' &&
       startsWith(github.ref, 'refs/tags/v')
 
-    needs: [lint, lint-zwave, unit-tests, test-packages]
+    needs: [build, lint, lint-zwave, unit-tests, test-packages]
 
     runs-on: ubuntu-latest
     strategy:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,13 +27,13 @@
 			"type": "node",
 			"request": "launch",
 			"name": "Debug locally",
-			"port": 9229,
 			"runtimeExecutable": "yarn",
 			"runtimeArgs": [
 				"node",
 				"--async-stack-traces",
 				"-r",
 				"./maintenance/esbuild-register.js",
+				"--conditions=@@dev",
 				"${workspaceFolder}/test/run.ts"
 			],
 			"env": {
@@ -43,35 +43,13 @@
 			},
 			"console": "integratedTerminal",
 			"skipFiles": ["<node_internals>/**"],
-			"sourceMaps": true,
-			"preLaunchTask": "npm: build"
-		},
-		{
-			"type": "node",
-			"request": "launch",
-			"name": "Test network mock",
-			"port": 9229,
-			"runtimeExecutable": "yarn",
-			"runtimeArgs": [
-				"node",
-				"--async-stack-traces",
-				"-r",
-				"./maintenance/esbuild-register.js",
-				"${workspaceFolder}/test/mock.ts"
-			],
-			"env": {
-				"NO_CACHE": "true"
-			},
-			"console": "integratedTerminal",
-			"skipFiles": ["<node_internals>/**"],
-			"sourceMaps": true,
-			"preLaunchTask": "npm: build"
+			"sourceMaps": true
+			// "preLaunchTask": "npm: build"
 		},
 		{
 			"type": "node",
 			"request": "launch",
 			"name": "Generate typed docs",
-			"port": 9229,
 			"runtimeExecutable": "yarn",
 			"runtimeArgs": [
 				"node",
@@ -83,24 +61,28 @@
 			],
 			"console": "integratedTerminal",
 			"skipFiles": ["<node_internals>/**"],
-			"sourceMaps": true
+			"sourceMaps": true,
+			// This needs the compiled sources (I think)
+			"preLaunchTask": "npm: build"
 		},
 		{
 			"type": "node",
 			"request": "launch",
 			"name": "Decode message",
-			"port": 9229,
 			"runtimeExecutable": "yarn",
 			"runtimeArgs": [
 				"node",
 				"--async-stack-traces",
 				"--inspect-brk=9229",
-				"${workspaceFolder}/test/debug.js"
+				"-r",
+				"./maintenance/esbuild-register.js",
+				"--conditions=@@dev",
+				"${workspaceFolder}/test/decodeMessage.ts"
 			],
 			"console": "integratedTerminal",
 			"skipFiles": ["<node_internals>/**"],
-			"sourceMaps": true,
-			"preLaunchTask": "npm: build"
+			"sourceMaps": true
+			// "preLaunchTask": "npm: build"
 		},
 		{
 			"type": "node",
@@ -114,34 +96,32 @@
 				"--inspect=9229",
 				"-r",
 				"./maintenance/esbuild-register.js",
+				"--conditions=@@dev",
 				"${workspaceFolder}/packages/config/maintenance/importConfig.ts",
 				"-dm -s zwa"
 			],
-			"console": "integratedTerminal",
-			"disableOptimisticBPs": true
+			"console": "integratedTerminal"
 		},
 		{
 			"type": "node",
 			"request": "launch",
 			"name": "Run Zniffer",
-			"port": 9229,
 			"runtimeExecutable": "yarn",
 			"runtimeArgs": [
 				"node",
 				"--async-stack-traces",
 				"-r",
 				"./maintenance/esbuild-register.js",
+				"--conditions=@@dev",
 				"${workspaceFolder}/test/run_zniffer.ts"
 			],
 			"env": {
 				"NODE_ENV": "development"
-				// "NO_CACHE": "true"
-				// "LOGLEVEL": "info"
 			},
 			"console": "integratedTerminal",
 			"skipFiles": ["<node_internals>/**"],
-			"sourceMaps": true,
-			"preLaunchTask": "npm: build"
+			"sourceMaps": true
+			// "preLaunchTask": "npm: build"
 		}
 	]
 }

--- a/ava.config.cjs
+++ b/ava.config.cjs
@@ -3,4 +3,7 @@ module.exports = {
 	extensions: ["ts"],
 	files: ["test/**", "**/*.test.ts", "!build/**"],
 	require: [path.join(__dirname, "./maintenance/esbuild-register.js")],
+	nodeArguments: [
+		"--conditions=@@dev",
+	],
 };

--- a/docs/api/CCs/Meter.md
+++ b/docs/api/CCs/Meter.md
@@ -7,19 +7,35 @@
 ### `get`
 
 ```ts
-async get(options?: MeterCCGetOptions): Promise<{ rateType: RateType; value: number; previousValue: MaybeNotKnown<number>; deltaTime: MaybeUnknown<number>; type: number; scale: MeterScale; } | undefined>;
+async get(options?: MeterCCGetOptions): Promise<{ rateType: RateType; value: number; previousValue: MaybeNotKnown<number>; deltaTime: MaybeUnknown<number>; type: number; scale: import("/home/dominic/Repositories/node-zwave-js/packages/core/build/index").MeterScale; } | undefined>;
+```
+
+### `sendReport`
+
+```ts
+async sendReport(
+	options: MeterCCReportOptions,
+): Promise<SupervisionResult | undefined>;
 ```
 
 ### `getAll`
 
 ```ts
-async getAll(): Promise<{ rateType: RateType; value: number; previousValue: MaybeNotKnown<number>; deltaTime: MaybeUnknown<number>; type: number; scale: MeterScale; }[]>;
+async getAll(accumulatedOnly: boolean = false): Promise<{ rateType: RateType; value: number; previousValue: MaybeNotKnown<number>; deltaTime: MaybeUnknown<number>; type: number; scale: import("/home/dominic/Repositories/node-zwave-js/packages/core/build/index").MeterScale; }[]>;
 ```
 
 ### `getSupported`
 
 ```ts
 async getSupported(): Promise<Pick<MeterCCSupportedReport, "type" | "supportsReset" | "supportedScales" | "supportedRateTypes"> | undefined>;
+```
+
+### `sendSupportedReport`
+
+```ts
+async sendSupportedReport(
+	options: MeterCCSupportedReportOptions,
+): Promise<void>;
 ```
 
 ### `reset`
@@ -50,7 +66,7 @@ async reset(
 - **secret:** false
 - **value type:** `"boolean"`
 
-### `resetSingle(meterType: number)`
+### `resetSingle(meterType: number, rateType: RateType, scale: number)`
 
 ```ts
 {
@@ -61,7 +77,7 @@ async reset(
 }
 ```
 
-- **label:** `Reset (${string})`
+- **label:** `Reset (${string})` | `Reset (Consumption, ${string})` | `Reset (Production, ${string})`
 - **min. CC version:** 1
 - **readable:** false
 - **writeable:** true

--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -907,6 +907,7 @@ interface ZWaveOptions extends ZWaveHostOptions {
 		 */
 		watchdog?: boolean;
 	};
+
 	preferences: {
 		/**
 		 * The preferred scales to use when querying sensors. The key is either:

--- a/package.json
+++ b/package.json
@@ -137,8 +137,8 @@
     "extract-api": "FORCE_COLOR=1 yarn turbo run extract-api",
     "accept-api": "yarn extract-api -- --local",
     "monopack": "yarn exec monopack",
-    "check-references": "workspaces-to-typescript-project-references --check && workspaces-to-typescript-project-references --check --tsconfigPath tsconfig.build.json",
-    "sync-references": "workspaces-to-typescript-project-references && workspaces-to-typescript-project-references --tsconfigPath tsconfig.build.json && yarn fmt > /dev/null"
+    "check-references": "workspaces-to-typescript-project-references --check --tsconfigPath tsconfig.build.json",
+    "sync-references": "workspaces-to-typescript-project-references --tsconfigPath tsconfig.build.json && yarn fmt > /dev/null"
   },
   "readme": "README.md",
   "config": {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "commit": "git-cz",
     "release": "release-script",
     "release:all": "release-script --publish-all",
-    "postinstall": "ts-patch install -s && yarn node maintenance/patch-tsserver.js",
+    "postinstall": "ts-patch install -s && yarn node maintenance/patch-tsserver.js && yarn turbo run bootstrap",
     "prepare": "husky && ts-patch install -s",
     "config": "yarn ts packages/config/maintenance/importConfig.ts",
     "docs": "docsify serve docs",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "colors": "1.4.0"
   },
   "scripts": {
-    "ts": "node -r source-map-support/register -r ./maintenance/esbuild-register.js",
+    "ts": "node -r source-map-support/register -r ./maintenance/esbuild-register.js --conditions=@@dev",
     "w": "yarn ts maintenance/watch.ts",
     "foreach": "yarn workspaces foreach -pvi --exclude @zwave-js/repo",
     "clean": "yarn turbo run clean",

--- a/packages/cc/package.json
+++ b/packages/cc/package.json
@@ -58,7 +58,7 @@
     "build": "tsc -b tsconfig.build.json --pretty",
     "clean": "del-cli build/ \"*.tsbuildinfo\"",
     "extract-api": "yarn api-extractor run",
-    "ts": "node -r esbuild-register",
+    "ts": "node -r esbuild-register --conditions=@@dev",
     "lint:ts": "eslint --cache --ext .ts \"src/**/*.ts\"",
     "lint:ts:fix": "yarn run lint:ts --fix",
     "test:ts": "ava",

--- a/packages/cc/package.json
+++ b/packages/cc/package.json
@@ -6,23 +6,26 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "type": "commonjs",
   "exports": {
     ".": {
+      "@@dev": "./src/index.ts",
       "types": "./build/index.d.ts",
       "default": "./build/index.js"
     },
     "./safe": {
+      "@@dev": "./src/index_safe.ts",
       "types": "./build/index_safe.d.ts",
       "default": "./build/index_safe.js"
     },
     "./cc": {
+      "@@dev": "./src/cc/index.ts",
       "types": "./build/cc/index.d.ts",
       "default": "./build/cc/index.js"
     },
     "./package.json": "./package.json",
     "./*": {
+      "@@dev": "./src/cc/*.ts",
       "types": "./build/cc/*.d.ts",
       "default": "./build/cc/*.js"
     }

--- a/packages/cc/tsconfig.build.json
+++ b/packages/cc/tsconfig.build.json
@@ -3,7 +3,9 @@
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "build"
+		"outDir": "build",
+		// Do not use the @@dev export for compiling
+		"customConditions": []
 	},
 	"references": [
 		{

--- a/packages/cc/tsconfig.json
+++ b/packages/cc/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"plugins": [
 			{

--- a/packages/cc/tsconfig.json
+++ b/packages/cc/tsconfig.json
@@ -8,29 +8,6 @@
 			}
 		]
 	},
-	"references": [
-		{
-			"path": "../core"
-		},
-		{
-			"path": "../host"
-		},
-		{
-			"path": "../serial"
-		},
-		{
-			"path": "../shared"
-		},
-		{
-			"path": "../maintenance"
-		},
-		{
-			"path": "../testing"
-		},
-		{
-			"path": "../transformers"
-		}
-	],
 	"include": ["maintenance/**/*.ts", "src/**/*.ts"],
 	"exclude": ["build/**", "node_modules/**"]
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -5,14 +5,15 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "type": "commonjs",
   "exports": {
     ".": {
+      "@@dev": "./src/index.ts",
       "types": "./build/index.d.ts",
       "default": "./build/index.js"
     },
     "./safe": {
+      "@@dev": "./src/index_safe.ts",
       "types": "./build/index_safe.d.ts",
       "default": "./build/index_safe.js"
     },

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -49,7 +49,7 @@
     "clean": "del-cli build/ \"*.tsbuildinfo\"",
     "extract-api": "yarn api-extractor run",
     "lint:zwave": "yarn ts maintenance/lintConfigFiles.ts && eslint --cache --cache-location .eslintcache/config --ext .json \"config/devices/**/*.json\"",
-    "ts": "node -r esbuild-register",
+    "ts": "node -r esbuild-register --conditions=@@dev",
     "lint:ts": "eslint --cache --cache-location .eslintcache/ts --ext .ts \"src/**/*.ts\"",
     "lint:ts:fix": "yarn run lint:ts --fix",
     "test:ts": "ava",

--- a/packages/config/tsconfig.build.json
+++ b/packages/config/tsconfig.build.json
@@ -3,7 +3,9 @@
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "build"
+		"outDir": "build",
+		// Do not use the @@dev export for compiling
+		"customConditions": []
 	},
 	"references": [
 		{

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {},
 	"references": [
 		{

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -2,17 +2,6 @@
 {
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {},
-	"references": [
-		{
-			"path": "../core"
-		},
-		{
-			"path": "../shared"
-		},
-		{
-			"path": "../maintenance"
-		}
-	],
 	"include": ["maintenance/**/*.ts", "src/**/*.ts"],
 	"exclude": ["build/**", "node_modules/**"]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,18 +6,20 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "type": "commonjs",
   "exports": {
     ".": {
+      "@@dev": "./src/index.ts",
       "types": "./build/index.d.ts",
       "default": "./build/index.js"
     },
     "./safe": {
+      "@@dev": "./src/index_safe.ts",
       "types": "./build/index_safe.d.ts",
       "default": "./build/index_safe.js"
     },
     "./test": {
+      "@@dev": "./src/index_test.ts",
       "types": "./build/index_test.d.ts",
       "default": "./build/index_test.js"
     },

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -5,7 +5,9 @@
 		"rootDir": "src",
 		"outDir": "build",
 		// Some @internal members need to be accessed from other modules in this monorepo
-		"stripInternal": false
+		"stripInternal": false,
+		// Do not use the @@dev export for compiling
+		"customConditions": []
 	},
 	"references": [
 		{

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {},
 	"references": [
 		{

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,11 +2,6 @@
 {
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {},
-	"references": [
-		{
-			"path": "../shared"
-		}
-	],
 	"include": ["src/**/*.ts"],
 	"exclude": ["build/**", "node_modules/**"]
 }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -29,6 +29,7 @@
   },
   "scripts": {
     "build": "tsc -b tsconfig.build.json --pretty",
+    "bootstrap": "yarn build",
     "clean": "del-cli build/ \"*.tsbuildinfo\"",
     "lint:ts": "eslint --cache --ext .ts \"src/**/*.ts\"",
     "lint:ts:fix": "yarn run lint:ts --fix"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -37,6 +37,7 @@
     "@types/eslint": "^8.56.7",
     "@typescript-eslint/utils": "^7.5.0",
     "@zwave-js/core": "workspace:*",
+    "eslint": "^8.57.0",
     "typescript": "5.4.4"
   }
 }

--- a/packages/eslint-plugin/tsconfig.build.json
+++ b/packages/eslint-plugin/tsconfig.build.json
@@ -3,7 +3,9 @@
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "build"
+		"outDir": "build",
+		// Do not use the @@dev export for compiling
+		"customConditions": []
 	},
 	"references": [
 		{

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"types": ["node", "@typescript-eslint/utils"]
 	},

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -4,11 +4,6 @@
 	"compilerOptions": {
 		"types": ["node", "@typescript-eslint/utils"]
 	},
-	"references": [
-		{
-			"path": "../core"
-		}
-	],
 	"include": [
 		"src/**/*.ts"
 	],

--- a/packages/flash/package.json
+++ b/packages/flash/package.json
@@ -7,6 +7,7 @@
     "access": "public"
   },
   "main": "build/cli.js",
+  "type": "commonjs",
   "files": [
     "bin/",
     "build/**/*.{js,d.ts,map}"

--- a/packages/flash/tsconfig.build.json
+++ b/packages/flash/tsconfig.build.json
@@ -3,7 +3,9 @@
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "build"
+		"outDir": "build",
+		// Do not use the @@dev export for compiling
+		"customConditions": []
 	},
 	"references": [
 		{

--- a/packages/flash/tsconfig.json
+++ b/packages/flash/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {},
 	"references": [
 		{

--- a/packages/flash/tsconfig.json
+++ b/packages/flash/tsconfig.json
@@ -1,15 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
 	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {},
-	"references": [
-		{
-			"path": "../core"
-		},
-		{
-			"path": "../zwave-js"
-		}
-	],
 	"include": ["src/**/*.ts"],
 	"exclude": ["build/**", "node_modules/**"]
 }

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -6,14 +6,15 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "type": "commonjs",
   "exports": {
     ".": {
+      "@@dev": "./src/index.ts",
       "types": "./build/index.d.ts",
       "default": "./build/index.js"
     },
     "./safe": {
+      "@@dev": "./src/index_safe.ts",
       "types": "./build/index_safe.d.ts",
       "default": "./build/index_safe.js"
     },

--- a/packages/host/tsconfig.build.json
+++ b/packages/host/tsconfig.build.json
@@ -3,7 +3,9 @@
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "build"
+		"outDir": "build",
+		// Do not use the @@dev export for compiling
+		"customConditions": []
 	},
 	"references": [
 		{

--- a/packages/host/tsconfig.json
+++ b/packages/host/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {},
 	"references": [
 		{

--- a/packages/host/tsconfig.json
+++ b/packages/host/tsconfig.json
@@ -2,17 +2,6 @@
 {
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {},
-	"references": [
-		{
-			"path": "../config"
-		},
-		{
-			"path": "../core"
-		},
-		{
-			"path": "../shared"
-		}
-	],
 	"include": ["src/**/*.ts"],
 	"exclude": ["build/**", "node_modules/**"]
 }

--- a/packages/maintenance/package.json
+++ b/packages/maintenance/package.json
@@ -29,7 +29,7 @@
     "node": ">= 18"
   },
   "scripts": {
-    "ts": "node -r esbuild-register",
+    "ts": "node -r esbuild-register --conditions=@@dev",
     "build": "tsc -b tsconfig.build.json --pretty",
     "clean": "del-cli build/ \"*.tsbuildinfo\"",
     "lint:ts": "eslint --cache --ext .ts \"src/**/*.ts\"",

--- a/packages/maintenance/src/generateTypedDocs.ts
+++ b/packages/maintenance/src/generateTypedDocs.ts
@@ -31,7 +31,7 @@ import { formatWithDprint } from "./dprint";
 import {
 	getCommandClassFromClassDeclaration,
 	projectRoot,
-	tsConfigFilePath,
+	tsConfigFilePathForDocs as tsConfigFilePath,
 } from "./tsAPITools";
 
 export function findSourceNode(

--- a/packages/maintenance/src/tsAPITools.ts
+++ b/packages/maintenance/src/tsAPITools.ts
@@ -9,7 +9,10 @@ export const repoRoot = path.normalize(
 );
 
 /** Used for ts-morph */
-export const tsConfigFilePath = path.join(repoRoot, "tsconfig.json");
+export const tsConfigFilePathForDocs = path.join(
+	repoRoot,
+	"tsconfig.docs.json",
+);
 
 export function loadTSConfig(
 	packageName: string = "",

--- a/packages/maintenance/tsconfig.build.json
+++ b/packages/maintenance/tsconfig.build.json
@@ -3,7 +3,9 @@
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "build"
+		"outDir": "build",
+		// Do not use the @@dev export for compiling
+		"customConditions": []
 	},
 	"references": [
 		{

--- a/packages/maintenance/tsconfig.json
+++ b/packages/maintenance/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"newLine": "lf",
 		"resolveJsonModule": true

--- a/packages/maintenance/tsconfig.json
+++ b/packages/maintenance/tsconfig.json
@@ -5,14 +5,6 @@
 		"newLine": "lf",
 		"resolveJsonModule": true
 	},
-	"references": [
-		{
-			"path": "../core"
-		},
-		{
-			"path": "../shared"
-		}
-	],
 	"include": ["src/**/*.ts", "src/**/*.json"],
 	"exclude": ["build/**", "node_modules/**"]
 }

--- a/packages/nvmedit/package.json
+++ b/packages/nvmedit/package.json
@@ -6,14 +6,15 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "type": "commonjs",
   "exports": {
     ".": {
+      "@@dev": "./src/index.ts",
       "types": "./build/index.d.ts",
       "default": "./build/index.js"
     },
     "./safe": {
+      "@@dev": "./src/index_safe.ts",
       "types": "./build/index_safe.d.ts",
       "default": "./build/index_safe.js"
     },

--- a/packages/nvmedit/tsconfig.build.json
+++ b/packages/nvmedit/tsconfig.build.json
@@ -3,7 +3,9 @@
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "build"
+		"outDir": "build",
+		// Do not use the @@dev export for compiling
+		"customConditions": []
 	},
 	"references": [
 		{

--- a/packages/nvmedit/tsconfig.json
+++ b/packages/nvmedit/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {},
 	"references": [
 		{

--- a/packages/nvmedit/tsconfig.json
+++ b/packages/nvmedit/tsconfig.json
@@ -2,14 +2,6 @@
 {
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {},
-	"references": [
-		{
-			"path": "../core"
-		},
-		{
-			"path": "../shared"
-		}
-	],
 	"include": ["src/**/*.ts"],
 	"exclude": ["build/**", "node_modules/**"]
 }

--- a/packages/serial/package.json
+++ b/packages/serial/package.json
@@ -5,18 +5,20 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "type": "commonjs",
   "exports": {
     ".": {
+      "@@dev": "./src/index.ts",
       "types": "./build/index.d.ts",
       "default": "./build/index.js"
     },
     "./safe": {
+      "@@dev": "./src/index_safe.ts",
       "types": "./build/index_safe.d.ts",
       "default": "./build/index_safe.js"
     },
     "./mock": {
+      "@@dev": "./src/index_mock.ts",
       "types": "./build/index_mock.d.ts",
       "default": "./build/index_mock.js"
     },

--- a/packages/serial/tsconfig.build.json
+++ b/packages/serial/tsconfig.build.json
@@ -3,7 +3,9 @@
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "build"
+		"outDir": "build",
+		// Do not use the @@dev export for compiling
+		"customConditions": []
 	},
 	"references": [
 		{

--- a/packages/serial/tsconfig.json
+++ b/packages/serial/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {},
 	"references": [
 		{

--- a/packages/serial/tsconfig.json
+++ b/packages/serial/tsconfig.json
@@ -2,17 +2,6 @@
 {
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {},
-	"references": [
-		{
-			"path": "../core"
-		},
-		{
-			"path": "../host"
-		},
-		{
-			"path": "../shared"
-		}
-	],
 	"include": ["src/**/*.ts"],
 	"exclude": ["build/**", "node_modules/**"]
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,14 +6,15 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "type": "commonjs",
   "exports": {
     ".": {
+      "@@dev": "./src/index.ts",
       "types": "./build/index.d.ts",
       "default": "./build/index.js"
     },
     "./safe": {
+      "@@dev": "./src/index_safe.ts",
       "types": "./build/index_safe.d.ts",
       "default": "./build/index_safe.js"
     },

--- a/packages/shared/tsconfig.build.json
+++ b/packages/shared/tsconfig.build.json
@@ -3,7 +3,9 @@
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "build"
+		"outDir": "build",
+		// Do not use the @@dev export for compiling
+		"customConditions": []
 	},
 	"references": [],
 	"include": ["src/**/*.ts"],

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {},
 	"references": [],
 	"include": ["src/**/*.ts"],

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -2,7 +2,6 @@
 {
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {},
-	"references": [],
 	"include": ["src/**/*.ts"],
 	"exclude": ["build/**", "node_modules/**"]
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -6,8 +6,15 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "type": "commonjs",
+  "exports": {
+    ".": {
+      "@@dev": "./src/index.ts",
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "build/**/*.{js,d.ts,map}"
   ],

--- a/packages/testing/tsconfig.build.json
+++ b/packages/testing/tsconfig.build.json
@@ -3,7 +3,9 @@
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "build"
+		"outDir": "build",
+		// Do not use the @@dev export for compiling
+		"customConditions": []
 	},
 	"references": [
 		{

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {},
 	"references": [
 		{

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -2,20 +2,6 @@
 {
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {},
-	"references": [
-		{
-			"path": "../core"
-		},
-		{
-			"path": "../host"
-		},
-		{
-			"path": "../serial"
-		},
-		{
-			"path": "../shared"
-		}
-	],
 	"include": ["src/**/*.ts"],
 	"exclude": ["build/**", "node_modules/**"]
 }

--- a/packages/transformers/package.json
+++ b/packages/transformers/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "build": "tsc -b tsconfig.build.json --pretty",
     "clean": "del-cli build/ \"*.tsbuildinfo\"",
+    "bootstrap": "yarn build",
     "pretest": "del-cli \"test/fixtures/*.js\" && tsc -p tsconfig.test.json && cpy \"test/build/test/fixtures/*.js\" test/fixtures && del-cli test/build",
     "lint:ts": "eslint --cache --ext .ts \"src/**/*.ts\"",
     "lint:ts:fix": "yarn run lint:ts --fix",

--- a/packages/transformers/src/index.ts
+++ b/packages/transformers/src/index.ts
@@ -62,6 +62,7 @@ export function validateArgs(options?: ValidateArgsOptions): PropertyDecorator {
 	return (target: unknown, property: string | number | symbol) => {
 		// this is a no-op that gets replaced during the build process using the transformer below
 		if (process.env.NODE_ENV === "test") return;
+		if (process.execArgv.includes("--conditions=@@dev")) return;
 		// Throw an error at runtime when this didn't get transformed
 		throw new Error(
 			"validateArgs is a compile-time decorator and must be compiled with a transformer",

--- a/packages/transformers/tsconfig.build.json
+++ b/packages/transformers/tsconfig.build.json
@@ -3,7 +3,9 @@
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "build"
+		"outDir": "build",
+		// Do not use the @@dev export for compiling
+		"customConditions": []
 	},
 	"references": [],
 	"include": ["src/**/*.ts"],

--- a/packages/transformers/tsconfig.json
+++ b/packages/transformers/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"newLine": "lf",
 		"experimentalDecorators": true,

--- a/packages/transformers/tsconfig.json
+++ b/packages/transformers/tsconfig.json
@@ -8,7 +8,6 @@
 			"@zwave-js/transformers": ["./src"]
 		}
 	},
-	"references": [],
 	"include": ["src/**/*.ts", "test/**/*.ts"],
 	"exclude": ["build/**", "node_modules/**"]
 }

--- a/packages/zwave-js/package.json
+++ b/packages/zwave-js/package.json
@@ -3,46 +3,55 @@
   "version": "13.0.0-beta.0",
   "description": "Z-Wave driver written entirely in JavaScript/TypeScript",
   "keywords": [],
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "type": "commonjs",
   "exports": {
     ".": {
+      "@@dev": "./src/index.ts",
       "types": "./build/index.d.ts",
       "default": "./build/index.js"
     },
     "./safe": {
+      "@@dev": "./src/index_safe.ts",
       "types": "./build/index_safe.d.ts",
       "default": "./build/index_safe.js"
     },
     "./Controller": {
+      "@@dev": "./src/Controller.ts",
       "types": "./build/Controller.d.ts",
       "default": "./build/Controller.js"
     },
     "./Driver": {
+      "@@dev": "./src/Driver.ts",
       "types": "./build/Driver.d.ts",
       "default": "./build/Driver.js"
     },
     "./Error": {
+      "@@dev": "./src/Error.ts",
       "types": "./build/Error.d.ts",
       "default": "./build/Error.js"
     },
     "./Node": {
+      "@@dev": "./src/Node.ts",
       "types": "./build/Node.d.ts",
       "default": "./build/Node.js"
     },
     "./Testing": {
+      "@@dev": "./src/Testing.ts",
       "types": "./build/Testing.d.ts",
       "default": "./build/Testing.js"
     },
     "./Utils": {
+      "@@dev": "./src/Utils.ts",
       "types": "./build/Utils.d.ts",
       "default": "./build/Utils.js"
     },
     "./Values": {
+      "@@dev": "./src/Values.ts",
       "types": "./build/Values.d.ts",
       "default": "./build/Values.js"
     },
     "./Zniffer": {
+      "@@dev": "./src/Zniffer.ts",
       "types": "./build/Zniffer.d.ts",
       "default": "./build/Zniffer.js"
     },

--- a/packages/zwave-js/package.json
+++ b/packages/zwave-js/package.json
@@ -84,7 +84,7 @@
     "node": ">= 18"
   },
   "scripts": {
-    "ts": "node -r esbuild-register",
+    "ts": "node -r esbuild-register --conditions=@@dev",
     "build": "tsc -b tsconfig.build.json --pretty",
     "clean": "del-cli build/ \"*.tsbuildinfo\"",
     "extract-api": "yarn api-extractor run",

--- a/packages/zwave-js/tsconfig.build.json
+++ b/packages/zwave-js/tsconfig.build.json
@@ -8,7 +8,9 @@
 			"src/lib/@types",
 			"node_modules/@types",
 			"../../node_modules/@types"
-		]
+		],
+		// Do not use the @@dev export for compiling
+		"customConditions": []
 	},
 	"references": [
 		{

--- a/packages/zwave-js/tsconfig.json
+++ b/packages/zwave-js/tsconfig.json
@@ -13,38 +13,6 @@
 			"../../node_modules/@types"
 		]
 	},
-	"references": [
-		{
-			"path": "../cc"
-		},
-		{
-			"path": "../config"
-		},
-		{
-			"path": "../core"
-		},
-		{
-			"path": "../host"
-		},
-		{
-			"path": "../nvmedit"
-		},
-		{
-			"path": "../serial"
-		},
-		{
-			"path": "../shared"
-		},
-		{
-			"path": "../testing"
-		},
-		{
-			"path": "../maintenance"
-		},
-		{
-			"path": "../transformers"
-		}
-	],
 	"include": ["src/**/*.ts"],
 	"exclude": ["build/**", "node_modules/**"]
 }

--- a/packages/zwave-js/tsconfig.json
+++ b/packages/zwave-js/tsconfig.json
@@ -1,6 +1,6 @@
 // tsconfig for IntelliSense - active in all files in the current package
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"plugins": [
 			{

--- a/test/decodeMessage.ts
+++ b/test/decodeMessage.ts
@@ -1,17 +1,17 @@
 // @ts-check
 
-require("reflect-metadata");
-require("zwave-js");
-const { Message } = require("@zwave-js/serial");
-const {
+import "reflect-metadata";
+import "zwave-js";
+import { isCommandClassContainer } from "@zwave-js/cc";
+import { ConfigManager } from "@zwave-js/config";
+import {
+	SPANState,
+	SecurityClass,
+	SecurityManager2,
 	generateAuthKey,
 	generateEncryptionKey,
-	SecurityManager2,
-	SecurityClass,
-	SPANState,
-} = require("@zwave-js/core");
-const { isCommandClassContainer } = require("@zwave-js/cc");
-const { ConfigManager } = require("@zwave-js/config");
+} from "@zwave-js/core";
+import { Message } from "@zwave-js/serial";
 
 (async () => {
 	const configManager = new ConfigManager();
@@ -53,8 +53,7 @@ const { ConfigManager } = require("@zwave-js/config");
 	});
 
 	console.log(Message.getMessageLength(data));
-	/** @type {any} */
-	const host = {
+	const host: any = {
 		getSafeCCVersion: () => 1,
 		getSupportedCCVersion: () => 1,
 		configManager,

--- a/test/run.ts
+++ b/test/run.ts
@@ -29,7 +29,6 @@ const driver = new Driver(port, {
 	// testingHooks: {
 	// 	skipNodeInterview: true,
 	// },
-	enableSoftReset: false,
 	securityKeys: {
 		S0_Legacy: Buffer.from("0102030405060708090a0b0c0d0e0f10", "hex"),
 		S2_Unauthenticated: Buffer.from(

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../tsconfig.base.json",
+	"include": ["*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,26 @@
+{
+	"extends": "@tsconfig/node18/tsconfig.json",
+	"compilerOptions": {
+		"composite": true,
+		"incremental": true,
+		"declaration": true,
+		"declarationMap": true,
+
+		"noEmitOnError": true,
+		"removeComments": false,
+		"experimentalDecorators": true,
+		"emitDecoratorMetadata": false,
+		"sourceMap": true,
+		"inlineSourceMap": false,
+		"stripInternal": true,
+
+		"pretty": true,
+		"types": ["node"],
+		"noErrorTruncation": true
+	}
+	// "include": [
+	// 	"maintenance/**/*.ts",
+	// 	"test/**/*.ts"
+	// ],
+	// "exclude": ["**/build/**", "node_modules/**", "./packages/**/node_modules"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,3 +1,4 @@
+// Shared tsconfig to be inherited by all other tsconfigs in this repo
 {
 	"extends": "@tsconfig/node18/tsconfig.json",
 	"compilerOptions": {
@@ -22,9 +23,4 @@
 		// From: https://colinhacks.com/essays/live-types-typescript-monorepo
 		"customConditions": ["@@dev"]
 	}
-	// "include": [
-	// 	"maintenance/**/*.ts",
-	// 	"test/**/*.ts"
-	// ],
-	// "exclude": ["**/build/**", "node_modules/**", "./packages/**/node_modules"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,7 +16,11 @@
 
 		"pretty": true,
 		"types": ["node"],
-		"noErrorTruncation": true
+		"noErrorTruncation": true,
+
+		// Look up source files instead of type definitions while developing
+		// From: https://colinhacks.com/essays/live-types-typescript-monorepo
+		"customConditions": ["@@dev"]
 	}
 	// "include": [
 	// 	"maintenance/**/*.ts",

--- a/tsconfig.docs.json
+++ b/tsconfig.docs.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig.base.json",
+	"compilerOptions": {
+		"customConditions": []
+	},
+	"include": ["packages/**/src/**/*.ts"]
+}

--- a/tsconfig.docs.json
+++ b/tsconfig.docs.json
@@ -1,3 +1,4 @@
+// Custom tsconfig for documentation generation
 {
 	"extends": "./tsconfig.base.json",
 	"compilerOptions": {

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,3 +1,4 @@
+// Custom tsconfig for eslint
 {
 	"extends": "./tsconfig.base.json",
 	"include": ["**/*.ts"],

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,5 +1,5 @@
 {
-	"extends": "./tsconfig.json",
+	"extends": "./tsconfig.base.json",
 	"include": ["**/*.ts"],
 	"exclude": ["**/build/**", "**/node_modules/**"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,28 +1,45 @@
 {
-	"extends": "@tsconfig/node18/tsconfig.json",
-	"compilerOptions": {
-		"composite": true,
-		"incremental": true,
-		"declaration": true,
-		"declarationMap": true,
-
-		"noEmitOnError": true,
-		"removeComments": false,
-		"experimentalDecorators": true,
-		"emitDecoratorMetadata": false,
-		"sourceMap": true,
-		"inlineSourceMap": false,
-		"stripInternal": true,
-
-		"pretty": true,
-		"types": ["node"],
-		"noErrorTruncation": true
-	},
-	"include": [
-		"packages/**/src/**/*.ts",
-		"packages/**/maintenance/**/*.ts",
-		"maintenance/**/*.ts",
-		"test/**/*.ts"
-	],
-	"exclude": ["**/build/**", "node_modules/**", "packages/**/node_modules"]
+	"files": [],
+	"include": [],
+	"references": [
+		{
+			"path": "./packages/cc"
+		},
+		{
+			"path": "./packages/config"
+		},
+		{
+			"path": "./packages/core"
+		},
+		{
+			"path": "./packages/eslint-plugin"
+		},
+		{
+			"path": "./packages/flash"
+		},
+		{
+			"path": "./packages/host"
+		},
+		{
+			"path": "./packages/maintenance"
+		},
+		{
+			"path": "./packages/nvmedit"
+		},
+		{
+			"path": "./packages/serial"
+		},
+		{
+			"path": "./packages/shared"
+		},
+		{
+			"path": "./packages/testing"
+		},
+		{
+			"path": "./packages/transformers"
+		},
+		{
+			"path": "./packages/zwave-js"
+		}
+	]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"extends": "./tsconfig.base.json",
 	"files": [],
 	"include": [],
 	"references": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,43 +1,18 @@
+// This is a "solution" tsconfig with references to all "entrypoints" in the monorepo
+// to power IntelliSense without having to open a specific package first
 {
 	"extends": "./tsconfig.base.json",
+	"compilerOptions": {
+		"noEmit": true
+	},
 	"files": [],
 	"include": [],
 	"references": [
-		{
-			"path": "./packages/cc"
-		},
-		{
-			"path": "./packages/config"
-		},
-		{
-			"path": "./packages/core"
-		},
 		{
 			"path": "./packages/eslint-plugin"
 		},
 		{
 			"path": "./packages/flash"
-		},
-		{
-			"path": "./packages/host"
-		},
-		{
-			"path": "./packages/maintenance"
-		},
-		{
-			"path": "./packages/nvmedit"
-		},
-		{
-			"path": "./packages/serial"
-		},
-		{
-			"path": "./packages/shared"
-		},
-		{
-			"path": "./packages/testing"
-		},
-		{
-			"path": "./packages/transformers"
 		},
 		{
 			"path": "./packages/zwave-js"

--- a/turbo.json
+++ b/turbo.json
@@ -38,6 +38,10 @@
 			"outputs": ["packages/*/build/**", "packages/*/*.tsbuildinfo"]
 		},
 
+		"@zwave-js/eslint-plugin#build": {
+			// Dummy task to enable building the eslint plugin
+		},
+
 		// Specific linting tasks: ESLint
 		"lint:ts": {
 			"dependsOn": ["//#build:turbo"],
@@ -67,9 +71,9 @@
 
 		"lint:zwave": {
 			// Dummy task to enable running all lint:zwave tasks
-			"dependsOn": ["//#build:turbo"]
 		},
 		"@zwave-js/config#lint:zwave": {
+			"dependsOn": ["@zwave-js/eslint-plugin#build"],
 			"inputs": ["**/*.ts", "config/**/*.json"]
 		},
 
@@ -81,7 +85,7 @@
 		},
 
 		"test:ts": {
-			"dependsOn": ["//#build:turbo"],
+			// "dependsOn": ["//#build:turbo"],
 			"inputs": ["src/**/*.ts", "ava.config.cjs", "../../ava.config.cjs"]
 			// TODO: consider snapshot files
 		}

--- a/turbo.json
+++ b/turbo.json
@@ -91,6 +91,7 @@
 		"yarn.lock",
 		// Build fresh when TS related stuff changes
 		"tsconfig.json",
+		"tsconfig.base.json",
 		"tsconfig.build.json"
 	]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,10 @@
 			"cache": false
 		},
 
+		"bootstrap": {
+			// Dummy task to enable running all bootstrap tasks
+		},
+
 		"codegen": {
 			// Dummy task to enable running all codegen tasks
 		},

--- a/turbo.json
+++ b/turbo.json
@@ -7,6 +7,7 @@
 
 		"bootstrap": {
 			// Dummy task to enable running all bootstrap tasks
+			"cache": false // TypeScript does the caching
 		},
 
 		"codegen": {
@@ -42,13 +43,9 @@
 			"outputs": ["packages/*/build/**", "packages/*/*.tsbuildinfo"]
 		},
 
-		"@zwave-js/eslint-plugin#build": {
-			// Dummy task to enable building the eslint plugin
-		},
-
 		// Specific linting tasks: ESLint
 		"lint:ts": {
-			"dependsOn": ["//#build:turbo"],
+			"dependsOn": ["bootstrap"],
 			"inputs": [
 				// https://github.com/vercel/turborepo/issues/1407
 				":!:build/",
@@ -60,7 +57,7 @@
 			]
 		},
 		"lint:ts:fix": {
-			"dependsOn": ["//#build:turbo"],
+			"dependsOn": ["bootstrap"],
 			"inputs": [
 				// https://github.com/vercel/turborepo/issues/1407
 				":!:build/",
@@ -74,10 +71,10 @@
 		},
 
 		"lint:zwave": {
+			"dependsOn": ["bootstrap"]
 			// Dummy task to enable running all lint:zwave tasks
 		},
 		"@zwave-js/config#lint:zwave": {
-			"dependsOn": ["@zwave-js/eslint-plugin#build"],
 			"inputs": ["**/*.ts", "config/**/*.json"]
 		},
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1975,6 +1975,7 @@ __metadata:
     "@types/eslint": "npm:^8.56.7"
     "@typescript-eslint/utils": "npm:^7.5.0"
     "@zwave-js/core": "workspace:*"
+    eslint: "npm:^8.57.0"
     typescript: "npm:5.4.4"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
With this PR, we now follow the official handbook for monorepos:
[typescriptlang.org/docs/handbook/project-references.html#overall-structure](https://www.typescriptlang.org/docs/handbook/project-references.html#overall-structure)

Hopefully this will improve the goto references functionality.

In addition, we also use the custom conditions trick explained in https://colinhacks.com/essays/live-types-typescript-monorepo to be able to edit and run most of the code without compiling first.