### PR TITLE
refactor: handle Basic CC interview separately, be very explicit when the CC is considered supported

### DIFF
--- a/packages/cc/src/cc/BasicCC.ts
+++ b/packages/cc/src/cc/BasicCC.ts
@@ -333,7 +333,8 @@ remaining duration: ${basicResponse.duration?.toString() ?? "undefined"}`;
 			ret.push(BasicCCValues.compatEvent.endpoint(endpoint.index));
 		} else if (
 			!endpoint.supportsCC(CommandClasses.Basic) && (
-				endpoint.controlsCC(CommandClasses.Basic)
+				(endpoint.controlsCC(CommandClasses.Basic)
+					&& compat?.mapBasicSet !== "Binary Sensor")
 				|| compat?.mapBasicReport === false
 				|| compat?.mapBasicSet === "report"
 			)

--- a/packages/cc/src/cc/BasicCC.ts
+++ b/packages/cc/src/cc/BasicCC.ts
@@ -257,17 +257,20 @@ export class BasicCC extends CommandClass {
 			direction: "none",
 		});
 
+		// Assume that the endpoint supports Basic CC, so the values get persisted correctly.
+		endpoint.addCC(CommandClasses.Basic, { isSupported: true });
+
 		// try to query the current state
 		await this.refreshValues(applHost);
 
-		// Remove Basic CC support when there was no response
+		// Remove Basic CC support again when there was no response
 		if (
 			this.getValue(applHost, BasicCCValues.currentValue) == undefined
 		) {
 			applHost.controllerLog.logNode(node.id, {
 				endpoint: this.endpointIndex,
 				message:
-					"No response to Basic Get command, assuming the node does not support Basic CC...",
+					"No response to Basic Get command, assuming Basic CC is unsupported...",
 			});
 			// SDS14223: A controlling node MUST conclude that the Basic Command Class is not supported by a node (or
 			// endpoint) if no Basic Report is returned.

--- a/packages/cc/src/cc/VersionCC.ts
+++ b/packages/cc/src/cc/VersionCC.ts
@@ -471,10 +471,20 @@ export class VersionCC extends CommandClass {
 				// Remember which CC version this endpoint supports
 				let logMessage: string;
 				if (supportedVersion > 0) {
-					endpoint.addCC(cc, {
-						isSupported: true,
-						version: supportedVersion,
-					});
+					// Basic CC has special rules for when it is considered supported
+					// Therefore we mark all other CCs as supported, but not Basic CC,
+					// for which support is determined later.
+					if (cc === CommandClasses.Basic) {
+						endpoint.addCC(cc, {
+							isControlled: true,
+							version: supportedVersion,
+						});
+					} else {
+						endpoint.addCC(cc, {
+							isSupported: true,
+							version: supportedVersion,
+						});
+					}
 					logMessage = `  supports CC ${CommandClasses[cc]} (${
 						num2hex(cc)
 					}) in version ${supportedVersion}`;

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1856,7 +1856,7 @@ export class ZWaveNode extends Endpoint
 					// Some device types are not allowed to support it, but there are devices that do.
 					// If a device type is forbidden to support Basic CC, remove the "support" portion of it
 					for (const endpoint of this.getAllEndpoints()) {
-						endpoint.removeBasicCCSupportIfForbidden();
+						endpoint.hideBasicCCSupportIfForbidden();
 					}
 
 					this.setInterviewStage(InterviewStage.CommandClasses);
@@ -2997,7 +2997,7 @@ protocol version:      ${this.protocolVersion}`;
 		}
 
 		// Mark Basic CC as not supported if any other actuator CC is supported
-		endpoint.hideBasicCCInFavorOfActuatorCCs();
+		endpoint.hideBasicCCSupportIfForbidden();
 
 		// Window Covering CC:
 		// CL:006A.01.51.01.2: A controlling node MUST NOT interview and provide controlling functionalities for the
