### PR TITLE
fix: preferred scale not found when set as string

### DIFF
--- a/packages/cc/src/cc/MultilevelSensorCC.ts
+++ b/packages/cc/src/cc/MultilevelSensorCC.ts
@@ -162,7 +162,7 @@ function getPreferredSensorScale(
 	if (typeof preferred === "string") {
 		for (const [key, scale] of Object.entries(sensor.scales)) {
 			if (scale.label === preferred || scale.unit === preferred) {
-				preferred = key;
+				preferred = parseInt(key, 10);
 				break;
 			}
 		}


### PR DESCRIPTION
fixes: https://github.com/zwave-js/node-zwave-js/issues/7285