### PR TITLE
fix(config): add alarm mapping for Schlage lock CKPD FE599

### DIFF
--- a/packages/config/config/devices/0x003b/fe599nx.json
+++ b/packages/config/config/devices/0x003b/fe599nx.json
@@ -92,5 +92,18 @@
 			"defaultValue": 255,
 			"unsigned": true
 		}
-	]
+	],
+	"compat": {
+		"alarmMapping": [
+			{
+				"$import": "templates/schlage_template.json#alarm_map_keymap_disabled"
+			},
+			{
+				"$import": "templates/schlage_template.json#alarm_map_keypad_busy"
+			},
+			{
+				"$import": "templates/schlage_template.json#alarm_map_keypad_unlock"
+			}
+		]
+	}
 }

--- a/packages/config/config/devices/0x003b/templates/schlage_template.json
+++ b/packages/config/config/devices/0x003b/templates/schlage_template.json
@@ -1,0 +1,34 @@
+{
+	"alarm_map_keymap_disabled": {
+		"from": {
+			"alarmType": 96,
+			"alarmLevel": 255
+		},
+		"to": {
+			"notificationType": 6, // Access Control
+			"notificationEvent": 16 // Keypad temporary disabled
+		}
+	},
+	"alarm_map_keypad_busy": {
+		"from": {
+			"alarmType": 144,
+			"alarmLevel": 255
+		},
+		"to": {
+			"notificationType": 6, // Access Control
+			"notificationEvent": 17 // Keypad busy
+		}
+	},
+	"alarm_map_keypad_unlock": {
+		"from": {
+			"alarmType": 16
+		},
+		"to": {
+			"notificationType": 6, // Access Control
+			"notificationEvent": 6, // Keypad unlock operation
+			"eventParameters": {
+				"userId": "alarmLevel"
+			}
+		}
+	}
+}


### PR DESCRIPTION
Added alarm mapping for the Schlage lock FE549 because it was not reporting any notifications. 
Maybe some other Schlage locks need the same mapping but I'm not sure of which ones.
