### PR TITLE
fix: handle synthetic multicast `SupervisionResult` in `sendCommand`

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -5654,8 +5654,22 @@ ${handlers.length} left`,
 		}
 
 		// Fall back to non-supervised commands
+		const result = await this.sendCommandInternal(command, options);
+
+		// When sending S2 multicast commands to supporting nodes, the singlecast followups
+		// may use supervision. In this case, the multicast message generator returns a
+		// synthetic SupervisionCCReport.
+		// sendCommand is supposed to return a SupervisionResult though.
+		if (
+			options?.s2MulticastGroupId != undefined
+			&& result instanceof SupervisionCCReport
+		) {
+			// @ts-expect-error TS doesn't know we've narrowed the return type to match
+			return result.toSupervisionResult();
+		}
+
 		// @ts-expect-error TS doesn't know we've narrowed the return type to match
-		return this.sendCommandInternal(command, options);
+		return result;
 	}
 
 	/** @internal */

--- a/packages/zwave-js/src/lib/node/VirtualNode.ts
+++ b/packages/zwave-js/src/lib/node/VirtualNode.ts
@@ -176,11 +176,6 @@ export class VirtualNode extends VirtualEndpoint implements IVirtualNode {
 				options,
 			);
 
-			// api.setValue could technically return a SupervisionResult
-			// but supervision isn't used for multicast / broadcast
-
-			// FIXME: It just may for S2 multicast
-
 			if (api.isSetValueOptimistic(valueId)) {
 				// If the call did not throw, assume that the call was successful and remember the new value
 				// for each node that was affected by this command


### PR DESCRIPTION
fixes: https://github.com/zwave-js/node-zwave-js/issues/6696

The problem was that the S2 multicast message generator creates a synthetic SupervisionResult as the response, but `sendCommand` did not handle this because the original message was not sent supervised.