### PR TITLE
feat: add support for EU Long Range

### DIFF
--- a/packages/core/src/capabilities/RFRegion.ts
+++ b/packages/core/src/capabilities/RFRegion.ts
@@ -3,11 +3,14 @@ export enum RFRegion {
 	"USA" = 0x01,
 	"Australia/New Zealand" = 0x02,
 	"Hong Kong" = 0x03,
+	// 0x04 is deprecated
 	"India" = 0x05,
 	"Israel" = 0x06,
 	"Russia" = 0x07,
 	"China" = 0x08,
 	"USA (Long Range)" = 0x09,
+	// 0x0a is deprecated
+	"EU (Long Range)" = 0x0b,
 	"Japan" = 0x20,
 	"Korea" = 0x21,
 	"Unknown" = 0xfe,

--- a/packages/core/src/capabilities/RFRegion.ts
+++ b/packages/core/src/capabilities/RFRegion.ts
@@ -10,7 +10,7 @@ export enum RFRegion {
 	"China" = 0x08,
 	"USA (Long Range)" = 0x09,
 	// 0x0a is deprecated
-	"EU (Long Range)" = 0x0b,
+	"Europe (Long Range)" = 0x0b,
 	"Japan" = 0x20,
 	"Korea" = 0x21,
 	"Unknown" = 0xfe,
@@ -35,6 +35,7 @@ export enum ZnifferRegion {
 	"China" = 0x08,
 	"USA (Long Range)" = 0x09,
 	"USA (Long Range, backup)" = 0x0a,
+	"Europe (Long Range)" = 0x0b,
 	"Japan" = 0x20,
 	"Korea" = 0x21,
 	"USA (Long Range, end device)" = 0x30,

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -6459,6 +6459,8 @@ ${associatedNodes.join(", ")}`,
 			if (filterSubsets) ret.delete(RFRegion.USA);
 
 			// EU Long Range was added in SDK 7.22 for 800 series chips
+			// 7.22.1 adds support for querying the supported regions, so the following
+			// is really only necessary for 7.22.0.
 			if (
 				typeof this._zwaveChipType === "string"
 				&& getChipTypeAndVersion(this._zwaveChipType)?.type === 8

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -73,6 +73,7 @@ import {
 	dskFromString,
 	dskToString,
 	encodeX25519KeyDERSPKI,
+	getChipTypeAndVersion,
 	indexDBsByNode,
 	isEmptyRoute,
 	isLongRangeNodeId,
@@ -6453,9 +6454,18 @@ ${associatedNodes.join(", ")}`,
 		]);
 
 		if (this.isLongRangeCapable()) {
+			// All LR capable controllers support USA Long Range
 			ret.add(RFRegion["USA (Long Range)"]);
-			if (filterSubsets) {
-				ret.delete(RFRegion.USA);
+			if (filterSubsets) ret.delete(RFRegion.USA);
+
+			// EU Long Range was added in SDK 7.22 for 800 series chips
+			if (
+				typeof this._zwaveChipType === "string"
+				&& getChipTypeAndVersion(this._zwaveChipType)?.type === 8
+				&& this.sdkVersionGte("7.22")
+			) {
+				ret.add(RFRegion["Europe (Long Range)"]);
+				if (filterSubsets) ret.delete(RFRegion.Europe);
 			}
 		}
 


### PR DESCRIPTION
This can be tested now on 800 series devkits using Simplicity Studio and the new **Simplicity SDK** from Silicon Labs in version 7.22.1.
Alternatively, the latest firmware versions of Z-Wave.me hardware also support EU LR.