### PR TITLE
fix(config): override Central Scene CC version for Springs Window Fashions BRZ

### DIFF
--- a/packages/config/config/devices/0x026e/brz1.json
+++ b/packages/config/config/devices/0x026e/brz1.json
@@ -28,5 +28,16 @@
 	"metadata": {
 		"reset": "Press and hold the button on the control for approximately 15 seconds (the LED will stop flashing when complete.\n\n\n\"Please use this procedure only when the network primary controller is missing or otherwise inoperable.\"",
 		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/1787/Graber%20Virtual%20Cord%20Owner's%20Manual.pdf"
+	},
+	"compat": {
+		// The device reports version 0 for the Central Scene command class
+		"commandClasses": {
+			"add": {
+				"Central Scene": {
+					"isSupported": true,
+					"version": 1
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION


<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

fixes  #6869
