### PR TITLE
feat(config): add LED indication parameter for Inovelli NZW31 dimmer

### DIFF
--- a/packages/config/config/devices/0x0312/nzw31.json
+++ b/packages/config/config/devices/0x0312/nzw31.json
@@ -33,6 +33,10 @@
 			"defaultValue": 1
 		},
 		{
+			"#": "3",
+			"$import": "~/templates/master_template.json#led_indicator_four_options"
+		},
+		{
 			"#": "4",
 			"$import": "~/templates/master_template.json#orientation"
 		},


### PR DESCRIPTION
This setting is documented and the nzw30.json includes it.  I cut and pasted what was there to here.

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->
