### PR TITLE
feat: allow specifying RF region for OTA firmware updates if unknown

### DIFF
--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -8207,7 +8207,7 @@ export class ZWaveController
 					productType,
 					productId,
 					firmwareVersion,
-					rfRegion: this.rfRegion,
+					rfRegion: this.rfRegion ?? options?.rfRegion,
 				},
 				{
 					userAgent: this.driver.getUserAgentStringWithComponents(
@@ -8250,6 +8250,7 @@ export class ZWaveController
 	): Promise<void> {
 		if (
 			deviceId.rfRegion !== undefined
+			&& this.rfRegion !== NOT_KNOWN
 			&& deviceId.rfRegion !== this.rfRegion
 		) {
 			throw new ZWaveError(

--- a/packages/zwave-js/src/lib/controller/_Types.ts
+++ b/packages/zwave-js/src/lib/controller/_Types.ts
@@ -52,6 +52,16 @@ export interface GetFirmwareUpdatesOptions {
 	additionalUserAgentComponents?: Record<string, string>;
 	/** Whether the returned firmware upgrades should include prereleases from the `"beta"` channel. Default: `false`. */
 	includePrereleases?: boolean;
+	/**
+	 * Can be used to specify the RF region if the Z-Wave controller
+	 * does not support querying this information.
+	 *
+	 * **WARNING:** Specifying the wrong region may result in bricking the device!
+	 *
+	 * For this reason, the specified value is only used as a fallback
+	 * if the RF region of the controller is not already known.
+	 */
+	rfRegion?: RFRegion;
 }
 
 export interface ControllerFirmwareUpdateProgress {


### PR DESCRIPTION
This PR expands the options for `Controller.getAvailableFirmwareUpdates` and adds a new `rfRegion` property that will be used as a fallback in case the controller's RF region cannot be determined.

This allows using the OTA update service with older controllers that have no support for querying or changing the RF region. This feature should be used with caution, as specifying the wrong region may result in bricking the device.

fixes: #6891
fixes: https://github.com/zwave-js/node-zwave-js/issues/7323