### PR TITLE
feat: add `inclusion state changed` event

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -1423,6 +1423,31 @@ A node could not be included into or excluded from the network for some reason.
 
 The process to include or exclude a node was stopped successfully. Note that these events are also emitted after a node was included or excluded.
 
+### `"inclusion state changed"`
+
+The controller's inclusion state has changed. The new state is passed as an argument.
+
+```ts
+(state: InclusionState) => void
+```
+
+<!-- #import InclusionState from "zwave-js" -->
+
+```ts
+enum InclusionState {
+	/** The controller isn't doing anything regarding inclusion. */
+	Idle,
+	/** The controller is waiting for a node to be included. */
+	Including,
+	/** The controller is waiting for a node to be excluded. */
+	Excluding,
+	/** The controller is busy including or excluding a node. */
+	Busy,
+	/** The controller listening for SmartStart nodes to announce themselves. */
+	SmartStart,
+}
+```
+
 ### `"node found"`
 
 A node has successfully been added to the network.

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -396,6 +396,7 @@ interface ControllerEventCallbacks
 	"exclusion started": () => void;
 	"inclusion stopped": () => void;
 	"exclusion stopped": () => void;
+	"inclusion state changed": (state: InclusionState) => void;
 	"node found": (node: FoundNode) => void;
 	"node added": (node: ZWaveNode, result: InclusionResult) => void;
 	"node removed": (node: ZWaveNode, reason: RemoveNodeReason) => void;
@@ -1960,6 +1961,7 @@ export class ZWaveController
 	public setInclusionState(state: InclusionState): void {
 		if (this._inclusionState === state) return;
 		this._inclusionState = state;
+		this.emit("inclusion state changed", state);
 		if (
 			state === InclusionState.Idle
 			&& this._smartStartEnabled


### PR DESCRIPTION
This PR adds a new event to notify applications about changes in the controller's inclusion state.

Related: https://github.com/zwave-js/zwave-js-ui/issues/3516
Fixes: https://github.com/zwave-js/node-zwave-js/issues/6609