### PR TITLE
refactor: replace `Controller.isAssociationAllowed` with `checkAssociation`

### DIFF
--- a/packages/cc/src/lib/_Types.ts
+++ b/packages/cc/src/lib/_Types.ts
@@ -42,6 +42,22 @@ export enum AssociationCommand {
 	SpecificGroupReport = 0x0c,
 }
 
+export enum AssociationCheckResult {
+	OK = 0x01,
+	/** The association is forbidden, because the destination is a ZWLR node. ZWLR does not support direct communication between end devices. */
+	Forbidden_DestinationIsLongRange,
+	/** The association is forbidden, because the source is a ZWLR node. ZWLR does not support direct communication between end devices. */
+	Forbidden_SourceIsLongRange,
+	/** The association is forbidden, because a node cannot be associated with itself. */
+	Forbidden_SelfAssociation,
+	/** The association is forbidden, because the source node's CC versions require the source and destination node to have the same (highest) security class. */
+	Forbidden_SecurityClassMismatch,
+	/** The association is forbidden, because the source node's CC versions require the source node to have the key for the destination node's highest security class. */
+	Forbidden_DestinationSecurityClassNotGranted,
+	/** The association is forbidden, because none of the CCs the source node sends are supported by the destination. */
+	Forbidden_NoSupportedCCs,
+}
+
 export enum AssociationGroupInfoCommand {
 	NameGet = 0x01,
 	NameReport = 0x02,

--- a/packages/cc/src/lib/utils.ts
+++ b/packages/cc/src/lib/utils.ts
@@ -392,10 +392,17 @@ export async function addAssociations(
 
 	// Disallow associating a node with itself. This is technically checked as part of
 	// checkAssociations, but here we provide a better error message.
-	if (destinations.some((d) => d.nodeId === endpoint.nodeId)) {
+	const selfAssociations = destinations.filter((d) =>
+		d.nodeId === endpoint.nodeId
+	);
+	if (selfAssociations.length > 0) {
 		throw new ZWaveError(
 			`Associating a node with itself is not allowed!`,
 			ZWaveErrorCodes.AssociationCC_NotAllowed,
+			selfAssociations.map((a) => ({
+				...a,
+				checkResult: AssociationCheckResult.Forbidden_SelfAssociation,
+			})),
 		);
 	}
 

--- a/packages/cc/src/lib/utils.ts
+++ b/packages/cc/src/lib/utils.ts
@@ -15,7 +15,11 @@ import {
 	isSensorCC,
 } from "@zwave-js/core/safe";
 import type { ZWaveApplicationHost } from "@zwave-js/host/safe";
-import { ObjectKeyMap, type ReadonlyObjectKeyMap } from "@zwave-js/shared/safe";
+import {
+	ObjectKeyMap,
+	type ReadonlyObjectKeyMap,
+	getEnumMemberName,
+} from "@zwave-js/shared/safe";
 import { distinct } from "alcalzone-shared/arrays";
 import { AssociationCC, AssociationCCValues } from "../cc/AssociationCC";
 import { AssociationGroupInfoCC } from "../cc/AssociationGroupInfoCC";
@@ -23,6 +27,7 @@ import { MultiChannelAssociationCC } from "../cc/MultiChannelAssociationCC";
 import { CCAPI } from "./API";
 import {
 	type AssociationAddress,
+	AssociationCheckResult,
 	type AssociationGroup,
 	AssociationGroupInfoProfile,
 	type EndpointAddress,
@@ -104,12 +109,12 @@ export function getAllAssociations(
 	return ret;
 }
 
-export function isAssociationAllowed(
+export function checkAssociation(
 	applHost: ZWaveApplicationHost,
 	endpoint: IZWaveEndpoint,
 	group: number,
 	destination: AssociationAddress,
-): boolean {
+): AssociationCheckResult {
 	// Check that the target endpoint exists except when adding an association to the controller
 	const targetNode = applHost.nodes.getOrThrow(destination.nodeId);
 	const targetEndpoint = destination.nodeId === applHost.ownNodeId
@@ -130,19 +135,23 @@ export function isAssociationAllowed(
 
 	// Associations to and from ZWLR devices are not allowed
 	if (isLongRangeNodeId(destination.nodeId)) {
-		return false;
+		return AssociationCheckResult.Forbidden_DestinationIsLongRange;
 	} else if (isLongRangeNodeId(endpoint.nodeId)) {
 		// Except the lifeline back to the host
 		if (group !== 1 || destination.nodeId !== applHost.ownNodeId) {
-			return false;
+			return AssociationCheckResult.Forbidden_SourceIsLongRange;
 		}
 	}
 
 	// The following checks don't apply to Lifeline associations
-	if (destination.nodeId === applHost.ownNodeId) return true;
+	if (destination.nodeId === applHost.ownNodeId) {
+		return AssociationCheckResult.OK;
+	}
 
 	// Disallow self-associations
-	if (destination.nodeId === endpoint.nodeId) return false;
+	if (destination.nodeId === endpoint.nodeId) {
+		return AssociationCheckResult.Forbidden_SelfAssociation;
+	}
 
 	// For Association version 1 and version 2 / MCA version 1-3:
 	// A controlling node MUST NOT associate Node A to a Node B destination
@@ -176,7 +185,7 @@ export function isAssociationAllowed(
 			securityClassMustMatch
 			&& sourceSecurityClass !== targetSecurityClass
 		) {
-			return false;
+			return AssociationCheckResult.Forbidden_SecurityClassMismatch;
 		} else if (
 			// Commands to insecure nodes are allowed
 			targetSecurityClass !== SecurityClass.None
@@ -184,7 +193,8 @@ export function isAssociationAllowed(
 			&& !securityClassMustMatch
 			&& !sourceNode.hasSecurityClass(targetSecurityClass)
 		) {
-			return false;
+			return AssociationCheckResult
+				.Forbidden_DestinationSecurityClassNotGranted;
 		}
 	}
 
@@ -195,7 +205,7 @@ export function isAssociationAllowed(
 	// To determine this, the node must support the AGI CC or we have no way of knowing which
 	// CCs the node will control
 	if (!endpoint.supportsCC(CommandClasses["Association Group Information"])) {
-		return true;
+		return AssociationCheckResult.OK;
 	}
 
 	const groupCommandList = AssociationGroupInfoCC.getIssuedCommandsCached(
@@ -205,7 +215,7 @@ export function isAssociationAllowed(
 	);
 	if (!groupCommandList || !groupCommandList.size) {
 		// We don't know which CCs this group controls, just allow it
-		return true;
+		return AssociationCheckResult.OK;
 	}
 	const groupCCs = [...groupCommandList.keys()];
 
@@ -215,11 +225,15 @@ export function isAssociationAllowed(
 		groupCCs.includes(CommandClasses.Basic)
 		&& actuatorCCs.some((cc) => targetEndpoint?.supportsCC(cc))
 	) {
-		return true;
+		return AssociationCheckResult.OK;
 	}
 
 	// Enforce that at least one issued CC is supported
-	return groupCCs.some((cc) => targetEndpoint?.supportsCC(cc));
+	if (groupCCs.some((cc) => targetEndpoint?.supportsCC(cc))) {
+		return AssociationCheckResult.OK;
+	} else {
+		return AssociationCheckResult.Forbidden_NoSupportedCCs;
+	}
 }
 
 export function getAssociationGroups(
@@ -377,7 +391,7 @@ export async function addAssociations(
 	}
 
 	// Disallow associating a node with itself. This is technically checked as part of
-	// isAssociationAllowed, but here we provide a better error message.
+	// checkAssociations, but here we provide a better error message.
 	if (destinations.some((d) => d.nodeId === endpoint.nodeId)) {
 		throw new ZWaveError(
 			`Associating a node with itself is not allowed!`,
@@ -405,8 +419,13 @@ export async function addAssociations(
 
 	if (groupIsMultiChannel) {
 		// Check that all associations are allowed
-		const disallowedAssociations = destinations.filter(
-			(a) => !isAssociationAllowed(applHost, endpoint, group, a),
+		const disallowedAssociations = destinations.map(
+			(a) => ({
+				...a,
+				checkResult: checkAssociation(applHost, endpoint, group, a),
+			}),
+		).filter(({ checkResult }) =>
+			checkResult !== AssociationCheckResult.OK
 		);
 		if (disallowedAssociations.length) {
 			let message = `The following associations are not allowed:`;
@@ -415,12 +434,18 @@ export async function addAssociations(
 					(a) =>
 						`\n· Node ${a.nodeId}${
 							a.endpoint ? `, endpoint ${a.endpoint}` : ""
+						}: ${
+							getEnumMemberName(
+								AssociationCheckResult,
+								a.checkResult,
+							).replace("Forbidden_", "")
 						}`,
 				)
 				.join("");
 			throw new ZWaveError(
 				message,
 				ZWaveErrorCodes.AssociationCC_NotAllowed,
+				disallowedAssociations,
 			);
 		}
 
@@ -447,17 +472,33 @@ export async function addAssociations(
 		}
 
 		// Check that all associations are allowed
-		const disallowedAssociations = destinations.filter(
-			(a) => !isAssociationAllowed(applHost, endpoint, group, a),
+		const disallowedAssociations = destinations.map(
+			(a) => ({
+				...a,
+				checkResult: checkAssociation(applHost, endpoint, group, a),
+			}),
+		).filter(({ checkResult }) =>
+			checkResult !== AssociationCheckResult.OK
 		);
 		if (disallowedAssociations.length) {
+			let message =
+				`The associations to the following nodes are not allowed`;
+			message += disallowedAssociations
+				.map(
+					(a) =>
+						`\n· Node ${a.nodeId}: ${
+							getEnumMemberName(
+								AssociationCheckResult,
+								a.checkResult,
+							).replace("Forbidden_", "")
+						}`,
+				)
+				.join("");
+
 			throw new ZWaveError(
-				`The associations to the following nodes are not allowed: ${
-					disallowedAssociations
-						.map((a) => a.nodeId)
-						.join(", ")
-				}`,
+				message,
 				ZWaveErrorCodes.AssociationCC_NotAllowed,
+				disallowedAssociations,
 			);
 		}
 

--- a/packages/zwave-js/src/lib/controller/Controller.manageAssociations.test.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.manageAssociations.test.ts
@@ -1,4 +1,5 @@
 import {
+	AssociationCheckResult,
 	AssociationGroupInfoCCValues,
 	BasicCommand,
 	utils as ccUtils,
@@ -80,9 +81,10 @@ test("associations between insecure nodes are allowed", (t) => {
 		commands,
 	);
 
-	t.true(
-		ccUtils.isAssociationAllowed(host, node2, groupId, {
+	t.is(
+		ccUtils.checkAssociation(host, node2, groupId, {
 			nodeId: 3,
 		}),
+		AssociationCheckResult.OK,
 	);
 });

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -5836,7 +5836,22 @@ ${associatedNodes.join(", ")}`,
 	}
 
 	/**
-	 * Adds associations to a node or endpoint
+	 * Adds associations to a node or endpoint.
+	 *
+	 * **Note:** This method will throw if:
+	 * * the source node, endpoint or association group does not exist,
+	 * * the source node is a ZWLR node and the destination is not the SIS
+	 * * the destination node is a ZWLR node
+	 * * the association is not allowed for other reasons. In this case, the error's
+	 * `context` property will contain an array with all forbidden destinations, each with an added `checkResult` property
+	 * which contains the reason why the association is forbidden:
+	 *     ```ts
+	 *     {
+	 *         checkResult: AssociationCheckResult;
+	 *         nodeId: number;
+	 *         endpoint?: number | undefined;
+	 *     }[]
+	 *     ```
 	 */
 	public async addAssociations(
 		source: AssociationAddress,

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -1,6 +1,7 @@
 import {
 	type AssociationAddress,
 	AssociationCC,
+	type AssociationCheckResult,
 	type AssociationGroup,
 	ECDHProfiles,
 	FLiRS2WakeUpTime,
@@ -5818,15 +5819,15 @@ ${associatedNodes.join(", ")}`,
 	/**
 	 * Checks if a given association is allowed.
 	 */
-	public isAssociationAllowed(
+	public checkAssociation(
 		source: AssociationAddress,
 		group: number,
 		destination: AssociationAddress,
-	): boolean {
+	): AssociationCheckResult {
 		const node = this.nodes.getOrThrow(source.nodeId);
 		const endpoint = node.getEndpointOrThrow(source.endpoint ?? 0);
 
-		return ccUtils.isAssociationAllowed(
+		return ccUtils.checkAssociation(
 			this.driver,
 			endpoint,
 			group,


### PR DESCRIPTION
This PR replaces the `Controller.isAssociationAllowed` method with the new `checkAssociation` method that returns the reason why an association is not allowed:
```ts
public checkAssociation(
	source: AssociationAddress,
	group: number,
	destination: AssociationAddress,
): AssociationCheckResult;
```
with
```ts
enum AssociationCheckResult {
	OK = 0x01,
	/** The association is forbidden, because the destination is a ZWLR node. ZWLR does not support direct communication between end devices. */
	Forbidden_DestinationIsLongRange,
	/** The association is forbidden, because the source is a ZWLR node. ZWLR does not support direct communication between end devices. */
	Forbidden_SourceIsLongRange,
	/** The association is forbidden, because a node cannot be associated with itself. */
	Forbidden_SelfAssociation,
	/** The association is forbidden, because the source node's CC versions require the source and destination node to have the same (highest) security class. */
	Forbidden_SecurityClassMismatch,
	/** The association is forbidden, because the source node's CC versions require the source node to have the key for the destination node's highest security class. */
	Forbidden_DestinationSecurityClassNotGranted,
	/** The association is forbidden, because none of the CCs the source node sends are supported by the destination. */
	Forbidden_NoSupportedCCs,
}
```

The old behavior can be restored by checking whether the returned result equals `AssociationCheckResult.OK`.

The errors thrown by `addAssociations` in case an association is not allowed (`code: ZWaveErrorCodes.AssociationCC_NotAllowed`) now contain an array with all forbidden destinations in the error's `context` property, each with an added `checkResult` property which contains the reason why the association is forbidden:
```ts
{
	checkResult: AssociationCheckResult;
	nodeId: number;
	endpoint?: number | undefined;
}[]
```

fixes: https://github.com/zwave-js/node-zwave-js/issues/6772