### PR TITLE
fix: respond to more queries from other devices, handle supervised queries correctly, harden S2 extension parsing and validation

### DIFF
--- a/packages/cc/src/cc/DeviceResetLocallyCC.ts
+++ b/packages/cc/src/cc/DeviceResetLocallyCC.ts
@@ -45,10 +45,13 @@ export class DeviceResetLocallyCCAPI extends CCAPI {
 		});
 
 		try {
+			// This command is sent immediately before a hard reset of the controller.
+			// If we don't wait for a callback (ack), the controller locks up when hard-resetting.
 			await this.applHost.sendCommand(cc, {
 				...this.commandOptions,
-				// Seems we need these options or some nodes won't accept the nonce
-				transmitOptions: TransmitOptions.DEFAULT_NOACK,
+				// Do not fall back to explorer frames
+				transmitOptions: TransmitOptions.ACK
+					| TransmitOptions.AutoRoute,
 				// Only try sending once
 				maxSendAttempts: 1,
 				// We don't want failures causing us to treat the node as asleep or dead

--- a/packages/cc/src/cc/IndicatorCC.ts
+++ b/packages/cc/src/cc/IndicatorCC.ts
@@ -383,6 +383,24 @@ export class IndicatorCCAPI extends CCAPI {
 	}
 
 	@validateArgs()
+	public async sendReport(
+		options: IndicatorCCReportSpecificOptions,
+	): Promise<void> {
+		this.assertSupportsCommand(
+			IndicatorCommand,
+			IndicatorCommand.Report,
+		);
+
+		const cc = new IndicatorCCReport(this.applHost, {
+			nodeId: this.endpoint.nodeId,
+			endpoint: this.endpoint.index,
+			...options,
+		});
+
+		await this.applHost.sendCommand(cc, this.commandOptions);
+	}
+
+	@validateArgs()
 	public async getSupported(indicatorId: number): Promise<
 		| {
 			indicatorId?: number;

--- a/packages/cc/src/cc/index.ts
+++ b/packages/cc/src/cc/index.ts
@@ -15,6 +15,7 @@ export type {
 	AssociationCCRemoveOptions,
 	AssociationCCReportSpecificOptions,
 	AssociationCCSetOptions,
+	AssociationCCSpecificGroupReportOptions,
 	AssociationCCSupportedGroupingsReportOptions,
 } from "./AssociationCC";
 export {
@@ -23,6 +24,8 @@ export {
 	AssociationCCRemove,
 	AssociationCCReport,
 	AssociationCCSet,
+	AssociationCCSpecificGroupGet,
+	AssociationCCSpecificGroupReport,
 	AssociationCCSupportedGroupingsGet,
 	AssociationCCSupportedGroupingsReport,
 	AssociationCCValues,
@@ -233,6 +236,7 @@ export {
 } from "./EntryControlCC";
 export type {
 	FirmwareUpdateMetaDataCCActivationSetOptions,
+	FirmwareUpdateMetaDataCCMetaDataReportOptions,
 	FirmwareUpdateMetaDataCCPrepareGetOptions,
 	FirmwareUpdateMetaDataCCReportOptions,
 	FirmwareUpdateMetaDataCCRequestGetOptions,
@@ -299,6 +303,7 @@ export {
 } from "./InclusionControllerCC";
 export type {
 	IndicatorCCDescriptionGetOptions,
+	IndicatorCCDescriptionReportOptions,
 	IndicatorCCGetOptions,
 	IndicatorCCReportSpecificOptions,
 	IndicatorCCSetOptions,
@@ -396,7 +401,9 @@ export {
 export type {
 	MultiChannelAssociationCCGetOptions,
 	MultiChannelAssociationCCRemoveOptions,
+	MultiChannelAssociationCCReportOptions,
 	MultiChannelAssociationCCSetOptions,
+	MultiChannelAssociationCCSupportedGroupingsReportOptions,
 } from "./MultiChannelAssociationCC";
 export {
 	MultiChannelAssociationCC,
@@ -508,6 +515,7 @@ export {
 	NotificationCCValues,
 } from "./NotificationCC";
 export type {
+	PowerlevelCCReportOptions,
 	PowerlevelCCSetOptions,
 	PowerlevelCCTestNodeSetOptions,
 } from "./PowerlevelCC";
@@ -827,6 +835,7 @@ export {
 	UserCodeCCValues,
 } from "./UserCodeCC";
 export type {
+	VersionCCCapabilitiesReportOptions,
 	VersionCCCommandClassGetOptions,
 	VersionCCCommandClassReportOptions,
 	VersionCCReportOptions,

--- a/packages/cc/src/lib/_Types.ts
+++ b/packages/cc/src/lib/_Types.ts
@@ -38,19 +38,8 @@ export enum AssociationCommand {
 	Remove = 0x04,
 	SupportedGroupingsGet = 0x05,
 	SupportedGroupingsReport = 0x06,
-	// TODO: These two commands are V2. I have no clue how this is supposed to function:
-	// SpecificGroupGet = 0x0b,
-	// SpecificGroupReport = 0x0c,
-
-	// Here's what the docs have to say:
-	// This functionality allows a supporting multi-button device to detect a key press and subsequently advertise
-	// the identity of the key. The following sequence of events takes place:
-	// * The user activates a special identification sequence and pushes the button to be identified
-	// * The device issues a Node Information frame (NIF)
-	// * The NIF allows the portable controller to determine the NodeID of the multi-button device
-	// * The portable controller issues an Association Specific Group Get Command to the multi-button device
-	// * The multi-button device returns an Association Specific Group Report Command that advertises the
-	//   association group that represents the most recently detected button
+	SpecificGroupGet = 0x0b,
+	SpecificGroupReport = 0x0c,
 }
 
 export enum AssociationGroupInfoCommand {

--- a/packages/core/src/error/ZWaveError.ts
+++ b/packages/core/src/error/ZWaveError.ts
@@ -87,6 +87,8 @@ export enum ZWaveErrorCodes {
 	CC_NotSupported,
 	CC_NotImplemented,
 	CC_NoAPI,
+	/** Used to communicate that a given operation triggered by another node was not successful */
+	CC_OperationFailed,
 
 	Deserialization_NotImplemented = 320,
 	Arithmetic,

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -761,6 +761,18 @@ export class ZWaveController
 		return this._nodes.get(this._ownNodeId!)!.valueDB;
 	}
 
+	/** @internal Which associations are currently configured */
+	public get associations(): readonly AssociationAddress[] {
+		return (
+			this.driver.cacheGet(cacheKeys.controller.associations(1)) ?? []
+		);
+	}
+
+	/** @internal */
+	public set associations(value: readonly AssociationAddress[]) {
+		this.driver.cacheSet(cacheKeys.controller.associations(1), value);
+	}
+
 	private _isRebuildingRoutes: boolean = false;
 	/** Returns whether the routes are currently being rebuilt for one or more nodes. */
 	public get isRebuildingRoutes(): boolean {
@@ -1778,7 +1790,7 @@ export class ZWaveController
 	public async hardReset(): Promise<void> {
 		// begin the reset process
 		try {
-			const associations = this.nodes.get(this._ownNodeId!)?.associations;
+			const associations = this.associations;
 			if (associations?.length) {
 				this.driver.controllerLog.print(
 					"Notifying associated nodes about reset...",

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -1822,9 +1822,7 @@ export class ZWaveController
 					const node = this.nodes.get(nodeId);
 					if (!node) continue;
 
-					void node.sendResetLocallyNotification().catch(() => {
-						// ignore
-					});
+					await node.sendResetLocallyNotification().catch(noop);
 				}
 			}
 

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -13,6 +13,7 @@ import {
 	KEXSchemes,
 	ManufacturerSpecificCCValues,
 	MultiChannelAssociationCC,
+	Powerlevel,
 	Security2CCKEXFail,
 	Security2CCKEXSet,
 	Security2CCNetworkKeyGet,
@@ -771,6 +772,25 @@ export class ZWaveController
 	/** @internal */
 	public set associations(value: readonly AssociationAddress[]) {
 		this.driver.cacheSet(cacheKeys.controller.associations(1), value);
+	}
+
+	/** @internal Remembers which powerlevel was set by another node */
+	public get powerlevel(): { powerlevel: Powerlevel; until: Date } {
+		return {
+			powerlevel: this.driver.cacheGet(cacheKeys.controller.powerlevel)
+				?? Powerlevel["Normal Power"],
+			until: this.driver.cacheGet(cacheKeys.controller.powerlevelTimeout)
+				?? new Date(),
+		};
+	}
+
+	/** @internal */
+	public set powerlevel(value: { powerlevel: Powerlevel; until: Date }) {
+		this.driver.cacheSet(cacheKeys.controller.powerlevel, value.powerlevel);
+		this.driver.cacheSet(
+			cacheKeys.controller.powerlevelTimeout,
+			value.until,
+		);
 	}
 
 	private _isRebuildingRoutes: boolean = false;

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -1783,7 +1783,10 @@ export class ZWaveController
 				this.driver.controllerLog.print(
 					"Notifying associated nodes about reset...",
 				);
-				for (const nodeId of associations) {
+				const nodeIdDestinations = distinct(
+					associations.map(({ nodeId }) => nodeId),
+				);
+				for (const nodeId of nodeIdDestinations) {
 					const node = this.nodes.get(nodeId);
 					if (!node) continue;
 

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -774,23 +774,21 @@ export class ZWaveController
 		this.driver.cacheSet(cacheKeys.controller.associations(1), value);
 	}
 
-	/** @internal Remembers which powerlevel was set by another node */
+	private _powerlevel: { powerlevel: Powerlevel; until: Date } | undefined;
+	/**
+	 * @internal
+	 * Remembers which powerlevel was set by another node.
+	 */
 	public get powerlevel(): { powerlevel: Powerlevel; until: Date } {
-		return {
-			powerlevel: this.driver.cacheGet(cacheKeys.controller.powerlevel)
-				?? Powerlevel["Normal Power"],
-			until: this.driver.cacheGet(cacheKeys.controller.powerlevelTimeout)
-				?? new Date(),
+		return this._powerlevel ?? {
+			powerlevel: Powerlevel["Normal Power"],
+			until: new Date(),
 		};
 	}
 
 	/** @internal */
 	public set powerlevel(value: { powerlevel: Powerlevel; until: Date }) {
-		this.driver.cacheSet(cacheKeys.controller.powerlevel, value.powerlevel);
-		this.driver.cacheSet(
-			cacheKeys.controller.powerlevelTimeout,
-			value.until,
-		);
+		this._powerlevel = value;
 	}
 
 	private _isRebuildingRoutes: boolean = false;

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -30,6 +30,7 @@ import {
 	inclusionTimeouts,
 	utils as ccUtils,
 } from "@zwave-js/cc";
+import { type IndicatorObject } from "@zwave-js/cc/IndicatorCC";
 import {
 	CommandClasses,
 	ControllerStatus,
@@ -790,6 +791,12 @@ export class ZWaveController
 	public set powerlevel(value: { powerlevel: Powerlevel; until: Date }) {
 		this._powerlevel = value;
 	}
+
+	/**
+	 * @internal
+	 * Remembers the indicator values set by another node
+	 */
+	public readonly indicatorValues = new Map<number, IndicatorObject[]>();
 
 	private _isRebuildingRoutes: boolean = false;
 	/** Returns whether the routes are currently being rebuilt for one or more nodes. */

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -3,7 +3,6 @@ import {
 	CRC16CC,
 	CRC16CCCommandEncapsulation,
 	type CommandClass,
-	DeviceResetLocallyCCNotification,
 	type FirmwareUpdateResult,
 	type ICommandClassContainer,
 	InvalidCC,
@@ -4416,30 +4415,6 @@ ${handlers.length} left`,
 			const nodeSessions = this.nodeSessions.get(nodeId);
 			// Check if we need to handle the command ourselves
 			if (
-				msg.command.ccId === CommandClasses["Device Reset Locally"]
-				&& msg.command instanceof DeviceResetLocallyCCNotification
-			) {
-				this.controllerLog.logNode(msg.command.nodeId, {
-					message: `The node was reset locally, removing it`,
-					direction: "inbound",
-				});
-
-				try {
-					await this.controller.removeFailedNodeInternal(
-						msg.command.nodeId,
-						RemoveNodeReason.Reset,
-					);
-				} catch (e) {
-					this.controllerLog.logNode(msg.command.nodeId, {
-						message: `removing the node failed: ${
-							getErrorMessage(
-								e,
-							)
-						}`,
-						level: "error",
-					});
-				}
-			} else if (
 				msg.command.ccId === CommandClasses.Supervision
 				&& msg.command instanceof SupervisionCCReport
 				&& nodeSessions?.supervision.has(msg.command.sessionId)

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -9,6 +9,7 @@ import {
 	KEXFailType,
 	MultiChannelCC,
 	Security2CC,
+	Security2CCCommandsSupportedGet,
 	Security2CCCommandsSupportedReport,
 	Security2CCMessageEncapsulation,
 	Security2CCNonceReport,
@@ -16,6 +17,7 @@ import {
 	SecurityCC,
 	SecurityCCCommandEncapsulation,
 	SecurityCCCommandEncapsulationNonceGet,
+	SecurityCCCommandsSupportedGet,
 	SecurityCCCommandsSupportedReport,
 	SecurityCommand,
 	SupervisionCC,
@@ -4220,9 +4222,12 @@ ${handlers.length} left`,
 
 				if (cmd instanceof SecurityCCCommandEncapsulation) {
 					// CommandsSupportedReport is always accepted to be able to learn security classes and interview nodes
+					// CommandsSupportedGet is always accepted, so others can learn our security classes
 					if (
 						cmd.encapsulated
 							instanceof SecurityCCCommandsSupportedReport
+						|| cmd.encapsulated
+							instanceof SecurityCCCommandsSupportedGet
 					) {
 						return true;
 					}
@@ -4236,8 +4241,14 @@ ${handlers.length} left`,
 					if (
 						cmd.encapsulated
 							instanceof Security2CCCommandsSupportedReport
-						|| cmd.encapsulated
-							instanceof SecurityCCCommandsSupportedReport
+					) {
+						return true;
+					}
+
+					// CommandsSupportedGet is always accepted, so others can learn our security classes
+					if (
+						cmd.encapsulated
+							instanceof Security2CCCommandsSupportedGet
 					) {
 						return true;
 					}

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -4675,7 +4675,13 @@ ${handlers.length} left`,
 		) {
 			const unwrapped = msg.command.encapsulated;
 			if (isArray(unwrapped)) {
-				// Multi Command CC cannot be further unwrapped
+				// Multi Command CC cannot be further unwrapped. Preserve the encapsulation flags though.
+				for (const cmd of unwrapped) {
+					cmd.toggleEncapsulationFlag(
+						msg.command.encapsulationFlags,
+						true,
+					);
+				}
 				return;
 			}
 

--- a/packages/zwave-js/src/lib/driver/NetworkCache.ts
+++ b/packages/zwave-js/src/lib/driver/NetworkCache.ts
@@ -30,8 +30,6 @@ export const cacheKeys = {
 	controller: {
 		provisioningList: "controller.provisioningList",
 		associations: (groupId: number) => `controller.associations.${groupId}`,
-		powerlevel: "controller.powerlevel",
-		powerlevelTimeout: "controller.powerlevelTimeout",
 	},
 	// TODO: somehow these functions should be combined with the pattern matching below
 	node: (nodeId: number) => {
@@ -458,14 +456,6 @@ export function deserializeNetworkCacheValue(
 			if (value) return value;
 			throw fail();
 		}
-		case cacheKeys.controller.powerlevel:
-			value = ensureType(value, "number");
-			if (value) return value;
-			throw fail();
-		case cacheKeys.controller.powerlevelTimeout:
-			value = tryParseDate(value);
-			if (value) return value;
-			throw fail();
 	}
 
 	return value;
@@ -552,10 +542,6 @@ export function serializeNetworkCacheValue(
 			}
 			return ret;
 		}
-
-		case cacheKeys.controller.powerlevelTimeout:
-			// Date stored as timestamp
-			return (value as Date).getTime();
 	}
 
 	return value;

--- a/packages/zwave-js/src/lib/driver/NetworkCache.ts
+++ b/packages/zwave-js/src/lib/driver/NetworkCache.ts
@@ -30,6 +30,8 @@ export const cacheKeys = {
 	controller: {
 		provisioningList: "controller.provisioningList",
 		associations: (groupId: number) => `controller.associations.${groupId}`,
+		powerlevel: "controller.powerlevel",
+		powerlevelTimeout: "controller.powerlevelTimeout",
 	},
 	// TODO: somehow these functions should be combined with the pattern matching below
 	node: (nodeId: number) => {
@@ -456,6 +458,14 @@ export function deserializeNetworkCacheValue(
 			if (value) return value;
 			throw fail();
 		}
+		case cacheKeys.controller.powerlevel:
+			value = ensureType(value, "number");
+			if (value) return value;
+			throw fail();
+		case cacheKeys.controller.powerlevelTimeout:
+			value = tryParseDate(value);
+			if (value) return value;
+			throw fail();
 	}
 
 	return value;
@@ -542,6 +552,10 @@ export function serializeNetworkCacheValue(
 			}
 			return ret;
 		}
+
+		case cacheKeys.controller.powerlevelTimeout:
+			// Date stored as timestamp
+			return (value as Date).getTime();
 	}
 
 	return value;

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3807,6 +3807,22 @@ protocol version:      ${this.protocolVersion}`;
 					});
 				}
 			} else if (
+				!this.deviceConfig?.compat?.mapBasicSet
+				&& !!(command.encapsulationFlags
+					& EncapsulationFlags.Supervision)
+			) {
+				// A controller MUST not support Basic CC per the specifications. While we can interpret its contents,
+				// we MUST respond to supervised Basic CC Set with "no support".
+				// All known devices that use BasicCCSet for reporting send it unsupervised, so this should be safe to do.
+				if (
+					command.encapsulationFlags & EncapsulationFlags.Supervision
+				) {
+					throw new ZWaveError(
+						"Basic CC is not supported",
+						ZWaveErrorCodes.CC_NotSupported,
+					);
+				}
+			} else if (
 				basicSetMapping === "auto" || basicSetMapping === "report"
 			) {
 				// Some devices send their current state using BasicCCSet to their associations

--- a/test/debug.js
+++ b/test/debug.js
@@ -3,7 +3,13 @@
 require("reflect-metadata");
 require("zwave-js");
 const { Message } = require("@zwave-js/serial");
-const { generateAuthKey, generateEncryptionKey } = require("@zwave-js/core");
+const {
+	generateAuthKey,
+	generateEncryptionKey,
+	SecurityManager2,
+	SecurityClass,
+	SPANState,
+} = require("@zwave-js/core");
 const { isCommandClassContainer } = require("@zwave-js/cc");
 const { ConfigManager } = require("@zwave-js/config");
 
@@ -19,11 +25,39 @@ const { ConfigManager } = require("@zwave-js/config");
 	await configManager.loadIndicators();
 
 	// The data to decode
-	const data = Buffer.from("010e00a80001c005710207018000a7cf", "hex");
+	const data = Buffer.from(
+		"012900a8000102209f035a0112c1a5ab925f01ee99f1c610bc6c0422f7fd5923f8f1688d1999114000b5d5",
+		"hex",
+	);
 	// The nonce needed to decode it
 	const nonce = Buffer.from("478d7aa05d83f3ea", "hex");
 	// The network key needed to decode it
 	const networkKey = Buffer.from("96bcdaa2da7b00621a7fa57e38813786", "hex");
+
+	const sm2 = new SecurityManager2();
+	// Small hack: We do not care about S2 duplicates
+	sm2.isDuplicateSinglecast = () => false;
+	sm2.setKey(
+		SecurityClass.S0_Legacy,
+		Buffer.from("0102030405060708090a0b0c0d0e0fff", "hex"),
+	);
+	sm2.setKey(
+		SecurityClass.S2_Unauthenticated,
+		Buffer.from("5369389EFA18EE2A4894C7FB48347FEA", "hex"),
+	);
+	sm2.setKey(
+		SecurityClass.S2_Authenticated,
+		Buffer.from("656EF5C0F020F3C14238C04A1748B7E1", "hex"),
+	);
+	sm2.setKey(
+		SecurityClass.S2_AccessControl,
+		Buffer.from("31132050077310B6F7032F91C79C2EB8", "hex"),
+	);
+
+	sm2.setSPANState(2, {
+		type: SPANState.LocalEI,
+		receiverEI: Buffer.from("3664023a7971465342fe3d82ebb4b8e9", "hex"),
+	});
 
 	console.log(Message.getMessageLength(data));
 	/** @type {any} */
@@ -61,6 +95,9 @@ const { ConfigManager } = require("@zwave-js/config");
 			authKey: generateAuthKey(networkKey),
 			encryptionKey: generateEncryptionKey(networkKey),
 		},
+		securityManager2: sm2,
+		getHighestSecurityClass: () => SecurityClass.S2_AccessControl,
+		hasSecurityClass: () => true,
 		isCCSecure: () => true,
 	};
 	const msg = Message.from(host, { data });


### PR DESCRIPTION
This PR fixes a lot of small deviations from the specifications and the handling of edge cases the CTT uses to test implementations. Also adds a lot of mandatory responses to queries that weren't handled before.

fixes: #6865
fixes: #6864