@@ -6309,7 +6309,7 @@ protocol version:      ${this.protocolVersion}`;
 		// 	compat?.mapBasicReport !== false && compat?.mapBasicSet !== "event"
 		// ) {
 		for (const endpoint of this.getAllEndpoints()) {
-			endpoint.hideBasicCCInFavorOfActuatorCCs();
+			endpoint.hideBasicCCSupportIfForbidden();
 		}
 		// }
 

--- a/packages/zwave-js/src/lib/test/compat/basicCCSupportWhenForbidden.test.ts
+++ b/packages/zwave-js/src/lib/test/compat/basicCCSupportWhenForbidden.test.ts
@@ -1,5 +1,6 @@
 import { BasicCCValues } from "@zwave-js/cc";
 import { CommandClasses } from "@zwave-js/core";
+import path from "node:path";
 import { integrationTest } from "../integrationTestSuite";
 
 integrationTest(
@@ -23,6 +24,63 @@ integrationTest(
 			t.true(
 				valueIDs.some((v) => BasicCCValues.currentValue.is(v)),
 				"Did not find Basic CC currentValue although it should be exposed",
+			);
+			t.false(
+				valueIDs.some((v) => BasicCCValues.targetValue.is(v)),
+				"Found Basic CC targetValue although it shouldn't be exposed",
+			);
+			t.false(
+				valueIDs.some((v) => BasicCCValues.duration.is(v)),
+				"Found Basic CC duration although it shouldn't be exposed",
+			);
+			t.false(
+				valueIDs.some((v) => BasicCCValues.restorePrevious.is(v)),
+				"Found Basic CC restorePrevious although it shouldn't be exposed",
+			);
+
+			t.false(
+				valueIDs.some((v) => BasicCCValues.compatEvent.is(v)),
+				"Found Basic CC compatEvent although it shouldn't be exposed",
+			);
+		},
+	},
+);
+
+integrationTest(
+	"On devices that MUST not support Basic CC, and map Basic Set to a different CC, NO Basic CC values should be exposed",
+	{
+		// debug: true,
+
+		nodeCapabilities: {
+			manufacturerId: 0xdead,
+			productType: 0xbeef,
+			productId: 0xcafe,
+
+			// Routing Multilevel Sensor, MUST not support Basic CC
+			genericDeviceClass: 0x21,
+			specificDeviceClass: 0x01,
+			commandClasses: [
+				CommandClasses["Manufacturer Specific"],
+				CommandClasses.Version,
+				// But it reports support if asked
+				CommandClasses.Basic,
+			],
+		},
+
+		additionalDriverOptions: {
+			storage: {
+				deviceConfigPriorityDir: path.join(
+					__dirname,
+					"fixtures/mapBasicSetBinarySensor",
+				),
+			},
+		},
+
+		async testBody(t, driver, node, mockController, mockNode) {
+			const valueIDs = node.getDefinedValueIDs();
+			t.false(
+				valueIDs.some((v) => BasicCCValues.currentValue.is(v)),
+				"Found Basic CC currentValue although it shouldn't be exposed",
 			);
 			t.false(
 				valueIDs.some((v) => BasicCCValues.targetValue.is(v)),

--- a/packages/zwave-js/src/lib/test/compat/fixtures/mapBasicSetBinarySensor/deviceConfig.json
+++ b/packages/zwave-js/src/lib/test/compat/fixtures/mapBasicSetBinarySensor/deviceConfig.json
@@ -1,0 +1,19 @@
+{
+	"manufacturer": "Test Manufacturer",
+	"manufacturerId": "0xdead",
+	"label": "Test Device",
+	"description": "With Basic Event",
+	"devices": [
+		{
+			"productType": "0xbeef",
+			"productId": "0xcafe"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"compat": {
+		"mapBasicSet": "Binary Sensor"
+	}
+}


### PR DESCRIPTION
Previously, Basic CC was interviewed as part of the normal CC interview machinery, but with added modifications inbetween steps. This made determining whether the CC is (supposed to be) supported very fragile and lead to confusing heuristics.

We now interview the Basic CC for the root device and all endpoints at the very end of the interview, and determine then whether the CC is supported and/or controlled.
In addition, `currentValue` is no longer exposed when the CC is controlled and Basic Sets are mapped to a different CC.