### PR TITLE
fix(config): add include, exclude, and wakeup instructions for VCZ1

### DIFF
--- a/packages/config/config/devices/0x026e/vcz1.json
+++ b/packages/config/config/devices/0x026e/vcz1.json
@@ -15,7 +15,10 @@
 		"max": "255.255"
 	},
 	"metadata": {
-		"reset": "Press and hold the button on the control for approximately 15 seconds (the LED will stop flashing when complete.\n\n\"Please use this procedure only when the network primary controller is missing or otherwise inoperable.\"",
+		"inclusion": "Press and hold the programming button until the LED light bar begins to flash green then release the button.",
+		"exclusion": "Press and hold the programming button until the LED light bar begins to flash green then release the button.",
+		"reset": "Press and hold the programming button until the LEDs stop blinking. LEDs will  blink green, amber, red, and then finally turn off (about 15 seconds). Local Reset must be performed on both the controllers and motors and should only be used if the primary controller is no longer available.",
+		"wakeup": "Press and release the programming button one time.",
 		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/1786/Graber%20Virtual%20Cord%20Owner's%20Manual.pdf"
 	},
 	"compat": {

--- a/packages/config/config/devices/0x026e/vcz1.json
+++ b/packages/config/config/devices/0x026e/vcz1.json
@@ -17,7 +17,7 @@
 	"metadata": {
 		"inclusion": "Press and hold the programming button until the LED light bar begins to flash green then release the button.",
 		"exclusion": "Press and hold the programming button until the LED light bar begins to flash green then release the button.",
-		"reset": "Press and hold the programming button until the LEDs stop blinking. LEDs will  blink green, amber, red, and then finally turn off (about 15 seconds). Local Reset must be performed on both the controllers and motors and should only be used if the primary controller is no longer available.",
+		"reset": "Press and hold the programming button until the LEDs stop blinking. LEDs will blink green, amber, red, and then finally turn off (about 15 seconds). Local Reset must be performed on both the controllers and motors and should only be used if the primary controller is no longer available.",
 		"wakeup": "Press and release the programming button one time.",
 		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/1786/Graber%20Virtual%20Cord%20Owner's%20Manual.pdf"
 	},


### PR DESCRIPTION
In addition to adding these instructions from the manual linked in help, I also modified the reset instructions to more closely match the manual with added verbiage similar to that often used in this project's reset help.