### PR TITLE
fix: do not persist or map values form force-removed CCs, do not persist values from mapped CCs

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -96,6 +96,7 @@ import {
 	serializeCacheValue,
 	stripUndefined,
 	timespan,
+	isEncapsulationCC,
 } from "@zwave-js/core";
 import type {
 	NodeSchedulePollOptions,
@@ -4711,6 +4712,9 @@ ${handlers.length} left`,
 	}
 
 	private shouldPersistCCValues(cc: CommandClass): boolean {
+		// Always persist encapsulation CCs, otherwise interviews don't work.
+		if (isEncapsulationCC(cc.ccId)) return true;
+
 		// Do not persist values for a node or endpoint that does not exist
 		const endpoint = this.tryGetEndpoint(cc);
 		const node = endpoint?.getNodeUnsafe();

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -4712,6 +4712,10 @@ ${handlers.length} left`,
 
 	/** Persists the values contained in a Command Class in the corresponding nodes's value DB */
 	private persistCCValues(cc: CommandClass) {
+		// Do not persist values for a CC that was force-removed via config
+		const endpoint = this.tryGetEndpoint(cc);
+		if (endpoint?.wasCCRemovedViaConfig(cc.ccId)) return;
+
 		cc.persistValues(this);
 		if (isEncapsulatingCommandClass(cc)) {
 			this.persistCCValues(cc.encapsulated);

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -86,6 +86,7 @@ import {
 	deserializeCacheValue,
 	getCCName,
 	highResTimestamp,
+	isEncapsulationCC,
 	isLongRangeNodeId,
 	isMissingControllerACK,
 	isMissingControllerCallback,
@@ -96,7 +97,6 @@ import {
 	serializeCacheValue,
 	stripUndefined,
 	timespan,
-	isEncapsulationCC,
 } from "@zwave-js/core";
 import type {
 	NodeSchedulePollOptions,

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -4740,9 +4740,10 @@ ${handlers.length} left`,
 
 	/** Persists the values contained in a Command Class in the corresponding nodes's value DB */
 	private persistCCValues(cc: CommandClass) {
-		if (!this.shouldPersistCCValues(cc)) return;
+		if (this.shouldPersistCCValues(cc)) {
+			cc.persistValues(this);
+		}
 
-		cc.persistValues(this);
 		if (isEncapsulatingCommandClass(cc)) {
 			this.persistCCValues(cc.encapsulated);
 		} else if (isMultiEncapsulatingCommandClass(cc)) {

--- a/packages/zwave-js/src/lib/node/Endpoint.ts
+++ b/packages/zwave-js/src/lib/node/Endpoint.ts
@@ -279,6 +279,19 @@ export class Endpoint implements IZWaveEndpoint {
 		}
 	}
 
+	/** Determines if support for a CC was force-removed via config file */
+	public wasCCRemovedViaConfig(cc: CommandClasses): boolean {
+		if (this.supportsCC(cc)) return false;
+
+		const compatConfig = this.getNodeUnsafe()?.deviceConfig?.compat;
+		if (!compatConfig) return false;
+
+		const removedEndpoints = compatConfig.removeCCs?.get(cc);
+		if (!removedEndpoints) return false;
+
+		return removedEndpoints == "*" || removedEndpoints.includes(this.index);
+	}
+
 	/**
 	 * Retrieves the version of the given CommandClass this endpoint implements.
 	 * Returns 0 if the CC is not supported.

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3042,6 +3042,21 @@ protocol version:      ${this.protocolVersion}`;
 			this.markAsAwake();
 		}
 
+		// If the received CC was force-removed via config file, ignore it completely
+		const endpoint = this.getEndpoint(command.endpointIndex);
+		if (endpoint?.wasCCRemovedViaConfig(command.ccId)) {
+			this.driver.controllerLog.logNode(
+				this.id,
+				{
+					endpoint: endpoint.index,
+					direction: "inbound",
+					message:
+						`Ignoring ${command.constructor.name} because CC support was removed via config file`,
+				},
+			);
+			return;
+		}
+
 		if (command instanceof BasicCC) {
 			return this.handleBasicCommand(command);
 		} else if (command instanceof MultilevelSwitchCC) {

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3662,11 +3662,7 @@ protocol version:      ${this.protocolVersion}`;
 				// Since the node sent us a Basic report, we are sure that it is at least supported
 				// If this is the only supported actuator CC, add it to the support list,
 				// so the information lands in the network cache
-				if (!actuatorCCs.some((cc) => sourceEndpoint.supportsCC(cc))) {
-					sourceEndpoint.addCC(CommandClasses.Basic, {
-						isControlled: true,
-					});
-				}
+				sourceEndpoint.maybeAddBasicCCAsFallback();
 			}
 		} else if (command instanceof BasicCCSet) {
 			// Treat BasicCCSet as value events if desired
@@ -3708,7 +3704,7 @@ protocol version:      ${this.protocolVersion}`;
 						),
 						command.targetValue,
 					);
-					// Since the node sent us a Basic command, we are sure that it is at least controlled
+					// Since the node sent us a Basic Set, we are sure that it is at least controlled
 					// Add it to the support list, so the information lands in the network cache
 					if (!sourceEndpoint.controlsCC(CommandClasses.Basic)) {
 						sourceEndpoint.addCC(CommandClasses.Basic, {

--- a/packages/zwave-js/src/lib/test/driver/receiveApplicationCommandHandlerBridge.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/receiveApplicationCommandHandlerBridge.test.ts
@@ -39,6 +39,12 @@ test.beforeEach(async (t) => {
 		removeAllListeners: () => {},
 	} as any;
 
+	driver.controller.nodes.getOrThrow = (nodeId: number) => {
+		const node = driver.controller.nodes.get(nodeId);
+		if (!node) throw new Error(`Node ${nodeId} not found`);
+		return node;
+	};
+
 	t.context = { driver, serialport };
 });
 

--- a/packages/zwave-js/src/lib/test/driver/unresponsiveStick.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/unresponsiveStick.test.ts
@@ -128,10 +128,10 @@ integrationTest(
 	},
 );
 
-integrationTest.only(
+integrationTest(
 	"The unresponsive controller recovery does not kick in when it was enabled via config",
 	{
-		debug: true,
+		// debug: true,
 
 		additionalDriverOptions: {
 			attempts: {


### PR DESCRIPTION
This fixes a long-standing issue where seemingly unsupported values appear for CCs that have been force-removed via a config file.

fixes https://github.com/zwave-js/node-zwave-js/issues/6555
TODO: solve https://github.com/zwave-js/node-zwave-js/issues/6318 as a followup
