### PR TITLE
feat: support Firmware Update Meta Data CC v8

### DIFF
--- a/packages/cc/src/lib/_Types.ts
+++ b/packages/cc/src/lib/_Types.ts
@@ -726,6 +726,8 @@ export interface FirmwareUpdateMetaData {
 	hardwareVersion?: number;
 	continuesToFunction: MaybeNotKnown<boolean>;
 	supportsActivation: MaybeNotKnown<boolean>;
+	supportsResuming?: MaybeNotKnown<boolean>;
+	supportsNonSecureTransfer?: MaybeNotKnown<boolean>;
 }
 
 export enum FirmwareUpdateRequestStatus {
@@ -790,6 +792,10 @@ export type FirmwareUpdateCapabilities =
 		readonly continuesToFunction: MaybeNotKnown<boolean>;
 		/** Indicates whether the node supports delayed activation of the new firmware */
 		readonly supportsActivation: MaybeNotKnown<boolean>;
+		/** Indicates whether the node supports resuming aborted firmware transfers */
+		readonly supportsResuming: MaybeNotKnown<boolean>;
+		/** Indicates whether the node supports non-secure firmware transfers */
+		readonly supportsNonSecureTransfer: MaybeNotKnown<boolean>;
 	};
 
 export interface FirmwareUpdateProgress {

--- a/packages/cc/src/lib/_Types.ts
+++ b/packages/cc/src/lib/_Types.ts
@@ -741,6 +741,14 @@ export enum FirmwareUpdateRequestStatus {
 	OK = 0xff,
 }
 
+export interface FirmwareUpdateInitResult {
+	status: FirmwareUpdateRequestStatus;
+	/** Whether the node will resume a previous transfer */
+	resume?: boolean;
+	/** Whether the node will accept non-secure firmware fragments */
+	nonSecureTransfer?: boolean;
+}
+
 export enum FirmwareUpdateStatus {
 	// Error_Timeout is not part of the Z-Wave standard, but we use it to report
 	// that no status report was received
@@ -820,6 +828,18 @@ export interface FirmwareUpdateResult {
 	waitTime?: number;
 	/** Whether the device will be re-interviewed. If this is `true`, applications should wait for the `"ready"` event to interact with the device again. */
 	reInterview: boolean;
+}
+
+export interface FirmwareUpdateOptions {
+	/**
+	 * Whether a previous attempt to update this node's firmware should be resumed (if supported).
+	 */
+	resume?: boolean;
+	/**
+	 * Whether the firmware data should be transferred without encryption (if supported).
+	 * This can massively reduce the time needed.
+	 */
+	nonSecureTransfer?: boolean;
 }
 
 export enum HailCommand {

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -5,6 +5,7 @@ import {
 	type AssociationGroup,
 	ECDHProfiles,
 	FLiRS2WakeUpTime,
+	type FirmwareUpdateOptions,
 	type FirmwareUpdateResult,
 	InclusionControllerCCComplete,
 	InclusionControllerCCInitiate,
@@ -7621,6 +7622,7 @@ ${associatedNodes.join(", ")}`,
 	public async firmwareUpdateOTA(
 		nodeId: number,
 		updateInfo: FirmwareUpdateInfo,
+		options?: FirmwareUpdateOptions,
 	): Promise<FirmwareUpdateResult> {
 		// Don't let two firmware updates happen in parallel
 		if (this.isAnyOTAFirmwareUpdateInProgress()) {
@@ -7727,7 +7729,7 @@ ${associatedNodes.join(", ")}`,
 			);
 		}
 
-		return node.updateFirmware(firmwares);
+		return node.updateFirmware(firmwares, options);
 	}
 
 	private _firmwareUpdateInProgress: boolean = false;

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -6488,6 +6488,7 @@ ${handlers.length} left`,
 	/** Computes the maximum net CC payload size for the given CC or SendDataRequest */
 	public computeNetCCPayloadSize(
 		commandOrMsg: CommandClass | SendDataRequest | SendDataBridgeRequest,
+		ignoreEncapsulation: boolean = false,
 	): number {
 		// Recreate the correct encapsulation structure
 		let msg: SendDataRequest | SendDataBridgeRequest;
@@ -6497,9 +6498,11 @@ ${handlers.length} left`,
 			const SendDataConstructor = this.getSendDataSinglecastConstructor();
 			msg = new SendDataConstructor(this, { command: commandOrMsg });
 		}
-		msg.command = this.encapsulateCommands(
-			msg.command,
-		) as SinglecastCC<CommandClass>;
+		if (!ignoreEncapsulation) {
+			msg.command = this.encapsulateCommands(
+				msg.command,
+			) as SinglecastCC<CommandClass>;
+		}
 		return msg.command.getMaxPayloadLength(this.getMaxPayloadLength(msg));
 	}
 

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -5574,6 +5574,12 @@ protocol version:      ${this.protocolVersion}`;
 		const additionalFirmwareIDs = this.getValue<number[]>(
 			FirmwareUpdateMetaDataCCValues.additionalFirmwareIDs.id,
 		);
+		const supportsResuming = this.getValue<boolean>(
+			FirmwareUpdateMetaDataCCValues.supportsResuming.id,
+		);
+		const supportsNonSecureTransfer = this.getValue<boolean>(
+			FirmwareUpdateMetaDataCCValues.supportsNonSecureTransfer.id,
+		);
 
 		// Ensure all information was queried
 		if (
@@ -5590,6 +5596,8 @@ protocol version:      ${this.protocolVersion}`;
 				.map((_, i) => i),
 			continuesToFunction,
 			supportsActivation,
+			supportsResuming,
+			supportsNonSecureTransfer,
 		};
 	}
 
@@ -5620,6 +5628,8 @@ protocol version:      ${this.protocolVersion}`;
 				.fill(0).map((_, i) => i),
 			continuesToFunction: meta.continuesToFunction,
 			supportsActivation: meta.supportsActivation,
+			supportsResuming: meta.supportsResuming,
+			supportsNonSecureTransfer: meta.supportsNonSecureTransfer,
 		};
 	}
 


### PR DESCRIPTION
This PR adds support for resuming aborted firmware updates and transferring firmware update data without encryption to reduce overhead. This requires end devices implementing version 8 of the firmware update CC.

The methods to perform firmware updates with or without the update service can now specify whether those features should be used if supported through an additional `options` parameter:
```ts
export interface FirmwareUpdateOptions {
	/**
	 * Whether a previous attempt to update this node's firmware should be resumed (if supported).
	 */
	resume?: boolean;
	/**
	 * Whether the firmware data should be transferred without encryption (if supported).
	 * This can massively reduce the time needed.
	 */
	nonSecureTransfer?: boolean;
}
```

fixes: #7075 