### PR TITLE
fix(config): fix for condtional parameters for zen16

### DIFF
--- a/packages/config/config/devices/0x027a/zen16.json
+++ b/packages/config/config/devices/0x027a/zen16.json
@@ -64,13 +64,13 @@
 		},
 		{
 			"#": "2",
-			"$if": "firmwareVersion <= 1.1",
+			"$if": "firmwareVersion <= 1.0.1",
 			"$import": "templates/zooz_template.json#zen16_switch_type",
 			"label": "Switch 1: Type"
 		},
 		{
 			"#": "2",
-			"$if": "firmwareVersion >= 1.2 && firmwareVersion < 2.0",
+			"$if": "firmwareVersion >= 1.0.2 && firmwareVersion < 2.0",
 			"$import": "templates/zooz_template.json#zen16_switch_type_v2",
 			"label": "Switch 1: Type"
 		},
@@ -82,13 +82,13 @@
 		},
 		{
 			"#": "3",
-			"$if": "firmwareVersion <= 1.1",
+			"$if": "firmwareVersion <= 1.0.1",
 			"$import": "templates/zooz_template.json#zen16_switch_type",
 			"label": "Switch 2: Type"
 		},
 		{
 			"#": "3",
-			"$if": "firmwareVersion >= 1.2 && firmwareVersion < 2.0",
+			"$if": "firmwareVersion >= 1.0.2 && firmwareVersion < 2.0",
 			"$import": "templates/zooz_template.json#zen16_switch_type_v2",
 			"label": "Switch 2: Type"
 		},
@@ -100,13 +100,13 @@
 		},
 		{
 			"#": "4",
-			"$if": "firmwareVersion <= 1.1",
+			"$if": "firmwareVersion <= 1.0.1",
 			"$import": "templates/zooz_template.json#zen16_switch_type",
 			"label": "Switch 3: Type"
 		},
 		{
 			"#": "4",
-			"$if": "firmwareVersion >= 1.2 && firmwareVersion < 2.0",
+			"$if": "firmwareVersion >= 1.0.2 && firmwareVersion < 2.0",
 			"$import": "templates/zooz_template.json#zen16_switch_type_v2",
 			"label": "Switch 3: Type"
 		},
