### PR TITLE
fix: only mark Basic CC as controlled if compat flags are set

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,7 @@
 		}
 	],
 	"dprint.experimentalLsp": true,
+	"dprint.path": "./node_modules/dprint/dprint",
 	"editor.defaultFormatter": "dprint.dprint",
 	"[jsonc]": {
 		"editor.formatOnSave": true,

--- a/packages/cc/src/cc/BasicCC.ts
+++ b/packages/cc/src/cc/BasicCC.ts
@@ -327,27 +327,20 @@ remaining duration: ${basicResponse.duration?.toString() ?? "undefined"}`;
 		applHost: ZWaveApplicationHost,
 	): ValueID[] {
 		const ret: ValueID[] = [];
-
-		// Defer to the base implementation if Basic CC is supported
 		const endpoint = this.getEndpoint(applHost)!;
-		if (endpoint.supportsCC(this.ccId)) {
-			ret.push(...super.getDefinedValueIDs(applHost));
-		}
 
 		const compat = applHost.getDeviceConfig?.(endpoint.nodeId)?.compat;
 		if (compat?.mapBasicSet === "event") {
 			// Add the compat event value if it should be exposed
 			ret.push(BasicCCValues.compatEvent.endpoint(endpoint.index));
-		} else if (
-			!endpoint.supportsCC(CommandClasses.Basic) && (
-				(endpoint.controlsCC(CommandClasses.Basic)
-					&& compat?.mapBasicSet !== "Binary Sensor")
-				|| compat?.mapBasicReport === false
-				|| compat?.mapBasicSet === "report"
-			)
-		) {
-			// Otherwise, only expose currentValue on devices that only control Basic CC,
-			// or devices where a compat flag indicates that currentValue is meant to be exposed
+		}
+
+		if (endpoint.supportsCC(this.ccId)) {
+			// Defer to the base implementation if Basic CC is supported.
+			// This implies that no other actuator CC is supported.
+			ret.push(...super.getDefinedValueIDs(applHost));
+		} else if (endpoint.controlsCC(CommandClasses.Basic)) {
+			// During the interview, we mark Basic CC as controlled only if we want to expose currentValue
 			ret.push(BasicCCValues.currentValue.endpoint(endpoint.index));
 		}
 

--- a/packages/cc/src/cc/VersionCC.ts
+++ b/packages/cc/src/cc/VersionCC.ts
@@ -480,7 +480,6 @@ export class VersionCC extends CommandClass {
 					// for which support is determined later.
 					if (cc === CommandClasses.Basic) {
 						endpoint.addCC(cc, {
-							isControlled: true,
 							version: supportedVersion,
 						});
 					} else {

--- a/packages/zwave-js/src/lib/test/compat/basicCCSupportWhenForbidden.test.ts
+++ b/packages/zwave-js/src/lib/test/compat/basicCCSupportWhenForbidden.test.ts
@@ -4,19 +4,33 @@ import path from "node:path";
 import { integrationTest } from "../integrationTestSuite";
 
 integrationTest(
-	"On devices that MUST not support Basic CC, but use Basic Set to report status, ONLY currentValue should be exposed",
+	"On devices that MUST not support Basic CC, and treat Basic Set as a report, ONLY currentValue should be exposed",
 	{
 		// debug: true,
 
 		nodeCapabilities: {
+			manufacturerId: 0xdead,
+			productType: 0xbeef,
+			productId: 0xcafe,
+
 			// Routing Multilevel Sensor, MUST not support Basic CC
 			genericDeviceClass: 0x21,
 			specificDeviceClass: 0x01,
 			commandClasses: [
+				CommandClasses["Manufacturer Specific"],
 				CommandClasses.Version,
 				// But it reports support if asked
 				CommandClasses.Basic,
 			],
+		},
+
+		additionalDriverOptions: {
+			storage: {
+				deviceConfigPriorityDir: path.join(
+					__dirname,
+					"fixtures/mapBasicSetReport",
+				),
+			},
 		},
 
 		async testBody(t, driver, node, mockController, mockNode) {

--- a/packages/zwave-js/src/lib/test/compat/fixtures/mapBasicSetReport/deviceConfig.json
+++ b/packages/zwave-js/src/lib/test/compat/fixtures/mapBasicSetReport/deviceConfig.json
@@ -2,7 +2,7 @@
 	"manufacturer": "Test Manufacturer",
 	"manufacturerId": "0xdead",
 	"label": "Test Device",
-	"description": "With Basic Set as Binary Sensor",
+	"description": "With Basic Set as Report",
 	"devices": [
 		{
 			"productType": "0xbeef",
@@ -14,6 +14,6 @@
 		"max": "255.255"
 	},
 	"compat": {
-		"mapBasicSet": "Binary Sensor"
+		"mapBasicSet": "report"
 	}
 }


### PR DESCRIPTION
Apparently the changes from 12.12.3 unintentionally exposed many Basic CC currentValue entities in cases where the CC should not be supported. With this PR, this should only happen if opted in with a Basic CC mapping compat flag.