### PR TITLE
refactor: remove `__dirname` from production code

### DIFF
--- a/packages/config/src/utils.ts
+++ b/packages/config/src/utils.ts
@@ -7,7 +7,10 @@ import { PACKAGE_VERSION } from "./_version";
 import type { DeviceConfigIndexEntry } from "./devices/DeviceConfig";
 
 /** The absolute path of the embedded configuration directory */
-export const configDir = path.resolve(__dirname, "../config");
+export const configDir = path.resolve(
+	path.dirname(require.resolve("@zwave-js/config/package.json")),
+	"config",
+);
 /** The (optional) absolute path of an external configuration directory */
 export function externalConfigDir(): string | undefined {
 	return process.env.ZWAVEJS_EXTERNAL_CONFIG;

--- a/packages/core/src/log/shared.ts
+++ b/packages/core/src/log/shared.ts
@@ -52,12 +52,7 @@ export class ZWaveLogContainer extends winston.Container {
 		maxFiles: 7,
 		nodeFilter: stringToNodeList(process.env.LOG_NODES),
 		transports: undefined as any,
-		filename: require.main
-			? path.join(
-				path.dirname(require.main.filename),
-				`zwavejs_%DATE%.log`,
-			)
-			: path.join(__dirname, "../../..", `zwavejs_%DATE%.log`),
+		filename: path.join(process.cwd(), `zwavejs_%DATE%.log`),
 		forceConsole: false,
 	};
 

--- a/packages/flash/src/cli.ts
+++ b/packages/flash/src/cli.ts
@@ -35,8 +35,8 @@ const driver = new Driver(port, {
 		loadConfiguration: false,
 	},
 	storage: {
-		cacheDir: path.join(__dirname, "cache"),
-		lockDir: path.join(__dirname, "cache/locks"),
+		cacheDir: path.join(process.cwd(), "cache"),
+		lockDir: path.join(process.cwd(), "cache/locks"),
 	},
 	allowBootloaderOnly: true,
 })


### PR DESCRIPTION
This PR removes a few instances where we were relying on the CommonJS builtin `__dirname` to determine the location of the current source file on disk.

This changes two paths:
1. The default logfile location is now in the cwd of the current process, rather than the main entry point
2. The cache files of the flasher utility are now in a subdirectory of the cwd of the current process.
3. The cache files of the driver itself have been changed by #7344 already