### PR TITLE
fix: try to handle non-implemented CCs

### DIFF
--- a/packages/zwave-js/src/lib/test/cc/CommandClass.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/CommandClass.test.ts
@@ -9,11 +9,7 @@ import {
 	getImplementedVersionStatic,
 	implementedVersion,
 } from "@zwave-js/cc";
-import {
-	CommandClasses,
-	ZWaveErrorCodes,
-	assertZWaveError,
-} from "@zwave-js/core";
+import { CommandClasses } from "@zwave-js/core";
 import { createTestingHost } from "@zwave-js/host";
 import test from "ava";
 import { SendDataRequest } from "../../serialapi/transport/SendDataMessages";
@@ -49,19 +45,17 @@ test(`creating and serializing should work for unspecified commands`, (t) => {
 	);
 });
 
-test("from() throws CC_NotImplemented when receiving a non-implemented CC", (t) => {
+test("from() returns an un-specialized instance when receiving a non-implemented CC", (t) => {
 	// This is a Node Provisioning CC. Change it when that CC is implemented
-	assertZWaveError(
-		t,
-		() =>
-			CommandClass.from(host, {
-				data: Buffer.from("78030100", "hex"),
-				nodeId: 5,
-			}),
-		{
-			errorCode: ZWaveErrorCodes.CC_NotImplemented,
-		},
-	);
+	const cc = CommandClass.from(host, {
+		data: Buffer.from("78030100", "hex"),
+		nodeId: 5,
+	});
+	t.is(cc.constructor, CommandClass);
+	t.is(cc.nodeId, 5);
+	t.is(cc.ccId, 0x78);
+	t.is(cc.ccCommand, 0x03);
+	t.deepEqual(cc.payload, Buffer.from([0x01, 0x00]));
 });
 
 test("from() does not throw when the CC is implemented", (t) => {

--- a/packages/zwave-js/src/lib/test/driver/handleNonImplementedCCs.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/handleNonImplementedCCs.test.ts
@@ -1,0 +1,45 @@
+import { CommandClass } from "@zwave-js/cc";
+import { CommandClasses } from "@zwave-js/core";
+import { createMockZWaveRequestFrame } from "@zwave-js/testing";
+import { integrationTest } from "../integrationTestSuite";
+
+integrationTest(
+	"Command classes that are not implemented are passed to awaiters before being dropped",
+	{
+		// debug: true,
+
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				CommandClasses.Basic,
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// Anti theft will not be implemented, so we can use it to test this
+			const awaited = driver.waitForCommand(
+				(cc) => cc.ccId === CommandClasses["Anti-Theft"],
+				1000,
+			);
+
+			const cc = new CommandClass(mockNode.host, {
+				nodeId: mockController.host.ownNodeId,
+				ccId: CommandClasses["Anti-Theft"],
+				ccCommand: 0x02, // Get
+				payload: Buffer.from([0x00, 0x01]), // Technically invalid
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+
+			const result = await awaited;
+			t.like(result, {
+				ccId: CommandClasses["Anti-Theft"],
+				ccCommand: 0x02,
+				payload: Buffer.from([0x00, 0x01]),
+			});
+		},
+	},
+);


### PR DESCRIPTION
With this PR, non-implemented CCs will no longer be dropped immediately. Instead possible awaiters are invoked first, in case the application is waiting for them.