### PR TITLE
feat(mock-server): support node dumps as input

### DIFF
--- a/packages/cc/src/index.ts
+++ b/packages/cc/src/index.ts
@@ -20,6 +20,10 @@ export {
 export * from "./lib/Security2/shared";
 export * from "./lib/SetValueResult";
 export { defaultCCValueOptions } from "./lib/Values";
-export type { CCValueOptions } from "./lib/Values";
+export type {
+	CCValueOptions,
+	CCValuePredicate,
+	PartialCCValuePredicate,
+} from "./lib/Values";
 export * from "./lib/_Types";
 export { utils };

--- a/packages/testing/src/MockNodeCapabilities.ts
+++ b/packages/testing/src/MockNodeCapabilities.ts
@@ -61,7 +61,10 @@ export function getDefaultMockNodeCapabilities(): MockNodeCapabilities {
 }
 
 export function getDefaultMockEndpointCapabilities(
-	nodeCaps: MockNodeCapabilities,
+	nodeCaps: {
+		genericDeviceClass: number;
+		specificDeviceClass: number;
+	},
 ): MockEndpointCapabilities {
 	return {
 		genericDeviceClass: nodeCaps.genericDeviceClass,

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -2,6 +2,10 @@ export * from "./CCSpecificCapabilities";
 export * from "./MockController";
 export { getDefaultSupportedFunctionTypes } from "./MockControllerCapabilities";
 export * from "./MockNode";
-export { ccCaps } from "./MockNodeCapabilities";
+export {
+	ccCaps,
+	getDefaultMockEndpointCapabilities,
+	getDefaultMockNodeCapabilities,
+} from "./MockNodeCapabilities";
 export type { PartialCCCapabilities } from "./MockNodeCapabilities";
 export * from "./MockZWaveFrame";

--- a/packages/zwave-js/bin/mock-server.js
+++ b/packages/zwave-js/bin/mock-server.js
@@ -1,5 +1,7 @@
 // @ts-check
-const { MockServer } = require("../build/mockServer");
+const { MockServer, createMockNodeOptionsFromDump } = require(
+	"../build/mockServer",
+);
 const { readFileSync, statSync, readdirSync } = require("fs");
 const path = require("path");
 
@@ -91,6 +93,16 @@ function getConfig(filename) {
 	} else if (filename.endsWith(".json")) {
 		// TODO: JSON5 support
 		return JSON.parse(readFileSync(filename, "utf8"));
+	} else if (filename.endsWith(".dump")) {
+		const node = createMockNodeOptionsFromDump(
+			JSON.parse(
+				readFileSync(
+					filename,
+					"utf8",
+				),
+			),
+		);
+		return { nodes: [node] };
 	}
 }
 
@@ -114,7 +126,9 @@ if (configPath) {
 		const files = readdirSync(absolutePath)
 			.filter(
 				(filename) =>
-					filename.endsWith(".js") || filename.endsWith(".json"),
+					filename.endsWith(".js")
+					|| filename.endsWith(".json")
+					|| filename.endsWith(".dump"),
 			)
 			.map((filename) => {
 				const fullPath = path.join(absolutePath, filename);

--- a/packages/zwave-js/src/Testing.ts
+++ b/packages/zwave-js/src/Testing.ts
@@ -1,5 +1,5 @@
 export { createAndStartDriverWithMockPort } from "./lib/driver/DriverMock";
-export { MockServer } from "./mockServer";
+export { MockServer, createMockNodeOptionsFromDump } from "./mockServer";
 export type {
 	MockServerControllerOptions,
 	MockServerNodeOptions,

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -7482,6 +7482,7 @@ ${formatRouteHealthCheckSummary(this.id, otherNode.id, summary)}`,
 		collectValues(0, (ccId) => ret.commandClasses[getCCName(ccId)]?.values);
 
 		for (const endpoint of this.getAllEndpoints()) {
+			if (endpoint.index === 0) continue;
 			ret.endpoints ??= {};
 			const endpointDump = endpoint.createEndpointDump();
 			collectValues(

--- a/packages/zwave-js/src/mockServer.ts
+++ b/packages/zwave-js/src/mockServer.ts
@@ -1,3 +1,4 @@
+import { CommandClasses } from "@zwave-js/core";
 import type { ZWaveSerialPort } from "@zwave-js/serial";
 import {
 	type MockPortBinding,
@@ -10,13 +11,18 @@ import {
 	MockNode,
 	type MockNodeBehavior,
 	type MockNodeOptions,
+	type PartialCCCapabilities,
+	getDefaultMockEndpointCapabilities,
+	getDefaultMockNodeCapabilities,
 } from "@zwave-js/testing";
 import { createDeferredPromise } from "alcalzone-shared/deferred-promise";
 import { type AddressInfo, type Server, createServer } from "node:net";
 import {
+	ProtocolVersion,
 	createDefaultMockControllerBehaviors,
 	createDefaultMockNodeBehaviors,
 } from "./Utils";
+import { type CommandClassDump, type NodeDump } from "./lib/node/Dump";
 
 export type MockServerControllerOptions =
 	& Pick<
@@ -183,4 +189,134 @@ function prepareMocks(
 		mockController,
 		mockNodes,
 	};
+}
+
+export function createMockNodeOptionsFromDump(
+	dump: NodeDump,
+): MockServerNodeOptions {
+	const ret: MockServerNodeOptions = {
+		id: dump.id,
+	};
+
+	ret.capabilities = getDefaultMockNodeCapabilities();
+
+	if (typeof dump.isListening === "boolean") {
+		ret.capabilities.isListening = dump.isListening;
+	}
+	if (dump.isFrequentListening !== "unknown") {
+		ret.capabilities.isFrequentListening = dump.isFrequentListening;
+	}
+	if (typeof dump.isRouting === "boolean") {
+		ret.capabilities.isRouting = dump.isRouting;
+	}
+	if (typeof dump.supportsBeaming === "boolean") {
+		ret.capabilities.supportsBeaming = dump.supportsBeaming;
+	}
+	if (typeof dump.supportsSecurity === "boolean") {
+		ret.capabilities.supportsSecurity = dump.supportsSecurity;
+	}
+	if (typeof dump.supportedDataRates === "boolean") {
+		ret.capabilities.supportedDataRates = dump.supportedDataRates;
+	}
+	if ((ProtocolVersion as any)[dump.protocol] !== undefined) {
+		ret.capabilities.protocolVersion =
+			(ProtocolVersion as any)[dump.protocol];
+	}
+
+	if (dump.deviceClass !== "unknown") {
+		ret.capabilities.basicDeviceClass = dump.deviceClass.basic.key;
+		ret.capabilities.genericDeviceClass = dump.deviceClass.generic.key;
+		ret.capabilities.specificDeviceClass = dump.deviceClass.specific.key;
+	}
+
+	ret.capabilities.firmwareVersion = dump.fingerprint.firmwareVersion;
+	ret.capabilities.manufacturerId = parseInt(
+		dump.fingerprint.manufacturerId,
+		16,
+	);
+	ret.capabilities.productType = parseInt(dump.fingerprint.productType, 16);
+	ret.capabilities.productId = parseInt(dump.fingerprint.productId, 16);
+
+	for (const [ccName, ccDump] of Object.entries(dump.commandClasses)) {
+		const ccId = (CommandClasses as any)[ccName];
+		if (ccId == undefined) continue;
+		// FIXME: Security encapsulation is not supported yet in mocks
+		if (
+			ccId === CommandClasses.Security
+			|| ccId === CommandClasses["Security 2"]
+		) {
+			continue;
+		}
+
+		ret.capabilities.commandClasses ??= [];
+		ret.capabilities.commandClasses.push(
+			createCCCapabilitiesFromDump(ccId, ccDump),
+		);
+	}
+
+	if (dump.endpoints) {
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		for (const [indexStr, endpointDump] of Object.entries(dump.endpoints)) {
+			// FIXME: The mocks expect endpoints to be consecutive
+			// const index = parseInt(indexStr);
+
+			const epCaps = getDefaultMockEndpointCapabilities(
+				// @ts-expect-error We are initializing the device classes above
+				ret.capabilities,
+			);
+			let epCCs: PartialCCCapabilities[] | undefined;
+			if (endpointDump.deviceClass !== "unknown") {
+				epCaps.genericDeviceClass =
+					endpointDump.deviceClass.generic.key;
+				epCaps.specificDeviceClass =
+					endpointDump.deviceClass.specific.key;
+			}
+
+			for (
+				const [ccName, ccDump] of Object.entries(
+					endpointDump.commandClasses,
+				)
+			) {
+				const ccId = (CommandClasses as any)[ccName];
+				if (ccId == undefined) continue;
+				// FIXME: Security encapsulation is not supported yet in mocks
+				if (
+					ccId === CommandClasses.Security
+					|| ccId === CommandClasses["Security 2"]
+				) {
+					continue;
+				}
+
+				epCCs ??= [];
+				epCCs.push(
+					createCCCapabilitiesFromDump(ccId, ccDump),
+				);
+			}
+
+			ret.capabilities.endpoints ??= [];
+			ret.capabilities.endpoints.push({
+				...epCaps,
+				commandClasses: epCCs,
+			});
+		}
+	}
+
+	return ret;
+}
+
+function createCCCapabilitiesFromDump(
+	ccId: CommandClasses,
+	dump: CommandClassDump,
+): PartialCCCapabilities {
+	const ret: PartialCCCapabilities = {
+		ccId,
+		isSupported: dump.isSupported,
+		isControlled: dump.isControlled,
+		secure: dump.secure,
+		version: dump.version,
+	};
+
+	// TODO: Parse CC specific info from values
+
+	return ret;
 }


### PR DESCRIPTION
With this PR, the `mock-server` can parse node dumps created by `node.createDump()`. This can either be done programmatically using the `createMockNodeOptionsFromDump` method, or by passing a file with extension `.dump` as the mock server config, either a standalone file or in a directory with mocks.

As a followup we should create more CC-specific capabilities from CC values. I don't have a useful dump handy right now.