### PR TITLE
fix: parsing of provisioning entries with numeric `supportedProtocols`

### DIFF
--- a/packages/zwave-js/src/lib/driver/NetworkCache.ts
+++ b/packages/zwave-js/src/lib/driver/NetworkCache.ts
@@ -321,7 +321,6 @@ function tryParseSerializedProtocol(
 	}
 }
 
-
 function tryParseDate(value: unknown): Date | undefined {
 	// Dates are stored as timestamps
 	if (typeof value === "number") {

--- a/packages/zwave-js/src/lib/driver/NetworkCache.ts
+++ b/packages/zwave-js/src/lib/driver/NetworkCache.ts
@@ -289,7 +289,8 @@ function isSerializedProtocol(
 	s: unknown,
 ): boolean {
 	// The list of supported protocols has been around since before we started
-	// saving them as their stringified variant, so we // now have to deal with the following variants:
+	// saving them as their stringified variant, so we
+	// now have to deal with the following variants:
 	// 1. plain numbers representing a valid Protocol: 0
 	// 2. strings representing a valid Protocols: "ZWave"
 	if (typeof s === "number" && s in Protocols) return true;
@@ -304,7 +305,8 @@ function tryParseSerializedProtocol(
 	value: unknown,
 ): Protocols | undefined {
 	// The list of supported protocols has been around since before we started
-	// saving them as their stringified variant, so we // now have to deal with the following variants:
+	// saving them as their stringified variant, so we
+	// now have to deal with the following variants:
 	// 1. plain numbers representing a valid Protocol: 0
 	// 2. strings representing a valid Protocols: "ZWave"
 


### PR DESCRIPTION
Older entries could already have the supportedProtocols field, but stored as a number. This PR fixes the parsing of those entries from cache.

fixes: https://github.com/zwave-js/node-zwave-js/issues/6755