### PR TITLE
fix: forget supported CCs of endpoints during re-interview

### DIFF
--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1739,6 +1739,9 @@ export class ZWaveNode extends Endpoint
 		this.deviceConfigHash = undefined;
 		this._hasEmittedNoS0NetworkKeyError = false;
 		this._hasEmittedNoS2NetworkKeyError = false;
+		for (const ep of this.getAllEndpoints()) {
+			ep["reset"]();
+		}
 		this._valueDB.clear({ noEvent: true });
 		this._endpointInstances.clear();
 		super.reset();


### PR DESCRIPTION
It was found that the list of supported CCs of endpoints would survive a re-interview, thus preserving incorrect information.