### PR TITLE
feat(config): parameter update for Zooz Zen16 v2.0 and v2.10

### DIFF
--- a/packages/config/config/devices/0x027a/templates/zooz_template.json
+++ b/packages/config/config/devices/0x027a/templates/zooz_template.json
@@ -954,6 +954,110 @@
 			}
 		]
 	},
+	// zen16 and zen17 relay devices now (Zen16 FW >=2.0, Zen17 FW >= 1.04) share common definition for switch type (and value inversion) and input trigger duration
+	"multi_universal_relay_switch_type": {
+		"valueSize": 1,
+		"defaultValue": 2,
+		"unsigned": true,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Momentary",
+				"value": 0
+			},
+			{
+				"label": "Toggle (Follow switch)",
+				"value": 1
+			},
+			{
+				"label": "Toggle (Change state on toggle)",
+				"value": 2
+			},
+			{
+				"label": "Garage door (Momentary mode for Z-Wave control)",
+				"value": 3
+			},
+			{
+				"label": "Leak alarm (Water sensor)",
+				"value": 4
+			},
+			{
+				"label": "Heat alarm",
+				"value": 5
+			},
+			{
+				"label": "Motion alert",
+				"value": 6
+			},
+			{
+				"label": "Open/Close alert (Door sensor)",
+				"value": 7
+			},
+			{
+				"label": "CO alarm",
+				"value": 8
+			},
+			{
+				"label": "CO2 alarm",
+				"value": 9
+			},
+			{
+				"label": "On/Off report (Dry contact switch/sensor)",
+				"value": 10
+			},
+			{
+				"label": "Garage door mode (Relay), door sensor (Input)",
+				"value": 11
+			}
+		]
+	},
+	"multi_universal_relay_reverse_reported_value": {
+		"valueSize": 1,
+		"defaultValue": 0,
+		"unsigned": true,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Values not reversed",
+				"value": 0
+			},
+			{
+				"label": "Leak alarm (Water sensor)",
+				"value": 4
+			},
+			{
+				"label": "Heat alarm",
+				"value": 5
+			},
+			{
+				"label": "Motion alert",
+				"value": 6
+			},
+			{
+				"label": "Open/Close alert (Door sensor)",
+				"value": 7
+			},
+			{
+				"label": "CO alarm",
+				"value": 8
+			},
+			{
+				"label": "CO2 alarm",
+				"value": 9
+			},
+			{
+				"label": "On/Off report (Dry contact switch/sensor)",
+				"value": 10
+			}
+		]
+	},
+	"multi_universal_relay_input_trigger_duration": {
+		"valueSize": 1,
+		"unit": "0.1 seconds",
+		"minValue": 1,
+		"maxValue": 100,
+		"defaultValue": 5
+	},
 	"zen16_manual_control": {
 		"valueSize": 1,
 		"defaultValue": 1,

--- a/packages/config/config/devices/0x027a/zen16.json
+++ b/packages/config/config/devices/0x027a/zen16.json
@@ -70,8 +70,14 @@
 		},
 		{
 			"#": "2",
-			"$if": "firmwareVersion >= 1.2",
+			"$if": "firmwareVersion >= 1.2 && firmwareVersion < 2.0",
 			"$import": "templates/zooz_template.json#zen16_switch_type_v2",
+			"label": "Switch 1: Type"
+		},
+		{
+			"#": "2",
+			"$if": "firmwareVersion >= 2.0",
+			"$import": "templates/zooz_template.json#multi_universal_relay_switch_type",
 			"label": "Switch 1: Type"
 		},
 		{
@@ -82,8 +88,14 @@
 		},
 		{
 			"#": "3",
-			"$if": "firmwareVersion >= 1.2",
+			"$if": "firmwareVersion >= 1.2 && firmwareVersion < 2.0",
 			"$import": "templates/zooz_template.json#zen16_switch_type_v2",
+			"label": "Switch 2: Type"
+		},
+		{
+			"#": "3",
+			"$if": "firmwareVersion >= 2.0",
+			"$import": "templates/zooz_template.json#multi_universal_relay_switch_type",
 			"label": "Switch 2: Type"
 		},
 		{
@@ -94,8 +106,14 @@
 		},
 		{
 			"#": "4",
-			"$if": "firmwareVersion >= 1.2",
+			"$if": "firmwareVersion >= 1.2 && firmwareVersion < 2.0",
 			"$import": "templates/zooz_template.json#zen16_switch_type_v2",
+			"label": "Switch 3: Type"
+		},
+		{
+			"#": "4",
+			"$if": "firmwareVersion >= 2.0",
+			"$import": "templates/zooz_template.json#multi_universal_relay_switch_type",
 			"label": "Switch 3: Type"
 		},
 		{
@@ -244,7 +262,7 @@
 			"#": "11",
 			"$if": "firmwareVersion >= 1.1",
 			"$import": "templates/zooz_template.json#auto_timer_base_0x_1x_3x_7x_nounit",
-			"label": "Relay 2: Auto Turn-On Timer",
+			"label": "Relay 3: Auto Turn-On Timer",
 			"description": "Unit defined in parameter 20."
 		},
 		{
@@ -344,10 +362,102 @@
 		},
 		{
 			"#": "24",
-			"$if": "firmwareVersion >= 1.3",
+			"$if": "firmwareVersion >= 1.3 && firmwareVersion < 2.10",
 			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "DC Motor Mode",
 			"description": "When enabled only one relay may be on at a time, the other relay is automatically turned off."
+		},
+		{
+			"#": "24",
+			"$if": "firmwareVersion >= 2.10",
+			"label": "DC Motor Mode",
+			"description": "When enabled only one relay may be on at a time, the other relay is automatically turned off.",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disabled (Relays turn on whenever activated)",
+					"value": 0
+				},
+				{
+					"label": "Enabled for R1 and R2 (R3 unaffected)",
+					"value": 1
+				},
+				{
+					"label": "Enabled for R1, R2, and R3",
+					"value": 2
+				}
+			]
+		},
+		{
+			"#": "25",
+			"$if": "firmwareVersion >= 2.0",
+			"$import": "templates/zooz_template.json#multi_universal_relay_reverse_reported_value",
+			"label": "Switch 1: Reverse Reported Value",
+			"description": "Select the same value as in parameter 2 to reverse the values for open and closed circuit."
+		},
+		{
+			"#": "26",
+			"$if": "firmwareVersion >= 2.0",
+			"$import": "templates/zooz_template.json#multi_universal_relay_reverse_reported_value",
+			"label": "Switch 2: Reverse Reported Value",
+			"description": "Select the same value as in parameter 3 to reverse the values for open and closed circuit."
+		},
+		{
+			"#": "27",
+			"$if": "firmwareVersion >= 2.0",
+			"$import": "templates/zooz_template.json#multi_universal_relay_reverse_reported_value",
+			"label": "Switch 3: Reverse Reported Value",
+			"description": "Select the same value as in parameter 4 to reverse the values for open and closed circuit."
+		},
+		{
+			"#": "28",
+			"$if": "firmwareVersion >= 2.10",
+			"$import": "templates/zooz_template.json#multi_universal_relay_input_trigger_duration",
+			"label": "Switch 1: Trigger Duration",
+			"description": "Time SW1 condition must be active before triggering associated action."
+		},
+		{
+			"#": "29",
+			"$if": "firmwareVersion >= 2.10",
+			"$import": "templates/zooz_template.json#multi_universal_relay_input_trigger_duration",
+			"label": "Switch 2: Trigger Duration",
+			"description": "Time SW2 condition must be active before triggering associated action."
+		},
+		{
+			"#": "30",
+			"$if": "firmwareVersion >= 2.10",
+			"$import": "templates/zooz_template.json#multi_universal_relay_input_trigger_duration",
+			"label": "Switch 3: Trigger Duration",
+			"description": "Time SW3 condition must be active before triggering associated action."
+		},
+		{
+			"#": "31",
+			"$if": "firmwareVersion >= 2.10",
+			"label": "Fixed Input Actions",
+			"description": "Use separate inputs to drive relay(s) on and off",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disabled",
+					"value": 0
+				},
+				{
+					"label": "SW1 turns on R1, SW2 turns off R1",
+					"value": 1
+				},
+				{
+					"label": "SW1 turns on R2, SW2 turns off R2",
+					"value": 2
+				},
+				{
+					"label": "SW1 turns on R1 and R2, SW2 turns off R1 and R2",
+					"value": 3
+				}
+			]
 		}
 	],
 	"compat": {

--- a/packages/config/config/devices/0x027a/zen16.json
+++ b/packages/config/config/devices/0x027a/zen16.json
@@ -435,26 +435,25 @@
 		{
 			"#": "31",
 			"$if": "firmwareVersion >= 2.10",
-			"label": "Fixed Input Actions",
-			"description": "Use separate inputs to drive relay(s) on and off",
+			"label": "Input Behavior",
 			"valueSize": 1,
 			"defaultValue": 0,
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Disabled",
+					"label": "SW1 turns R1 on/off, SW2 turns R2 on/off",
 					"value": 0
 				},
 				{
-					"label": "SW1 turns on R1, SW2 turns off R1",
+					"label": "SW1 turns R1 on, SW2 turns R1 off",
 					"value": 1
 				},
 				{
-					"label": "SW1 turns on R2, SW2 turns off R2",
+					"label": "SW1 turns R2 on, SW2 turns R2 off",
 					"value": 2
 				},
 				{
-					"label": "SW1 turns on R1 and R2, SW2 turns off R1 and R2",
+					"label": "SW1 turns R1 and R2 on, SW2 turns R1 and R2 off",
 					"value": 3
 				}
 			]


### PR DESCRIPTION
Support for Zen16 FW 2.0 and 2.1. Added new parameters (Reverse Reported Input Value, params 25-27; Input Trigger Duration, params 28-30; Fixed Input Actions, param 31) and updated defined option values for Switch Types (params 2-4) and DC Motor Mode (param 24). Moved some definitions to Zooz template as they are now common between the Zen16 and Zen17 relays. Based on Zooz Zen16 [Advanced Settings](https://www.support.getzooz.com/kb/article/471-zen16-multirelay-advanced-settings/) documentation and [2.10 Release Notes](https://www.support.getzooz.com/kb/article/356-zen16-multirelay-change-log/).
