### PR TITLE
fix: devcontainer setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
 	"image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
 
-	"updateContentCommand": "yarn && yarn build",
+	"updateContentCommand": "yarn workspaces focus -A && yarn build",
 
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,11 @@
 {
 	"image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
+	"containerEnv": {
+		"YARN_ENABLE_GLOBAL_CACHE": "false", // Avoids cross-link issues due to different filesystems between /home and /workspaces
+		"COREPACK_ENABLE_DOWNLOAD_PROMPT": "0" // Avoids interactive prompt causing container creation to hang
+	},
 
+	"updateContentCommand": "sudo corepack enable && yarn && yarn build",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,6 @@
 {
 	"image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
 
-	"updateContentCommand": "yarn workspaces focus -A && yarn build",
-
 	"customizations": {
 		"vscode": {
 			"extensions": [


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

Devcontainer setup needed some updates to work with current development tree. 
