### PR TITLE
fix: set priority for messages to sleeping nodes again

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -5381,6 +5381,9 @@ ${handlers.length} left`,
 		this.ensureReady();
 
 		let node: ZWaveNode | undefined;
+		if (isNodeQuery(msg) || isCommandClassContainer(msg)) {
+			node = this.getNodeUnsafe(msg);
+		}
 
 		if (options.priority == undefined) {
 			options.priority = getDefaultPriority(msg);

--- a/packages/zwave-js/src/lib/log/Driver.ts
+++ b/packages/zwave-js/src/lib/log/Driver.ts
@@ -210,11 +210,13 @@ export class DriverLogger extends ZWaveLoggerBase<DriverLogContext> {
 						}]`
 						: "";
 					const command = isCommandClassContainer(trns.message)
-						? ` (${trns.message.command.constructor.name})`
+						? `: ${trns.message.command.constructor.name}`
 						: "";
 					message += `\n· ${prefix} ${
 						FunctionType[trns.message.functionType]
-					}${command}${postfix}`;
+					}${command}${postfix} (P: ${
+						getEnumMemberName(MessagePriority, trns.priority)
+					})`;
 				}
 			} else {
 				message += " (empty)";


### PR DESCRIPTION
#6944 broke queuing message to sleeping nodes due to too much code being removed. This PR adds a test for the situation and fixes the break.

fixes: #6952