### PR TITLE
feat(mock-server): support add and remove mode

### DIFF
--- a/packages/testing/src/MockControllerCapabilities.ts
+++ b/packages/testing/src/MockControllerCapabilities.ts
@@ -43,6 +43,8 @@ export function getDefaultSupportedFunctionTypes(): FunctionType[] {
 		FunctionType.GetNodeProtocolInfo,
 		FunctionType.RequestNodeInfo,
 		FunctionType.AssignSUCReturnRoute,
+		FunctionType.AddNodeToNetwork,
+		FunctionType.RemoveNodeFromNetwork,
 	];
 }
 

--- a/packages/zwave-js/src/lib/controller/MockControllerState.ts
+++ b/packages/zwave-js/src/lib/controller/MockControllerState.ts
@@ -1,9 +1,16 @@
 export enum MockControllerStateKeys {
 	CommunicationState = "communicationState",
+	InclusionState = "inclusionState",
 }
 
 export enum MockControllerCommunicationState {
 	Idle,
 	Sending,
 	WaitingForNode,
+}
+
+export enum MockControllerInclusionState {
+	Idle,
+	AddingNode,
+	RemovingNode,
 }

--- a/packages/zwave-js/src/lib/serialapi/network-mgmt/RemoveNodeFromNetworkRequest.ts
+++ b/packages/zwave-js/src/lib/serialapi/network-mgmt/RemoveNodeFromNetworkRequest.ts
@@ -1,6 +1,7 @@
 import {
 	type CommandClasses,
 	MessagePriority,
+	encodeNodeID,
 	parseNodeID,
 } from "@zwave-js/core";
 import type { ZWaveHost } from "@zwave-js/host";
