### PR TITLE
fix: consider max LR payload size in firmware updates

### DIFF
--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -690,6 +690,18 @@ export class ZWaveController
 		return this._supportsLongRange;
 	}
 
+	private _maxPayloadSize: MaybeNotKnown<number>;
+	/** The maximum payload size that can be transmitted with a Z-Wave explorer frame */
+	public get maxPayloadSize(): MaybeNotKnown<number> {
+		return this._maxPayloadSize;
+	}
+
+	private _maxPayloadSizeLR: MaybeNotKnown<number>;
+	/** The maximum payload size that can be transmitted with a Z-Wave Long Range frame */
+	public get maxPayloadSizeLR(): MaybeNotKnown<number> {
+		return this._maxPayloadSizeLR;
+	}
+
 	private _nodes: ThrowingMap<number, ZWaveNode>;
 	/** A dictionary of the nodes connected to this controller */
 	public get nodes(): ReadonlyThrowingMap<number, ZWaveNode> {
@@ -1100,18 +1112,16 @@ export class ZWaveController
 		}
 
 		// Figure out the maximum payload size for outgoing commands
-		let maxPayloadSize: number | undefined;
 		if (
 			this.isSerialAPISetupCommandSupported(
 				SerialAPISetupCommand.GetMaximumPayloadSize,
 			)
 		) {
 			this.driver.controllerLog.print(`querying max. payload size...`);
-			maxPayloadSize = await this.getMaxPayloadSize();
+			this._maxPayloadSize = await this.getMaxPayloadSize();
 			this.driver.controllerLog.print(
-				`maximum payload size: ${maxPayloadSize} bytes`,
+				`maximum payload size: ${this._maxPayloadSize} bytes`,
 			);
-			// TODO: cache this information
 		}
 
 		this.driver.controllerLog.print(
@@ -1147,15 +1157,12 @@ export class ZWaveController
 		// Fetch the list of Long Range nodes
 		const lrNodeIds = await this.getLongRangeNodes();
 
-		let maxPayloadSizeLR: number | undefined;
 		if (
 			this.isSerialAPISetupCommandSupported(
 				SerialAPISetupCommand.GetLongRangeMaximumPayloadSize,
 			)
 		) {
-			maxPayloadSizeLR = await this.getMaxPayloadSizeLongRange();
-
-			// TODO: cache this information
+			this._maxPayloadSizeLR = await this.getMaxPayloadSizeLongRange();
 		}
 
 		let lrChannel: LongRangeChannel | undefined;
@@ -1171,7 +1178,7 @@ export class ZWaveController
 
 		this.driver.controllerLog.print(
 			`received Z-Wave Long Range capabilities:
-  max. payload size: ${maxPayloadSizeLR} bytes
+  max. payload size: ${this._maxPayloadSizeLR} bytes
   channel:           ${
 				lrChannel
 					? getEnumMemberName(LongRangeChannel, lrChannel)

--- a/packages/zwave-js/src/lib/driver/MessageGenerators.ts
+++ b/packages/zwave-js/src/lib/driver/MessageGenerators.ts
@@ -50,7 +50,6 @@ import {
 	createDeferredPromise,
 } from "alcalzone-shared/deferred-promise";
 import {
-	exceedsMaxPayloadLength,
 	isSendData,
 	isTransmitReport,
 } from "../serialapi/transport/SendDataShared";
@@ -134,7 +133,7 @@ export const simpleMessageGenerator: MessageGeneratorImplementation =
 		additionalCommandTimeoutMs = 0,
 	) {
 		// Make sure we can send this message
-		if (isSendData(msg) && exceedsMaxPayloadLength(msg)) {
+		if (isSendData(msg) && driver.exceedsMaxPayloadLength(msg)) {
 			// We use explorer frames by default, but this reduces the maximum payload length by 2 bytes compared to AUTO_ROUTE
 			// Try disabling explorer frames for this message and see if it fits now.
 			const fail = () => {
@@ -145,7 +144,7 @@ export const simpleMessageGenerator: MessageGeneratorImplementation =
 			};
 			if (msg.transmitOptions & TransmitOptions.Explore) {
 				msg.transmitOptions &= ~TransmitOptions.Explore;
-				if (exceedsMaxPayloadLength(msg)) {
+				if (driver.exceedsMaxPayloadLength(msg)) {
 					// Still too large
 					throw fail();
 				}
@@ -226,7 +225,7 @@ export const maybeTransportServiceGenerator: MessageGeneratorImplementation =
 			node?.supportsCC(CommandClasses["Transport Service"])
 			&& node.getCCVersion(CommandClasses["Transport Service"]) >= 2;
 
-		if (!mayUseTransportService || !exceedsMaxPayloadLength(msg)) {
+		if (!mayUseTransportService || !driver.exceedsMaxPayloadLength(msg)) {
 			// Transport Service isn't needed for this message
 			return yield* simpleMessageGenerator(
 				driver,

--- a/packages/zwave-js/src/lib/serialapi/transport/SendDataBridgeMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/transport/SendDataBridgeMessages.ts
@@ -156,14 +156,6 @@ export class SendDataBridgeRequest<CCType extends CommandClass = CommandClass>
 		};
 	}
 
-	/** Computes the maximum payload size that can be transmitted with this message */
-	public getMaxPayloadLength(): number {
-		// From INS13954-7, chapter 4.3.3.1.5
-		if (this.transmitOptions & TransmitOptions.Explore) return 46;
-		if (this.transmitOptions & TransmitOptions.AutoRoute) return 48;
-		return 54;
-	}
-
 	public expectsNodeUpdate(): boolean {
 		return (
 			// Only true singlecast commands may expect a response
@@ -405,15 +397,6 @@ export class SendDataMulticastBridgeRequest<
 				"callback id": this.callbackId,
 			},
 		};
-	}
-	/** Computes the maximum payload size that can be transmitted with this message */
-	public getMaxPayloadLength(): number {
-		// From INS13954-13, chapter 4.3.3.6
-		if (this.transmitOptions & TransmitOptions.ACK) {
-			if (this.transmitOptions & TransmitOptions.Explore) return 17;
-			if (this.transmitOptions & TransmitOptions.AutoRoute) return 19;
-		}
-		return 25;
 	}
 }
 

--- a/packages/zwave-js/src/lib/serialapi/transport/SendDataMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/transport/SendDataMessages.ts
@@ -191,14 +191,6 @@ export class SendDataRequest<CCType extends CommandClass = CommandClass>
 		};
 	}
 
-	/** Computes the maximum payload size that can be transmitted with this message */
-	public getMaxPayloadLength(): number {
-		// From INS13954-7, chapter 4.3.3.1.5
-		if (this.transmitOptions & TransmitOptions.Explore) return 46;
-		if (this.transmitOptions & TransmitOptions.AutoRoute) return 48;
-		return 54;
-	}
-
 	public expectsNodeUpdate(): boolean {
 		return (
 			// Only true singlecast commands may expect a response
@@ -505,16 +497,6 @@ export class SendDataMulticastRequest<
 				"callback id": this.callbackId,
 			},
 		};
-	}
-
-	/** Computes the maximum payload size that can be transmitted with this message */
-	public getMaxPayloadLength(): number {
-		// From INS13954-13, chapter 4.3.3.6
-		if (this.transmitOptions & TransmitOptions.ACK) {
-			if (this.transmitOptions & TransmitOptions.Explore) return 17;
-			if (this.transmitOptions & TransmitOptions.AutoRoute) return 19;
-		}
-		return 25;
 	}
 }
 

--- a/packages/zwave-js/src/lib/serialapi/transport/SendDataShared.ts
+++ b/packages/zwave-js/src/lib/serialapi/transport/SendDataShared.ts
@@ -324,7 +324,3 @@ export function hasTXReport(
 		&& !!msg.txReport
 	);
 }
-
-export function exceedsMaxPayloadLength(msg: SendDataMessage): boolean {
-	return msg.serializeCC().length > msg.getMaxPayloadLength();
-}


### PR DESCRIPTION
This effectively increases the fragment size and reduces the update time by a factor of 5 🤯

[Screencast from 11.04.2024 09:52:42.webm](https://github.com/zwave-js/node-zwave-js/assets/17641229/833bf5f6-b1fc-44f3-bd76-0a32fb55f25c)
