### PR TITLE
chore: include config editor VSCode extension in workspace

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -57,6 +57,7 @@
 		".yarn/plugins",
 		".yarn/releases",
 		".tmp/",
+		".vscode/extensions/",
 		"cache/",
 		"packages/*/*.api.md",
 		"CHANGELOG*.md",

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "specs"]
 	path = specs
 	url = https://github.com/zwave-js/specs
+[submodule ".vscode/extensions/zwave-js-config-editor"]
+	path = .vscode/extensions/zwave-js-config-editor
+	url = https://github.com/zwave-js/vscode-config-editor

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,10 @@
 [submodule "specs"]
 	path = specs
 	url = https://github.com/zwave-js/specs
+	branch = master
 	update = rebase
 [submodule ".vscode/extensions/zwave-js-config-editor"]
 	path = .vscode/extensions/zwave-js-config-editor
 	url = https://github.com/zwave-js/vscode-config-editor
+	branch = main
 	update = rebase

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "specs"]
 	path = specs
 	url = https://github.com/zwave-js/specs
+	update = rebase
 [submodule ".vscode/extensions/zwave-js-config-editor"]
 	path = .vscode/extensions/zwave-js-config-editor
 	url = https://github.com/zwave-js/vscode-config-editor
+	update = rebase

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -106,6 +106,6 @@
 	"search.exclude": {
 		"**/.yarn": true
 	},
-	"git.ignoredRepositories": ["specs"],
+	"git.ignoredRepositories": ["specs", "vscode-config-editor"],
 	"search.followSymlinks": false
 }

--- a/maintenance/bootstrap.sh
+++ b/maintenance/bootstrap.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 set -e
 
-echo "CI = '$CI'"
-
 # Setup main repo
 echo "🏗️  Preparing repository..."
 echo ""
@@ -13,7 +11,7 @@ yarn turbo run bootstrap
 echo "✅ Repository ready"
 
 # Do not install VSCode extension on CI
-if [ -n "$CI" ]; then
+if [ -z "$CI" ]; then
 	# Install/Update VSCode extension
 	echo ""
 	echo "🏗️  Preparing VSCode extension..."

--- a/maintenance/bootstrap.sh
+++ b/maintenance/bootstrap.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -e
+
+# Setup main repo
+echo "🏗️  Preparing repository..."
+echo ""
+yarn
+ts-patch install
+yarn node maintenance/patch-typescript.js
+yarn turbo run bootstrap
+echo "✅ Repository ready"
+
+
+# Install/Update VSCode extension
+echo ""
+echo "🏗️  Preparing VSCode extension..."
+echo ""
+git submodule update -- .vscode/extensions/zwave-js-config-editor
+cd .vscode/extensions/zwave-js-config-editor
+npm i
+# TODO check if this can be made better. We want to build in any case.
+if [ -d out ]; then
+	npm run build
+	echo ""
+	echo "✅ VSCode extension ready"
+	echo ""
+else
+	npm run build
+	echo ""
+	echo "✅ VSCode extension ready. Install the recommended workspace extension to use it!"
+	echo ""
+fi

--- a/maintenance/bootstrap.sh
+++ b/maintenance/bootstrap.sh
@@ -10,24 +10,26 @@ yarn node maintenance/patch-typescript.js
 yarn turbo run bootstrap
 echo "✅ Repository ready"
 
-
-# Install/Update VSCode extension
-echo ""
-echo "🏗️  Preparing VSCode extension..."
-echo ""
-git submodule update --init -- .vscode/extensions/zwave-js-config-editor
-cd .vscode/extensions/zwave-js-config-editor
-git checkout main
-npm i
-# TODO check if this can be made better. We want to build in any case.
-if [ -d out ]; then
-	npm run build
+# Do not install VSCode extension on CI
+if [ -n "$CI" ]; then
+	# Install/Update VSCode extension
 	echo ""
-	echo "✅ VSCode extension ready"
+	echo "🏗️  Preparing VSCode extension..."
 	echo ""
-else
-	npm run build
-	echo ""
-	echo "✅ VSCode extension ready. Install the recommended workspace extension to use it!"
-	echo ""
+	git submodule update --init -- .vscode/extensions/zwave-js-config-editor
+	cd .vscode/extensions/zwave-js-config-editor
+	git checkout main
+	npm i
+	# TODO check if this can be made better. We want to build in any case.
+	if [ -d out ]; then
+		npm run build
+		echo ""
+		echo "✅ VSCode extension ready"
+		echo ""
+	else
+		npm run build
+		echo ""
+		echo "✅ VSCode extension ready. Install the recommended workspace extension to use it!"
+		echo ""
+	fi
 fi

--- a/maintenance/bootstrap.sh
+++ b/maintenance/bootstrap.sh
@@ -17,6 +17,7 @@ echo "🏗️  Preparing VSCode extension..."
 echo ""
 git submodule update --init -- .vscode/extensions/zwave-js-config-editor
 cd .vscode/extensions/zwave-js-config-editor
+git checkout main
 npm i
 # TODO check if this can be made better. We want to build in any case.
 if [ -d out ]; then

--- a/maintenance/bootstrap.sh
+++ b/maintenance/bootstrap.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+echo "CI = '$CI'"
+
 # Setup main repo
 echo "🏗️  Preparing repository..."
 echo ""

--- a/maintenance/bootstrap.sh
+++ b/maintenance/bootstrap.sh
@@ -15,7 +15,7 @@ echo "✅ Repository ready"
 echo ""
 echo "🏗️  Preparing VSCode extension..."
 echo ""
-git submodule update -- .vscode/extensions/zwave-js-config-editor
+git submodule update --init -- .vscode/extensions/zwave-js-config-editor
 cd .vscode/extensions/zwave-js-config-editor
 npm i
 # TODO check if this can be made better. We want to build in any case.

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "commit": "git-cz",
     "release": "release-script",
     "release:all": "release-script --publish-all",
-    "bootstrap": "yarn && ts-patch install && yarn node maintenance/patch-typescript.js && yarn turbo run bootstrap",
+    "bootstrap": "./maintenance/bootstrap.sh",
     "config": "yarn ts packages/config/maintenance/importConfig.ts",
     "docs": "docsify serve docs",
     "docs:generate": "yarn ts packages/maintenance/src/generateTypedDocs.ts",


### PR DESCRIPTION
Since 1.89, VSCode can load extensions from the local workspace: https://code.visualstudio.com/updates/v1_89#_local-workspace-extensions

With this PR, we make use of this, so the extension does not have to be hosted on a marketplace anymore.

TODO:
- [x] Include updating, compiling in bootstrap script