### PR TITLE
feat: add driver option to configure vendor-specific constants

### DIFF
--- a/packages/cc/src/cc/VersionCC.ts
+++ b/packages/cc/src/cc/VersionCC.ts
@@ -724,8 +724,7 @@ export class VersionCCReport extends VersionCC {
 				.split(".")
 				.map((n) => parseInt(n))
 				.slice(0, 2),
-			// The value 0x00 SHOULD NOT be used for the Hardware Version
-			this.hardwareVersion ?? 0x01,
+			this.hardwareVersion ?? 0x00,
 			this.firmwareVersions.length - 1,
 		]);
 

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1029,6 +1029,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks>
 			"inclusionUserCallbacks",
 			"interview",
 			"preferences",
+			"vendor",
 		]);
 
 		// Create a new deep-merged copy of the options so we can check them for validity

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -320,6 +320,23 @@ export interface ZWaveOptions extends ZWaveHostOptions {
 	 */
 	userAgent?: Record<string, string>;
 
+	/**
+	 * Specify application-specific information to use in queries from other devices
+	 */
+	vendor?: {
+		manufacturerId: number;
+		productType: number;
+		productId: number;
+
+		/** The version of the hardware the application is running on. Can be omitted if unknown. */
+		hardwareVersion?: number;
+
+		/** The icon type to use for installers. Default: 0x0500 - Generic Gateway */
+		installerIcon?: number;
+		/** The icon type to use for users. Default: 0x0500 - Generic Gateway */
+		userIcon?: number;
+	};
+
 	/** DO NOT USE! Used for testing internally */
 	testingHooks?: {
 		serialPortBinding?: typeof SerialPort;
@@ -361,7 +378,7 @@ export type PartialZWaveOptions = Expand<
 	& Partial<
 		Pick<
 			ZWaveOptions,
-			"inclusionUserCallbacks" | "testingHooks"
+			"inclusionUserCallbacks" | "testingHooks" | "vendor"
 		>
 	>
 	& {
@@ -379,6 +396,7 @@ export type EditableZWaveOptions = Expand<
 		| "interview"
 		| "logConfig"
 		| "preferences"
+		| "vendor"
 	>
 	& {
 		userAgent?: Record<string, string | null | undefined>;

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3971,8 +3971,9 @@ protocol version:      ${this.protocolVersion}`;
 				zwavePlusVersion: 2,
 				roleType: ZWavePlusRoleType.CentralStaticController,
 				nodeType: ZWavePlusNodeType.Node,
-				installerIcon: 0x0500, // Generic Gateway // FIXME: Make configurable
-				userIcon: 0x0500, // Generic Gateway
+				installerIcon: this.driver.options.vendor?.installerIcon
+					?? 0x0500, // Generic Gateway
+				userIcon: this.driver.options.vendor?.userIcon ?? 0x0500, // Generic Gateway
 			});
 	}
 
@@ -3994,6 +3995,7 @@ protocol version:      ${this.protocolVersion}`;
 			libraryType: ZWaveLibraryTypes["Static Controller"],
 			protocolVersion: this.driver.controller.protocolVersion!,
 			firmwareVersions: [this.driver.controller.firmwareVersion!],
+			hardwareVersion: this.driver.options.vendor?.hardwareVersion,
 		});
 	}
 
@@ -4050,9 +4052,10 @@ protocol version:      ${this.protocolVersion}`;
 			});
 
 		await api.sendReport({
-			manufacturerId: 0x0466, // Nabu Casa - FIXME: make dynamic!
-			productType: 0x0000,
-			productId: 0x0000,
+			manufacturerId: this.driver.options.vendor?.manufacturerId
+				?? 0xffff, // Reserved manufacturer ID, definitely invalid!
+			productType: this.driver.options.vendor?.productType ?? 0xffff,
+			productId: this.driver.options.vendor?.productId ?? 0xffff,
 		});
 	}
 
@@ -6026,9 +6029,10 @@ protocol version:      ${this.protocolVersion}`;
 
 		// We do not support the firmware to be upgraded.
 		await api.reportMetaData({
-			manufacturerId: 0x0466, // Nabu Casa - FIXME: Make this configurable
+			manufacturerId: this.driver.options.vendor?.manufacturerId
+				?? 0xffff,
 			firmwareUpgradable: false,
-			hardwareVersion: 1, // FIXME: Make configurable, must be the same as in Version CC
+			hardwareVersion: this.driver.options.vendor?.hardwareVersion ?? 0,
 		});
 	}
 


### PR DESCRIPTION
This PR adds a way to configure the values of some constants used in responses to queries from other nodes.

@raman325 we may need support in the server for this, although `updateOptions` should handle it already.
@spudwebb this might interest you too

fixes: #6854