### PR TITLE
fix: don't ping dead nodes before attempting communication

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -5382,20 +5382,6 @@ ${handlers.length} left`,
 
 		let node: ZWaveNode | undefined;
 
-		// Don't send messages to dead nodes
-		if (isNodeQuery(msg) || isCommandClassContainer(msg)) {
-			node = this.getNodeUnsafe(msg);
-			if (!messageIsPing(msg) && node?.status === NodeStatus.Dead) {
-				// Instead of throwing immediately, try to ping the node first - if it responds, continue
-				if (!(await node.ping())) {
-					throw new ZWaveError(
-						`The message cannot be sent because node ${node.id} is dead`,
-						ZWaveErrorCodes.Controller_MessageDropped,
-					);
-				}
-			}
-		}
-
 		if (options.priority == undefined) {
 			options.priority = getDefaultPriority(msg);
 		}

--- a/packages/zwave-js/src/lib/driver/Transaction.ts
+++ b/packages/zwave-js/src/lib/driver/Transaction.ts
@@ -80,6 +80,8 @@ export class Transaction implements Comparable<Transaction> {
 				"creationTimestamp",
 				"changeNodeStatusOnTimeout",
 				"pauseSendThread",
+				"priority",
+				"tag",
 				"requestWakeUpOnDemand",
 			] as const
 		) {

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepNoReject.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepNoReject.test.ts
@@ -63,6 +63,7 @@ integrationTest(
 			const sendQueue = driver["queue"];
 			driver.driverLog.sendQueue(sendQueue);
 			t.is(sendQueue.length, 2);
+			// with priority WakeUp
 			t.is(
 				sendQueue.transactions.get(0)?.priority,
 				MessagePriority.WakeUp,


### PR DESCRIPTION
With this PR, we no longer ping dead nodes before attempting the actual communication.
It didn't really achieve anything, as the ping still needs to be sent to the device. In case of failure, nothing is gained. In case of success, we had to send an additional command.