### PR TITLE
feat(config): add fingerprint for Climax Technology SDCO-1

### DIFF
--- a/packages/config/config/devices/0x018e/sdco.json
+++ b/packages/config/config/devices/0x018e/sdco.json
@@ -13,6 +13,11 @@
 			"productType": "0x0003",
 			"productId": "0x0015",
 			"zwaveAllianceId": 3670
+		},
+		{
+			"productType": "0x0003",
+			"productId": "0x001a",
+			"zwaveAllianceId": 3724
 		}
 	],
 	"firmwareVersion": {

--- a/packages/config/config/devices/0x018e/sdco.json
+++ b/packages/config/config/devices/0x018e/sdco.json
@@ -16,8 +16,7 @@
 		},
 		{
 			"productType": "0x0003",
-			"productId": "0x001a",
-			"zwaveAllianceId": 3724
+			"productId": "0x001a"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
I believe Climax Technology gives all their SDCO-1 models with localized additional languages a separate product id.

It is hard to find good documentation on this, but everything on the device itself identifies as a regular SDCO-1, only indication that something is different is that the zwave product id is `0x001a` instead of the expected `0x0014` for the battery driven SDCO device.

It might be the same for the AC variant (id `0x0015`), but since I don't know, I won't be adding that now.

This is a Norwegian language model. I would guess that each individual language either share this id, or they will have their own.