### PR TITLE
fix(config): versioning logic for parameter 26 of Zooz ZEN72

### DIFF
--- a/packages/config/config/devices/0x027a/zen32.json
+++ b/packages/config/config/devices/0x027a/zen32.json
@@ -2,7 +2,7 @@
 // 1.1 -> 10.0 -> 10.10 -> 10.20 -> 10.30 -> (10.40 ≅ 2.10) -> 2.20
 
 // Conditionals:
-// 10.0  and later: firmwareVersion >= 10.0 || firmwareVersion >= 2.10 && firmwareVersion < 10.0
+// 10.0 and later: firmwareVersion >= 2.10
 // 10.10 and later: firmwareVersion >= 10.10 || firmwareVersion >= 2.10 && firmwareVersion < 10.0
 // 10.20 and later: firmwareVersion >= 10.20 || firmwareVersion >= 2.10 && firmwareVersion < 10.0
 // 10.30 and later: firmwareVersion >= 10.30 || firmwareVersion >= 2.10 && firmwareVersion < 10.0
@@ -224,12 +224,12 @@
 		},
 		{
 			"#": "21",
-			"$if": "firmwareVersion >= 10.0 || firmwareVersion >= 2.10 && firmwareVersion < 10.0",
+			"$if": "firmwareVersion >= 2.10",
 			"$import": "templates/zooz_template.json#3way_switch_type"
 		},
 		{
 			"#": "22",
-			"$if": "firmwareVersion >= 10.0 || firmwareVersion >= 2.10 && firmwareVersion < 10.0",
+			"$if": "firmwareVersion >= 2.10",
 			"$import": "templates/zooz_template.json#local_programming"
 		},
 		{

--- a/packages/config/config/devices/0x027a/zen72.json
+++ b/packages/config/config/devices/0x027a/zen72.json
@@ -2,7 +2,7 @@
 // 1.1 -> 10.0 -> (10.20 = 2.0) -> (10.30 = 2.10) -> (10.40 = 2.20 = 3.10) -> 3.20
 
 // Conditionals:
-// 10.0 and later: firmwareVersion >= 10.0
+// 10.0 and later: firmwareVersion >= 2.0
 // 10.20 and later: firmwareVersion >= 2.0 && firmwareVersion < 10.0 || firmwareVersion >= 10.20
 // 10.30 and later: firmwareVersion >= 2.10 && firmwareVersion < 10.0 || firmwareVersion >= 10.30
 // 10.40 and later: firmwareVersion >= 2.20 && firmwareVersion < 10.0 || firmwareVersion >= 10.40
@@ -198,7 +198,7 @@
 		},
 		{
 			"#": "26",
-			"$if": "firmwareVersion >= 10.0",
+			"$if": "firmwareVersion >= 2.0",
 			"$import": "templates/zooz_template.json#local_programming"
 		},
 		{


### PR DESCRIPTION
This now matches correct logic of ZEN77. ZEN32 also updated correspondingly to remove redundant compares, without changing logic.

My symptom was that parameter 26 wasn’t recognized for a ZEN72 800LR running firmware v3.30.0.