### PR TITLE
feat: add `node info received` event

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -1581,3 +1581,11 @@ interface RouteStatistics {
 	routeFailedBetween?: [number, number];
 }
 ```
+
+### `"node info received"`
+
+The node has sent a node information frame (NIF) Z-Wave JS did not expect. This can be caused by the user pushing a button on the device. Some older devices also send a NIF to notify the controller that their status has changed. The callback only references the node itself:
+
+```ts
+(node: ZWaveNode) => void
+```

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -2621,6 +2621,8 @@ export class ZWaveController
 				// Resolve active pings that would fail otherwise
 				this.driver.resolvePendingPings(node.id);
 
+				node.emit("node info received", node);
+
 				if (
 					node.canSleep
 					&& node.supportsCC(CommandClasses["Wake Up"])

--- a/packages/zwave-js/src/lib/node/_Types.ts
+++ b/packages/zwave-js/src/lib/node/_Types.ts
@@ -209,6 +209,7 @@ export interface ZWaveNodeEventCallbacks extends ZWaveNodeValueEventCallbacks {
 	ready: (node: ZWaveNode) => void;
 	"interview stage completed": (node: ZWaveNode, stageName: string) => void;
 	"interview started": (node: ZWaveNode) => void;
+	"node info received": (node: ZWaveNode) => void;
 }
 
 export type ZWaveNodeEvents = Extract<keyof ZWaveNodeEventCallbacks, string>;


### PR DESCRIPTION
This PR adds the new `node info received` event to signal to applications that a node has unexpectedly sent a NIF. This can be used to automate value refreshes on some older devices.

fixes: #6867