### PR TITLE
feat: rework compat flags for Basic CC mapping

### DIFF
--- a/.github/workflows/zwave-js-bot_comment.yml
+++ b/.github/workflows/zwave-js-bot_comment.yml
@@ -477,7 +477,7 @@ jobs:
   # Adds a compat flag to an existing file when an authorized person posts
   # @zwave-js-bot add compat flag to <deviceId>
   # ```
-  # enableBasicSetMapping: true
+  # mapBasicSet: "auto"
   # ```
   add-compat-flag:
     if: |

--- a/.vscode/deviceSnippets.code-snippets
+++ b/.vscode/deviceSnippets.code-snippets
@@ -135,7 +135,7 @@
 		"body": [
 			"\"compat\": {",
 			"\t$LINE_COMMENT This device incorrectly ${1:[problem]}",
-			"\t\"${2|disableBasicMapping,disableStrictEntryControlDataValidation,disableStrictMeasurementValidation,forceNotificationIdleReset,mapRootReportsToEndpoint,preserveRootApplicationCCValueIDs,skipConfigurationNameQuery,skipConfigurationInfoQuery,treatMultilevelSwitchSetAsEvent,treatSetAsReport,treatDestinationEndpointAsSource|}\": true",
+			"\t\"${2|disableStrictEntryControlDataValidation,disableStrictMeasurementValidation,forceNotificationIdleReset,mapRootReportsToEndpoint,preserveRootApplicationCCValueIDs,skipConfigurationNameQuery,skipConfigurationInfoQuery,treatMultilevelSwitchSetAsEvent,treatSetAsReport,treatDestinationEndpointAsSource|}\": true",
 			"},"
 		],
 		"description": "Insert parameter condition"

--- a/.vscode/deviceSnippets.code-snippets
+++ b/.vscode/deviceSnippets.code-snippets
@@ -135,7 +135,7 @@
 		"body": [
 			"\"compat\": {",
 			"\t$LINE_COMMENT This device incorrectly ${1:[problem]}",
-			"\t\"${2|disableBasicMapping,disableStrictEntryControlDataValidation,disableStrictMeasurementValidation,enableBasicSetMapping,forceNotificationIdleReset,mapRootReportsToEndpoint,preserveRootApplicationCCValueIDs,skipConfigurationNameQuery,skipConfigurationInfoQuery,treatBasicSetAsEvent,treatMultilevelSwitchSetAsEvent,treatSetAsReport,treatDestinationEndpointAsSource|}\": true",
+			"\t\"${2|disableBasicMapping,disableStrictEntryControlDataValidation,disableStrictMeasurementValidation,forceNotificationIdleReset,mapRootReportsToEndpoint,preserveRootApplicationCCValueIDs,skipConfigurationNameQuery,skipConfigurationInfoQuery,treatMultilevelSwitchSetAsEvent,treatSetAsReport,treatDestinationEndpointAsSource|}\": true",
 			"},"
 		],
 		"description": "Insert parameter condition"

--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -380,12 +380,6 @@ Without the additional integrity checks that encapsulation CCs like `CRC-16`, `S
 
 Some devices incorrectly encode this support information though, making the checks discard otherwise correct data. To disable the checks, set `disableStrictMeasurementValidation` to `true`.
 
-### `enableBasicSetMapping`
-
-`Basic CC::Set` commands are not meant to be mapped to other CCs. Some devices still use them to report status. By setting `enableBasicSetMapping` to `true`, `Basic CC::Set` commands are mapped just like `Basic CC::Report`s.
-
-> [!NOTE] The option `disableBasicMapping` has precedence. If that is `true`, no `Basic` commands will be mapped.
-
 ### `forceNotificationIdleReset`
 
 Version 8 of the `Notification CC` added the requirement that devices must issue an idle notification after a notification variable is no longer active. Several legacy devices and some misbehaving V8 devices do not return their variables to idle automatically. By setting `forceNotificationIdleReset` to `true`, `zwave-js` auto-idles supporting notification variables after 5 minutes.
@@ -397,6 +391,15 @@ The specifications mandate that each `Scene Controller Configuration CC` Group I
 ### `manualValueRefreshDelayMs`
 
 Some legacy devices emit an NIF when a local event occurs (e.g. a button press) to signal that the controller should request a status update. However, some of these devices require a delay before they are ready to respond to this request. `manualValueRefreshDelayMs` specifies that delay, expressed in milliseconds. If unset, there will be no delay.
+
+### `mapBasicSet`
+
+`Basic CC::Set` commands are meant to control other devices, yet some devices use them to "report" their status or expose secondary functionality. The `mapBasicSet` flag defines how Z-Wave JS should handle these commands:
+
+- `report` **(default)**: The command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
+- `event`: Emit a `value event` for the `"event"` property instead. This property is exclusively used in this case in order to avoid conflicts with regular value IDs.
+- `auto`: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type.
+- `Binary Sensor`: Regardless or the device type, the command is treated like a `Binary Sensor CC::Report`.
 
 ### `mapRootReportsToEndpoint`
 
@@ -491,13 +494,6 @@ Some devices spam the network with lots of `ConfigurationCC::NameReport`s in res
 ### `skipConfigurationInfoQuery`
 
 Some devices spam the network with lots of (sometimes invalid) `ConfigurationCC::InfoReport`s in response to the `InfoGet` command. Set this flag to `true` to skip this query for affected devices.
-
-### `treatBasicSetAsEvent`
-
-By default, `Basic CC::Set` commands are interpreted as status updates. This flag causes the driver to emit a `value event` for the `"event"` property instead. Note that this property is exclusively used in this case in order to avoid conflicts with regular value IDs.
-
-> [!NOTE]
-> If this option is `true`, it has precedence over `disableBasicMapping`.
 
 ### `treatMultilevelSwitchSetAsEvent`
 

--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -360,10 +360,6 @@ If a device reports support for a CCs but does not correctly support it, this ca
 
 Several command classes are refreshed regularly (every couple of hours) if they do not report all of their values automatically. It has been found that some devices respond with invalid reports when queried. By setting `disableAutoRefresh` to `true`, this feature can be disabled.
 
-### `disableBasicMapping`
-
-By default, received `Basic CC::Report` commands are mapped to a more appropriate CC. Setting `disableBasicMapping` to `true` disables this feature.
-
 ### `disableCallbackFunctionTypeCheck`
 
 By default, responses or callbacks for Serial API commands must have the same function type (command identifier) in order to be recognized. However, in some situations, certain controllers send a callback with an invalid function type. In this case, the faulty commands may be listed in the `disableCallbackFunctionTypeCheck` array to disable the check for a matching function type.
@@ -392,14 +388,22 @@ The specifications mandate that each `Scene Controller Configuration CC` Group I
 
 Some legacy devices emit an NIF when a local event occurs (e.g. a button press) to signal that the controller should request a status update. However, some of these devices require a delay before they are ready to respond to this request. `manualValueRefreshDelayMs` specifies that delay, expressed in milliseconds. If unset, there will be no delay.
 
+### `mapBasicReport`
+
+`Basic CC::Report` commands are like their name implies, Basic. They contain no information about **what** they are reporting. By default, Z-Wave JS uses the device type to map these commands to a more appropriate CC. The `mapBasicReport` can influence this behavior. It has the following options:
+
+- `false`: treat the report verbatim without mapping
+- `"auto"` **(default)**: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type. If no matching mapping is found, the command is treated verbatim without mapping.
+- `"Binary Sensor"`: Regardless or the device type, the command is treated like a `Binary Sensor CC::Report`.
+
 ### `mapBasicSet`
 
 `Basic CC::Set` commands are meant to control other devices, yet some devices use them to "report" their status or expose secondary functionality. The `mapBasicSet` flag defines how Z-Wave JS should handle these commands:
 
-- `report` **(default)**: The command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
-- `event`: Emit a `value event` for the `"event"` property instead. This property is exclusively used in this case in order to avoid conflicts with regular value IDs.
-- `auto`: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type.
-- `Binary Sensor`: Regardless or the device type, the command is treated like a `Binary Sensor CC::Report`.
+- `"report"` **(default)**: The command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
+- `"auto"`: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type. If no matching mapping is found, the command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
+- `"event"`: Emit a `value event` for the `"event"` property instead. This property is exclusively used in this case in order to avoid conflicts with regular value IDs.
+- `"Binary Sensor"`: Regardless or the device type, the command is treated like a `Binary Sensor CC::Report`.
 
 ### `mapRootReportsToEndpoint`
 

--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -394,7 +394,7 @@ Some legacy devices emit an NIF when a local event occurs (e.g. a button press) 
 
 - `false`: treat the report verbatim without mapping
 - `"auto"` **(default)**: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type. If no matching mapping is found, the command is treated verbatim without mapping.
-- `"Binary Sensor"`: Regardless or the device type, the command is treated like a `Binary Sensor CC::Report`.
+- `"Binary Sensor"`: Regardless of the device type, the command is treated like a `Binary Sensor CC::Report`.
 
 ### `mapBasicSet`
 
@@ -402,8 +402,8 @@ Some legacy devices emit an NIF when a local event occurs (e.g. a button press) 
 
 - `"report"` **(default)**: The command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
 - `"auto"`: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type. If no matching mapping is found, the command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
-- `"event"`: Emit a `value event` for the `"event"` property instead. This property is exclusively used in this case in order to avoid conflicts with regular value IDs.
-- `"Binary Sensor"`: Regardless or the device type, the command is treated like a `Binary Sensor CC::Report`.
+- `"event"`: Emit a `value event` for the Basic `"event"` property.
+- `"Binary Sensor"`: Regardless of the device type, the command is treated like a `Binary Sensor CC::Report`.
 
 ### `mapRootReportsToEndpoint`
 

--- a/docs/config-files/style-guide.md
+++ b/docs/config-files/style-guide.md
@@ -17,7 +17,7 @@ Our device files are parsed as JSON5 and may contain comments. Comments may (and
 	// ...
 	"compat": {
 		// The device is a Binary Sensor, but uses Basic Sets to report its status
-		"enableBasicSetMapping": true
+		"mapBasicSet": "auto"
 	}
 }
 ```

