### PR TITLE
fix(config): update Zooz devices

### DIFF
--- a/packages/config/config/devices/0x027a/zen14.json
+++ b/packages/config/config/devices/0x027a/zen14.json
@@ -1,8 +1,9 @@
+// 800 series (LR) starting with firmware 2.0
 {
 	"manufacturer": "Zooz",
 	"manufacturerId": "0x027a",
 	"label": "ZEN14",
-	"description": "700 Series Outdoor Double Plug",
+	"description": "Outdoor Double Plug",
 	"devices": [
 		{
 			"productType": "0x7000",

--- a/packages/config/config/devices/0x027a/zen30.json
+++ b/packages/config/config/devices/0x027a/zen30.json
@@ -14,14 +14,8 @@
 {
 	"manufacturer": "Zooz",
 	"manufacturerId": "0x027a",
-	"label": [
-		{
-			"$if": "firmwareVersion >= 4.10",
-			"value": "ZEN30 800LR"
-		},
-		"ZEN30"
-	],
-	"description": "Dimmer & Dry Contact Relay",
+	"label": "ZEN30",
+	"description": "Double Switch",
 	"devices": [
 		{
 			"productType": "0xa000",
@@ -316,7 +310,7 @@
 		{
 			// This device exposes a Multilevel Switch (Dimmer) on endpoint 0, and a Binary Switch (Relay) on endpoint 1
 			// Our heuristic currently detects endpoint 1 as unnecessary and hides it from the user.
-			// This problem is fixed in firmare 3.20 and higher
+			// This problem is fixed in firmware 3.20 and higher
 			"$if": "firmwareVersion < 3.20",
 			"preserveEndpoints": "*",
 			"preserveRootApplicationCCValueIDs": true

--- a/packages/config/config/devices/0x027a/zen32.json
+++ b/packages/config/config/devices/0x027a/zen32.json
@@ -12,13 +12,7 @@
 {
 	"manufacturer": "Zooz",
 	"manufacturerId": "0x027a",
-	"label": [
-		{
-			"$if": "firmwareVersion >= 2.10 && firmwareVersion < 10.0",
-			"value": "ZEN32 800LR"
-		},
-		"ZEN32"
-	],
+	"label": "ZEN32",
 	"description": "Scene Controller",
 	"devices": [
 		{

--- a/packages/config/config/devices/0x027a/zen34.json
+++ b/packages/config/config/devices/0x027a/zen34.json
@@ -1,8 +1,9 @@
+// 800 series (LR) starting with firmware 2.0
 {
 	"manufacturer": "Zooz",
 	"manufacturerId": "0x027a",
 	"label": "ZEN34",
-	"description": "Z-Wave Plus 700 Series Remote Switch",
+	"description": "Remote Switch",
 	"devices": [
 		{
 			"productType": "0x0004",

--- a/packages/config/config/devices/0x027a/zen51.json
+++ b/packages/config/config/devices/0x027a/zen51.json
@@ -1,14 +1,8 @@
 {
 	"manufacturer": "Zooz",
 	"manufacturerId": "0x027a",
-	"label": [
-		{
-			"$if": "productType === 0x0904",
-			"value": "ZEN51 LR"
-		},
-		"ZEN51"
-	],
-	"description": "700 Series Dry Contact Relay",
+	"label": "ZEN51",
+	"description": "Dry Contact Relay",
 	"devices": [
 		{
 			// Regular Z-Wave version:
@@ -17,7 +11,7 @@
 			"zwaveAllianceId": 4610
 		},
 		{
-			// Long Range capable version:
+			// Long Range capable version (firmware 1.50+):
 			"productType": "0x0904",
 			"productId": "0x0201"
 		}

--- a/packages/config/config/devices/0x027a/zen52.json
+++ b/packages/config/config/devices/0x027a/zen52.json
@@ -1,14 +1,8 @@
 {
 	"manufacturer": "Zooz",
 	"manufacturerId": "0x027a",
-	"label": [
-		{
-			"$if": "productType === 0x0904",
-			"value": "ZEN52 LR"
-		},
-		"ZEN52"
-	],
-	"description": "700 Series Double Relay",
+	"label": "ZEN52",
+	"description": "Double Relay",
 	"devices": [
 		{
 			// Regular Z-Wave version:
@@ -17,7 +11,7 @@
 			"zwaveAllianceId": 4609
 		},
 		{
-			// Long Range capable version:
+			// Long Range capable version (firmware 1.50+):
 			"productType": "0x0904",
 			"productId": "0x0202"
 		}

--- a/packages/config/config/devices/0x027a/zen71.json
+++ b/packages/config/config/devices/0x027a/zen71.json
@@ -12,14 +12,8 @@
 {
 	"manufacturer": "Zooz",
 	"manufacturerId": "0x027a",
-	"label": [
-		{
-			"$if": "firmwareVersion >= 3.10 && firmwareVersion < 10.0",
-			"value": "ZEN71 800LR"
-		},
-		"ZEN71"
-	],
-	"description": "ON/OFF Switch",
+	"label": "ZEN71",
+	"description": "On/Off Switch",
 	"devices": [
 		{
 			"productType": "0x7000",

--- a/packages/config/config/devices/0x027a/zen72.json
+++ b/packages/config/config/devices/0x027a/zen72.json
@@ -11,14 +11,8 @@
 {
 	"manufacturer": "Zooz",
 	"manufacturerId": "0x027a",
-	"label": [
-		{
-			"$if": "firmwareVersion >= 3.10 && firmwareVersion < 10.0",
-			"value": "ZEN72 800LR"
-		},
-		"ZEN72"
-	],
-	"description": "Dimmer Switch",
+	"label": "ZEN72",
+	"description": "Dimmer",
 	"devices": [
 		{
 			"productType": "0x7000",

--- a/packages/config/config/devices/0x027a/zen73.json
+++ b/packages/config/config/devices/0x027a/zen73.json
@@ -1,8 +1,9 @@
+// 800 series (LR) starting with firmware 2.10
 {
 	"manufacturer": "Zooz",
 	"manufacturerId": "0x027a",
 	"label": "ZEN73",
-	"description": "700 Toggle Switch",
+	"description": "Toggle Switch",
 	"devices": [
 		{
 			"productType": "0x7000",

--- a/packages/config/config/devices/0x027a/zen74.json
+++ b/packages/config/config/devices/0x027a/zen74.json
@@ -1,8 +1,9 @@
+// 800 series (LR) starting with firmware 2.10
 {
 	"manufacturer": "Zooz",
 	"manufacturerId": "0x027a",
 	"label": "ZEN74",
-	"description": "700 Toggle Dimmer",
+	"description": "Toggle Dimmer",
 	"devices": [
 		{
 			"productType": "0x7000",

--- a/packages/config/config/devices/0x027a/zen76.json
+++ b/packages/config/config/devices/0x027a/zen76.json
@@ -8,14 +8,8 @@
 {
 	"manufacturer": "Zooz",
 	"manufacturerId": "0x027a",
-	"label": [
-		{
-			"$if": "firmwareVersion >= 3.10 && firmwareVersion < 10.0",
-			"value": "ZEN76 800LR"
-		},
-		"ZEN76"
-	],
-	"description": "S2 ON/OFF Switch",
+	"label": "ZEN76",
+	"description": "S2 On/Off Switch",
 	"devices": [
 		{
 			"productType": "0x7000",

--- a/packages/config/config/devices/0x027a/zen77.json
+++ b/packages/config/config/devices/0x027a/zen77.json
@@ -14,14 +14,8 @@
 {
 	"manufacturer": "Zooz",
 	"manufacturerId": "0x027a",
-	"label": [
-		{
-			"$if": "firmwareVersion >= 4.10 && firmwareVersion < 10.0",
-			"value": "ZEN77 800LR"
-		},
-		"ZEN77"
-	],
-	"description": "S2 Dimmer Switch",
+	"label": "ZEN77",
+	"description": "S2 Dimmer",
 	"devices": [
 		{
 			"productType": "0x7000",

--- a/packages/config/config/devices/0x027a/zse11.json
+++ b/packages/config/config/devices/0x027a/zse11.json
@@ -1,3 +1,4 @@
+// 800 series (LR) starting with firmware 2.0
 {
 	"manufacturer": "Zooz",
 	"manufacturerId": "0x027a",
@@ -133,16 +134,20 @@
 			]
 		}
 	],
-	"compat": {
-		"commandClasses": {
-			"remove": {
-				// The wakeup destination cannot be set using Supervision, resulting in missing wakeup reports
-				"Supervision": {
-					"endpoints": "*"
+	"compat": [
+		{
+			// On the 500 series version of this device, the wakeup destination
+			// cannot be set using Supervision, resulting in missing wakeup reports
+			"$if": "firmwareVersion < 2.0",
+			"commandClasses": {
+				"remove": {
+					"Supervision": {
+						"endpoints": "*"
+					}
 				}
 			}
 		}
-	},
+	],
 	"metadata": {
 		"inclusion": "Put your Z-Wave hub into inclusion mode and click the Z-Wave button 3 times as quickly as possible. The LED indicator will start blinking to confirm inclusion mode and turn off once inclusion is completed. The sensor will automatically pair as a repeater if connected to USB power, no special button sequence required",
 		"exclusion": "1. Bring the sensor within direct range of your Z-Wave gateway (hub).\n2. Put the Z-Wave hub into exclusion mode (not sure how to do that? ask@getzooz.com).\n3. Press and release the Z-Wave button 3 times quickly.\n4. Your hub will confirm exclusion and the sensor will disappear from your controller's device list",

--- a/packages/config/config/devices/0x027a/zse18.json
+++ b/packages/config/config/devices/0x027a/zse18.json
@@ -1,8 +1,9 @@
+// 800 series (LR) starting with firmware 2.0
 {
 	"manufacturer": "Zooz",
 	"manufacturerId": "0x027a",
 	"label": "ZSE18",
-	"description": "Motion and Vibration Sensor",
+	"description": "Motion Sensor",
 	"devices": [
 		{
 			"productType": "0x0301",


### PR DESCRIPTION
This PR removes the distinction between 500/700/800/LR in the device labels and/or description. According to Zooz this caused more confusion than it helped.

Supervision CC is no longer disabled for the 800 series version of ZSE11, as it supports the CC properly now.