### PR TITLE
fix(config): correct max. value of SKU parameters for Kwikset locks

### DIFF
--- a/packages/config/config/devices/0x0090/templates/kwikset_template.json
+++ b/packages/config/config/devices/0x0090/templates/kwikset_template.json
@@ -229,7 +229,8 @@
 		"minValue": 0,
 		"maxValue": 4294967295,
 		"defaultValue": 0,
-		"unsigned": true
+		"unsigned": true,
+		"readOnly": true
 	},
 	"dipswitch_sku_lastfour": {
 		"label": "SKU Number (Last 4 Bytes)",
@@ -237,7 +238,8 @@
 		"minValue": 0,
 		"maxValue": 4294967295,
 		"defaultValue": 0,
-		"unsigned": true
+		"unsigned": true,
+		"readOnly": true
 	},
 	"reset": {
 		"label": "Reset to Default",

--- a/packages/config/config/devices/0x0090/templates/kwikset_template.json
+++ b/packages/config/config/devices/0x0090/templates/kwikset_template.json
@@ -227,7 +227,7 @@
 		"label": "SKU Number (First 4 Bytes)",
 		"valueSize": 4,
 		"minValue": 0,
-		"maxValue": 0,
+		"maxValue": 4294967295,
 		"defaultValue": 0,
 		"unsigned": true
 	},
@@ -235,7 +235,7 @@
 		"label": "SKU Number (Last 4 Bytes)",
 		"valueSize": 4,
 		"minValue": 0,
-		"maxValue": 0,
+		"maxValue": 4294967295,
 		"defaultValue": 0,
 		"unsigned": true
 	},


### PR DESCRIPTION
Without this, when using ZWave-JS-UI, openHAB is complaining that the value my locks are reporting is not in range 0 to 0.