@@ -143,20 +143,20 @@
 		},
 		{
 			"#": "6",
-			"$if": "firmwareVersion < 1.1",
+			"$if": "firmwareVersion < 1.0.1",
 			"$import": "templates/zooz_template.json#auto_off_timer_0x_1x_3x_7x",
 			"label": "Relay 1: Auto Turn-Off Timer"
 		},
 		{
 			"#": "6",
-			"$if": "firmwareVersion >= 1.1",
+			"$if": "firmwareVersion >= 1.0.1",
 			"$import": "templates/zooz_template.json#auto_timer_base_0x_1x_3x_7x_nounit",
 			"label": "Relay 1: Auto Turn-Off Timer",
 			"description": "Unit defined in parameter 15."
 		},
 		{
 			"#": "15",
-			"$if": "firmwareVersion >= 1.1",
+			"$if": "firmwareVersion >= 1.0.1",
 			"label": "Relay 1: Auto Turn-Off Timer Unit",
 			"valueSize": 1,
 			"defaultValue": 0,
@@ -178,109 +178,109 @@
 		},
 		{
 			"#": "7",
-			"$if": "firmwareVersion < 1.1",
+			"$if": "firmwareVersion < 1.0.1",
 			"$import": "templates/zooz_template.json#auto_on_timer_0x_1x_3x_7x",
 			"label": "Relay 1: Auto Turn-On Timer"
 		},
 		{
 			"#": "7",
-			"$if": "firmwareVersion >= 1.1",
+			"$if": "firmwareVersion >= 1.0.1",
 			"$import": "templates/zooz_template.json#auto_timer_base_0x_1x_3x_7x_nounit",
 			"label": "Relay 1: Auto Turn-On Timer",
 			"description": "Unit defined in parameter 16."
 		},
 		{
 			"#": "16",
-			"$if": "firmwareVersion >= 1.1",
+			"$if": "firmwareVersion >= 1.0.1",
 			"$import": "#paramInformation/15",
 			"label": "Relay 1: Auto Turn-On Timer Unit"
 		},
 		{
 			"#": "8",
-			"$if": "firmwareVersion < 1.1",
+			"$if": "firmwareVersion < 1.0.1",
 			"$import": "templates/zooz_template.json#auto_off_timer_0x_1x_3x_7x",
 			"label": "Relay 2: Auto Turn-Off Timer"
 		},
 		{
 			"#": "8",
-			"$if": "firmwareVersion >= 1.1",
+			"$if": "firmwareVersion >= 1.0.1",
 			"$import": "templates/zooz_template.json#auto_timer_base_0x_1x_3x_7x_nounit",
 			"label": "Relay 2: Auto Turn-Off Timer",
 			"description": "Unit defined in parameter 17."
 		},
 		{
 			"#": "17",
-			"$if": "firmwareVersion >= 1.1",
+			"$if": "firmwareVersion >= 1.0.1",
 			"$import": "#paramInformation/15",
 			"label": "Relay 2: Auto Turn-Off Timer Unit"
 		},
 		{
 			"#": "9",
-			"$if": "firmwareVersion < 1.1",
+			"$if": "firmwareVersion < 1.0.1",
 			"$import": "templates/zooz_template.json#auto_on_timer_0x_1x_3x_7x",
 			"label": "Relay 2: Auto Turn-On Timer"
 		},
 		{
 			"#": "9",
-			"$if": "firmwareVersion >= 1.1",
+			"$if": "firmwareVersion >= 1.0.1",
 			"$import": "templates/zooz_template.json#auto_timer_base_0x_1x_3x_7x_nounit",
 			"label": "Relay 2: Auto Turn-On Timer",
 			"description": "Unit defined in parameter 18."
 		},
 		{
 			"#": "18",
-			"$if": "firmwareVersion >= 1.1",
+			"$if": "firmwareVersion >= 1.0.1",
 			"$import": "#paramInformation/15",
 			"label": "Relay 2: Auto Turn-On Timer Unit"
 		},
 		{
 			"#": "10",
-			"$if": "firmwareVersion < 1.1",
+			"$if": "firmwareVersion < 1.0.1",
 			"$import": "templates/zooz_template.json#auto_off_timer_0x_1x_3x_7x",
 			"label": "Relay 3: Auto Turn-Off Timer"
 		},
 		{
 			"#": "10",
-			"$if": "firmwareVersion >= 1.1",
+			"$if": "firmwareVersion >= 1.0.1",
 			"$import": "templates/zooz_template.json#auto_timer_base_0x_1x_3x_7x_nounit",
 			"label": "Relay 3: Auto Turn-Off Timer",
 			"description": "Unit defined in parameter 19."
 		},
 		{
 			"#": "19",
-			"$if": "firmwareVersion >= 1.1",
+			"$if": "firmwareVersion >= 1.0.1",
 			"$import": "#paramInformation/15",
 			"label": "Relay 3: Auto Turn-Off Timer Unit"
 		},
 		{
 			"#": "11",
-			"$if": "firmwareVersion < 1.1",
+			"$if": "firmwareVersion < 1.0.1",
 			"$import": "templates/zooz_template.json#auto_on_timer_0x_1x_3x_7x",
 			"label": "Relay 3: Auto Turn-On Timer"
 		},
 		{
 			"#": "11",
-			"$if": "firmwareVersion >= 1.1",
+			"$if": "firmwareVersion >= 1.0.1",
 			"$import": "templates/zooz_template.json#auto_timer_base_0x_1x_3x_7x_nounit",
 			"label": "Relay 3: Auto Turn-On Timer",
 			"description": "Unit defined in parameter 20."
 		},
 		{
 			"#": "20",
-			"$if": "firmwareVersion >= 1.1",
+			"$if": "firmwareVersion >= 1.0.1",
 			"$import": "#paramInformation/15",
 			"label": "Relay 3: Auto Turn-On Timer Unit"
 		},
 		{
 			"#": "12",
-			"$if": "firmwareVersion < 1.2",
+			"$if": "firmwareVersion < 1.0.2",
 			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Switch 1: Manual Control",
 			"defaultValue": 1
 		},
 		{
 			"#": "12",
-			"$if": "firmwareVersion >= 1.2",
+			"$if": "firmwareVersion >= 1.0.2",
 			"label": "Switch 1: Manual Control",
 			"valueSize": 1,
 			"defaultValue": 1,
@@ -302,33 +302,33 @@
 		},
 		{
 			"#": "13",
-			"$if": "firmwareVersion < 1.2",
+			"$if": "firmwareVersion < 1.0.2",
 			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Switch 2: Manual Control",
 			"defaultValue": 1
 		},
 		{
 			"#": "13",
-			"$if": "firmwareVersion >= 1.2",
+			"$if": "firmwareVersion >= 1.0.2",
 			"$import": "templates/zooz_template.json#zen16_manual_control",
 			"label": "Switch 2: Manual Control"
 		},
 		{
 			"#": "14",
-			"$if": "firmwareVersion < 1.2",
+			"$if": "firmwareVersion < 1.0.2",
 			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Switch 3: Manual Control",
 			"defaultValue": 1
 		},
 		{
 			"#": "14",
-			"$if": "firmwareVersion >= 1.2",
+			"$if": "firmwareVersion >= 1.0.2",
 			"$import": "templates/zooz_template.json#zen16_manual_control",
 			"label": "Switch 3: Manual Control"
 		},
 		{
 			"#": "21",
-			"$if": "firmwareVersion >= 1.3",
+			"$if": "firmwareVersion >= 1.0.3",
 			"label": "Relay 1: Type",
 			"valueSize": 1,
 			"defaultValue": 0,
@@ -350,19 +350,19 @@
 		},
 		{
 			"#": "22",
-			"$if": "firmwareVersion >= 1.3",
+			"$if": "firmwareVersion >= 1.0.3",
 			"$import": "#paramInformation/21",
 			"label": "Relay 2: Type"
 		},
 		{
 			"#": "23",
-			"$if": "firmwareVersion >= 1.3",
+			"$if": "firmwareVersion >= 1.0.3",
 			"$import": "#paramInformation/21",
 			"label": "Relay 3: Type"
 		},
 		{
 			"#": "24",
-			"$if": "firmwareVersion >= 1.3 && firmwareVersion < 2.10",
+			"$if": "firmwareVersion >= 1.0.3 && firmwareVersion < 2.10",
 			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "DC Motor Mode",
 			"description": "When enabled only one relay may be on at a time, the other relay is automatically turned off."


### PR DESCRIPTION
Fixed conditional parameter checks per https://www.support.getzooz.com/kb/article/356-zen16-multirelay-change-log/

Conditional checks incorrectly assume 1.1, 1.2, and 1.3 for items that are actually 1.0.1, 1.0.2, and 1.0.3. Note: the link above lists them as 1.01, 1.02, and 1.03. My devices are on the latest firmware (1.20) for hardware version 1 which is reported as 1.2. As such, with the current config file I cannot access parameters (21-24) that I should be able to. 