### PR TITLE
fix(config): remove endpoint workaround for Zooz ZEN30, FW 3.20+

### DIFF
--- a/packages/config/config/devices/0x027a/zen30.json
+++ b/packages/config/config/devices/0x027a/zen30.json
@@ -316,8 +316,8 @@
 		{
 			// This device exposes a Multilevel Switch (Dimmer) on endpoint 0, and a Binary Switch (Relay) on endpoint 1
 			// Our heuristic currently detects endpoint 1 as unnecessary and hides it from the user.
-			// This problem is fixed in the 800 series version of the device (firmwareVersion >= 4.0)
-			"$if": "firmwareVersion < 4.0",
+			// This problem is fixed in firmare 3.20 and higher
+			"$if": "firmwareVersion < 3.20",
 			"preserveEndpoints": "*",
 			"preserveRootApplicationCCValueIDs": true
 		}


### PR DESCRIPTION
According to Zooz, this issue is also fixed in FW 3.20