### PR TITLE
fix: do not deep-clone old log config in `updateOptions`

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1093,12 +1093,14 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks>
 		]);
 
 		// Create a new deep-merged copy of the options so we can check them for validity
-		// without affecting our own options
+		// without affecting our own options. logConfig is potentially unsafe to clone, so just preserve it.
+		const { logConfig, ...rest } = this._options;
 		const newOptions = mergeDeep(
-			cloneDeep(this._options),
+			cloneDeep(rest),
 			safeOptions,
 			true,
 		) as ZWaveOptions;
+		newOptions.logConfig = logConfig;
 		checkOptions(newOptions);
 
 		if (options.userAgent && !isObject(options.userAgent)) {


### PR DESCRIPTION
This PR fixes an issue where passing a custom log transport to `updateOptions` would cause a call stack overflow.