### PR TITLE
fix(config): use HomeSeer template for LED Indicator (parameter 3) for all HomeSeer switches

### DIFF
--- a/packages/config/config/devices/0x000c/hs-fc200.json
+++ b/packages/config/config/devices/0x000c/hs-fc200.json
@@ -17,7 +17,7 @@
 	"paramInformation": [
 		{
 			"#": "3",
-			"$import": "~/templates/master_template.json#led_indicator_two_options"
+			"$import": "templates/homeseer_template.json#led_indicator"
 		},
 		{
 			"#": "4",

--- a/packages/config/config/devices/0x000c/hs-wd200.json
+++ b/packages/config/config/devices/0x000c/hs-wd200.json
@@ -17,7 +17,7 @@
 	"paramInformation": [
 		{
 			"#": "3",
-			"$import": "~/templates/master_template.json#led_indicator_two_options"
+			"$import": "templates/homeseer_template.json#led_indicator"
 		},
 		{
 			"#": "4",

--- a/packages/config/config/devices/0x000c/hs-ws200.json
+++ b/packages/config/config/devices/0x000c/hs-ws200.json
@@ -17,7 +17,7 @@
 	"paramInformation": [
 		{
 			"#": "3",
-			"$import": "~/templates/master_template.json#led_indicator_two_options"
+			"$import": "templates/homeseer_template.json#led_indicator"
 		},
 		{
 			"#": "4",

--- a/packages/config/config/devices/0x000c/hs-wx300.json
+++ b/packages/config/config/devices/0x000c/hs-wx300.json
@@ -32,7 +32,7 @@
 	"paramInformation": [
 		{
 			"#": "3",
-			"$import": "~/templates/master_template.json#led_indicator_two_options",
+			"$import": "templates/homeseer_template.json#led_indicator_inverted",
 			"label": "Bottom LED Operation"
 		},
 		{
@@ -150,6 +150,7 @@
 			"minValue": 0,
 			"maxValue": 1,
 			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "3 wire mode (Neutral, line & load)",

--- a/packages/config/config/devices/0x000c/hs-wx300.json
+++ b/packages/config/config/devices/0x000c/hs-wx300.json
@@ -147,8 +147,6 @@
 			"#": "32",
 			"label": "Wire Mode",
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
 			"defaultValue": 0,
 			"allowManualEntry": false,
 			"options": [

--- a/packages/config/config/devices/0x000c/templates/homeseer_template.json
+++ b/packages/config/config/devices/0x000c/templates/homeseer_template.json
@@ -289,5 +289,37 @@
 		"$import": "~/templates/master_template.json#base_0-100_nounit",
 		"label": "Range Sensitivity",
 		"description": "Higher values increase sensitivity"
+	},
+	"led_indicator": {
+		"label": "LED Indicator",
+		"valueSize": 1,
+		"defaultValue": 1,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "On when load is off",
+				"value": 0
+			},
+			{
+				"label": "Off when load is off",
+				"value": 1
+			}
+		]
+	},
+	"led_indicator_inverted": {
+		"label": "LED Indicator",
+		"valueSize": 1,
+		"defaultValue": 0,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Off when load is off",
+				"value": 0
+			},
+			{
+				"label": "On when load is off",
+				"value": 1
+			}
+		]
 	}
 }


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->
Fix LED indicator (parameter 3) for all HomeSeer switches, fixes #4047
Also fix small issue with parameter 32 for WX300 which should not allow manual entry.

