### PR TITLE
feat: add methods to reset SPAN of one or all nodes

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -6985,4 +6985,22 @@ ${handlers.length} left`,
 			};
 		}
 	}
+
+	/**
+	 * Resets the S2 singlecast encryption state (SPAN) for the given node, which forces
+	 * a re-synchronization on the next communication attempt.
+	 */
+	public resetSPAN(nodeId: number): void {
+		this.getSecurityManager2(nodeId)?.deleteNonce(nodeId);
+	}
+
+	/**
+	 * Resets the S2 singlecast encryption state (SPAN) for all nodes, which forces
+	 * a re-synchronization on the next communication attempt.
+	 */
+	public resetAllSPANs(): void {
+		for (const nodeId of this.controller.nodes.keys()) {
+			this.resetSPAN(nodeId);
+		}
+	}
 }


### PR DESCRIPTION
This can be used to help Zniffer decode encrypted traffic.

fixes: #7104

/cc @robertsLando this would be good to have in the UI