### PR TITLE
fix: health checks for ZWLR nodes, throw when requesting neighbors

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -531,10 +531,18 @@ interface LifelineHealthCheckResult {
 	 * Will use the time in TX reports if available, otherwise fall back to measuring the round trip time.
 	 */
 	latency: number;
-	/** How many routing neighbors this node has. Higher = better, ideally > 2. */
-	numNeighbors: number;
-	/** How many pings were not ACKed by the node. Lower = better, ideally 0. */
+
+	/**
+	 * How many routing neighbors this node has (Z-Wave Classic only). Higher = better, ideally > 2.
+	 * For Z-Wave LR, this is undefined.
+	 */
+	numNeighbors?: number;
+
+	/**
+	 * How many pings were not ACKed by the node. Lower = better, ideally 0.
+	 */
 	failedPingsNode: number;
+
 	/**
 	 * The minimum powerlevel where all pings from the node were ACKed by the controller. Higher = better, ideally 6dBm or more.
 	 *
@@ -547,6 +555,7 @@ interface LifelineHealthCheckResult {
 	 * Only available if the node supports Powerlevel CC
 	 */
 	failedPingsController?: number;
+
 	/**
 	 * An estimation of the Signal-to-Noise Ratio Margin in dBm.
 	 *

--- a/packages/core/src/error/ZWaveError.ts
+++ b/packages/core/src/error/ZWaveError.ts
@@ -62,6 +62,9 @@ export enum ZWaveErrorCodes {
 	/** Tried to send a message that is too large */
 	Controller_MessageTooLarge,
 
+	/** Tried to perform an action for a Long Range node that does not make sense for ZWLR */
+	Controller_NotSupportedForLongRange,
+
 	/** Could not fetch some information to determine firmware upgrades from a node */
 	FWUpdateService_MissingInformation = 260,
 	/** Any error related to HTTP requests during firmware update communication */

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -6547,12 +6547,21 @@ ${associatedNodes.join(", ")}`,
 	}
 
 	/**
-	 * Returns the known list of neighbors for a node
+	 * Returns the known list of neighbors for a node.
+	 *
+	 * Throws when the node is a Long Range node.
 	 */
 	public async getNodeNeighbors(
 		nodeId: number,
 		onlyRepeaters: boolean = false,
 	): Promise<readonly number[]> {
+		if (isLongRangeNodeId(nodeId)) {
+			throw new ZWaveError(
+				`Cannot request node neighbors for Long Range node ${nodeId}`,
+				ZWaveErrorCodes.Controller_NotSupportedForLongRange,
+			);
+		}
+
 		this.driver.controllerLog.logNode(nodeId, {
 			message: "requesting node neighbors...",
 			direction: "outbound",

--- a/packages/zwave-js/src/lib/node/HealthCheck.ts
+++ b/packages/zwave-js/src/lib/node/HealthCheck.ts
@@ -66,14 +66,20 @@ export function formatLifelineHealthCheckRound(
 export function formatLifelineHealthCheckSummary(
 	summary: LifelineHealthCheckSummary,
 ): string {
-	return `
+	let ret = `
 rating:                   ${summary.rating} (${
 		healthCheckRatingToWord(
 			summary.rating,
 		)
-	})
-no. of routing neighbors: ${summary.results.at(-1)!.numNeighbors}
- 
+	})`;
+	const numNeighbors = summary.results.at(-1)!.numNeighbors;
+	if (numNeighbors != undefined) {
+		ret += `
+no. of routing neighbors: ${summary.results.at(-1)!.numNeighbors}`;
+	}
+
+	ret += `
+
 Check rounds:
 ${
 		summary.results
@@ -81,7 +87,9 @@ ${
 				formatLifelineHealthCheckRound(i + 1, summary.results.length, r)
 			)
 			.join("\n \n")
-	}`.trim();
+	}`;
+
+	return ret.trim();
 }
 
 export function formatRouteHealthCheckRound(
@@ -134,14 +142,20 @@ export function formatRouteHealthCheckSummary(
 	targetNodeId: number,
 	summary: RouteHealthCheckSummary,
 ): string {
-	return `
+	let ret = `
 rating:                   ${summary.rating} (${
 		healthCheckRatingToWord(
 			summary.rating,
 		)
-	})
-no. of routing neighbors: ${summary.results.at(-1)!.numNeighbors}
- 
+	})`;
+	const numNeighbors = summary.results.at(-1)!.numNeighbors;
+	if (numNeighbors != undefined) {
+		ret += `
+no. of routing neighbors: ${summary.results.at(-1)!.numNeighbors}`;
+	}
+
+	ret += `
+
 Check rounds:
 ${
 		summary.results
@@ -155,5 +169,7 @@ ${
 				)
 			)
 			.join("\n \n")
-	}`.trim();
+	}`;
+
+	return ret.trim();
 }

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -6762,6 +6762,19 @@ ${formatLifelineHealthCheckSummary(summary)}`,
 		) => void,
 	): Promise<RouteHealthCheckSummary> {
 		const otherNode = this.driver.controller.nodes.getOrThrow(targetNodeId);
+
+		if (this.protocol === Protocols.ZWaveLongRange) {
+			throw new ZWaveError(
+				`Cannot perform route health check for Long Range node ${this.id}.`,
+				ZWaveErrorCodes.Controller_NotSupportedForLongRange,
+			);
+		} else if (otherNode.protocol === Protocols.ZWaveLongRange) {
+			throw new ZWaveError(
+				`Cannot perform route health check for Long Range node ${otherNode.id}.`,
+				ZWaveErrorCodes.Controller_NotSupportedForLongRange,
+			);
+		}
+
 		if (otherNode.canSleep) {
 			throw new ZWaveError(
 				"Nodes which can sleep are not a valid target for a route health check!",

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -6459,9 +6459,10 @@ protocol version:      ${this.protocolVersion}`;
 			if (latency > 100) return 5;
 			if (minPowerlevel < Powerlevel["-6 dBm"] || snrMargin < 17) {
 				// Lower powerlevel reductions (= higher power) have lower numeric values
+				if (numNeighbors == undefined) return 7; // ZWLR has no neighbors
 				return numNeighbors > 2 ? 7 : 6;
 			}
-			if (numNeighbors <= 2) return 8;
+			if (numNeighbors != undefined && numNeighbors <= 2) return 8; // ZWLR has no neighbors
 			if (latency > 50) return 9;
 			return 10;
 		};
@@ -6508,10 +6509,14 @@ protocol version:      ${this.protocolVersion}`;
 		for (let round = 1; round <= rounds; round++) {
 			if (this._healthCheckAborted) return aborted();
 
-			// Determine the number of repeating neighbors
-			const numNeighbors = (
-				await this.driver.controller.getNodeNeighbors(this.id, true)
-			).length;
+			// Determine the number of repeating neighbors for Z-Wave Classic
+			let numNeighbors: number | undefined;
+			if (this.protocol === Protocols.ZWave) {
+				numNeighbors = (await this.driver.controller.getNodeNeighbors(
+					this.id,
+					true,
+				)).length;
+			}
 
 			// Ping the node 10x, measuring the RSSI
 			let txReport: TXReport | undefined;

--- a/packages/zwave-js/src/lib/node/_Types.ts
+++ b/packages/zwave-js/src/lib/node/_Types.ts
@@ -251,10 +251,18 @@ export interface LifelineHealthCheckResult {
 	 * Will use the time in TX reports if available, otherwise fall back to measuring the round trip time.
 	 */
 	latency: number;
-	/** How many routing neighbors this node has. Higher = better, ideally > 2. */
-	numNeighbors: number;
-	/** How many pings were not ACKed by the node. Lower = better, ideally 0. */
+
+	/**
+	 * How many routing neighbors this node has (Z-Wave Classic only). Higher = better, ideally > 2.
+	 * For Z-Wave LR, this is undefined.
+	 */
+	numNeighbors?: number;
+
+	/**
+	 * How many pings were not ACKed by the node. Lower = better, ideally 0.
+	 */
 	failedPingsNode: number;
+
 	/**
 	 * The minimum powerlevel where all pings from the node were ACKed by the controller. Higher = better, ideally 6dBm or more.
 	 *
@@ -267,6 +275,7 @@ export interface LifelineHealthCheckResult {
 	 * Only available if the node supports Powerlevel CC
 	 */
 	failedPingsController?: number;
+
 	/**
 	 * An estimation of the Signal-to-Noise Ratio Margin in dBm.
 	 *
@@ -304,6 +313,7 @@ export interface LifelineHealthCheckSummary {
 	 * | ❌   0 |           10 |             - |                - |               - |          - |
 	 *
 	 * If the min. powerlevel or SNR margin can not be measured, the condition is assumed to be fulfilled.
+	 * The no. of neighbors is only relevant for Z-Wave Classic. The condition is assumed to be fulfilled for Z-Wave LR.
 	 */
 	rating: number;
 }


### PR DESCRIPTION
The lifeline health check now no longer requests node neighbors for ZWLR nodes and no longer considers the neighbor count when computing the lifeline health.

### Breaking changes

The route health check `node.checkRouteHealth(...)` now throws when either the source or target node is ZWLR.
`LifelineHealthCheckResult.numNeighbors` is now an optional property and may be `undefined`.


fixes: https://github.com/zwave-js/node-zwave-js/issues/6627