--- a/maintenance/schemas/device-config.json
+++ b/maintenance/schemas/device-config.json
@@ -582,9 +582,6 @@
 				"disableStrictMeasurementValidation": {
 					"const": true
 				},
-				"enableBasicSetMapping": {
-					"const": true
-				},
 				"forceNotificationIdleReset": {
 					"const": true
 				},
@@ -596,6 +593,10 @@
 				"manualValueRefreshDelayMs": {
 					"type": "number",
 					"minimum": 0
+				},
+				"mapBasicSet": {
+					"type": "string",
+					"enum": ["event", "report", "auto", "Binary Sensor"]
 				},
 				"mapRootReportsToEndpoint": {
 					"type": "number",
@@ -694,9 +695,6 @@
 					"const": true
 				},
 				"skipConfigurationInfoQuery": {
-					"const": true
-				},
-				"treatBasicSetAsEvent": {
 					"const": true
 				},
 				"treatMultilevelSwitchSetAsEvent": {

--- a/maintenance/schemas/device-config.json
+++ b/maintenance/schemas/device-config.json
@@ -565,9 +565,6 @@
 				"disableAutoRefresh": {
 					"const": true
 				},
-				"disableBasicMapping": {
-					"const": true
-				},
 				"disableCallbackFunctionTypeCheck": {
 					"type": "array",
 					"items": {
@@ -593,6 +590,17 @@
 				"manualValueRefreshDelayMs": {
 					"type": "number",
 					"minimum": 0
+				},
+				"mapBasicReport": {
+					"oneOf": [
+						{
+							"const": false
+						},
+						{
+							"type": "string",
+							"enum": ["auto", "Binary Sensor"]
+						}
+					]
 				},
 				"mapBasicSet": {
 					"type": "string",

--- a/packages/cc/src/cc/BasicCC.ts
+++ b/packages/cc/src/cc/BasicCC.ts
@@ -328,8 +328,8 @@ remaining duration: ${basicResponse.duration?.toString() ?? "undefined"}`;
 		}
 
 		if (
-			!!applHost.getDeviceConfig?.(endpoint.nodeId)?.compat
-				?.treatBasicSetAsEvent
+			applHost.getDeviceConfig?.(endpoint.nodeId)?.compat?.mapBasicSet
+				=== "event"
 		) {
 			// Add the compat event value if it should be exposed
 			ret.push(BasicCCValues.compatEvent.endpoint(endpoint.index));

--- a/packages/config/config/devices/0x0005/pe653.json
+++ b/packages/config/config/devices/0x0005/pe653.json
@@ -523,7 +523,7 @@
 			},
 			// The device sometimes sends BASIC_SET to the lifeline association when the state of Switch 1
 			// changes but the value is always 0 so treat it as an event.
-			"treatBasicSetAsEvent": true
+			"mapBasicSet": "event"
 		},
 		{
 			"commandClasses": {

--- a/packages/config/config/devices/0x001a/rf9501.json
+++ b/packages/config/config/devices/0x001a/rf9501.json
@@ -110,6 +110,6 @@
 		}
 	],
 	"compat": {
-		"enableBasicSetMapping": true
+		"mapBasicSet": "auto"
 	}
 }

--- a/packages/config/config/devices/0x001a/rf9540-n_0.0_1.1.json
+++ b/packages/config/config/devices/0x001a/rf9540-n_0.0_1.1.json
@@ -172,6 +172,6 @@
 		}
 	],
 	"compat": {
-		"enableBasicSetMapping": true
+		"mapBasicSet": "auto"
 	}
 }

--- a/packages/config/config/devices/0x001a/rf9540-n_1.2.json
+++ b/packages/config/config/devices/0x001a/rf9540-n_1.2.json
@@ -180,6 +180,6 @@
 		}
 	],
 	"compat": {
-		"enableBasicSetMapping": true
+		"mapBasicSet": "auto"
 	}
 }

--- a/packages/config/config/devices/0x001a/rf9542.json
+++ b/packages/config/config/devices/0x001a/rf9542.json
@@ -122,6 +122,6 @@
 		}
 	],
 	"compat": {
-		"enableBasicSetMapping": true
+		"mapBasicSet": "auto"
 	}
 }

--- a/packages/config/config/devices/0x001a/rfwc5.json
+++ b/packages/config/config/devices/0x001a/rfwc5.json
@@ -89,6 +89,6 @@
 	],
 	"compat": {
 		// Basic CC is required to react to Scene Off commands
-		"disableBasicMapping": true
+		"mapBasicReport": false
 	}
 }

--- a/packages/config/config/devices/0x0039/39336_39443_zw3104.json
+++ b/packages/config/config/devices/0x0039/39336_39443_zw3104.json
@@ -145,7 +145,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add\nthe smart dimmer to the Z-Wave network.\n2. Once the controller is ready to add your smart dimmer, single\npress and release the manual/program button on the smart\ndimmer to add it in the network.\nPlease reference the controller/gateway’s manual for instructions",

--- a/packages/config/config/devices/0x0039/39339_39346_zw3107.json
+++ b/packages/config/config/devices/0x0039/39339_39346_zw3107.json
@@ -131,7 +131,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add\nthe smart dimmer to the Z-Wave network.\n2. Once the controller is ready to add your smart dimmer, single\npress and release the manual/program button on the smart\ndimmer to add it in the network.\nPlease reference the controller/gateway’s manual for instructions",

--- a/packages/config/config/devices/0x0039/39342_39449_zw4106.json
+++ b/packages/config/config/devices/0x0039/39342_39449_zw4106.json
@@ -55,7 +55,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "Adding your device to a Z-Wave network:\n1. Follow the instructions for your Z-Wave certified controller to\ninclude the device to the Z-Wave network.\n2. Once the controller is ready to include your smart switch,\nsingle press and release the manual/program button on the\nsmart switch to include it in the network.\nNow you have complete control to turn your lamp ON/OFF\naccording to groups, scenes, schedules and interactive\nautomations programmed by your controller.\nIf your Z-Wave certified controller features Remote Access,\nyou can now control your lighting from your mobile devices",

--- a/packages/config/config/devices/0x0039/39348_39455_zw4005.json
+++ b/packages/config/config/devices/0x0039/39348_39455_zw4005.json
@@ -90,7 +90,7 @@
 	],
 	"compat": {
 		"disableBasicMapping": true,
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to include a device to the Z-Wave network.\n2. Once the controller is ready to include your device, press and release the top or bottom of the wireless smart switch(rocker) to include it in the network.\n3. Once your controller has confirmed that the device has been included, refresh the Z-Wave network to optimize performance",

--- a/packages/config/config/devices/0x0039/39348_39455_zw4005.json
+++ b/packages/config/config/devices/0x0039/39348_39455_zw4005.json
@@ -89,7 +89,7 @@
 		}
 	],
 	"compat": {
-		"disableBasicMapping": true,
+		"mapBasicReport": false,
 		"mapBasicSet": "event"
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x0039/39348_39455_zw4008.json
+++ b/packages/config/config/devices/0x0039/39348_39455_zw4008.json
@@ -77,7 +77,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and release the top or bottom of the wireless smart switch (rocker) to add it in the network.\n\nIf prompted by the controller to enter the S2 security code, refer to the QR code/security number on the back of the box, or the QR code label on the product",

--- a/packages/config/config/devices/0x0039/39351_39458_zw3005.json
+++ b/packages/config/config/devices/0x0039/39351_39458_zw3005.json
@@ -131,7 +131,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to\ninclude a device to the Z-Wave network.\n2. Once the controller is ready to add your device,\npress and release the top or bottom of the wireless smart\nswitch (rocker) to add it in the network.\nPlease reference the controller’s manual for instructions",

--- a/packages/config/config/devices/0x0039/39351_39458_zw3010.json
+++ b/packages/config/config/devices/0x0039/39351_39458_zw3010.json
@@ -143,7 +143,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and release the top or bottom of the wireless smart dimmer (rocker) to add it in the network.\nIf prompted by the controller to enter the S2 security code, refer to the QR code/security number on the back of the box, or the QR code label on the product",

--- a/packages/config/config/devices/0x0039/39354_39461_zw4003.json
+++ b/packages/config/config/devices/0x0039/39354_39461_zw4003.json
@@ -86,7 +86,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press up on the toggle.\n\nA. If prompted by the controller to enter the S2 security code, refer to the QR code/security number on the back of the box, or the QR code label on the product.\n\nNow you have complete control to turn your fixture ON/OFF according to groups, scenes, schedules and interactive automations programmed by your controller. If your Z-Wave certified controller features remote access, you can control your fixture from your mobile devices",

--- a/packages/config/config/devices/0x0039/39354_39461_zw4009.json
+++ b/packages/config/config/devices/0x0039/39354_39461_zw4009.json
@@ -86,7 +86,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press up on the toggle.\n\nA. If prompted by the controller to enter the S2 security code, refer to the QR code/security number on the back of the box, or the QR code label on the product.\n\nNow you have complete control to turn your fixture ON/OFF according to groups, scenes, schedules and interactive automations programmed by your controller. If your Z-Wave certified controller features remote access, you can control your fixture from your mobile devices",

--- a/packages/config/config/devices/0x0039/39357_39464_zw3004.json
+++ b/packages/config/config/devices/0x0039/39357_39464_zw3004.json
@@ -134,7 +134,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to\ninclude a device to the Z-Wave network.\n2. Once the controller is ready to include your device, press\nand release the top or bottom of the wireless smart dimmer\n(rocker) to include it in the network",

--- a/packages/config/config/devices/0x0039/39357_39464_zw3011.json
+++ b/packages/config/config/devices/0x0039/39357_39464_zw3011.json
@@ -126,7 +126,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press up and release the toggle.\nIf prompted by the controller to enter the S2 security code, refer to the QR code/security number on the back of the box, or the QR code label on the product",

--- a/packages/config/config/devices/0x0039/39358_39465_zw4002.json
+++ b/packages/config/config/devices/0x0039/39358_39465_zw4002.json
@@ -50,7 +50,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true,
+		"mapBasicSet": "event",
 		"commandClasses": {
 			"remove": {
 				"Supervision": {

--- a/packages/config/config/devices/0x0039/39363_39470_zw4203.json
+++ b/packages/config/config/devices/0x0039/39363_39470_zw4203.json
@@ -72,7 +72,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network. \n\n2. Once the controller is ready to add your device, press and the manual/program button on the smart switch.\n\nIf prompted by the controller to enter the S2 security code, refer to the QR code/security number on the box or the QR code label on the product. Enter the 5-digit code",

--- a/packages/config/config/devices/0x0060/hac01.json
+++ b/packages/config/config/devices/0x0060/hac01.json
@@ -44,7 +44,7 @@
 		}
 	],
 	"compat": {
-		"enableBasicSetMapping": true,
+		"mapBasicSet": "auto",
 		// The device supports Binary Switch CC, despite the Version query telling otherwise
 		"commandClasses": {
 			"add": {

--- a/packages/config/config/devices/0x0060/hsp02.json
+++ b/packages/config/config/devices/0x0060/hsp02.json
@@ -104,6 +104,6 @@
 	],
 	"compat": {
 		// The device is a Binary Sensor, but uses Basic Sets to report its status
-		"enableBasicSetMapping": true
+		"mapBasicSet": "auto"
 	}
 }

--- a/packages/config/config/devices/0x0060/sm103.json
+++ b/packages/config/config/devices/0x0060/sm103.json
@@ -48,6 +48,6 @@
 	],
 	"compat": {
 		// The device is a Binary Sensor, but uses Basic Sets to report its status
-		"enableBasicSetMapping": true
+		"mapBasicSet": "auto"
 	}
 }

--- a/packages/config/config/devices/0x0063/12729_zw3004.json
+++ b/packages/config/config/devices/0x0063/12729_zw3004.json
@@ -61,6 +61,6 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x0063/12730_zw4002.json
+++ b/packages/config/config/devices/0x0063/12730_zw4002.json
@@ -40,7 +40,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true,
+		"mapBasicSet": "event",
 		"commandClasses": {
 			"remove": {
 				"Supervision": {

--- a/packages/config/config/devices/0x0063/14287_zw4002.json
+++ b/packages/config/config/devices/0x0063/14287_zw4002.json
@@ -42,7 +42,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true,
+		"mapBasicSet": "event",
 		"commandClasses": {
 			"remove": {
 				"Supervision": {

--- a/packages/config/config/devices/0x0063/14291_zw4005.json
+++ b/packages/config/config/devices/0x0063/14291_zw4005.json
@@ -45,6 +45,6 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x0063/14292_zw4003.json
+++ b/packages/config/config/devices/0x0063/14292_zw4003.json
@@ -40,6 +40,6 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x0063/14294_zw3005.json
+++ b/packages/config/config/devices/0x0063/14294_zw3005.json
@@ -65,6 +65,6 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x0063/14295_zw3004.json
+++ b/packages/config/config/devices/0x0063/14295_zw3004.json
@@ -61,6 +61,6 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x0063/14296_zw3011.json
+++ b/packages/config/config/devices/0x0063/14296_zw3011.json
@@ -60,6 +60,6 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x0063/14298_zw4203.json
+++ b/packages/config/config/devices/0x0063/14298_zw4203.json
@@ -41,7 +41,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified\ncontroller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and\nrelease the top or bottom of the wireless smart switch (rocker)",

--- a/packages/config/config/devices/0x0063/14299_zw3006.json
+++ b/packages/config/config/devices/0x0063/14299_zw3006.json
@@ -48,6 +48,6 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x0063/14311_zw4201.json
+++ b/packages/config/config/devices/0x0063/14311_zw4201.json
@@ -31,7 +31,7 @@
 		}
 	},
 	"compat": {
-		"disableBasicMapping": true
+		"mapBasicReport": false
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to\ninclude the smart switch to the Z-Wave network.\n2. Once the controller is ready to include your outdoor smart\nswitch, single press and release the manual/program\nbutton on the smart switch to include it in the network.\n3. Once your controller has confirmed that the smart switch\nhas been included, refresh the Z-Wave network to\noptimize performance",

--- a/packages/config/config/devices/0x0063/14313_zw1001.json
+++ b/packages/config/config/devices/0x0063/14313_zw1001.json
@@ -37,7 +37,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-wave certified\ncontroller to include a device to the Z-wave network.\n2. Once the controller is ready to include your device, press and\nrelease the Program Button to include it in the network.\n3. Once your controller has confirmed that the device has been\nincluded, refresh the Z-wave network to optimize performance",

--- a/packages/config/config/devices/0x0063/14314_zw4002.json
+++ b/packages/config/config/devices/0x0063/14314_zw4002.json
@@ -37,7 +37,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true,
+		"mapBasicSet": "event",
 		"commandClasses": {
 			"remove": {
 				"Supervision": {

--- a/packages/config/config/devices/0x0063/14319_zw4003.json
+++ b/packages/config/config/devices/0x0063/14319_zw4003.json
@@ -37,7 +37,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to include a device to the Z-Wave network. \n2. Once the controller is ready to include your device, press up and release on the toggle to include it in the network. \n3. Once your controller has confirmed that the device has been included, refresh the Z-Wave network to optimize performance.",

--- a/packages/config/config/devices/0x0063/14320_zw4003.json
+++ b/packages/config/config/devices/0x0063/14320_zw4003.json
@@ -44,6 +44,6 @@
 		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/2054/Binder2.pdf"
 	},
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x0063/14322_zw3004.json
+++ b/packages/config/config/devices/0x0063/14322_zw3004.json
@@ -61,7 +61,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "Adding your device to a Z-wave network:\n1. Follow the instructions for your Z-wave certified controller to include a device to\nthe Z-wave network.\n2. Once the controller is ready to include your device, press up and release on the\ntoggle to include it in the network.\n3. Once your controller has confirmed that the device has been included, refresh\nthe Z-wave network to optimize performance.\nPlease reference the controller’s manual for instructions.\nNow you have complete control to turn your fixture ON/OFF or dim\naccording to groups, scenes, schedules and interactive automations\nprogrammed by your controller.\nIf your Z-wave certified controller features Remote Access, you can now control\nyour fixture from your mobile devices",

--- a/packages/config/config/devices/0x0063/14325_zw4203.json
+++ b/packages/config/config/devices/0x0063/14325_zw4203.json
@@ -41,7 +41,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add the smart switch to the Z-Wave network.\n2. Once the controller is ready to add your outdoor smart switch, press and release the manual/program button on the smart switch.\n3. The controller’s app will indicate if it has discovered the switch. If prompted by the controller to enter the S2 security code, refer to the QR code/security number on the side of the box or the QR code label on the product (see Figure 1). Enter the 5-digit code",

--- a/packages/config/config/devices/0x0063/14326_zw3006.json
+++ b/packages/config/config/devices/0x0063/14326_zw3006.json
@@ -65,7 +65,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "Adding your device to a Z-wave network\n1. Follow the instructions for your Z-wave certified controller to include a device to the Z-wave\nnetwork.\n2. Once the controller is ready to include your device, press and release the top or bottom of the\nwireless smart switch(rocker) to include it in the network.\n3. Once your controller has confirmed that the device has been included, refresh the Z-wave network\nto optimize performance.\nPlease reference the controller’s manual for instructions.\nNow you have complete control to turn your fixture ON/OFFaccording to groups, scenes, schedules\nand interactive automations programmed by your controller.\nIf your Z-wave certified controller features Remote Access, you can now control your fixture from\nyour mobile devices",

--- a/packages/config/config/devices/0x0063/26931_zw4006.json
+++ b/packages/config/config/devices/0x0063/26931_zw4006.json
@@ -71,6 +71,6 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x0063/26932_zw3008.json
+++ b/packages/config/config/devices/0x0063/26932_zw3008.json
@@ -105,7 +105,7 @@
 	// Add compat flag to re-enable basic command events to replicate central scene functionality.
 	// Allows user to detect switch button presses as events when zwave controller is added to Group 2 or 3.
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/2108/26933%20EnFrSp%20QSG%20v1.3%20and%20Parameters.pdf"

--- a/packages/config/config/devices/0x0063/26933_zw3008.json
+++ b/packages/config/config/devices/0x0063/26933_zw3008.json
@@ -105,7 +105,7 @@
 	// Add compat flag to re-enable basic command events to replicate central scene functionality.
 	// Allows user to detect switch button presses as events when zwave controller is added to Group 2 or 3.
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/2108/26933%20EnFrSp%20QSG%20v1.3%20and%20Parameters.pdf"

--- a/packages/config/config/devices/0x0063/28166_zw3104.json
+++ b/packages/config/config/devices/0x0063/28166_zw3104.json
@@ -66,7 +66,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-wave certified controller to include the device to the Z-wave network.\n2. Once the controller is ready to include your smart switch, single press and release the manual/program button on the smart dimmer to include it in the network.\n3. Once your controller has confirmed that the smart switch has been included, refresh the Z-wave network to optimize performance",

--- a/packages/config/config/devices/0x0063/28170_zw3105.json
+++ b/packages/config/config/devices/0x0063/28170_zw3105.json
@@ -61,7 +61,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-wave certified controller to include the device to the Z-wave network.\n2. Once the controller is ready to include your smart switch, single press and release the manual/program button on the smart dimmer to include it in the network.\n3. Once your controller has confirmed that the smart switch has been included, refresh the Z-wave network to optimize performance",

--- a/packages/config/config/devices/0x0063/28172_zw4104.json
+++ b/packages/config/config/devices/0x0063/28172_zw4104.json
@@ -37,7 +37,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-wave certified controller to include the device to the Z-wave network.\n2. Once the controller is ready to include your smart switch, single press and release the manual/program button on the smart switch to include it in the network.\n3. Once your controller has confirmed that the smart switch has been included, refresh the Z-wave network to optimize performance",

--- a/packages/config/config/devices/0x0063/28173_zw4104.json
+++ b/packages/config/config/devices/0x0063/28173_zw4104.json
@@ -37,7 +37,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-wave certified controller to include the device to the Z-wave network.\n2. Once the controller is ready to include your smart switch, single press and release the manual/program button on the smart switch to include it in the network.\n3. Once your controller has confirmed that the smart switch has been included, refresh the Z-wave network to optimize performance",

--- a/packages/config/config/devices/0x0063/28174_zw3106.json
+++ b/packages/config/config/devices/0x0063/28174_zw3106.json
@@ -61,7 +61,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "Adding your device to a Z-wave network:\n1. Follow the instructions for your Z-wave certified controller to\ninclude the smart dimmer to the Z-wave network.\n2. Once the controller is ready to include your smart dimmer,\nsingle press and release the manual/program button on the\nsmart dimmer to include it in the network.\n3. Once your controller has confirmed that the smart dimmer\nhas been included, refresh the Z-wave network to optimize\nperformance.\nPlease reference the controller/gateway’s manual\nfor instructions.\nNow you have complete control to turn your lamp ON/OFF or set\nDim levels according to groups, scenes, schedules and interactive\nautomations programmed by your controller.\nIf your Z-wave certified controller features Remote Access, you can now control your lighting from your mobile devices",

--- a/packages/config/config/devices/0x0063/28176_zw4105.json
+++ b/packages/config/config/devices/0x0063/28176_zw4105.json
@@ -37,7 +37,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-wave certified controller to\nadd the device to the Z-wave network.\n2. Once the controller is ready to add your smart switch,\nsingle press and release the manual/program button on the\nsmart switch to add it in the network.\n3. Once your controller has confirmed that the smart switch\nhas been added, refresh the Z-wave network to optimize\nperformance.",

--- a/packages/config/config/devices/0x0063/39348_54890_54891_zw4008.json
+++ b/packages/config/config/devices/0x0063/39348_54890_54891_zw4008.json
@@ -41,7 +41,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and release the top or bottom of the smart switch (rocker)",

--- a/packages/config/config/devices/0x0063/39351_zw3010.json
+++ b/packages/config/config/devices/0x0063/39351_zw3010.json
@@ -61,7 +61,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and release the top or bottom of the smart dimmer (rocker)",

--- a/packages/config/config/devices/0x0063/39354_54912_zw4009.json
+++ b/packages/config/config/devices/0x0063/39354_54912_zw4009.json
@@ -41,7 +41,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press up on the toggle",

--- a/packages/config/config/devices/0x0063/43072_zw4008dv.json
+++ b/packages/config/config/devices/0x0063/43072_zw4008dv.json
@@ -41,7 +41,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and release the top or bottom of the wireless smart switch (rocker)",

--- a/packages/config/config/devices/0x0063/43074_zw4009dv.json
+++ b/packages/config/config/devices/0x0063/43074_zw4009dv.json
@@ -41,7 +41,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and release the top or bottom of the wireless smart switch (rocker)",

--- a/packages/config/config/devices/0x0063/43105_zw3010dv.json
+++ b/packages/config/config/devices/0x0063/43105_zw3010dv.json
@@ -57,7 +57,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press up and release the top or bottom of the rocker.\n3. The controller’s app will indicate if it has discovered the switch. If prompted by the controller to enter the S2 security code, refer to the QR code/security number on the side of the box or the QR code label on the product (see Figure 1). Enter the 5-digit code",

--- a/packages/config/config/devices/0x0063/43107_zw3011dv.json
+++ b/packages/config/config/devices/0x0063/43107_zw3011dv.json
@@ -61,7 +61,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press up and release the toggle.\n3. The controller’s app will indicate if it discovers the switch. If prompted by the controller to enter the S2 security code, refer to the QR code/security number on the side of the box or the QR code label on the product (see Figure 1). Enter the 5-digit code",

--- a/packages/config/config/devices/0x0063/45604_zw4201.json
+++ b/packages/config/config/devices/0x0063/45604_zw4201.json
@@ -30,6 +30,6 @@
 		}
 	},
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x0063/45609_zw4001.json
+++ b/packages/config/config/devices/0x0063/45609_zw4001.json
@@ -42,6 +42,6 @@
 	],
 	"compat": {
 		// Enable double-tap support
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x0063/45655_zw4001.json
+++ b/packages/config/config/devices/0x0063/45655_zw4001.json
@@ -42,6 +42,6 @@
 	],
 	"compat": {
 		// Enable double-tap support
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x0063/45658_zw4201.json
+++ b/packages/config/config/devices/0x0063/45658_zw4201.json
@@ -30,6 +30,6 @@
 		}
 	},
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x0063/45743_zw4002.json
+++ b/packages/config/config/devices/0x0063/45743_zw4002.json
@@ -37,7 +37,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true,
+		"mapBasicSet": "event",
 		"commandClasses": {
 			"remove": {
 				"Supervision": {

--- a/packages/config/config/devices/0x0063/46201_zw4008.json
+++ b/packages/config/config/devices/0x0063/46201_zw4008.json
@@ -42,7 +42,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified\ncontroller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and\nrelease the top or bottom of the wireless smart switch (rocker)",

--- a/packages/config/config/devices/0x0063/46202_zw4009.json
+++ b/packages/config/config/devices/0x0063/46202_zw4009.json
@@ -45,7 +45,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press up and release the toggle.",

--- a/packages/config/config/devices/0x0063/46203_zw3010.json
+++ b/packages/config/config/devices/0x0063/46203_zw3010.json
@@ -65,7 +65,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and release the top or bottom of the wireless smart dimmer (rocker) to add it in the network.\nIf prompted by the controller to enter the S2 security code, refer to the QR code/security number on the back of the box, or the QR code label on the product",

--- a/packages/config/config/devices/0x0063/46204_zw3011.json
+++ b/packages/config/config/devices/0x0063/46204_zw3011.json
@@ -61,7 +61,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified\ncontroller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and release\nthe top or bottom of the wireless smart dimmer (rocker)",

--- a/packages/config/config/devices/0x0063/46562_zw4008.json
+++ b/packages/config/config/devices/0x0063/46562_zw4008.json
@@ -41,7 +41,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified\ncontroller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and\nrelease the top or bottom of the wireless smart switch (rocker)",

--- a/packages/config/config/devices/0x0063/46563_zw4009.json
+++ b/packages/config/config/devices/0x0063/46563_zw4009.json
@@ -41,7 +41,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified\ncontroller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and\nrelease the top or bottom of the wireless smart switch (rocker)",

--- a/packages/config/config/devices/0x0063/46564_zw3010.json
+++ b/packages/config/config/devices/0x0063/46564_zw3010.json
@@ -61,7 +61,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified\ncontroller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and release\nthe top or bottom of the wireless smart dimmer (rocker)",

--- a/packages/config/config/devices/0x0063/46565_zw3011.json
+++ b/packages/config/config/devices/0x0063/46565_zw3011.json
@@ -61,7 +61,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified\ncontroller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and release\nthe top or bottom of the wireless smart dimmer (rocker)",

--- a/packages/config/config/devices/0x0063/52252_zw3012.json
+++ b/packages/config/config/devices/0x0063/52252_zw3012.json
@@ -69,7 +69,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and release the top or bottom of the smart dimmer (rocker)",

--- a/packages/config/config/devices/0x0063/53829_zw5313.json
+++ b/packages/config/config/devices/0x0063/53829_zw5313.json
@@ -37,7 +37,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified hub to add a device to the Z-Wave network.\n2. Once the hub is ready to add your device, press and hold either button for three seconds.\n3. The LED will flash two times when the remote sends add notification (NIF).\n4. The LED will keep lighting up for one minute if inclusion is successful.5. Following the instructions for your Z-Wave certified hub, assign actions for each button press. An action can be many combinations of scenes, groups\nor events, and is greatly dependent on the hub capabilities.",

--- a/packages/config/config/devices/0x0063/53831_zw5314.json
+++ b/packages/config/config/devices/0x0063/53831_zw5314.json
@@ -37,7 +37,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified hub to add a device to the Z-Wave network.\n2. Once the hub is ready to add your device, press and hold either button for three seconds.\n3. The LED will flash two times when the remote sends add notification (NIF).\n4. The LED will keep lighting up for one minute if inclusion is successful.\n5. Following the instructions for your Z-Wave certified hub, assign actions for each button press. An action can be many combinations of scenes, groups or events, and is greatly dependent on the hub capabilities.",

--- a/packages/config/config/devices/0x0063/55249_zw4106.json
+++ b/packages/config/config/devices/0x0063/55249_zw4106.json
@@ -37,7 +37,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add the sensor in the Z-Wave network.\n2. Once the controller is ready to add your sensor, ensure battery is installed with the correct polarity in the sensor and the battery tab has\nbeen removed.\n3. Press and release the programming button (see Figure 2). This starts the manual add process. The red LED (see Figure 2) will begin to\nflash quickly as it begins the add process.\n4. The red LED will activate for 3 seconds to confirm the sensor has been added in the network.\n5. The controller’s app will indicate if it has discovered the sensor. If prompted by the controller to enter the S2 security code, refer to the QR\ncode/security number on the back of the box, or the QR code label on the product (see Figure 3). Enter the 5-digit code.\nNote: Your controller may need to be within 10ft. of the sensor to be added.\nUsing the controller, you can activate interactive automations when the sensor detects when a door or window is opened or closed.\nFunctions may vary depending on gateway or controller",

--- a/packages/config/config/devices/0x0063/55250_zw4104.json
+++ b/packages/config/config/devices/0x0063/55250_zw4104.json
@@ -37,7 +37,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add the smart switch to the Z-Wave network.\n2. Once the controller is ready to add your smart switch, press and release the manual/program button on the smart switch",

--- a/packages/config/config/devices/0x0063/55251_zw3107.json
+++ b/packages/config/config/devices/0x0063/55251_zw3107.json
@@ -61,7 +61,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your smart dimmer, single press and release the manual/program button on\nthe smart dimmer",

--- a/packages/config/config/devices/0x0063/55252_zw3105.json
+++ b/packages/config/config/devices/0x0063/55252_zw3105.json
@@ -61,7 +61,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press the program button of the smart dimmer",

--- a/packages/config/config/devices/0x0063/55256_zw1002.json
+++ b/packages/config/config/devices/0x0063/55256_zw1002.json
@@ -37,7 +37,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network. 2. Once the controller is ready to add your device, press and release the program button",

--- a/packages/config/config/devices/0x0063/55257_zw1002.json
+++ b/packages/config/config/devices/0x0063/55257_zw1002.json
@@ -37,7 +37,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and release the program button",

--- a/packages/config/config/devices/0x0063/55258_zw4002.json
+++ b/packages/config/config/devices/0x0063/55258_zw4002.json
@@ -37,7 +37,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true,
+		"mapBasicSet": "event",
 		"commandClasses": {
 			"remove": {
 				"Supervision": {

--- a/packages/config/config/devices/0x0063/55259_zw4002.json
+++ b/packages/config/config/devices/0x0063/55259_zw4002.json
@@ -37,7 +37,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true,
+		"mapBasicSet": "event",
 		"commandClasses": {
 			"remove": {
 				"Supervision": {

--- a/packages/config/config/devices/0x0063/56590_zw3012.json
+++ b/packages/config/config/devices/0x0063/56590_zw3012.json
@@ -69,7 +69,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and release the top or bottom of the smart dimmer (rocker)",

--- a/packages/config/config/devices/0x0063/58433_59344_zwa4011.json
+++ b/packages/config/config/devices/0x0063/58433_59344_zwa4011.json
@@ -73,7 +73,7 @@
 	],
 	"compat": {
 		// Enables Basic Set via Group 3 as an alternative way to detect double taps (instead of Central Scene)
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and release the top or bottom of the smart dimmer (rocker)",

--- a/packages/config/config/devices/0x0063/58438_59346_zwa3016.json
+++ b/packages/config/config/devices/0x0063/58438_59346_zwa3016.json
@@ -83,7 +83,7 @@
 	],
 	"compat": {
 		// Needed for double-tap support
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and release the top or bottom of the smart dimmer (rocker)",

--- a/packages/config/config/devices/0x0063/59368_zwa4012.json
+++ b/packages/config/config/devices/0x0063/59368_zwa4012.json
@@ -70,7 +70,7 @@
 	],
 	"compat": {
 		// Needed for double-tap support
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and release the top or bottom of the smart dimmer (rocker)",

--- a/packages/config/config/devices/0x007a/506219.json
+++ b/packages/config/config/devices/0x007a/506219.json
@@ -96,6 +96,6 @@
 	],
 	"compat": {
 		// The device uses Basic Set to control other devices
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x007a/5071xx.json
+++ b/packages/config/config/devices/0x007a/5071xx.json
@@ -78,6 +78,6 @@
 	],
 	"compat": {
 		// The device uses Basic Set to control other devices
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x0086/zw100.json
+++ b/packages/config/config/devices/0x0086/zw100.json
@@ -567,7 +567,7 @@
 	],
 	"compat": {
 		// In the default configuration this device sends Basic CC Sets instead of Binary Sensor Reports
-		"enableBasicSetMapping": true,
+		"mapBasicSet": "Binary Sensor",
 		// Querying some values can take a bit longer if certain reports are disabled
 		"reportTimeout": 2000
 	},

--- a/packages/config/config/devices/0x0086/zw111.json
+++ b/packages/config/config/devices/0x0086/zw111.json
@@ -488,7 +488,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true,
+		"mapBasicSet": "event",
 		"treatMultilevelSwitchSetAsEvent": true
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x0086/zw116.json
+++ b/packages/config/config/devices/0x0086/zw116.json
@@ -437,7 +437,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "Turn the primary controller of Z-Wave network into inclusion mode, short press the product’s Action button that you can find on the product's housing",

--- a/packages/config/config/devices/0x0086/zw132.json
+++ b/packages/config/config/devices/0x0086/zw132.json
@@ -510,7 +510,7 @@
 	"compat": {
 		"preserveRootApplicationCCValueIDs": true,
 		// The device can report S1/S2 switch operation via Basic Set to groups 3 and 4
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "Turn the primary controller of Z-Wave network into inclusion mode, short press the product’s Action button that you can find on the product's housing",

--- a/packages/config/config/devices/0x0109/zd2102.json
+++ b/packages/config/config/devices/0x0109/zd2102.json
@@ -33,6 +33,6 @@
 	},
 	"compat": {
 		// The device is a Binary Sensor, but uses Basic Sets to report its status
-		"enableBasicSetMapping": true
+		"mapBasicSet": "auto"
 	}
 }

--- a/packages/config/config/devices/0x0109/zg8101.json
+++ b/packages/config/config/devices/0x0109/zg8101.json
@@ -26,7 +26,7 @@
 		}
 	},
 	"compat": {
-		"enableBasicSetMapping": true,
+		"mapBasicSet": "auto",
 		// The device does not idle its own notifications
 		"forceNotificationIdleReset": true
 	},

--- a/packages/config/config/devices/0x0109/zp3102.json
+++ b/packages/config/config/devices/0x0109/zp3102.json
@@ -81,6 +81,6 @@
 		}
 	],
 	"compat": {
-		"enableBasicSetMapping": true
+		"mapBasicSet": "auto"
 	}
 }

--- a/packages/config/config/devices/0x010f/fgbs001.json
+++ b/packages/config/config/devices/0x010f/fgbs001.json
@@ -311,7 +311,7 @@
 		}
 	],
 	"compat": {
-		"enableBasicSetMapping": true,
+		"mapBasicSet": "auto",
 		"commandClasses": {
 			"remove": {
 				// Alarm Sensor CC is reported as supported, but we either get no response

--- a/packages/config/config/devices/0x010f/fgk101.json
+++ b/packages/config/config/devices/0x010f/fgk101.json
@@ -655,11 +655,11 @@
 			"preserveRootApplicationCCValueIDs": true,
 
 			// The device is a Binary Sensor, but uses Basic Sets to report its status
-			"enableBasicSetMapping": true
+			"mapBasicSet": "auto"
 		},
 		{
 			// The device is a Binary Sensor, but uses Basic Sets to report its status
-			"enableBasicSetMapping": true
+			"mapBasicSet": "auto"
 		}
 	]
 }

--- a/packages/config/config/devices/0x0113/lfm-20.json
+++ b/packages/config/config/devices/0x0113/lfm-20.json
@@ -33,7 +33,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "Put your controller in INCLUDE mode, and double tap the button on the face of the device.",

--- a/packages/config/config/devices/0x0113/lom15.json
+++ b/packages/config/config/devices/0x0113/lom15.json
@@ -14,6 +14,6 @@
 		"max": "255.255"
 	},
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x0113/lpm-15.json
+++ b/packages/config/config/devices/0x0113/lpm-15.json
@@ -56,6 +56,6 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x0113/lsm-15.json
+++ b/packages/config/config/devices/0x0113/lsm-15.json
@@ -52,6 +52,6 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x0118/tz35s_tz35d_tz55s_tz55d.json
+++ b/packages/config/config/devices/0x0118/tz35s_tz35d_tz55s_tz55d.json
@@ -100,6 +100,6 @@
 	],
 	"compat": {
 		// The right paddle sends its status via Basic Set commands
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x0118/tz56.json
+++ b/packages/config/config/devices/0x0118/tz56.json
@@ -16,6 +16,6 @@
 	},
 	"compat": {
 		// The right paddle sends its status via Basic Set commands
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x0118/tz66d.json
+++ b/packages/config/config/devices/0x0118/tz66d.json
@@ -181,6 +181,6 @@
 	],
 	"compat": {
 		// The right paddle sends its status via Basic Set commands
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x011a/zw15s.json
+++ b/packages/config/config/devices/0x011a/zw15s.json
@@ -49,6 +49,6 @@
 	],
 	"compat": {
 		// Enable double-tap support
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x011a/zwn-bpc_0.0-5.9.json
+++ b/packages/config/config/devices/0x011a/zwn-bpc_0.0-5.9.json
@@ -34,6 +34,6 @@
 	],
 	"compat": {
 		// This device uses Basic Set to report the motion sensor status
-		"enableBasicSetMapping": true
+		"mapBasicSet": "auto"
 	}
 }

--- a/packages/config/config/devices/0x0131/zp3102.json
+++ b/packages/config/config/devices/0x0131/zp3102.json
@@ -52,6 +52,6 @@
 		}
 	],
 	"compat": {
-		"enableBasicSetMapping": true
+		"mapBasicSet": "auto"
 	}
 }

--- a/packages/config/config/devices/0x013c/psr03-a.json
+++ b/packages/config/config/devices/0x013c/psr03-a.json
@@ -72,6 +72,6 @@
 	},
 	"compat": {
 		// The device uses Basic Set to indicate pressed buttons in Lighting Control Mode
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x013c/psr03-b.json
+++ b/packages/config/config/devices/0x013c/psr03-b.json
@@ -126,6 +126,6 @@
 	},
 	"compat": {
 		// The device uses Basic Set to indicate pressed buttons in Lighting Control Mode
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x014f/wadwaz-1.json
+++ b/packages/config/config/devices/0x014f/wadwaz-1.json
@@ -21,7 +21,7 @@
 		}
 	},
 	"compat": {
-		"enableBasicSetMapping": true
+		"mapBasicSet": "auto"
 	},
 	"metadata": {
 		"inclusion": "With your Controller in Inclusion mode, depress the internal program switch for 1 second then release.",

--- a/packages/config/config/devices/0x014f/wapirz-1.json
+++ b/packages/config/config/devices/0x014f/wapirz-1.json
@@ -33,6 +33,6 @@
 		}
 	],
 	"compat": {
-		"enableBasicSetMapping": true
+		"mapBasicSet": "auto"
 	}
 }

--- a/packages/config/config/devices/0x014f/wo15z.json
+++ b/packages/config/config/devices/0x014f/wo15z.json
@@ -20,7 +20,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "Put the controller in to INCLUDE mode. Press the button on the unit once.",

--- a/packages/config/config/devices/0x014f/wt00z-1.json
+++ b/packages/config/config/devices/0x014f/wt00z-1.json
@@ -134,6 +134,6 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/config/config/devices/0x014f/zwn-bpc.json
+++ b/packages/config/config/devices/0x014f/zwn-bpc.json
@@ -34,6 +34,6 @@
 	],
 	"compat": {
 		// This device uses Basic Set to report the motion sensor status
-		"enableBasicSetMapping": true
+		"mapBasicSet": "auto"
 	}
 }

--- a/packages/config/config/devices/0x0166/sw-zcs-1.json
+++ b/packages/config/config/devices/0x0166/sw-zcs-1.json
@@ -55,6 +55,6 @@
 	],
 	"compat": {
 		// The device only sends Binary Switch Reports as broadcast (not routed) and Basic Sets
-		"enableBasicSetMapping": true
+		"mapBasicSet": "auto"
 	}
 }

--- a/packages/config/config/devices/0x016a/ft100.json
+++ b/packages/config/config/devices/0x016a/ft100.json
@@ -37,7 +37,6 @@
 		}
 	},
 	// Fantem is an OEM for Aeotec
-	// Fantem is an OEM for Aeotec
 	"paramInformation": [
 		{
 			"#": "2",
@@ -533,7 +532,7 @@
 	],
 	"compat": {
 		// In the default configuration this device sends Basic CC Sets instead of Binary Sensor Reports
-		"enableBasicSetMapping": true
+		"mapBasicSet": "Binary Sensor"
 	},
 	"metadata": {
 		"inclusion": "Turn the primary controller of Z-Wave network into inclusion mode, short press the product’s Z-Wave button that you can find in the back of the product",

--- a/packages/config/config/devices/0x016a/ft111.json
+++ b/packages/config/config/devices/0x016a/ft111.json
@@ -475,7 +475,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "Turn the primary controller of Z-Wave network into inclusion mode, short press the product’s Action button that you can find on the product's housing",

--- a/packages/config/config/devices/0x019b/tf016_tf021.json
+++ b/packages/config/config/devices/0x019b/tf016_tf021.json
@@ -227,7 +227,7 @@
 	],
 	"compat": {
 		// The device reports its relay state via the Basic CC
-		"disableBasicMapping": true
+		"mapBasicReport": false
 	},
 	"metadata": {
 		"inclusion": "To include the thermostat to your home automation gateway, press Center (confirm) for 10 seconds.\nThe display will show OFF. Press Right (down) 4 times till you see Con in the display.\nNow start adding the device in your home automation software. Start inclusion mode by pressing Center (confirm) for approximately 2 seconds. The inclusion/exclusion icon will appear in the display. Confirmation will show Inc/EcL in the display. If inclusion fails, Err (error) will appear.\nLeave programming mode by choosing ESC in menu. Your thermostat is ready for use with default settings",

--- a/packages/config/config/devices/0x0234/zdb5100.json
+++ b/packages/config/config/devices/0x0234/zdb5100.json
@@ -717,6 +717,6 @@
 	},
 	"compat": {
 		// Starting in Firmware 1.6, the device no longer uses Central Scene for Pressed / Released, only Basic CC
-		"disableBasicMapping": true
+		"mapBasicReport": false
 	}
 }

--- a/packages/config/config/devices/0x0293/hc-tb-zw.json
+++ b/packages/config/config/devices/0x0293/hc-tb-zw.json
@@ -27,7 +27,7 @@
 		}
 	},
 	"compat": {
-		"disableBasicMapping": true
+		"mapBasicReport": false
 	},
 	"metadata": {
 		"inclusion": "1. Put the controller into INCLUSION mode. Follow the instructions\nprovided by the controller manufacturer.\n\n2. Press and hold the config button for more than 2 seconds. ALL indicator lights will blink 3 times. At this point release the config button, the device will start the inclusion process",

--- a/packages/config/config/devices/0x041b/39446_zw3107.json
+++ b/packages/config/config/devices/0x041b/39446_zw3107.json
@@ -130,7 +130,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified\ncontroller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press\nand release the manual/program button on the smart\ndimmer. Repeat as necessary to add the dimmer to\nthe network.\nYou have complete control",

--- a/packages/config/config/devices/0x041b/39449_zw4106.json
+++ b/packages/config/config/devices/0x041b/39449_zw4106.json
@@ -55,7 +55,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified\ncontroller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press\nand release the manual/program button on the smart\nswitch. Repeat as necessary to add the switch to\nthe network",

--- a/packages/config/config/devices/0x041b/39453_zw4203.json
+++ b/packages/config/config/devices/0x041b/39453_zw4203.json
@@ -76,7 +76,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified\ncontroller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press\nand release the manual/program button on the smart\nswitch to add it in the network.\n3. The controller’s app will indicate if it has discovered the\nswitch. If prompted by the controller to enter the S2\nsecurity code, refer to the QR code/security number on\nthe side of the box or the QR code label on the product\n(see Figure 1). Enter the 5-digit code",

--- a/packages/config/config/devices/0x041b/39455_zw4008.json
+++ b/packages/config/config/devices/0x041b/39455_zw4008.json
@@ -75,7 +75,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and release the top or bottom of the smart switch (rocker) to add it in the network.\nIf prompted by the controller to enter the S2 security code, refer to the QR code/security number on the back of the box, or the QR code label on the product",

--- a/packages/config/config/devices/0x041b/39456_zw1002.json
+++ b/packages/config/config/devices/0x041b/39456_zw1002.json
@@ -55,7 +55,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a\ndevice to the Z-Wave network.\n2. Once the controller is ready to add your device, press and release the\nprogram button. Repeat as necessary to add the smart outlet to\nthe network.\nYou have complete control",

--- a/packages/config/config/devices/0x041b/39458_zw3010.json
+++ b/packages/config/config/devices/0x041b/39458_zw3010.json
@@ -139,7 +139,7 @@
 		}
 	],
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	},
 	"metadata": {
 		"inclusion": "This dimmer is SmartStart enabled. If your controller supports SmartStart inclusion, this dimmer can be added into the Z-Wave network by following the instructions for your controller or hub and scanning the Z-Wave QR Code on the front or on the package when instructed. No further action is required, and the dimmer will be added automatically within 10 minutes of being powered up while in range Z-Wave network.",

--- a/packages/config/maintenance/importConfig.ts
+++ b/packages/config/maintenance/importConfig.ts
@@ -1538,7 +1538,7 @@ async function parseZWAProduct(
 			addCompat = true;
 
 			newConfig.compat ??= {};
-			newConfig.compat.treatBasicSetAsEvent = true;
+			newConfig.compat.mapBasicSet = "event";
 		}
 
 		newAssociations[ass.GroupNumber] = {

--- a/packages/config/src/devices/ConditionalDeviceConfig.test.ts
+++ b/packages/config/src/devices/ConditionalDeviceConfig.test.ts
@@ -185,7 +185,7 @@ test("parses a device config with conditional compat flags", (t) => {
 		compat: [
 			{
 				$if: "firmwareVersion < 1.0",
-				enableBasicSetMapping: true,
+				mapBasicSet: "auto",
 			},
 		],
 	};
@@ -203,7 +203,7 @@ test("parses a device config with conditional compat flags", (t) => {
 		firmwareVersion: "0.5",
 	});
 	t.deepEqual(evaluated1.compat, {
-		enableBasicSetMapping: true,
+		mapBasicSet: "auto",
 	});
 
 	const evaluated2 = condConfig.evaluate({

--- a/packages/config/src/devices/DeviceConfig.ts
+++ b/packages/config/src/devices/DeviceConfig.ts
@@ -858,13 +858,12 @@ export class DeviceConfig {
 			// Copy some simple flags over
 			for (
 				const prop of [
-					"enableBasicSetMapping",
 					"forceSceneControllerGroupCount",
 					"mapRootReportsToEndpoint",
+					"mapBasicSet",
 					"preserveRootApplicationCCValueIDs",
 					"preserveEndpoints",
 					"removeEndpoints",
-					"treatBasicSetAsEvent",
 					"treatMultilevelSwitchSetAsEvent",
 				] as const
 			) {

--- a/packages/zwave-js/src/lib/test/compat/fixtures/basicEventNoSupport/deviceConfig.json
+++ b/packages/zwave-js/src/lib/test/compat/fixtures/basicEventNoSupport/deviceConfig.json
@@ -14,6 +14,6 @@
 		"max": "255.255"
 	},
 	"compat": {
-		"treatBasicSetAsEvent": true
+		"mapBasicSet": "event"
 	}
 }

--- a/packages/zwave-js/src/lib/test/compat/treatBasicSetAsEvent.test.ts
+++ b/packages/zwave-js/src/lib/test/compat/treatBasicSetAsEvent.test.ts
@@ -37,9 +37,9 @@ integrationTest(
 
 		async testBody(t, driver, node, mockController, mockNode) {
 			// Make sure the custom config is loaded
-			const treatBasicSetAsEvent = node.deviceConfig?.compat
-				?.treatBasicSetAsEvent;
-			t.is(treatBasicSetAsEvent, true);
+			const mapBasicSet = node.deviceConfig?.compat
+				?.mapBasicSet;
+			t.is(mapBasicSet, "event");
 
 			const valueIDs = node.getDefinedValueIDs();
 			t.false(
@@ -97,9 +97,9 @@ integrationTest(
 
 		async testBody(t, driver, node, mockController, mockNode) {
 			// Make sure the custom config is loaded
-			const treatBasicSetAsEvent = node.deviceConfig?.compat
-				?.treatBasicSetAsEvent;
-			t.is(treatBasicSetAsEvent, true);
+			const mapBasicSet = node.deviceConfig?.compat
+				?.mapBasicSet;
+			t.is(mapBasicSet, "event");
 
 			const valueIDs = node.getDefinedValueIDs();
 			t.false(


### PR DESCRIPTION
Over time we have collected a couple of compat flags related to handing received Basic CC Set/Report commands. Those became a bit conflated, mutually exclusive and less flexible than we need. As of this PR, the flags `disableBasicMapping`, `enableBasicSetMapping`, and `treatBasicSetAsEvent` have been merged into two flags, each dedicated to one of those commands:

`mapBasicReport` defines how `Basic CC Report`s are handled:

- `false`: treat the report verbatim without mapping
- `"auto"` **(default)**: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type. If no matching mapping is found, the command is treated verbatim without mapping.
- `"Binary Sensor"`: Regardless of the device type, the command is treated like a `Binary Sensor CC::Report`.

`mapBasicSet` defines how `Basic CC Set`s are handled:

- `"report"` **(default)**: The command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
- `"auto"`: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type. If no matching mapping is found, the command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
- `"event"`: Emit a `value event` for the Basic `"event"` property.
- `"Binary Sensor"`: Regardless of the device type, the command is treated like a `Binary Sensor CC::Report`.
