### PR TITLE
feat(config): add Minoston MP24Z 800LR Outdoor Smart Plug - 2 Outlet

### DIFF
--- a/packages/config/config/devices/0x0312/mp24z_800.json
+++ b/packages/config/config/devices/0x0312/mp24z_800.json
@@ -1,0 +1,51 @@
+{
+	"manufacturer": "Minoston",
+	"manufacturerId": "0x0312",
+	"label": "MP24Z",
+	"description": "Outdoor Smart Plug - 2 Outlet (800S)",
+	"devices": [
+		{
+			"productType": "0xff01",
+			"productId": "0xff97",
+			"zwaveAllianceId": 3719
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+  "paramInformation": [
+		{
+			"#": "1",
+			"$import": "~/templates/master_template.json#led_indicator_three_options_inverted"
+		},
+		{
+			"#": "2",
+			"$import": "templates/minoston_template.json#auto_off_timer",
+			"label": "Outlet 1 (Left): Auto Off Timer"
+		},
+		{
+			"#": "3",
+			"$import": "templates/minoston_template.json#auto_off_timer",
+			"label": "Outlet 2 (Right): Auto Off Timer"
+		},
+		{
+			"#": "4",
+			"$import": "templates/minoston_template.json#auto_on_timer",
+			"label": "Outlet 1 (Left): Auto On Timer"
+		},
+		{
+			"#": "5",
+			"$import": "templates/minoston_template.json#auto_on_timer",
+			"label": "Outlet 2 (Right): Auto On Timer"
+		},
+		{
+			"#": "6",
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
+		},
+    {
+			"#": "7",
+			"$import": "templates/minoston_template.json#led_indicator_brightness"
+    }
+	]
+}

--- a/packages/config/config/devices/0x0312/mp24z_800.json
+++ b/packages/config/config/devices/0x0312/mp24z_800.json
@@ -43,9 +43,9 @@
 			"#": "6",
 			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
 		},
-    {
+		{
 			"#": "7",
 			"$import": "templates/minoston_template.json#led_indicator_brightness"
-    }
+		}
 	]
 }

--- a/packages/config/config/devices/0x0312/mp24z_800.json
+++ b/packages/config/config/devices/0x0312/mp24z_800.json
@@ -14,7 +14,7 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
-  "paramInformation": [
+	"paramInformation": [
 		{
 			"#": "1",
 			"$import": "~/templates/master_template.json#led_indicator_three_options_inverted"


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

PR for Minoston MP24Z 800LR Outdoor Smart Plug - 2 Outlet
[Product Site](https://minoston.com/products/minoston-z-wave-800-series-dual-smart-plug-for-outdoor-and-indoor-mp24z)
[Manual](https://cdn-files.myshopline.com/file/store/1701829637050/MP24Z(800-Series)-Manual-V2-0-2023-12-7.pdf)

