### PR TITLE
fix: do not assign routes after adding an association to a LR node

### DIFF
--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -5852,6 +5852,8 @@ ${associatedNodes.join(", ")}`,
 			destinations,
 		);
 
+		if (isLongRangeNodeId(source.nodeId)) return;
+
 		// Nodes need a return route to be able to send commands to other nodes
 		const destinationNodeIDs = distinct(
 			destinations.map((d) => d.nodeId),


### PR DESCRIPTION
This just results in unnecessary warnings being logged.