### PR TITLE
feat: add Thermostat Setback mocks, fix state encoding, remove CC values

### DIFF
--- a/packages/cc/src/cc/index.ts
+++ b/packages/cc/src/cc/index.ts
@@ -472,6 +472,7 @@ export type {
 	MultilevelSwitchCCReportOptions,
 	MultilevelSwitchCCSetOptions,
 	MultilevelSwitchCCStartLevelChangeOptions,
+	MultilevelSwitchCCSupportedReportOptions,
 } from "./MultilevelSwitchCC";
 export {
 	MultilevelSwitchCC,
@@ -735,13 +736,15 @@ export {
 	ThermostatOperatingStateCCReport,
 	ThermostatOperatingStateCCValues,
 } from "./ThermostatOperatingStateCC";
-export type { ThermostatSetbackCCSetOptions } from "./ThermostatSetbackCC";
+export type {
+	ThermostatSetbackCCReportOptions,
+	ThermostatSetbackCCSetOptions,
+} from "./ThermostatSetbackCC";
 export {
 	ThermostatSetbackCC,
 	ThermostatSetbackCCGet,
 	ThermostatSetbackCCReport,
 	ThermostatSetbackCCSet,
-	ThermostatSetbackCCValues,
 } from "./ThermostatSetbackCC";
 export type {
 	ThermostatSetpointCCCapabilitiesGetOptions,

--- a/packages/cc/src/lib/Values.ts
+++ b/packages/cc/src/lib/Values.ts
@@ -643,8 +643,6 @@ export interface CCValues {
 		typeof import("../cc/ThermostatModeCC").ThermostatModeCCValues;
 	"Thermostat Operating State":
 		typeof import("../cc/ThermostatOperatingStateCC").ThermostatOperatingStateCCValues;
-	"Thermostat Setback":
-		typeof import("../cc/ThermostatSetbackCC").ThermostatSetbackCCValues;
 	"Thermostat Setpoint":
 		typeof import("../cc/ThermostatSetpointCC").ThermostatSetpointCCValues;
 	"Time Parameters":

--- a/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
+++ b/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
@@ -35,6 +35,7 @@ import { NotificationCCBehaviors } from "./mockCCBehaviors/Notification";
 import { ScheduleEntryLockCCBehaviors } from "./mockCCBehaviors/ScheduleEntryLock";
 import { SoundSwitchCCBehaviors } from "./mockCCBehaviors/SoundSwitch";
 import { ThermostatModeCCBehaviors } from "./mockCCBehaviors/ThermostatMode";
+import { ThermostatSetbackCCBehaviors } from "./mockCCBehaviors/ThermostatSetback";
 import { ThermostatSetpointCCBehaviors } from "./mockCCBehaviors/ThermostatSetpoint";
 import { UserCodeCCBehaviors } from "./mockCCBehaviors/UserCode";
 import { WindowCoveringCCBehaviors } from "./mockCCBehaviors/WindowCovering";
@@ -193,6 +194,7 @@ export function createDefaultBehaviors(): MockNodeBehavior[] {
 		...SoundSwitchCCBehaviors,
 		...ThermostatModeCCBehaviors,
 		...ThermostatSetpointCCBehaviors,
+		...ThermostatSetbackCCBehaviors,
 		...UserCodeCCBehaviors,
 		...WindowCoveringCCBehaviors,
 	];

--- a/packages/zwave-js/src/lib/node/mockCCBehaviors/ThermostatSetback.ts
+++ b/packages/zwave-js/src/lib/node/mockCCBehaviors/ThermostatSetback.ts
@@ -1,0 +1,50 @@
+import { type SetbackState, SetbackType } from "@zwave-js/cc";
+import {
+	ThermostatSetbackCCGet,
+	ThermostatSetbackCCReport,
+	ThermostatSetbackCCSet,
+} from "@zwave-js/cc/ThermostatSetbackCC";
+import { type MockNodeBehavior } from "@zwave-js/testing";
+
+const STATE_KEY_PREFIX = "ThermostatSetback_";
+const StateKeys = {
+	setbackType: `${STATE_KEY_PREFIX}setbackType`,
+	setbackState: `${STATE_KEY_PREFIX}setbackState`,
+} as const;
+
+const respondToThermostatSetbackSet: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		if (receivedCC instanceof ThermostatSetbackCCSet) {
+			self.state.set(StateKeys.setbackType, receivedCC.setbackType);
+			self.state.set(StateKeys.setbackState, receivedCC.setbackState);
+			return { action: "ok" };
+		}
+	},
+};
+
+const respondToThermostatSetbackGet: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		if (receivedCC instanceof ThermostatSetbackCCGet) {
+			const setbackType = (
+				self.state.get(StateKeys.setbackType)
+					?? SetbackType.None
+			) as SetbackType;
+			const setbackState = (
+				self.state.get(StateKeys.setbackState)
+					?? "Unused"
+			) as SetbackState;
+
+			const cc = new ThermostatSetbackCCReport(self.host, {
+				nodeId: controller.host.ownNodeId,
+				setbackType,
+				setbackState,
+			});
+			return { action: "sendCC", cc };
+		}
+	},
+};
+
+export const ThermostatSetbackCCBehaviors = [
+	respondToThermostatSetbackGet,
+	respondToThermostatSetbackSet,
+];


### PR DESCRIPTION
While implementing the mocks for Thermostat Setback CC, I noticed that the CC values don't really make sense. They cannot be used to set the setback type or state, they don't have useful states, and the setback state does not expose the special values. So they are now removed.