### PR TITLE
fix: do not delete `deviceClass` when instantiating a node

### DIFF
--- a/packages/zwave-js/src/lib/node/Endpoint.ts
+++ b/packages/zwave-js/src/lib/node/Endpoint.ts
@@ -59,7 +59,8 @@ export class Endpoint implements IZWaveEndpoint {
 			},
 		);
 
-		this.deviceClass = deviceClass;
+		// Optionally initialize the device class
+		if (deviceClass) this.deviceClass = deviceClass;
 
 		// Add optional CCs
 		if (supportedCCs != undefined) {


### PR DESCRIPTION
fixes: #6839