### PR TITLE
fix(config): update Z-Wave SDK warnings to mention fixed versions

### DIFF
--- a/packages/config/config/devices/0x0000/700_800_series_controller.json
+++ b/packages/config/config/devices/0x0000/700_800_series_controller.json
@@ -22,12 +22,14 @@
 				"$import": "~/templates/master_template.json#7xx_firmware_bug_pre_7_17_2"
 			},
 			{
-				"$if": "firmwareVersion === 7.19.1",
-				"$import": "~/templates/master_template.json#7xx_firmware_bug_7_19_1"
+				// Not sure if this is a 700 or 800 series controller. Show the generic warning
+				"$if": "firmwareVersion >= 7.19.1 && firmwareVersion <= 7.21.3",
+				"$import": "~/templates/master_template.json#7xx_8xx_firmware_bug_7_19_to_7_21_3_or_7_22_1"
 			},
 			{
-				"$if": "firmwareVersion === 7.19.3",
-				"$import": "~/templates/master_template.json#7xx_firmware_bug_7_19_3"
+				// 7.22.x is limited to 800 series
+				"$if": "firmwareVersion === 7.22.0",
+				"$import": "~/templates/master_template.json#8xx_firmware_bug_pre_7_22_1"
 			}
 		]
 	}

--- a/packages/config/config/devices/0x027a/zac93.json
+++ b/packages/config/config/devices/0x027a/zac93.json
@@ -17,13 +17,10 @@
 		// 700/800 series firmware bugs that affect multiple controllers
 		"comments": [
 			// https://www.support.getzooz.com/kb/article/1158-zooz-ota-firmware-files/
-			// These controllers started shipping with 7.18.1:
-			// 1.1 = 7.18.1
-			// (1.3 = 1.4 = 1.10) = 7.18.3
-			// 1.20 = 7.19.3
+			// 1.40 = SDK 7.22.0. No fixed version available yet.
 			{
-				"$if": "firmwareVersion === 1.20",
-				"$import": "~/templates/master_template.json#7xx_firmware_bug_7_19_3"
+				"$if": "firmwareVersion <= 1.40",
+				"$import": "~/templates/master_template.json#8xx_firmware_bug_pre_7_22_1"
 			}
 		]
 	}

--- a/packages/config/config/devices/0x027a/zst10_700.json
+++ b/packages/config/config/devices/0x027a/zst10_700.json
@@ -21,12 +21,8 @@
 				"$import": "~/templates/master_template.json#7xx_firmware_bug_pre_7_17_2"
 			},
 			{
-				"$if": "firmwareVersion === 7.19.1",
-				"$import": "~/templates/master_template.json#7xx_firmware_bug_7_19_1"
-			},
-			{
-				"$if": "firmwareVersion === 7.19.3",
-				"$import": "~/templates/master_template.json#7xx_firmware_bug_7_19_3"
+				"$if": "firmwareVersion >= 7.19.1 && firmwareVersion <= 7.21.3",
+				"$import": "~/templates/master_template.json#7xx_firmware_bug_7_19_to_7_21_3"
 			}
 		]
 	}

--- a/packages/config/config/devices/0x027a/zst39lr.json
+++ b/packages/config/config/devices/0x027a/zst39lr.json
@@ -17,13 +17,10 @@
 		// 700/800 series firmware bugs that affect multiple controllers
 		"comments": [
 			// https://www.support.getzooz.com/kb/article/1352-zst39-800-long-range-z-wave-stick-change-log/
-			// These controllers started shipping with 7.18.1:
-			// 1.1 = 7.18.1
-			// (1.3 = 1.4 = 1.10) = 7.18.3
-			// 1.20 = 7.19.3
+			// 1.50 = SDK 7.22.1
 			{
-				"$if": "firmwareVersion === 1.20",
-				"$import": "~/templates/master_template.json#7xx_firmware_bug_7_19_3"
+				"$if": "firmwareVersion < 1.50",
+				"$import": "~/templates/master_template.json#8xx_firmware_bug_pre_7_22_1"
 			}
 		]
 	}

--- a/packages/config/config/devices/templates/master_template.json
+++ b/packages/config/config/devices/templates/master_template.json
@@ -661,14 +661,19 @@
 		"level": "warning",
 		"text": "Early 700 series firmware revisions had a bug that could cause the mesh to be flooded on some networks and the controller to become unresponsive. It appears that this bug is largely, if not completely, resolved as of SDK version 7.17.2.\nDirections for upgrading the firmware can be found at https://zwave-js.github.io/node-zwave-js/#/troubleshooting/otw-upgrade"
 	},
-	"7xx_firmware_bug_7_19_1": {
+	"7xx_firmware_bug_7_19_to_7_21_3": {
 		"level": "warning",
-		"text": "Controller firmwares based on Z-Wave SDK 7.19.1 have a bug that causes the controller to randomly restart. It is strongly recommended to update to a firmware based on version 7.19.2, but not later since those firmwares have another bug causing the controller to become unresponsive."
+		"text": "700 series controller firmwares based on Z-Wave SDKs 7.19 through 7.21.3 are plagued by a variety of bugs causing instability of the controller and/or the mesh. It is strongly recommended to update to a firmware based on version 7.21.4 or later."
 	},
-	"7xx_firmware_bug_7_19_3": {
+	"8xx_firmware_bug_pre_7_22_1": {
 		"level": "warning",
-		"text": "Controller firmwares based on Z-Wave SDK 7.19.3 have a bug that causes the controller to randomly hang during transmission until it is restarted. It is currently unclear if this bug is fixed in a later firmware version."
+		"text": "800 series controller firmwares based on Z-Wave SDKs before 7.22.1 are plagued by a variety of bugs causing instability of the controller and/or the mesh. It is strongly recommended to update to a firmware based on version 7.22.1 or later."
 	},
+	"7xx_8xx_firmware_bug_7_19_to_7_21_3_or_7_22_1": {
+		"level": "warning",
+		"text": "Controller firmwares based on Z-Wave SDKs 7.19 through 7.21.3 (700 series) or 7.22.0 (800 series) are plagued by a variety of bugs causing instability of the controller and/or the mesh. For 700 series controllers, it is strongly recommended to update to a firmware based on version 7.21.4 or later. For 800 series controllers, it is strongly recommended to update to a firmware based on version 7.22.1 or later."
+	},
+
 	"500_series_controller_compat_flags": {
 		// It seems that all 500 series controllers have a firmware bug:
 


### PR DESCRIPTION
We now recommend firmware versions 7.21.4 or later (700 series) and 7.22.1 or later (800 series). This PR updates the warnings accordingly.