### PR TITLE
feat: export `NodeDump` type

### DIFF
--- a/packages/zwave-js/src/Node.ts
+++ b/packages/zwave-js/src/Node.ts
@@ -7,6 +7,7 @@ export {
 } from "@zwave-js/core/safe";
 export type { DataRate, FLiRS } from "@zwave-js/core/safe";
 export { DeviceClass } from "./lib/node/DeviceClass";
+export type { NodeDump } from "./lib/node/Dump";
 export { Endpoint } from "./lib/node/Endpoint";
 export { ZWaveNode } from "./lib/node/Node";
 export type {


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

This type was not exported and therefore couldn't be used in applications consuming the library
