### PR TITLE
fix(config): typo product ID

### DIFF
--- a/packages/config/config/devices/0x0010/tz45.json
+++ b/packages/config/config/devices/0x0010/tz45.json
@@ -10,7 +10,7 @@
 		},
 		{
 			"productType": "0x0001",
-			"productId": "0x000b"
+			"productId": "0x000d"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

Updated the product ID to match boards in my  environment.
