### PR TITLE
fix: attempt to recover jammed controller by soft-resetting

### DIFF
--- a/packages/zwave-js/src/lib/test/driver/controllerJammed.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/controllerJammed.test.ts
@@ -4,7 +4,9 @@ import {
 	TransmitStatus,
 	ZWaveErrorCodes,
 	assertZWaveError,
+	getZWaveChipType,
 } from "@zwave-js/core";
+import { FunctionType } from "@zwave-js/serial";
 import { type MockControllerBehavior } from "@zwave-js/testing";
 import { wait } from "alcalzone-shared/async";
 import sinon from "sinon";
@@ -12,6 +14,7 @@ import {
 	MockControllerCommunicationState,
 	MockControllerStateKeys,
 } from "../../controller/MockControllerState";
+import { SoftResetRequest } from "../../serialapi/misc/SoftResetRequest";
 import {
 	SendDataAbort,
 	SendDataRequest,
@@ -138,6 +141,131 @@ integrationTest("update the controller status and wait if TX status is Fail", {
 	},
 });
 
+integrationTest(
+	"When sending fails continuously, soft-reset to recover",
+	{
+		// debug: true,
+		// provisioningDirectory: path.join(
+		// 	__dirname,
+		// 	"__fixtures/supervision_binary_switch",
+		// ),
+
+		additionalDriverOptions: {
+			testingHooks: {
+				skipNodeInterview: true,
+			},
+		},
+
+		customSetup: async (driver, controller, mockNode) => {
+			// Return a TX status of Fail when desired
+			const handleSendData: MockControllerBehavior = {
+				async onHostMessage(host, controller, msg) {
+					// Soft reset should restore normal operation
+					if (msg instanceof SoftResetRequest) {
+						shouldFail = false;
+
+						// Call the original handler
+						return false;
+					} else if (msg instanceof SendDataRequest) {
+						if (!shouldFail) {
+							// Defer to the default behavior
+							return false;
+						}
+
+						// Check if this command is legal right now
+						const state = controller.state.get(
+							MockControllerStateKeys.CommunicationState,
+						) as MockControllerCommunicationState | undefined;
+						if (
+							state != undefined
+							&& state !== MockControllerCommunicationState.Idle
+						) {
+							throw new Error(
+								"Received SendDataRequest while not idle",
+							);
+						}
+
+						// Put the controller into sending state
+						controller.state.set(
+							MockControllerStateKeys.CommunicationState,
+							MockControllerCommunicationState.Sending,
+						);
+
+						// Notify the host that the message was sent
+						const res = new SendDataResponse(host, {
+							wasSent: true,
+						});
+						await controller.sendToHost(res.serialize());
+
+						await wait(100);
+
+						controller.state.set(
+							MockControllerStateKeys.CommunicationState,
+							MockControllerCommunicationState.Idle,
+						);
+
+						const cb = new SendDataRequestTransmitReport(host, {
+							callbackId: msg.callbackId,
+							transmitStatus: TransmitStatus.Fail,
+							txReport: {
+								txTicks: 0,
+								routeSpeed: 0 as any,
+								routingAttempts: 0,
+								ackRSSI: 0,
+							},
+						});
+						await controller.sendToHost(cb.serialize());
+
+						return true;
+					} else if (msg instanceof SendDataAbort) {
+						// Put the controller into idle state
+						controller.state.set(
+							MockControllerStateKeys.CommunicationState,
+							MockControllerCommunicationState.Idle,
+						);
+					}
+				},
+			};
+			controller.defineBehavior(handleSendData);
+		},
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			node.markAsAlive();
+
+			const statusChanges: ControllerStatus[] = [];
+			driver.controller.on("status changed", (status) => {
+				statusChanges.push(status);
+			});
+
+			const nodeDead = sinon.spy();
+			node.on("dead", nodeDead);
+
+			shouldFail = true;
+			const promise = node.ping();
+			await wait(500);
+
+			// The controller should now be jammed, but the node's status must not change
+			t.is(driver.controller.status, ControllerStatus.Jammed);
+			t.is(node.status, NodeStatus.Alive);
+
+			// After soft-resetting (done automatically), the controller should be sending normally again
+			await promise;
+			// And the controller should have been soft-reset
+			mockController.assertReceivedHostMessage((msg) =>
+				msg.functionType === FunctionType.SoftReset
+			);
+
+			t.is(driver.controller.status, ControllerStatus.Ready);
+			t.is(node.status, NodeStatus.Alive);
+
+			sinon.assert.notCalled(nodeDead);
+			t.deepEqual(statusChanges, [
+				ControllerStatus.Jammed,
+				ControllerStatus.Ready,
+			]);
+		},
+	},
+);
+
 integrationTestMulti(
 	"Prevent an infinite loop when the controller is unable to transmit a command to a specific node",
 	{
@@ -151,6 +279,12 @@ integrationTestMulti(
 			testingHooks: {
 				skipNodeInterview: true,
 			},
+		},
+
+		controllerCapabilities: {
+			// 500 series controller, where the soft-reset workaround does not make sense
+			libraryVersion: "Z-Wave 6.84",
+			zwaveChipType: getZWaveChipType(0x05, 0x00),
 		},
 
 		nodeCapabilities: [
@@ -242,7 +376,7 @@ integrationTestMulti(
 
 			driver.options.timeouts.retryJammed = 100;
 
-			t.true(await node3.ping());
+			// Commands to node 2 will fail forever
 			await assertZWaveError(
 				t,
 				() => node2.commandClasses.Basic.set(99),
@@ -250,6 +384,9 @@ integrationTestMulti(
 					errorCode: ZWaveErrorCodes.Controller_MessageDropped,
 				},
 			);
+
+			// But commands to node 3 should still continue afterwards
+			t.true(await node3.ping());
 		},
 	},
 );


### PR DESCRIPTION
This PR implements the workaround for jammed controllers mentioned in the [SDK 7.21.3 release notes](https://www.silabs.com/documents/public/release-notes/SRN14930-7.21.3.0.pdf). When a 700/800 series controller fails to transmit continuously (status = Jammed), we now soft-reset the controller and try transmitting once after the soft-reset. If that attempt also fails, we return to normal operation as previously and hope for the best.

Fixes: https://github.com/zwave-js/node-zwave-js/issues/6814