### PR TITLE
feat(config): add fingerprint to Remotec ZXT-800.json

### DIFF
--- a/packages/config/config/devices/0x5254/zxt-800.json
+++ b/packages/config/config/devices/0x5254/zxt-800.json
@@ -8,6 +8,11 @@
 			"productType": "0x0004",
 			"productId": "0x8492",
 			"zwaveAllianceId": 4788
+		},
+		{
+			"productType": "0x0100",
+			"productId": "0x8493",
+			"zwaveAllianceId": 4788
 		}
 	],
 	"firmwareVersion": {

--- a/packages/config/config/devices/0x5254/zxt-800.json
+++ b/packages/config/config/devices/0x5254/zxt-800.json
@@ -6,8 +6,7 @@
 	"devices": [
 		{
 			"productType": "0x0004",
-			"productId": "0x8492",
-			"zwaveAllianceId": 4788
+			"productId": "0x8492"
 		},
 		{
 			"productType": "0x0100",


### PR DESCRIPTION
The ZXT-800 device configuration already exists. This PR adds an additional device to the `devices` array.

I pulled the `productType` and `productId` from https://products.z-wavealliance.org/products/4788 and confirmed via the "Download Diagnostics" button in Home Assistant.