### PR TITLE
fix: parse removal messages for ZWLR nodes correctly

### DIFF
--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/RemoveNodeFromNetworkRequest.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/RemoveNodeFromNetworkRequest.ts
@@ -1,7 +1,7 @@
 import {
 	type CommandClasses,
 	MessagePriority,
-	parseNodeUpdatePayload,
+	parseNodeID,
 } from "@zwave-js/core";
 import type { ZWaveHost } from "@zwave-js/host";
 import type { SuccessIndicator } from "@zwave-js/serial";
@@ -146,13 +146,15 @@ export class RemoveNodeFromNetworkRequestStatusReport
 				break;
 
 			case RemoveNodeStatus.RemovingController:
-			case RemoveNodeStatus.RemovingSlave:
-				// the payload contains a node information frame
-				this.statusContext = parseNodeUpdatePayload(
+			case RemoveNodeStatus.RemovingSlave: {
+				// the payload contains the node ID
+				const { nodeId } = parseNodeID(
 					this.payload.subarray(2),
 					this.host.nodeIdType,
 				);
+				this.statusContext = { nodeId };
 				break;
+			}
 		}
 	}
 


### PR DESCRIPTION
16-bit node IDs weren't parsed correctly when removing a node, causing Z-Wave JS to think that the node is still around until restart.