### PR TITLE
fix: parse ZW inclusion frames from ZWLR devices, recognize ZWLR protocol frames, include CC in routed frames, add Zniffer active property

### DIFF
--- a/packages/cc/src/cc/ZWaveLongRangeCC.ts
+++ b/packages/cc/src/cc/ZWaveLongRangeCC.ts
@@ -1,0 +1,12 @@
+import { CommandClasses } from "@zwave-js/core";
+import { CommandClass } from "../lib/CommandClass";
+import {
+	commandClass,
+	implementedVersion,
+} from "../lib/CommandClassDecorators";
+
+@commandClass(CommandClasses["Z-Wave Long Range"])
+@implementedVersion(1)
+export class ZWaveLongRangeCC extends CommandClass {
+	// declare ccCommand: ZWaveLongRangeCommand;
+}

--- a/packages/cc/src/cc/index.ts
+++ b/packages/cc/src/cc/index.ts
@@ -873,6 +873,7 @@ export {
 	WindowCoveringCCSupportedReport,
 	WindowCoveringCCValues,
 } from "./WindowCoveringCC";
+export { ZWaveLongRangeCC } from "./ZWaveLongRangeCC";
 export type { ZWavePlusCCReportOptions } from "./ZWavePlusCC";
 export {
 	ZWavePlusCC,

--- a/packages/zwave-js/src/lib/zniffer/Zniffer.ts
+++ b/packages/zwave-js/src/lib/zniffer/Zniffer.ts
@@ -228,6 +228,10 @@ export class Zniffer extends TypedEventEmitter<ZnifferEventCallbacks> {
 	private awaitedMessages: AwaitedMessageEntry[] = [];
 
 	private _active: boolean;
+	/** Whether the Zniffer instance is currently capturing */
+	public get active(): boolean {
+		return this._active;
+	}
 
 	/** A list of raw captured frames that can be saved to a .zlf file later */
 	private capturedDataFrames: CapturedData[] = [];
@@ -308,7 +312,9 @@ export class Zniffer extends TypedEventEmitter<ZnifferEventCallbacks> {
 				}
   supported frequencies: ${
 					freqs.supportedFrequencies.map((f) =>
-						`\n  · ${getEnumMemberName(ZnifferRegion, f)}`
+						`\n  · ${f.toString().padStart(2, " ")}: ${
+							getEnumMemberName(ZnifferRegion, f)
+						}`
 					).join("")
 				}`,
 				"info",


### PR DESCRIPTION
This PR adds a bit of polishing for Zniffer and some bugfixes:

- The `active` property can be used to determine whether Zniffer is currently running
- ZWLR protocol frames are recognized (but not parsed in detail) instead of logging an error
- ZW Classic inclusion frames from ZWLR devices are now parsed instead of erroring
- The `payload` property for routed frames contains the parsed CC now