### PR TITLE
fix(config): add params 12, 20, 254 for Aeotec DSB09

### DIFF
--- a/packages/config/config/devices/0x0086/dsb09.json
+++ b/packages/config/config/devices/0x0086/dsb09.json
@@ -78,13 +78,15 @@
 		{
 			"#": "12",
 			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Battery Power Reporting",
-			"description": "Enable reporting when battery powered"
+			"label": "Report While Battery Powered"
 		},
 		{
 			"#": "20",
-			"$import": "templates/aeotec_template.json#current_power_mode",
+			"label": "Current Power Mode",
 			"valueSize": 1,
+			"defaultValue": 0,
+			"readOnly": true,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Battery",
@@ -244,21 +246,21 @@
 			"#": "111",
 			"$import": "templates/aeotec_template.json#report_interval",
 			"label": "Report Interval (Group 1)",
-			"description": "(Rounded up to the nearest 4 minutes when battery powered)",
+			"description": "Rounded up to the nearest 4 minutes when battery powered",
 			"maxValue": 167400
 		},
 		{
 			"#": "112",
 			"$import": "templates/aeotec_template.json#report_interval",
 			"label": "Report Interval (Group 2)",
-			"description": "(Rounded up to the nearest 4 minutes when battery powered)",
+			"description": "Rounded up to the nearest 4 minutes when battery powered",
 			"maxValue": 167400
 		},
 		{
 			"#": "113",
 			"$import": "templates/aeotec_template.json#report_interval",
 			"label": "Report Interval (Group 3)",
-			"description": "(Rounded up to the nearest 4 minutes when battery powered)",
+			"description": "Rounded up to the nearest 4 minutes when battery powered",
 			"maxValue": 167400
 		},
 		{

--- a/packages/config/config/devices/0x0086/dsb09.json
+++ b/packages/config/config/devices/0x0086/dsb09.json
@@ -41,8 +41,7 @@
 		},
 		{
 			"#": "3",
-			"$import": "templates/aeotec_template.json#selective_reporting",
-			"label": "Selective Reporting"
+			"$import": "templates/aeotec_template.json#selective_reporting"
 		},
 		{
 			"#": "4",
@@ -75,6 +74,27 @@
 		{
 			"#": "11",
 			"$import": "templates/aeotec_template.json#percent_threshold_clamp3"
+		},
+		{
+			"#": "12",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Battery Power Reporting",
+			"description": "Enable reporting when battery powered"
+		},
+		{
+			"#": "20",
+			"$import": "templates/aeotec_template.json#current_power_mode",
+			"valueSize": 1,
+			"options": [
+				{
+					"label": "Battery",
+					"value": 0
+				},
+				{
+					"label": "USB power",
+					"value": 1
+				}
+			]
 		},
 		{
 			"#": "100",
@@ -224,19 +244,26 @@
 			"#": "111",
 			"$import": "templates/aeotec_template.json#report_interval",
 			"label": "Report Interval (Group 1)",
+			"description": "(Rounded up to the nearest 4 minutes when battery powered)",
 			"maxValue": 167400
 		},
 		{
 			"#": "112",
 			"$import": "templates/aeotec_template.json#report_interval",
 			"label": "Report Interval (Group 2)",
+			"description": "(Rounded up to the nearest 4 minutes when battery powered)",
 			"maxValue": 167400
 		},
 		{
 			"#": "113",
 			"$import": "templates/aeotec_template.json#report_interval",
 			"label": "Report Interval (Group 3)",
+			"description": "(Rounded up to the nearest 4 minutes when battery powered)",
 			"maxValue": 167400
+		},
+		{
+			"#": "254",
+			"$import": "templates/aeotec_template.json#device_tag"
 		},
 		{
 			"#": "255",


### PR DESCRIPTION
Add missing parameters for Aeotec DSB09 Home Energy Meter: 12, 20 and 254. Add descriptions for Report Interval parameters.
 
Reference: https://doc.eedomus.com/files/Aeon%20Labs%20Home%20Energy%20Meter.pdf