### PR TITLE
feat: add `ZWaveNode.createDump()` method

### DIFF
--- a/packages/cc/src/lib/CommandClass.ts
+++ b/packages/cc/src/lib/CommandClass.ts
@@ -804,7 +804,10 @@ export class CommandClass implements ICommandClass {
 	}
 
 	/** Returns a list of all value names that are defined for this CommandClass */
-	public getDefinedValueIDs(applHost: ZWaveApplicationHost): ValueID[] {
+	public getDefinedValueIDs(
+		applHost: ZWaveApplicationHost,
+		includeInternal: boolean = false,
+	): ValueID[] {
 		// In order to compare value ids, we need them to be strings
 		const ret = new Map<string, ValueID>();
 
@@ -844,7 +847,7 @@ export class CommandClass implements ICommandClass {
 			}
 
 			// Skip internal values
-			if (value.options.internal) continue;
+			if (value.options.internal && !includeInternal) continue;
 
 			// And determine if this value should be automatically "created"
 			if (!this.shouldAutoCreateValue(applHost, value)) continue;
@@ -864,7 +867,7 @@ export class CommandClass implements ICommandClass {
 			// ... which don't have a CC value definition
 			// ... or one that does not mark the value ID as internal
 			const ccValue = ccValues.find((value) => value.is(valueId));
-			if (!ccValue || !ccValue.options.internal) {
+			if (!ccValue || !ccValue.options.internal || includeInternal) {
 				addValueId(valueId.property, valueId.propertyKey);
 			}
 		}

--- a/packages/core/src/security/SecurityClass.ts
+++ b/packages/core/src/security/SecurityClass.ts
@@ -32,6 +32,16 @@ export function securityClassIsS2(
 	);
 }
 
+/** Tests if the given security class is valid for use with Z-Wave LR */
+export function securityClassIsLongRange(
+	secClass: SecurityClass | undefined,
+): secClass is S2SecurityClass {
+	return (
+		secClass === SecurityClass.S2_AccessControl
+		|| secClass === SecurityClass.S2_Authenticated
+	);
+}
+
 /** An array of security classes, ordered from high (index 0) to low (index > 0) */
 export const securityClassOrder = [
 	SecurityClass.S2_AccessControl,

--- a/packages/core/src/values/Cache.ts
+++ b/packages/core/src/values/Cache.ts
@@ -6,7 +6,12 @@ import type { ValueMetadata } from "./Metadata";
 import type { ValueID } from "./_Types";
 
 // export type SerializableValue = number | string | boolean | Map<string | number, any> | JSONObject;
-type SerializedValue = number | string | boolean | JSONObject | undefined;
+export type SerializedValue =
+	| number
+	| string
+	| boolean
+	| JSONObject
+	| undefined;
 
 export interface CacheValue
 	extends Pick<ValueID, "endpoint" | "property" | "propertyKey">

--- a/packages/zwave-js/src/lib/node/Dump.ts
+++ b/packages/zwave-js/src/lib/node/Dump.ts
@@ -1,0 +1,79 @@
+import type {
+	CommandClassInfo,
+	DataRate,
+	FLiRS,
+	SerializedValue,
+	ValueMetadata,
+} from "@zwave-js/core/safe";
+import { type JSONObject } from "@zwave-js/shared";
+
+export interface DeviceClassDump {
+	key: number;
+	label: string;
+}
+
+export interface DeviceClassesDump {
+	basic: DeviceClassDump;
+	generic: DeviceClassDump;
+	specific: DeviceClassDump;
+}
+
+export interface CommandClassDump extends CommandClassInfo {
+	values: ValueDump[];
+}
+
+export interface ValueDump {
+	property: string | number;
+	propertyKey?: string | number;
+	metadata?: ValueMetadata;
+	value?: SerializedValue;
+	timestamp?: string;
+	internal?: boolean;
+}
+
+export interface EndpointDump {
+	index: number;
+	deviceClass: DeviceClassesDump | "unknown";
+	maySupportBasicCC: boolean;
+	commandClasses: Record<string, CommandClassDump>;
+}
+
+export interface NodeDump {
+	id: number;
+	manufacturer?: string;
+	label?: string;
+	description?: string;
+	fingerprint: {
+		// Hex representation:
+		manufacturerId: string;
+		productType: string;
+		productId: string;
+		firmwareVersion: string;
+		hardwareVersion?: number;
+	};
+	interviewStage: string;
+	ready: boolean;
+
+	dsk?: string;
+	securityClasses: Record<string, boolean | "unknown">;
+
+	isListening: boolean | "unknown";
+	isFrequentListening: FLiRS | "unknown";
+	isRouting: boolean | "unknown";
+	supportsBeaming: boolean | "unknown";
+	supportsSecurity: boolean | "unknown";
+	protocol: string;
+	supportedProtocols?: string[];
+	protocolVersion: string;
+	sdkVersion: string;
+	supportedDataRates: DataRate[] | "unknown";
+
+	deviceClass: DeviceClassesDump | "unknown";
+	maySupportBasicCC: boolean;
+	commandClasses: Record<string, CommandClassDump>;
+
+	endpoints?: Record<number, EndpointDump>;
+
+	configFileName?: string;
+	compatFlags?: JSONObject;
+}

--- a/packages/zwave-js/src/lib/node/utils.ts
+++ b/packages/zwave-js/src/lib/node/utils.ts
@@ -299,6 +299,18 @@ export function getDefinedValueIDs(
 	applHost: ZWaveApplicationHost,
 	node: IZWaveNode,
 ): TranslatedValueID[] {
+	return getDefinedValueIDsInternal(applHost, node, false);
+}
+
+/**
+ * @internal
+ * Returns a list of all value names that are defined on all endpoints of this node
+ */
+export function getDefinedValueIDsInternal(
+	applHost: ZWaveApplicationHost,
+	node: IZWaveNode,
+	includeInternal: boolean = false,
+): TranslatedValueID[] {
 	let ret: ValueID[] = [];
 	const allowControlled: CommandClasses[] = [
 		CommandClasses.Basic,
@@ -316,7 +328,12 @@ export function getDefinedValueIDs(
 					cc,
 				);
 				if (ccInstance) {
-					ret.push(...ccInstance.getDefinedValueIDs(applHost));
+					ret.push(
+						...ccInstance.getDefinedValueIDs(
+							applHost,
+							includeInternal,
+						),
+					);
 				}
 			}
 		}


### PR DESCRIPTION
This PR adds the `createDump` method to the `ZWaveNode` class which allows exporting all known information about that node as a JSON object, including internal values which are not exposed to applications otherwise.