### PR TITLE
feat: enable hardware watchdog on 700/800 series controllers

### DIFF
--- a/packages/core/src/error/ZWaveError.ts
+++ b/packages/core/src/error/ZWaveError.ts
@@ -14,7 +14,7 @@ export enum ZWaveErrorCodes {
 
 	/** The driver failed to start */
 	Driver_Failed = 100,
-	Driver_Reset,
+	Driver_Reset, // FIXME: This is not used
 	Driver_Destroyed,
 	Driver_NotReady,
 	Driver_InvalidDataReceived,
@@ -35,6 +35,9 @@ export enum ZWaveErrorCodes {
 	Controller_ResponseNOK,
 	Controller_CallbackNOK,
 	Controller_Jammed,
+	/** The controller was reset in the middle of a Serial API command */
+	Controller_Reset,
+
 	Controller_InclusionFailed,
 	Controller_ExclusionFailed,
 
@@ -292,6 +295,15 @@ export function isMissingControllerACK(
 	return isZWaveError(e)
 		&& e.code === ZWaveErrorCodes.Controller_Timeout
 		&& e.context === "ACK";
+}
+
+export function wasControllerReset(
+	e: unknown,
+): e is ZWaveError & {
+	code: ZWaveErrorCodes.Controller_Reset;
+} {
+	return isZWaveError(e)
+		&& e.code === ZWaveErrorCodes.Controller_Reset;
 }
 
 export function isMissingControllerResponse(

--- a/packages/serial/src/message/Constants.ts
+++ b/packages/serial/src/message/Constants.ts
@@ -157,9 +157,9 @@ export enum FunctionType {
 
 	UNKNOWN_FUNC_UNKNOWN_0xB4 = 0xb4, // ??
 
-	UNKNOWN_FUNC_WATCH_DOG_ENABLE = 0xb6,
-	UNKNOWN_FUNC_WATCH_DOG_DISABLE = 0xb7,
-	UNKNOWN_FUNC_WATCH_DOG_KICK = 0xb8,
+	EnableWatchdog500 = 0xb6, // Enable Watchdog (500 series and older)
+	DisableWatchdog500 = 0xb7, // Disable Watchdog (500 series and older)
+	KickWatchdog500 = 0xb8, // Kick Watchdog (500 series and older)
 	UNKNOWN_FUNC_UNKNOWN_0xB9 = 0xb9, // ??
 	UNKNOWN_FUNC_RF_POWERLEVEL_GET = 0xba, // Get RF Power level
 
@@ -170,8 +170,9 @@ export enum FunctionType {
 	FUNC_ID_ZW_SET_PROMISCUOUS_MODE = 0xd0, // Set controller into promiscuous mode to listen to all messages
 	FUNC_ID_PROMISCUOUS_APPLICATION_COMMAND_HANDLER = 0xd1,
 
-	UNKNOWN_FUNC_UNKNOWN_0xD2 = 0xd2, // ??
-	UNKNOWN_FUNC_UNKNOWN_0xD3 = 0xd3, // ??
+	StartWatchdog = 0xd2, // Start Hardware Watchdog (700 series and newer)
+	StopWatchdog = 0xd3, // Stop Hardware Watchdog (700 series and newer)
+
 	UNKNOWN_FUNC_UNKNOWN_0xD4 = 0xd4, // ??
 
 	Shutdown = 0xd9, // Instruct the Z-Wave API to shut down in order to safely remove the power

--- a/packages/serial/src/message/Message.ts
+++ b/packages/serial/src/message/Message.ts
@@ -330,6 +330,12 @@ export class Message {
 		}
 	}
 
+	/** Tests whether this message expects an ACK from the controller */
+	public expectsAck(): boolean {
+		// By default, all commands expect an ACK
+		return true;
+	}
+
 	/** Tests whether this message expects a response from the controller */
 	public expectsResponse(): boolean {
 		return !!this.expectedResponse;

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -290,6 +290,8 @@ const defaultOptions: ZWaveOptions = {
 		// By default enable the unresponsive controller recovery unless the env variable is set
 		unresponsiveControllerRecovery: !process.env
 			.ZWAVEJS_DISABLE_UNRESPONSIVE_CONTROLLER_RECOVERY,
+		// By default enable the watchdog, unless the env variable is set
+		watchdog: !process.env.ZWAVEJS_DISABLE_WATCHDOG,
 	},
 	interview: {
 		queryAllUserCodes: false,
@@ -2663,6 +2665,11 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks>
 
 		// This is a bit hacky, but what the heck...
 		if (!this._enteringBootloader) {
+			// Start the watchdog again, unless disabled
+			if (this.options.features.watchdog) {
+				await this._controller?.startWatchdog();
+			}
+
 			// If desired, re-configure the controller to use 16 bit node IDs
 			void this._controller?.trySetNodeIDType(NodeIDType.Long);
 

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -100,6 +100,7 @@ import {
 	serializeCacheValue,
 	stripUndefined,
 	timespan,
+	wasControllerReset,
 } from "@zwave-js/core";
 import type {
 	NodeSchedulePollOptions,
@@ -171,7 +172,10 @@ import {
 import { ApplicationCommandRequest } from "../serialapi/application/ApplicationCommandRequest";
 import { ApplicationUpdateRequest } from "../serialapi/application/ApplicationUpdateRequest";
 import { BridgeApplicationCommandRequest } from "../serialapi/application/BridgeApplicationCommandRequest";
-import type { SerialAPIStartedRequest } from "../serialapi/application/SerialAPIStartedRequest";
+import {
+	SerialAPIStartedRequest,
+	SerialAPIWakeUpReason,
+} from "../serialapi/application/SerialAPIStartedRequest";
 import { GetControllerVersionRequest } from "../serialapi/capability/GetControllerVersionMessages";
 import { SoftResetRequest } from "../serialapi/misc/SoftResetRequest";
 import {
@@ -4203,6 +4207,69 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks>
 	}
 
 	/**
+	 * Is called when the Serial API restart unexpectedly.
+	 */
+	private async handleSerialAPIStartedUnexpectedly(
+		msg: SerialAPIStartedRequest,
+	): Promise<boolean> {
+		// Normally, the soft reset command includes waiting for this message.
+		// If we end up here, it is unexpected.
+
+		switch (msg.wakeUpReason) {
+			// All wakeup reasons that indicate a reset of the Serial API
+			// need to be handled here, so we interpret node IDs correctly.
+			case SerialAPIWakeUpReason.Reset:
+			case SerialAPIWakeUpReason.WatchdogReset:
+			case SerialAPIWakeUpReason.SoftwareReset:
+			case SerialAPIWakeUpReason.EmergencyWatchdogReset:
+			case SerialAPIWakeUpReason.BrownoutCircuit: {
+				// The Serial API restarted unexpectedly
+				this.controllerLog.print(
+					`Serial API restarted unexpectedly.`,
+					"warn",
+				);
+
+				// In this situation, we may be executing a Serial API command, which will never complete.
+				// Bail out of it, without rejecting the actual transaction
+				if (
+					this.serialAPIInterpreter?.status
+						=== InterpreterStatus.Running
+				) {
+					this.serialAPIInterpreter.stop();
+				}
+				if (this._currentSerialAPICommandPromise) {
+					this.controllerLog.print(
+						`Currently active command will be retried...`,
+						"warn",
+					);
+					this._currentSerialAPICommandPromise.reject(
+						new ZWaveError(
+							"The Serial API restarted unexpectedly",
+							ZWaveErrorCodes.Controller_Reset,
+						),
+					);
+				}
+
+				// Restart the watchdog unless disabled
+				if (this.options.features.watchdog) {
+					await this._controller?.startWatchdog();
+				}
+
+				if (this._controller?.nodeIdType === NodeIDType.Long) {
+					// We previously used 16 bit node IDs, but the controller was reset.
+					// Remember this and try to go back to 16 bit.
+					this._controller.nodeIdType = NodeIDType.Short;
+					await this._controller.trySetNodeIDType(NodeIDType.Long);
+				}
+
+				return true; // Don't invoke any more handlers
+			}
+		}
+
+		return false; // Not handled
+	}
+
+	/**
 	 * Registers a handler for messages that are not handled by the driver as part of a message exchange.
 	 * The handler function needs to return a boolean indicating if the message has been handled.
 	 * Registered handlers are called in sequence until a handler returns `true`.
@@ -4653,6 +4720,10 @@ ${handlers.length} left`,
 			// Make sure we're ready to handle this command
 			this.ensureReady(true);
 			return this.controller.handleApplicationUpdateRequest(msg);
+		} else if (msg instanceof SerialAPIStartedRequest) {
+			if (await this.handleSerialAPIStartedUnexpectedly(msg)) {
+				return;
+			}
 		} else {
 			// TODO: This deserves a nicer formatting
 			this.driverLog.print(
@@ -5144,6 +5215,9 @@ ${handlers.length} left`,
 						} else if (isMissingControllerACK(e)) {
 							// The controller is unresponsive. Reject the transaction, so we can attempt to recover
 							throw e;
+						} else if (wasControllerReset(e)) {
+							// The controller was reset unexpectedly. Reject the transaction, so we can attempt to recover
+							throw e;
 						} else if (
 							e.code === ZWaveErrorCodes.Controller_MessageDropped
 						) {
@@ -5176,6 +5250,13 @@ ${handlers.length} left`,
 		transaction.setProgress({ state: TransactionState.Completed });
 	}
 
+	/**
+	 * Provides access to the result Promise for the currently executed serial API command
+	 */
+	private _currentSerialAPICommandPromise:
+		| DeferredPromise<Message | undefined>
+		| undefined;
+
 	/** Handles sequencing of queued Serial API commands */
 	private async drainSerialAPIQueue(): Promise<void> {
 		for await (const item of this.serialAPIQueue) {
@@ -5188,6 +5269,8 @@ ${handlers.length} left`,
 				result.resolve(ret);
 			} catch (e) {
 				result.reject(e);
+			} finally {
+				this._currentSerialAPICommandPromise = undefined;
 			}
 		}
 	}
@@ -5362,6 +5445,7 @@ ${handlers.length} left`,
 
 		this.serialAPIInterpreter.start();
 
+		this._currentSerialAPICommandPromise = result;
 		return result;
 	}
 
@@ -6007,6 +6091,15 @@ ${handlers.length} left`,
 			if (
 				this.handleMissingSendDataResponseOrCallback(transaction, error)
 			) return;
+		} else if (wasControllerReset(error)) {
+			// The controller was reset in the middle of a transaction.
+			// Re-queue the transaction, so it can get handled again
+			// Its message generator may have finished, so reset that too.
+			transaction.reset();
+			this.getQueueForTransaction(transaction).add(
+				transaction.clone(),
+			);
+			return;
 		}
 
 		this.rejectTransaction(transaction, error);

--- a/packages/zwave-js/src/lib/driver/SerialAPICommandMachine.ts
+++ b/packages/zwave-js/src/lib/driver/SerialAPICommandMachine.ts
@@ -207,6 +207,7 @@ export function getSerialAPICommandMachineConfig(
 				},
 			},
 			waitForACK: {
+				always: [{ target: "success", cond: "expectsNoAck" }],
 				on: {
 					CAN: {
 						target: "retry",
@@ -390,6 +391,7 @@ export function getSerialAPICommandMachineOptions(
 		guards: {
 			mayRetry: (ctx) => ctx.attempts < ctx.maxAttempts,
 			isSendData: (ctx) => isSendData(ctx.msg),
+			expectsNoAck: (ctx) => !ctx.msg.expectsAck(),
 			expectsNoResponse: (ctx) => !ctx.msg.expectsResponse(),
 			expectsNoCallback: (ctx) => !ctx.msg.expectsCallback(),
 			isExpectedMessage: (ctx, evt, meta) =>

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -217,6 +217,14 @@ export interface ZWaveOptions extends ZWaveHostOptions {
 		 * Default: `true`, except when the ZWAVEJS_DISABLE_UNRESPONSIVE_CONTROLLER_RECOVERY env variable is set.
 		 */
 		unresponsiveControllerRecovery?: boolean;
+
+		/**
+		 * Controllers of the 700 series and newer have a hardware watchdog that can be enabled to automatically
+		 * reset the chip in case it becomes unresponsive. This option controls whether the watchdog should be enabled.
+		 *
+		 * Default: `true`, except when the ZWAVEJS_DISABLE_WATCHDOG env variable is set.
+		 */
+		watchdog?: boolean;
 	};
 
 	/**

--- a/packages/zwave-js/src/lib/serialapi/misc/WatchdogMessages.ts
+++ b/packages/zwave-js/src/lib/serialapi/misc/WatchdogMessages.ts
@@ -1,0 +1,26 @@
+import { MessagePriority } from "@zwave-js/core";
+import {
+	FunctionType,
+	Message,
+	MessageType,
+	messageTypes,
+	priority,
+} from "@zwave-js/serial";
+
+// These commands expect no ACK, no response, no callback
+
+@messageTypes(MessageType.Request, FunctionType.StartWatchdog)
+@priority(MessagePriority.Controller)
+export class StartWatchdogRequest extends Message {
+	public override expectsAck(): boolean {
+		return false;
+	}
+}
+
+@messageTypes(MessageType.Request, FunctionType.StopWatchdog)
+@priority(MessagePriority.Controller)
+export class StopWatchdogRequest extends Message {
+	public override expectsAck(): boolean {
+		return false;
+	}
+}

--- a/packages/zwave-js/src/lib/test/messages.ts
+++ b/packages/zwave-js/src/lib/test/messages.ts
@@ -11,6 +11,7 @@ const defaultImplementations = {
 	getCallbackTimeout: () => undefined,
 	markAsSent: () => void 0,
 	markAsCompleted: () => void 0,
+	expectsAck: () => true,
 };
 
 export const dummyResponseOK = {


### PR DESCRIPTION
I was told that Z/IP Gateway enables the hardware watchdog on 700/800 series controllers. Unlike on 500 series, we don't have to feed it ourselves. This should help with the lockup issue, as the controller is automatically restarted when it fails to feed the watchdog.

This feature is enabled by default, unless the `ZWAVEJS_DISABLE_WATCHDOG` env variable is set, or the `features.watchdog` driver option is set to `false`.