### PR TITLE
fix(zniffer): do not query region info on Zniffers before FW 2.55

### DIFF
--- a/packages/core/src/capabilities/RFRegion.ts
+++ b/packages/core/src/capabilities/RFRegion.ts
@@ -31,3 +31,30 @@ export enum ZnifferRegion {
 	"Unknown" = 0xfe,
 	"Default (EU)" = 0xff,
 }
+
+/** Definitions for Zniffer regions on legacy (500 series and older) Zniffers */
+export enum ZnifferRegionLegacy {
+	EU = 0,
+	US = 1,
+	ANZ = 2,
+	HK = 3,
+	MY = 8,
+	IN = 9,
+	JP = 10,
+	RU = 26,
+	IL = 27,
+	KR = 28,
+	CN = 29,
+	TF_866 = 4,
+	TF_870 = 5,
+	TF_906 = 6,
+	TF_910 = 7,
+	TF_878 = 11,
+	TF_882 = 12,
+	TF_886 = 13,
+	TF_932_3CH = 14,
+	TF_940_3CH = 15,
+	TF_835_3CH = 24,
+	TF_840_3CH = 16,
+	TF_850_3CH = 17,
+}


### PR DESCRIPTION
Not sure in which version the `GetFrequencyInfo` command was implemented, but 2.55 definitely supports it. Before that, just assume the regions are the same ones as in 2.55.