@@ -11,6 +12,7 @@ import {
 	type MessageBaseOptions,
 	type MessageDeserializationOptions,
 	type MessageOptions,
+	MessageOrigin,
 	MessageType,
 	expectedCallback,
 	gotDeserializationOptions,
@@ -52,12 +54,24 @@ interface RemoveNodeFromNetworkRequestOptions extends MessageBaseOptions {
 @priority(MessagePriority.Controller)
 export class RemoveNodeFromNetworkRequestBase extends Message {
 	public constructor(host: ZWaveHost, options: MessageOptions) {
-		if (
-			gotDeserializationOptions(options)
-			&& (new.target as any) !== RemoveNodeFromNetworkRequestStatusReport
-		) {
-			return new RemoveNodeFromNetworkRequestStatusReport(host, options);
+		if (gotDeserializationOptions(options)) {
+			if (
+				options.origin === MessageOrigin.Host
+				&& (new.target as any) !== RemoveNodeFromNetworkRequest
+			) {
+				return new RemoveNodeFromNetworkRequest(host, options);
+			} else if (
+				options.origin !== MessageOrigin.Host
+				&& (new.target as any)
+					!== RemoveNodeFromNetworkRequestStatusReport
+			) {
+				return new RemoveNodeFromNetworkRequestStatusReport(
+					host,
+					options,
+				);
+			}
 		}
+
 		super(host, options);
 	}
 }
@@ -95,13 +109,23 @@ export class RemoveNodeFromNetworkRequest
 {
 	public constructor(
 		host: ZWaveHost,
-		options: RemoveNodeFromNetworkRequestOptions = {},
+		options:
+			| MessageDeserializationOptions
+			| RemoveNodeFromNetworkRequestOptions = {},
 	) {
 		super(host, options);
 
-		this.removeNodeType = options.removeNodeType;
-		this.highPower = !!options.highPower;
-		this.networkWide = !!options.networkWide;
+		if (gotDeserializationOptions(options)) {
+			const config = this.payload[0];
+			this.highPower = !!(config & RemoveNodeFlags.HighPower);
+			this.networkWide = !!(config & RemoveNodeFlags.NetworkWide);
+			this.removeNodeType = config & 0b11111;
+			this.callbackId = this.payload[1];
+		} else {
+			this.removeNodeType = options.removeNodeType;
+			this.highPower = !!options.highPower;
+			this.networkWide = !!options.networkWide;
+		}
 	}
 
 	/** The type of node to remove */
@@ -122,38 +146,65 @@ export class RemoveNodeFromNetworkRequest
 	}
 }
 
+export type RemoveNodeFromNetworkRequestStatusReportOptions = {
+	status:
+		| RemoveNodeStatus.Ready
+		| RemoveNodeStatus.NodeFound
+		| RemoveNodeStatus.Failed
+		| RemoveNodeStatus.Done;
+} | {
+	status:
+		| RemoveNodeStatus.RemovingController
+		| RemoveNodeStatus.RemovingSlave;
+	nodeId: number;
+};
+
 export class RemoveNodeFromNetworkRequestStatusReport
 	extends RemoveNodeFromNetworkRequestBase
 	implements SuccessIndicator
 {
 	public constructor(
 		host: ZWaveHost,
-		options: MessageDeserializationOptions,
+		options:
+			| MessageDeserializationOptions
+			| (
+				& RemoveNodeFromNetworkRequestStatusReportOptions
+				& MessageBaseOptions
+			),
 	) {
 		super(host, options);
-		this.callbackId = this.payload[0];
-		this.status = this.payload[1];
-		switch (this.status) {
-			case RemoveNodeStatus.Ready:
-			case RemoveNodeStatus.NodeFound:
-			case RemoveNodeStatus.Failed:
-			case RemoveNodeStatus.Done:
-				// no context for the status to parse
-				// TODO:
-				// An application MUST time out waiting for the REMOVE_NODE_STATUS_REMOVING_SLAVE status
-				// if it does not receive the indication within a 14 sec after receiving the
-				// REMOVE_NODE_STATUS_NODE_FOUND status.
-				break;
 
-			case RemoveNodeStatus.RemovingController:
-			case RemoveNodeStatus.RemovingSlave: {
-				// the payload contains the node ID
-				const { nodeId } = parseNodeID(
-					this.payload.subarray(2),
-					this.host.nodeIdType,
-				);
-				this.statusContext = { nodeId };
-				break;
+		if (gotDeserializationOptions(options)) {
+			this.callbackId = this.payload[0];
+			this.status = this.payload[1];
+			switch (this.status) {
+				case RemoveNodeStatus.Ready:
+				case RemoveNodeStatus.NodeFound:
+				case RemoveNodeStatus.Failed:
+				case RemoveNodeStatus.Done:
+					// no context for the status to parse
+					// TODO:
+					// An application MUST time out waiting for the REMOVE_NODE_STATUS_REMOVING_SLAVE status
+					// if it does not receive the indication within a 14 sec after receiving the
+					// REMOVE_NODE_STATUS_NODE_FOUND status.
+					break;
+
+				case RemoveNodeStatus.RemovingController:
+				case RemoveNodeStatus.RemovingSlave: {
+					// the payload contains the node ID
+					const { nodeId } = parseNodeID(
+						this.payload.subarray(2),
+						this.host.nodeIdType,
+					);
+					this.statusContext = { nodeId };
+					break;
+				}
+			}
+		} else {
+			this.callbackId = options.callbackId;
+			this.status = options.status;
+			if ("nodeId" in options) {
+				this.statusContext = { nodeId: options.nodeId };
 			}
 		}
 	}
@@ -162,6 +213,18 @@ export class RemoveNodeFromNetworkRequestStatusReport
 		// Some of the status codes are for unsolicited callbacks, but
 		// Failed is the only NOK status.
 		return this.status !== RemoveNodeStatus.Failed;
+	}
+
+	public serialize(): Buffer {
+		this.payload = Buffer.from([this.callbackId, this.status]);
+		if (this.statusContext?.nodeId != undefined) {
+			this.payload = Buffer.concat([
+				this.payload,
+				encodeNodeID(this.statusContext.nodeId, this.host.nodeIdType),
+			]);
+		}
+
+		return super.serialize();
 	}
 
 	public readonly status: RemoveNodeStatus;


### PR DESCRIPTION
With this PR, the controller simulated by the mock-server can be put into inclusion and exclusion mode. No nodes will be found, but at least there won't be an error when trying to start those modes.