### PR TITLE
fix: re-introduce mandatory CCs to DeviceClass as deprecated

### DIFF
--- a/packages/zwave-js/src/lib/node/DeviceClass.ts
+++ b/packages/zwave-js/src/lib/node/DeviceClass.ts
@@ -4,6 +4,7 @@ import type {
 	GenericDeviceClass,
 	SpecificDeviceClass,
 } from "@zwave-js/config";
+import { type CommandClasses } from "@zwave-js/core";
 import type { JSONObject } from "@zwave-js/shared";
 
 export class DeviceClass {
@@ -24,6 +25,16 @@ export class DeviceClass {
 	public readonly basic: BasicDeviceClass;
 	public readonly generic: GenericDeviceClass;
 	public readonly specific: SpecificDeviceClass;
+
+	/** @deprecated This property is no longer in use and contains no information. */
+	public get mandatorySupportedCCs(): readonly CommandClasses[] {
+		return [];
+	}
+
+	/** @deprecated This property is no longer in use and contains no information. */
+	public get mandatoryControlledCCs(): readonly CommandClasses[] {
+		return [];
+	}
 
 	public toJSON(): JSONObject {
 		return {


### PR DESCRIPTION
https://github.com/zwave-js/node-zwave-js/pull/6788 was a breaking change for Z-Wave JS Server and HA. This PR re-introduces the mandatory CC fields in `DeviceClass`, but as deprecated.

@raman325 FYI, these can be removed from the server