### PR TITLE
feat: implement playing tones in Sound Switch CC mocks, parse more switch-type dumps

### DIFF
--- a/packages/cc/src/cc/SoundSwitchCC.ts
+++ b/packages/cc/src/cc/SoundSwitchCC.ts
@@ -89,7 +89,7 @@ export const SoundSwitchCCValues = Object.freeze({
 			"defaultToneId",
 			{
 				...ValueMetadata.Number,
-				min: 0,
+				min: 1,
 				max: 254,
 				label: "Default tone ID",
 			} as const,
@@ -632,11 +632,9 @@ export class SoundSwitchCCConfigurationSet extends SoundSwitchCC {
 	) {
 		super(host, options);
 		if (gotDeserializationOptions(options)) {
-			// TODO: Deserialize payload
-			throw new ZWaveError(
-				`${this.constructor.name}: deserialization not implemented`,
-				ZWaveErrorCodes.Deserialization_NotImplemented,
-			);
+			validatePayload(this.payload.length >= 2);
+			this.defaultVolume = this.payload[0];
+			this.defaultToneId = this.payload[1];
 		} else {
 			this.defaultVolume = options.defaultVolume;
 			this.defaultToneId = options.defaultToneId;
@@ -663,9 +661,7 @@ export class SoundSwitchCCConfigurationSet extends SoundSwitchCC {
 }
 
 // @publicAPI
-export interface SoundSwitchCCConfigurationReportOptions
-	extends CCCommandOptions
-{
+export interface SoundSwitchCCConfigurationReportOptions {
 	defaultVolume: number;
 	defaultToneId: number;
 }
@@ -676,7 +672,7 @@ export class SoundSwitchCCConfigurationReport extends SoundSwitchCC {
 		host: ZWaveHost,
 		options:
 			| CommandClassDeserializationOptions
-			| SoundSwitchCCConfigurationReportOptions,
+			| (CCCommandOptions & SoundSwitchCCConfigurationReportOptions),
 	) {
 		super(host, options);
 		if (gotDeserializationOptions(options)) {
@@ -716,7 +712,7 @@ export class SoundSwitchCCConfigurationReport extends SoundSwitchCC {
 export class SoundSwitchCCConfigurationGet extends SoundSwitchCC {}
 
 // @publicAPI
-export interface SoundSwitchCCTonePlaySetOptions extends CCCommandOptions {
+export interface SoundSwitchCCTonePlaySetOptions {
 	toneId: ToneId | number;
 	// V2+
 	volume?: number;
@@ -729,15 +725,15 @@ export class SoundSwitchCCTonePlaySet extends SoundSwitchCC {
 		host: ZWaveHost,
 		options:
 			| CommandClassDeserializationOptions
-			| SoundSwitchCCTonePlaySetOptions,
+			| (CCCommandOptions & SoundSwitchCCTonePlaySetOptions),
 	) {
 		super(host, options);
 		if (gotDeserializationOptions(options)) {
-			// TODO: Deserialize payload
-			throw new ZWaveError(
-				`${this.constructor.name}: deserialization not implemented`,
-				ZWaveErrorCodes.Deserialization_NotImplemented,
-			);
+			validatePayload(this.payload.length >= 1);
+			this.toneId = this.payload[0];
+			if (this.toneId !== 0 && this.payload.length >= 2) {
+				this.volume = this.payload[1];
+			}
 		} else {
 			this.toneId = options.toneId;
 			this.volume = options.volume;
@@ -766,17 +762,31 @@ export class SoundSwitchCCTonePlaySet extends SoundSwitchCC {
 	}
 }
 
+// @publicAPI
+export interface SoundSwitchCCTonePlayReportOptions {
+	toneId: ToneId | number;
+	// V2+
+	volume?: number;
+}
+
 @CCCommand(SoundSwitchCommand.TonePlayReport)
 export class SoundSwitchCCTonePlayReport extends SoundSwitchCC {
 	public constructor(
 		host: ZWaveHost,
-		options: CommandClassDeserializationOptions,
+		options:
+			| CommandClassDeserializationOptions
+			| (CCCommandOptions & SoundSwitchCCTonePlayReportOptions),
 	) {
 		super(host, options);
-		validatePayload(this.payload.length >= 1);
-		this.toneId = this.payload[0];
-		if (this.toneId !== 0 && this.payload.length >= 2) {
-			this.volume = this.payload[1];
+		if (gotDeserializationOptions(options)) {
+			validatePayload(this.payload.length >= 1);
+			this.toneId = this.payload[0];
+			if (this.toneId !== 0 && this.payload.length >= 2) {
+				this.volume = this.payload[1];
+			}
+		} else {
+			this.toneId = options.toneId;
+			this.volume = options.volume;
 		}
 	}
 
@@ -785,6 +795,11 @@ export class SoundSwitchCCTonePlayReport extends SoundSwitchCC {
 
 	@ccValue(SoundSwitchCCValues.volume)
 	public volume?: number;
+
+	public serialize(): Buffer {
+		this.payload = Buffer.from([this.toneId, this.volume ?? 0]);
+		return super.serialize();
+	}
 
 	public toLogEntry(host?: ZWaveValueHost): MessageOrCCLogEntry {
 		const message: MessageRecord = {

--- a/packages/cc/src/cc/index.ts
+++ b/packages/cc/src/cc/index.ts
@@ -673,6 +673,7 @@ export type {
 	SoundSwitchCCConfigurationSetOptions,
 	SoundSwitchCCToneInfoGetOptions,
 	SoundSwitchCCToneInfoReportOptions,
+	SoundSwitchCCTonePlayReportOptions,
 	SoundSwitchCCTonePlaySetOptions,
 	SoundSwitchCCTonesNumberReportOptions,
 } from "./SoundSwitchCC";

--- a/packages/testing/src/CCSpecificCapabilities.ts
+++ b/packages/testing/src/CCSpecificCapabilities.ts
@@ -85,7 +85,7 @@ export interface MultilevelSensorCCCapabilities {
 }
 
 export interface MultilevelSwitchCCCapabilities {
-	defaultValue: MaybeUnknown<number>;
+	defaultValue?: MaybeUnknown<number>;
 	primarySwitchType: SwitchType;
 }
 


### PR DESCRIPTION
With this PR, "playing" sounds on mocked sirens is now possible. Also extends the parsing of dump files for Binary/Multilevel Switch capabilities and Sound Switch capabilities.