### PR TITLE
refactor: asynchronous serialization and parsing

### DIFF
--- a/packages/cc/src/cc/AlarmSensorCC.ts
+++ b/packages/cc/src/cc/AlarmSensorCC.ts
@@ -452,6 +452,7 @@ export class AlarmSensorCCGet extends AlarmSensorCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.sensorType]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/AssociationCC.ts
+++ b/packages/cc/src/cc/AssociationCC.ts
@@ -542,6 +542,7 @@ export class AssociationCCSet extends AssociationCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.groupId, ...this.nodeIds]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -604,6 +605,7 @@ export class AssociationCCRemove extends AssociationCC {
 			this.groupId || 0,
 			...(this.nodeIds || []),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -714,6 +716,7 @@ export class AssociationCCReport extends AssociationCC {
 			this.reportsToFollow,
 			...this.nodeIds,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -765,6 +768,7 @@ export class AssociationCCGet extends AssociationCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.groupId]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -809,6 +813,7 @@ export class AssociationCCSupportedGroupingsReport extends AssociationCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.groupCount]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -856,6 +861,7 @@ export class AssociationCCSpecificGroupReport extends AssociationCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.group]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/AssociationCC.ts
+++ b/packages/cc/src/cc/AssociationCC.ts
@@ -685,6 +685,7 @@ export class AssociationCCReport extends AssociationCC {
 		return this.reportsToFollow > 0;
 	}
 
+	/** @deprecated Use {@link mergePartialCCsAsync} instead */
 	public mergePartialCCs(
 		partials: AssociationCCReport[],
 		_ctx: CCParsingContext,
@@ -693,6 +694,17 @@ export class AssociationCCReport extends AssociationCC {
 		this.nodeIds = [...partials, this]
 			.map((report) => report.nodeIds)
 			.reduce((prev, cur) => prev.concat(...cur), []);
+	}
+
+	public mergePartialCCsAsync(
+		partials: AssociationCCReport[],
+		_ctx: CCParsingContext,
+	): Promise<void> {
+		// Concat the list of nodes
+		this.nodeIds = [...partials, this]
+			.map((report) => report.nodeIds)
+			.reduce((prev, cur) => prev.concat(...cur), []);
+		return Promise.resolve();
 	}
 
 	public serialize(ctx: CCEncodingContext): Bytes {

--- a/packages/cc/src/cc/AssociationGroupInfoCC.ts
+++ b/packages/cc/src/cc/AssociationGroupInfoCC.ts
@@ -526,6 +526,7 @@ export class AssociationGroupInfoCCNameReport extends AssociationGroupInfoCC {
 			Bytes.from([this.groupId, this.name.length]),
 			Bytes.from(this.name, "utf8"),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -572,6 +573,7 @@ export class AssociationGroupInfoCCNameGet extends AssociationGroupInfoCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.groupId]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -678,6 +680,7 @@ export class AssociationGroupInfoCCInfoReport extends AssociationGroupInfoCC {
 			// The remaining bytes are zero
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -763,6 +766,7 @@ export class AssociationGroupInfoCCInfoGet extends AssociationGroupInfoCC {
 			optionByte,
 			isListMode ? 0 : this.groupId!,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -852,6 +856,7 @@ export class AssociationGroupInfoCCCommandListReport
 		}
 		this.payload[1] = offset - 2; // list length
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -918,6 +923,7 @@ export class AssociationGroupInfoCCCommandListGet
 			this.allowCache ? 0b1000_0000 : 0,
 			this.groupId,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/BarrierOperatorCC.ts
+++ b/packages/cc/src/cc/BarrierOperatorCC.ts
@@ -574,6 +574,7 @@ export class BarrierOperatorCCSet extends BarrierOperatorCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.targetState]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -763,6 +764,7 @@ export class BarrierOperatorCCEventSignalingSet extends BarrierOperatorCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.subsystemType, this.subsystemState]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -883,6 +885,7 @@ export class BarrierOperatorCCEventSignalingGet extends BarrierOperatorCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.subsystemType]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/BasicCC.ts
+++ b/packages/cc/src/cc/BasicCC.ts
@@ -399,6 +399,7 @@ export class BasicCCSet extends BasicCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.targetValue]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -524,6 +525,7 @@ export class BasicCCReport extends BasicCC {
 			this.payload = this.payload.subarray(0, 1);
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/BatteryCC.ts
+++ b/packages/cc/src/cc/BatteryCC.ts
@@ -587,6 +587,7 @@ export class BatteryCCReport extends BatteryCC {
 				]),
 			]);
 		}
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/BinarySensorCC.ts
+++ b/packages/cc/src/cc/BinarySensorCC.ts
@@ -402,6 +402,7 @@ export class BinarySensorCCReport extends BinarySensorCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.value ? 0xff : 0x00, this.type]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -462,6 +463,7 @@ export class BinarySensorCCGet extends BinarySensorCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.sensorType ?? BinarySensorType.Any]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -526,6 +528,7 @@ export class BinarySensorCCSupportedReport extends BinarySensorCC {
 			undefined,
 			0,
 		);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/BinarySwitchCC.ts
+++ b/packages/cc/src/cc/BinarySwitchCC.ts
@@ -356,6 +356,7 @@ export class BinarySwitchCCSet extends BinarySwitchCC {
 			this.payload = this.payload.subarray(0, 1);
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -439,6 +440,7 @@ export class BinarySwitchCCReport extends BinarySwitchCC {
 				]),
 			]);
 		}
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/CentralSceneCC.ts
+++ b/packages/cc/src/cc/CentralSceneCC.ts
@@ -599,6 +599,7 @@ export class CentralSceneCCConfigurationSet extends CentralSceneCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.slowRefresh ? 0b1000_0000 : 0]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/ClimateControlScheduleCC.ts
+++ b/packages/cc/src/cc/ClimateControlScheduleCC.ts
@@ -261,6 +261,7 @@ export class ClimateControlScheduleCCSet extends ClimateControlScheduleCC {
 			Bytes.from([this.weekday & 0b111]),
 			...allSwitchPoints.map((sp) => encodeSwitchpoint(sp)),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -394,6 +395,7 @@ export class ClimateControlScheduleCCGet extends ClimateControlScheduleCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.weekday & 0b111]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -556,6 +558,7 @@ export class ClimateControlScheduleCCOverrideSet
 			[this.overrideType & 0b11],
 			encodeSetbackState(this.overrideState),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/ClockCC.ts
+++ b/packages/cc/src/cc/ClockCC.ts
@@ -182,6 +182,7 @@ export class ClockCCSet extends ClockCC {
 			((this.weekday & 0b111) << 5) | (this.hour & 0b11111),
 			this.minute,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/ColorSwitchCC.ts
+++ b/packages/cc/src/cc/ColorSwitchCC.ts
@@ -723,6 +723,7 @@ export class ColorSwitchCCSupportedReport extends ColorSwitchCC {
 			15, // fixed 2 bytes
 			ColorComponent["Warm White"],
 		);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -879,6 +880,7 @@ export class ColorSwitchCCReport extends ColorSwitchCC {
 				]),
 			]);
 		}
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -951,6 +953,7 @@ export class ColorSwitchCCGet extends ColorSwitchCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this._colorComponent]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1057,6 +1060,7 @@ export class ColorSwitchCCSet extends ColorSwitchCC {
 			this.payload = this.payload.subarray(0, -1);
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1165,6 +1169,7 @@ export class ColorSwitchCCStartLevelChange extends ColorSwitchCC {
 			this.payload = this.payload.subarray(0, -1);
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1221,6 +1226,7 @@ export class ColorSwitchCCStopLevelChange extends ColorSwitchCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.colorComponent]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/ConfigurationCC.ts
+++ b/packages/cc/src/cc/ConfigurationCC.ts
@@ -1765,6 +1765,7 @@ export class ConfigurationCCReport extends ConfigurationCC {
 			this.value,
 		);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1827,6 +1828,7 @@ export class ConfigurationCCGet extends ConfigurationCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.parameter]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1945,6 +1947,7 @@ export class ConfigurationCCSet extends ConfigurationCC {
 				);
 			}
 		}
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -2112,6 +2115,7 @@ export class ConfigurationCCBulkSet extends ConfigurationCC {
 				}
 			}
 		}
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -2323,6 +2327,7 @@ export class ConfigurationCCBulkGet extends ConfigurationCC {
 		this.payload = new Bytes(3);
 		this.payload.writeUInt16BE(this.parameters[0], 0);
 		this.payload[2] = this.parameters.length;
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -2423,6 +2428,7 @@ export class ConfigurationCCNameReport extends ConfigurationCC {
 		this.payload[2] = this.reportsToFollow;
 		this.payload.set(nameBuffer, 3);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -2497,6 +2503,7 @@ export class ConfigurationCCNameGet extends ConfigurationCC {
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = new Bytes(2);
 		this.payload.writeUInt16BE(this.parameter, 0);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -2610,6 +2617,7 @@ export class ConfigurationCCInfoReport extends ConfigurationCC {
 		this.payload[2] = this.reportsToFollow;
 		this.payload.set(infoBuffer, 3);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -2684,6 +2692,7 @@ export class ConfigurationCCInfoGet extends ConfigurationCC {
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = new Bytes(2);
 		this.payload.writeUInt16BE(this.parameter, 0);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -2977,6 +2986,7 @@ export class ConfigurationCCPropertiesReport extends ConfigurationCC {
 			| (this.noBulkSupport ? 0b10 : 0);
 		this.payload[offset] = options2;
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -3046,6 +3056,7 @@ export class ConfigurationCCPropertiesGet extends ConfigurationCC {
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = new Bytes(2);
 		this.payload.writeUInt16BE(this.parameter, 0);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/ConfigurationCC.ts
+++ b/packages/cc/src/cc/ConfigurationCC.ts
@@ -2435,6 +2435,7 @@ export class ConfigurationCCNameReport extends ConfigurationCC {
 		return this.reportsToFollow > 0;
 	}
 
+	/** @deprecated Use {@link mergePartialCCsAsync} instead */
 	public mergePartialCCs(
 		partials: ConfigurationCCNameReport[],
 		_ctx: CCParsingContext,
@@ -2443,6 +2444,17 @@ export class ConfigurationCCNameReport extends ConfigurationCC {
 		this.name = [...partials, this]
 			.map((report) => report.name)
 			.reduce((prev, cur) => prev + cur, "");
+	}
+
+	public mergePartialCCsAsync(
+		partials: ConfigurationCCNameReport[],
+		_ctx: CCParsingContext,
+	): Promise<void> {
+		// Concat the name
+		this.name = [...partials, this]
+			.map((report) => report.name)
+			.reduce((prev, cur) => prev + cur, "");
+		return Promise.resolve();
 	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
@@ -2610,6 +2622,7 @@ export class ConfigurationCCInfoReport extends ConfigurationCC {
 		return this.reportsToFollow > 0;
 	}
 
+	/** @deprecated Use {@link mergePartialCCsAsync} instead */
 	public mergePartialCCs(
 		partials: ConfigurationCCInfoReport[],
 		_ctx: CCParsingContext,
@@ -2618,6 +2631,17 @@ export class ConfigurationCCInfoReport extends ConfigurationCC {
 		this.info = [...partials, this]
 			.map((report) => report.info)
 			.reduce((prev, cur) => prev + cur, "");
+	}
+
+	public mergePartialCCsAsync(
+		partials: ConfigurationCCInfoReport[],
+		_ctx: CCParsingContext,
+	): Promise<void> {
+		// Concat the info
+		this.info = [...partials, this]
+			.map((report) => report.info)
+			.reduce((prev, cur) => prev + cur, "");
+		return Promise.resolve();
 	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {

--- a/packages/cc/src/cc/DoorLockCC.ts
+++ b/packages/cc/src/cc/DoorLockCC.ts
@@ -861,6 +861,7 @@ export class DoorLockCCOperationSet extends DoorLockCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.mode]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1394,6 +1395,7 @@ export class DoorLockCCConfigurationSet extends DoorLockCC {
 			6,
 		);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/DoorLockLoggingCC.ts
+++ b/packages/cc/src/cc/DoorLockLoggingCC.ts
@@ -432,6 +432,7 @@ export class DoorLockLoggingCCRecordGet extends DoorLockLoggingCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.recordNumber]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/EnergyProductionCC.ts
+++ b/packages/cc/src/cc/EnergyProductionCC.ts
@@ -255,6 +255,7 @@ export class EnergyProductionCCReport extends EnergyProductionCC {
 			Bytes.from([this.parameter]),
 			encodeFloatWithScale(this.value, this.scale.key),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -315,6 +316,7 @@ export class EnergyProductionCCGet extends EnergyProductionCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.parameter]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/EntryControlCC.ts
+++ b/packages/cc/src/cc/EntryControlCC.ts
@@ -791,6 +791,7 @@ export class EntryControlCCConfigurationSet extends EntryControlCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.keyCacheSize, this.keyCacheTimeout]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/FirmwareUpdateMetaDataCC.ts
+++ b/packages/cc/src/cc/FirmwareUpdateMetaDataCC.ts
@@ -482,6 +482,7 @@ export class FirmwareUpdateMetaDataCCMetaDataReport
 			| (this.supportsNonSecureTransfer ? 0b100 : 0)
 			| (this.supportsResuming ? 0b1000 : 0);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -679,6 +680,7 @@ export class FirmwareUpdateMetaDataCCRequestGet
 			| (this.resume ? 0b100 : 0);
 		this.payload[10] = this.hardwareVersion ?? 0x00;
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -826,6 +828,7 @@ export class FirmwareUpdateMetaDataCCReport extends FirmwareUpdateMetaDataCC {
 			this.payload = commandBuffer;
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1033,6 +1036,7 @@ export class FirmwareUpdateMetaDataCCActivationSet
 		this.payload.writeUInt16BE(this.checksum, 4);
 		this.payload[6] = this.firmwareTarget;
 		this.payload[7] = this.hardwareVersion ?? 0x00;
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1155,6 +1159,7 @@ export class FirmwareUpdateMetaDataCCPrepareGet
 		this.payload[4] = this.firmwareTarget;
 		this.payload.writeUInt16BE(this.fragmentSize, 5);
 		this.payload[7] = this.hardwareVersion;
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/HumidityControlModeCC.ts
+++ b/packages/cc/src/cc/HumidityControlModeCC.ts
@@ -315,6 +315,7 @@ export class HumidityControlModeCCSet extends HumidityControlModeCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.mode & 0b1111]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/HumidityControlSetpointCC.ts
+++ b/packages/cc/src/cc/HumidityControlSetpointCC.ts
@@ -557,6 +557,7 @@ export class HumidityControlSetpointCCSet extends HumidityControlSetpointCC {
 			Bytes.from([this.setpointType & 0b1111]),
 			encodeFloatWithScale(this.value, this.scale),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -719,6 +720,7 @@ export class HumidityControlSetpointCCGet extends HumidityControlSetpointCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.setpointType & 0b1111]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -892,6 +894,7 @@ export class HumidityControlSetpointCCScaleSupportedGet
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.setpointType & 0b1111]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1039,6 +1042,7 @@ export class HumidityControlSetpointCCCapabilitiesGet
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.setpointType & 0b1111]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/InclusionControllerCC.ts
+++ b/packages/cc/src/cc/InclusionControllerCC.ts
@@ -126,6 +126,7 @@ export class InclusionControllerCCComplete extends InclusionControllerCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.step, this.status]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -183,6 +184,7 @@ export class InclusionControllerCCInitiate extends InclusionControllerCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.includedNodeId, this.step]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/IndicatorCC.ts
+++ b/packages/cc/src/cc/IndicatorCC.ts
@@ -974,6 +974,7 @@ export class IndicatorCCSet extends IndicatorCC {
 			// V1
 			this.payload = Bytes.from([this.indicator0Value ?? 0]);
 		}
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1195,6 +1196,7 @@ export class IndicatorCCReport extends IndicatorCC {
 			// V1
 			this.payload = Bytes.from([this.indicator0Value ?? 0]);
 		}
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1256,6 +1258,7 @@ export class IndicatorCCGet extends IndicatorCC {
 		if (this.indicatorId != undefined) {
 			this.payload = Bytes.from([this.indicatorId]);
 		}
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1348,6 +1351,7 @@ export class IndicatorCCSupportedReport extends IndicatorCC {
 			bitmask,
 		]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1413,6 +1417,7 @@ export class IndicatorCCSupportedGet extends IndicatorCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.indicatorId]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1485,6 +1490,7 @@ export class IndicatorCCDescriptionReport extends IndicatorCC {
 			Bytes.from([this.indicatorId, description.length]),
 			description,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1547,6 +1553,7 @@ export class IndicatorCCDescriptionGet extends IndicatorCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.indicatorId]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/IrrigationCC.ts
+++ b/packages/cc/src/cc/IrrigationCC.ts
@@ -1689,6 +1689,7 @@ export class IrrigationCCSystemConfigSet extends IrrigationCC {
 			encodeFloatWithScale(this.lowPressureThreshold, 0 /* kPa */),
 			Bytes.from([polarity]),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -2068,6 +2069,7 @@ export class IrrigationCCValveInfoGet extends IrrigationCC {
 			this.valveId === "master" ? 1 : 0,
 			this.valveId === "master" ? 1 : this.valveId || 1,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -2150,6 +2152,7 @@ export class IrrigationCCValveConfigSet extends IrrigationCC {
 				| (this.useMoistureSensor ? 0b10 : 0),
 			]),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -2391,6 +2394,7 @@ export class IrrigationCCValveConfigGet extends IrrigationCC {
 			this.valveId === "master" ? 1 : 0,
 			this.valveId === "master" ? 1 : this.valveId || 1,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -2447,6 +2451,7 @@ export class IrrigationCCValveRun extends IrrigationCC {
 			0,
 		]);
 		this.payload.writeUInt16BE(this.duration, 2);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -2510,6 +2515,7 @@ export class IrrigationCCValveTableSet extends IrrigationCC {
 			this.payload[offset] = entry.valveId;
 			this.payload.writeUInt16BE(entry.duration, offset + 1);
 		}
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -2639,6 +2645,7 @@ export class IrrigationCCValveTableGet extends IrrigationCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.tableId]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -2692,6 +2699,7 @@ export class IrrigationCCValveTableRun extends IrrigationCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from(this.tableIDs);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -2745,6 +2753,7 @@ export class IrrigationCCSystemShutoff extends IrrigationCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.duration ?? 255]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/LanguageCC.ts
+++ b/packages/cc/src/cc/LanguageCC.ts
@@ -232,6 +232,7 @@ export class LanguageCCSet extends LanguageCC {
 				Bytes.from(this._country, "ascii"),
 			]);
 		}
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/LockCC.ts
+++ b/packages/cc/src/cc/LockCC.ts
@@ -213,6 +213,7 @@ export class LockCCSet extends LockCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.locked ? 1 : 0]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/ManufacturerProprietaryCC.ts
+++ b/packages/cc/src/cc/ManufacturerProprietaryCC.ts
@@ -156,6 +156,7 @@ export class ManufacturerProprietaryCC extends CommandClass {
 			manufacturerId,
 		);
 		if (PCConstructor) {
+			// eslint-disable-next-line @typescript-eslint/no-deprecated
 			return PCConstructor.from(
 				raw.withPayload(raw.payload.subarray(2)),
 				ctx,
@@ -200,6 +201,7 @@ export class ManufacturerProprietaryCC extends CommandClass {
 			]),
 			this.payload,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/ManufacturerSpecificCC.ts
+++ b/packages/cc/src/cc/ManufacturerSpecificCC.ts
@@ -276,6 +276,7 @@ export class ManufacturerSpecificCCReport extends ManufacturerSpecificCC {
 		this.payload.writeUInt16BE(this.manufacturerId, 0);
 		this.payload.writeUInt16BE(this.productType, 2);
 		this.payload.writeUInt16BE(this.productId, 4);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -391,6 +392,7 @@ export class ManufacturerSpecificCCDeviceSpecificGet
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([(this.deviceIdType || 0) & 0b111]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/MeterCC.ts
+++ b/packages/cc/src/cc/MeterCC.ts
@@ -1085,6 +1085,7 @@ export class MeterCCReport extends MeterCC {
 			]);
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1192,6 +1193,7 @@ export class MeterCCGet extends MeterCC {
 		this.payload[0] = (rateTypeFlags << 6) | (scale1 << 3);
 		if (scale2) this.payload[1] = scale2;
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1366,6 +1368,7 @@ export class MeterCCSupportedReport extends MeterCC {
 			]);
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1470,6 +1473,7 @@ export class MeterCCReset extends MeterCC {
 				]);
 			}
 		}
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/MultiChannelAssociationCC.ts
+++ b/packages/cc/src/cc/MultiChannelAssociationCC.ts
@@ -848,6 +848,7 @@ export class MultiChannelAssociationCCReport extends MultiChannelAssociationCC {
 		return this.reportsToFollow > 0;
 	}
 
+	/** @deprecated Use {@link mergePartialCCsAsync} instead */
 	public mergePartialCCs(
 		partials: MultiChannelAssociationCCReport[],
 		_ctx: CCParsingContext,
@@ -860,6 +861,21 @@ export class MultiChannelAssociationCCReport extends MultiChannelAssociationCC {
 		this.endpoints = [...partials, this]
 			.map((report) => [...report.endpoints])
 			.reduce((prev, cur) => prev.concat(...cur), []);
+	}
+
+	public mergePartialCCsAsync(
+		partials: MultiChannelAssociationCCReport[],
+		_ctx: CCParsingContext,
+	): Promise<void> {
+		// Concat the list of nodes
+		this.nodeIds = [...partials, this]
+			.map((report) => [...report.nodeIds])
+			.reduce((prev, cur) => prev.concat(...cur), []);
+		// Concat the list of endpoints
+		this.endpoints = [...partials, this]
+			.map((report) => [...report.endpoints])
+			.reduce((prev, cur) => prev.concat(...cur), []);
+		return Promise.resolve();
 	}
 
 	public serialize(ctx: CCEncodingContext): Bytes {

--- a/packages/cc/src/cc/MultiChannelAssociationCC.ts
+++ b/packages/cc/src/cc/MultiChannelAssociationCC.ts
@@ -676,6 +676,7 @@ export class MultiChannelAssociationCCSet extends MultiChannelAssociationCC {
 				this.endpoints,
 			),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -747,6 +748,7 @@ export class MultiChannelAssociationCCRemove extends MultiChannelAssociationCC {
 				this.endpoints || [],
 			),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -891,6 +893,7 @@ export class MultiChannelAssociationCCReport extends MultiChannelAssociationCC {
 			]),
 			destinations,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -945,6 +948,7 @@ export class MultiChannelAssociationCCGet extends MultiChannelAssociationCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.groupId]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -993,6 +997,7 @@ export class MultiChannelAssociationCCSupportedGroupingsReport
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.groupCount]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/MultiCommandCC.ts
+++ b/packages/cc/src/cc/MultiCommandCC.ts
@@ -178,16 +178,31 @@ export class MultiCommandCCCommandEncapsulation extends MultiCommandCC {
 
 	public encapsulated: CommandClass[];
 
+	/** @deprecated Use {@link serializeAsync} instead */
 	public serialize(ctx: CCEncodingContext): Bytes {
 		const buffers: Bytes[] = [];
 		buffers.push(Bytes.from([this.encapsulated.length]));
 		for (const cmd of this.encapsulated) {
+			// eslint-disable-next-line @typescript-eslint/no-deprecated
 			const cmdBuffer = cmd.serialize(ctx);
 			buffers.push(Bytes.from([cmdBuffer.length]));
 			buffers.push(cmdBuffer);
 		}
 		this.payload = Bytes.concat(buffers);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
+	}
+
+	public async serializeAsync(ctx: CCEncodingContext): Promise<Bytes> {
+		const buffers: Bytes[] = [];
+		buffers.push(Bytes.from([this.encapsulated.length]));
+		for (const cmd of this.encapsulated) {
+			const cmdBuffer = await cmd.serializeAsync(ctx);
+			buffers.push(Bytes.from([cmdBuffer.length]));
+			buffers.push(cmdBuffer);
+		}
+		this.payload = Bytes.concat(buffers);
+		return super.serializeAsync(ctx);
 	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {

--- a/packages/cc/src/cc/MultiCommandCC.ts
+++ b/packages/cc/src/cc/MultiCommandCC.ts
@@ -114,6 +114,7 @@ export class MultiCommandCCCommandEncapsulation extends MultiCommandCC {
 		}
 	}
 
+	/** @deprecated Use {@link fromAsync} instead */
 	public static from(
 		raw: CCRaw,
 		ctx: CCParsingContext,
@@ -127,7 +128,38 @@ export class MultiCommandCCCommandEncapsulation extends MultiCommandCC {
 			const cmdLength = raw.payload[offset];
 			validatePayload(raw.payload.length >= offset + 1 + cmdLength);
 			encapsulated.push(
+				// eslint-disable-next-line @typescript-eslint/no-deprecated
 				CommandClass.parse(
+					raw.payload.subarray(
+						offset + 1,
+						offset + 1 + cmdLength,
+					),
+					ctx,
+				),
+			);
+			offset += 1 + cmdLength;
+		}
+
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			encapsulated,
+		});
+	}
+
+	public static async fromAsync(
+		raw: CCRaw,
+		ctx: CCParsingContext,
+	): Promise<MultiCommandCCCommandEncapsulation> {
+		validatePayload(raw.payload.length >= 1);
+		const numCommands = raw.payload[0];
+		const encapsulated: CommandClass[] = [];
+		let offset = 1;
+		for (let i = 0; i < numCommands; i++) {
+			validatePayload(raw.payload.length >= offset + 1);
+			const cmdLength = raw.payload[offset];
+			validatePayload(raw.payload.length >= offset + 1 + cmdLength);
+			encapsulated.push(
+				await CommandClass.parseAsync(
 					raw.payload.subarray(
 						offset + 1,
 						offset + 1 + cmdLength,

--- a/packages/cc/src/cc/MultilevelSensorCC.ts
+++ b/packages/cc/src/cc/MultilevelSensorCC.ts
@@ -758,6 +758,7 @@ export class MultilevelSensorCCReport extends MultilevelSensorCC {
 			Bytes.from([this.type]),
 			encodeFloatWithScale(this.value, this.scale),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -837,6 +838,7 @@ export class MultilevelSensorCCGet extends MultilevelSensorCC {
 				(this.scale & 0b11) << 3,
 			]);
 		}
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -903,6 +905,7 @@ export class MultilevelSensorCCSupportedSensorReport
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = encodeBitMask(this.supportedSensorTypes);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -971,6 +974,7 @@ export class MultilevelSensorCCSupportedScaleReport extends MultilevelSensorCC {
 			Bytes.from([this.sensorType]),
 			encodeBitMask(this.supportedScales, 4, 0),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1025,6 +1029,7 @@ export class MultilevelSensorCCGetSupportedScale extends MultilevelSensorCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.sensorType]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/MultilevelSwitchCC.ts
+++ b/packages/cc/src/cc/MultilevelSwitchCC.ts
@@ -674,6 +674,7 @@ export class MultilevelSwitchCCSet extends MultilevelSwitchCC {
 			this.payload = this.payload.subarray(0, 1);
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -751,6 +752,7 @@ export class MultilevelSwitchCCReport extends MultilevelSwitchCC {
 			this.targetValue ?? 0xfe,
 			(this.duration ?? Duration.default()).serializeReport(),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -854,6 +856,7 @@ export class MultilevelSwitchCCStartLevelChange extends MultilevelSwitchCC {
 			this.payload = this.payload.subarray(0, -1);
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -919,6 +922,7 @@ export class MultilevelSwitchCCSupportedReport extends MultilevelSwitchCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.switchType & 0b11111]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/NodeNamingCC.ts
+++ b/packages/cc/src/cc/NodeNamingCC.ts
@@ -320,6 +320,7 @@ export class NodeNamingAndLocationCCNameSet extends NodeNamingAndLocationCC {
 			nameBuffer.subarray(0, Math.min(16, nameBuffer.length)),
 			0,
 		);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -432,6 +433,7 @@ export class NodeNamingAndLocationCCLocationSet
 			locationBuffer.subarray(0, Math.min(16, locationBuffer.length)),
 			0,
 		);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/NotificationCC.ts
+++ b/packages/cc/src/cc/NotificationCC.ts
@@ -1315,6 +1315,9 @@ export class NotificationCCReport extends NotificationCC {
 				// Try to parse the event parameters - if this fails, we should still handle the notification report
 				try {
 					// Convert CommandClass instances to a standardized object representation
+					// FIXME: We do not really want to parse asynchronously here. Once parseAsync becomes the standard,
+					// we should add sync methods to only those CCs that will be parsed here - or make the entire call chain async.
+					// eslint-disable-next-line @typescript-eslint/no-deprecated
 					const cc = CommandClass.parse(this.eventParameters, {
 						...ctx,
 						frameType: "singlecast",

--- a/packages/cc/src/cc/NotificationCC.ts
+++ b/packages/cc/src/cc/NotificationCC.ts
@@ -959,6 +959,7 @@ export class NotificationCCSet extends NotificationCC {
 			this.notificationType,
 			this.notificationStatus ? 0xff : 0x00,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1466,6 +1467,7 @@ export class NotificationCCReport extends NotificationCC {
 			]);
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -1533,6 +1535,7 @@ export class NotificationCCGet extends NotificationCC {
 			this.notificationType ?? 0xff,
 			notificationEvent ?? 0x00,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1625,6 +1628,7 @@ export class NotificationCCSupportedReport extends NotificationCC {
 			]),
 			bitMask,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1766,6 +1770,7 @@ export class NotificationCCEventSupportedReport extends NotificationCC {
 			this.payload = Bytes.concat([this.payload, bitMask]);
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1822,6 +1827,7 @@ export class NotificationCCEventSupportedGet extends NotificationCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.notificationType]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/PowerlevelCC.ts
+++ b/packages/cc/src/cc/PowerlevelCC.ts
@@ -262,6 +262,7 @@ export class PowerlevelCCSet extends PowerlevelCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.powerlevel, this.timeout ?? 0x00]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -324,6 +325,7 @@ export class PowerlevelCCReport extends PowerlevelCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.powerlevel, this.timeout ?? 0x00]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -388,6 +390,7 @@ export class PowerlevelCCTestNodeSet extends PowerlevelCC {
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.testNodeId, this.powerlevel, 0, 0]);
 		this.payload.writeUInt16BE(this.testFrameCount, 2);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -452,6 +455,7 @@ export class PowerlevelCCTestNodeReport extends PowerlevelCC {
 			0,
 		]);
 		this.payload.writeUInt16BE(this.acknowledgedFrames, 2);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/ProtectionCC.ts
+++ b/packages/cc/src/cc/ProtectionCC.ts
@@ -546,6 +546,7 @@ export class ProtectionCCSet extends ProtectionCC {
 			this.payload = this.payload.subarray(0, 1);
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -819,6 +820,7 @@ export class ProtectionCCExclusiveControlSet extends ProtectionCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.exclusiveControlNodeId]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -911,6 +913,7 @@ export class ProtectionCCTimeoutSet extends ProtectionCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.timeout.serialize()]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/SceneActivationCC.ts
+++ b/packages/cc/src/cc/SceneActivationCC.ts
@@ -175,6 +175,7 @@ export class SceneActivationCCSet extends SceneActivationCC {
 			this.sceneId,
 			this.dimmingDuration?.serializeSet() ?? 0xff,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/SceneActuatorConfigurationCC.ts
+++ b/packages/cc/src/cc/SceneActuatorConfigurationCC.ts
@@ -398,6 +398,7 @@ export class SceneActuatorConfigurationCCSet
 			this.level != undefined ? 0b1000_0000 : 0,
 			this.level ?? 0xff,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -559,6 +560,7 @@ export class SceneActuatorConfigurationCCGet
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.sceneId]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/SceneControllerConfigurationCC.ts
+++ b/packages/cc/src/cc/SceneControllerConfigurationCC.ts
@@ -530,6 +530,7 @@ export class SceneControllerConfigurationCCSet
 			this.sceneId,
 			this.dimmingDuration.serializeSet(),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -669,6 +670,7 @@ export class SceneControllerConfigurationCCGet
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.groupId]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/ScheduleEntryLockCC.ts
+++ b/packages/cc/src/cc/ScheduleEntryLockCC.ts
@@ -959,6 +959,7 @@ export class ScheduleEntryLockCCEnableSet extends ScheduleEntryLockCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.userId, this.enabled ? 0x01 : 0x00]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1005,6 +1006,7 @@ export class ScheduleEntryLockCCEnableAllSet extends ScheduleEntryLockCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.enabled ? 0x01 : 0x00]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1074,6 +1076,7 @@ export class ScheduleEntryLockCCSupportedReport extends ScheduleEntryLockCC {
 			this.numYearDaySlots,
 			this.numDailyRepeatingSlots ?? 0,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1196,6 +1199,7 @@ export class ScheduleEntryLockCCWeekDayScheduleSet extends ScheduleEntryLockCC {
 			this.stopHour ?? 0xff,
 			this.stopMinute ?? 0xff,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1356,6 +1360,7 @@ export class ScheduleEntryLockCCWeekDayScheduleReport
 			this.stopHour ?? 0xff,
 			this.stopMinute ?? 0xff,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1427,6 +1432,7 @@ export class ScheduleEntryLockCCWeekDayScheduleGet extends ScheduleEntryLockCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.userId, this.slotId]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1565,6 +1571,7 @@ export class ScheduleEntryLockCCYearDayScheduleSet extends ScheduleEntryLockCC {
 			this.stopHour ?? 0xff,
 			this.stopMinute ?? 0xff,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1777,6 +1784,7 @@ export class ScheduleEntryLockCCYearDayScheduleReport
 			this.stopHour ?? 0xff,
 			this.stopMinute ?? 0xff,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1851,6 +1859,7 @@ export class ScheduleEntryLockCCYearDayScheduleGet extends ScheduleEntryLockCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.userId, this.slotId]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1903,6 +1912,7 @@ export class ScheduleEntryLockCCTimeOffsetSet extends ScheduleEntryLockCC {
 			standardOffset: this.standardOffset,
 			dstOffset: this.dstOffset,
 		});
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1954,6 +1964,7 @@ export class ScheduleEntryLockCCTimeOffsetReport extends ScheduleEntryLockCC {
 			standardOffset: this.standardOffset,
 			dstOffset: this.dstOffset,
 		});
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -2086,6 +2097,7 @@ export class ScheduleEntryLockCCDailyRepeatingScheduleSet
 			this.payload = Bytes.concat([this.payload, Bytes.alloc(5, 0xff)]);
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -2238,6 +2250,7 @@ export class ScheduleEntryLockCCDailyRepeatingScheduleReport
 			this.payload = Bytes.concat([this.payload, Bytes.alloc(5, 0)]);
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -2313,6 +2326,7 @@ export class ScheduleEntryLockCCDailyRepeatingScheduleGet
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.userId, this.slotId]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/Security2CC.ts
+++ b/packages/cc/src/cc/Security2CC.ts
@@ -1359,6 +1359,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 		}
 	}
 
+	/** @deprecated Use {@link fromAsync} instead */
 	public static from(
 		raw: CCRaw,
 		ctx: CCParsingContext,
@@ -1676,7 +1677,346 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 			// make sure this contains a complete CC command that's worth splitting
 			validatePayload(decryptedCCBytes.length >= 2);
 			// and deserialize the CC
+			// eslint-disable-next-line @typescript-eslint/no-deprecated
 			encapsulated = CommandClass.parse(decryptedCCBytes, ctx);
+		}
+
+		const ret = new Security2CCMessageEncapsulation({
+			nodeId: ctx.sourceNodeId,
+			sequenceNumber,
+			securityClass,
+			extensions,
+			encapsulated,
+		});
+
+		// Remember for debugging purposes
+		ret.key = key;
+		ret.iv = iv;
+		ret.authData = authData;
+		ret.authTag = authTag;
+		ret.plaintext = decryptedCCBytes;
+
+		return ret;
+	}
+
+	public static async fromAsync(
+		raw: CCRaw,
+		ctx: CCParsingContext,
+	): Promise<Security2CCMessageEncapsulation> {
+		const securityManager = assertSecurityRX(ctx);
+
+		validatePayload(raw.payload.length >= 2);
+		// Check the sequence number to avoid duplicates
+		const sequenceNumber: number | undefined = raw.payload[0];
+
+		// Ensure the node has a security class
+		validatePayload.withReason("No security class granted")(
+			ctx.getHighestSecurityClass(
+				ctx.sourceNodeId,
+			) !== SecurityClass.None,
+		);
+
+		const hasExtensions = !!(raw.payload[1] & 0b1);
+		const hasEncryptedExtensions = !!(raw.payload[1] & 0b10);
+
+		let offset = 2;
+		const extensions: Security2Extension[] = [];
+		let mustDiscardCommand = false;
+
+		const parseExtensions = (buffer: Uint8Array, wasEncrypted: boolean) => {
+			while (true) {
+				if (buffer.length < offset + 2) {
+					// An S2 extension was expected, but the buffer is too short
+					mustDiscardCommand = true;
+					return;
+				}
+
+				// The length field could be too large, which would cause part of the actual ciphertext
+				// to be ignored. Try to avoid this for known extensions by checking the actual and expected length.
+				const { actual: actualLength, expected: expectedLength } =
+					Security2Extension
+						.getExtensionLength(
+							buffer.subarray(offset),
+						);
+
+				// Parse the extension using the expected length if possible
+				const extensionLength = expectedLength ?? actualLength;
+				if (extensionLength < 2) {
+					// An S2 extension was expected, but the length is too short
+					mustDiscardCommand = true;
+					return;
+				} else if (
+					extensionLength
+						> buffer.length
+							- offset
+							- (wasEncrypted
+								? 0
+								: SECURITY_S2_AUTH_TAG_LENGTH)
+				) {
+					// The supposed length is longer than the space the extensions may occupy
+					mustDiscardCommand = true;
+					return;
+				}
+
+				const extensionData = buffer.subarray(
+					offset,
+					offset + extensionLength,
+				);
+				offset += extensionLength;
+
+				const ext = Security2Extension.parse(extensionData);
+
+				switch (validateS2Extension(ext, wasEncrypted)) {
+					case ValidateS2ExtensionResult.OK:
+						if (
+							expectedLength != undefined
+							&& actualLength !== expectedLength
+						) {
+							// The extension length field does not match, ignore the extension
+						} else {
+							extensions.push(ext);
+						}
+						break;
+					case ValidateS2ExtensionResult.DiscardExtension:
+						// Do nothing
+						break;
+					case ValidateS2ExtensionResult.DiscardCommand:
+						mustDiscardCommand = true;
+						break;
+				}
+
+				// Check if that was the last extension
+				if (!ext.moreToFollow) break;
+			}
+		};
+		if (hasExtensions) parseExtensions(raw.payload, false);
+
+		const mcctx = ((): MulticastContext => {
+			const multicastGroupId = getMulticastGroupId(extensions);
+			if (
+				ctx.frameType === "multicast" || ctx.frameType === "broadcast"
+			) {
+				if (multicastGroupId == undefined) {
+					validatePayload.fail(
+						"Multicast frames without MGRP extension",
+					);
+				}
+				return {
+					isMulticast: true,
+					groupId: multicastGroupId,
+				};
+			} else {
+				return { isMulticast: false, groupId: multicastGroupId };
+			}
+		})();
+
+		// If a command is to be discarded before decryption,
+		// we still need to increment the SPAN or MPAN state
+		if (mustDiscardCommand) {
+			if (mcctx.isMulticast) {
+				securityManager.nextPeerMPAN(
+					ctx.sourceNodeId,
+					mcctx.groupId,
+				);
+			} else {
+				securityManager.nextNonce(ctx.sourceNodeId);
+			}
+			validatePayload.fail(
+				"Invalid S2 extension",
+			);
+		}
+
+		let prevSequenceNumber: number | undefined;
+		let mpanState:
+			| ReturnType<SecurityManager2["getPeerMPAN"]>
+			| undefined;
+		if (mcctx.isMulticast) {
+			mpanState = securityManager.getPeerMPAN(
+				ctx.sourceNodeId,
+				mcctx.groupId,
+			);
+		} else {
+			// Don't accept duplicate Singlecast commands
+			prevSequenceNumber = validateSequenceNumber(
+				securityManager,
+				ctx.sourceNodeId,
+				sequenceNumber,
+			);
+
+			// When a node receives a singlecast message after a multicast group was marked out of sync,
+			// it must forget about the group.
+			if (mcctx.groupId == undefined) {
+				securityManager.resetOutOfSyncMPANs(
+					ctx.sourceNodeId,
+				);
+			}
+		}
+
+		const unencryptedPayload = raw.payload.subarray(0, offset);
+		const ciphertext = raw.payload.subarray(
+			offset,
+			-SECURITY_S2_AUTH_TAG_LENGTH,
+		);
+		const authTag = raw.payload.subarray(-SECURITY_S2_AUTH_TAG_LENGTH);
+		const messageLength =
+			2 /* CommandClass.computeEncapsulationOverhead() */
+			+ raw.payload.length;
+
+		const authData = getAuthenticationData(
+			ctx.sourceNodeId,
+			getDestinationIDRX(ctx, extensions),
+			ctx.homeId,
+			messageLength,
+			unencryptedPayload,
+		);
+
+		let decrypt: () => DecryptionResult;
+		if (mcctx.isMulticast) {
+			// For incoming multicast commands, make sure we have an MPAN
+			if (mpanState?.type !== MPANState.MPAN) {
+				// If we don't, mark the MPAN as out of sync, so we can respond accordingly on the singlecast followup
+				securityManager.storePeerMPAN(
+					ctx.sourceNodeId,
+					mcctx.groupId,
+					{ type: MPANState.OutOfSync },
+				);
+				failNoMPAN();
+			}
+
+			decrypt = () =>
+				decryptMulticast(
+					ctx.sourceNodeId,
+					securityManager,
+					mcctx.groupId,
+					ciphertext,
+					authData,
+					authTag,
+				);
+		} else {
+			// Decrypt payload and verify integrity
+			const spanState = securityManager.getSPANState(
+				ctx.sourceNodeId,
+			);
+
+			// If we are not able to establish an SPAN yet, fail the decryption
+			if (spanState.type === SPANState.None) {
+				failNoSPAN();
+			} else if (spanState.type === SPANState.RemoteEI) {
+				// TODO: The specs are not clear how to handle this case
+				// For now, do the same as if we didn't have any EI
+				failNoSPAN();
+			}
+
+			decrypt = () =>
+				decryptSinglecast(
+					ctx,
+					securityManager,
+					ctx.sourceNodeId,
+					sequenceNumber,
+					prevSequenceNumber!,
+					ciphertext,
+					authData,
+					authTag,
+					spanState,
+					extensions,
+				);
+		}
+
+		let plaintext: Uint8Array | undefined;
+		let authOK = false;
+		let key: Uint8Array | undefined;
+		let iv: Uint8Array | undefined;
+		let decryptionSecurityClass: SecurityClass | undefined;
+
+		// If the Receiver is unable to authenticate the singlecast message with the current SPAN,
+		// the Receiver SHOULD try decrypting the message with one or more of the following SPAN values,
+		// stopping when decryption is successful or the maximum number of iterations is reached.
+
+		// If the Receiver is unable to decrypt the S2 MC frame with the current MPAN, the Receiver MAY try
+		// decrypting the frame with one or more of the subsequent MPAN values, stopping when decryption is
+		// successful or the maximum number of iterations is reached.
+		const decryptAttempts = mcctx.isMulticast
+			? MAX_DECRYPT_ATTEMPTS_MULTICAST
+			: mcctx.groupId != undefined
+			? MAX_DECRYPT_ATTEMPTS_SC_FOLLOWUP
+			: MAX_DECRYPT_ATTEMPTS_SINGLECAST;
+
+		for (let i = 0; i < decryptAttempts; i++) {
+			({
+				plaintext,
+				authOK,
+				key,
+				iv,
+				securityClass: decryptionSecurityClass,
+			} = decrypt());
+			if (!!authOK && !!plaintext) break;
+			// No need to try further SPANs if we just got the sender's EI
+			if (!!getSenderEI(extensions)) break;
+		}
+
+		// If authentication fails, do so with an error code that instructs the
+		// applHost to tell the node we have no nonce
+		if (!authOK || !plaintext) {
+			if (mcctx.isMulticast) {
+				// Mark the MPAN as out of sync
+				securityManager.storePeerMPAN(
+					ctx.sourceNodeId,
+					mcctx.groupId,
+					{ type: MPANState.OutOfSync },
+				);
+				validatePayload.fail(
+					ZWaveErrorCodes.Security2CC_CannotDecodeMulticast,
+				);
+			} else {
+				validatePayload.fail(
+					ZWaveErrorCodes.Security2CC_CannotDecode,
+				);
+			}
+		} else if (!mcctx.isMulticast && mcctx.groupId != undefined) {
+			// After reception of a singlecast followup, the MPAN state must be increased
+			securityManager.tryIncrementPeerMPAN(
+				ctx.sourceNodeId,
+				mcctx.groupId,
+			);
+		}
+
+		// Remember which security class was used to decrypt this message, so we can discard it later
+		const securityClass: SecurityClass | undefined =
+			decryptionSecurityClass;
+
+		offset = 0;
+		if (hasEncryptedExtensions) parseExtensions(plaintext, true);
+
+		// Before we can continue, check if the command must be discarded
+		if (mustDiscardCommand) {
+			validatePayload.fail("Invalid extension");
+		}
+
+		// If the MPAN extension was received, store the MPAN
+		if (!mcctx.isMulticast) {
+			const mpanExtension = extensions.find((e) =>
+				e instanceof MPANExtension
+			);
+			if (mpanExtension) {
+				securityManager.storePeerMPAN(
+					ctx.sourceNodeId,
+					mpanExtension.groupId,
+					{
+						type: MPANState.MPAN,
+						currentMPAN: mpanExtension.innerMPANState,
+					},
+				);
+			}
+		}
+
+		// Not every S2 message includes an encapsulated CC
+		const decryptedCCBytes = plaintext.subarray(offset);
+		let encapsulated: CommandClass | undefined;
+		if (decryptedCCBytes.length > 0) {
+			// make sure this contains a complete CC command that's worth splitting
+			validatePayload(decryptedCCBytes.length >= 2);
+			// and deserialize the CC
+			encapsulated = await CommandClass.parseAsync(decryptedCCBytes, ctx);
 		}
 
 		const ret = new Security2CCMessageEncapsulation({

--- a/packages/cc/src/cc/SecurityCC.ts
+++ b/packages/cc/src/cc/SecurityCC.ts
@@ -586,6 +586,7 @@ export class SecurityCCNonceReport extends SecurityCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.view(this.nonce);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -797,6 +798,7 @@ export class SecurityCCCommandEncapsulation extends SecurityCC {
 		this.encapsulated.encapsulatingCC = this as any;
 	}
 
+	/** @deprecated Use {@link serializeAsync} instead */
 	public serialize(ctx: CCEncodingContext): Bytes {
 		if (!this.nonce) throwNoNonce();
 		if (this.nonce.length !== HALF_NONCE_SIZE) {
@@ -816,6 +818,7 @@ export class SecurityCCCommandEncapsulation extends SecurityCC {
 			encryptionKey = ctx.securityManager.encryptionKey;
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		const serializedCC = this.encapsulated.serialize(ctx);
 		const plaintext = Bytes.concat([
 			Bytes.from([0]), // TODO: frame control
@@ -848,7 +851,62 @@ export class SecurityCCCommandEncapsulation extends SecurityCC {
 			Bytes.from([this.nonceId!]),
 			authCode,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
+	}
+
+	public async serializeAsync(ctx: CCEncodingContext): Promise<Bytes> {
+		if (!this.nonce) throwNoNonce();
+		if (this.nonce.length !== HALF_NONCE_SIZE) {
+			throwNoNonce("Invalid nonce size");
+		}
+		assertSecurityTX(ctx);
+
+		let authKey: Uint8Array;
+		let encryptionKey: Uint8Array;
+		if (this.alternativeNetworkKey) {
+			authKey = generateAuthKey(this.alternativeNetworkKey);
+			encryptionKey = generateEncryptionKey(
+				this.alternativeNetworkKey,
+			);
+		} else {
+			authKey = ctx.securityManager.authKey;
+			encryptionKey = ctx.securityManager.encryptionKey;
+		}
+
+		const serializedCC = await this.encapsulated.serializeAsync(ctx);
+		const plaintext = Bytes.concat([
+			Bytes.from([0]), // TODO: frame control
+			serializedCC,
+		]);
+		// Encrypt the payload
+		const senderNonce = randomBytes(HALF_NONCE_SIZE);
+		const iv = Bytes.concat([senderNonce, this.nonce]);
+		const ciphertext = encryptAES128OFB(plaintext, encryptionKey, iv);
+		// And generate the auth code
+		const authData = getAuthenticationData(
+			senderNonce,
+			this.nonce,
+			this.ccCommand,
+			ctx.ownNodeId,
+			this.nodeId,
+			ciphertext,
+		);
+		const authCode = computeMAC(authData, authKey);
+
+		// Remember for debugging purposes
+		this.iv = iv;
+		this.authData = authData;
+		this.authCode = authCode;
+		this.ciphertext = ciphertext;
+
+		this.payload = Bytes.concat([
+			senderNonce,
+			ciphertext,
+			Bytes.from([this.nonceId!]),
+			authCode,
+		]);
+		return super.serializeAsync(ctx);
 	}
 
 	protected computeEncapsulationOverhead(): number {
@@ -921,6 +979,7 @@ export class SecurityCCSchemeReport extends SecurityCC {
 	public serialize(ctx: CCEncodingContext): Bytes {
 		// Since it is unlikely that any more schemes will be added to S0, we hardcode the default scheme here (bit 0 = 0)
 		this.payload = Bytes.from([0]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -939,6 +998,7 @@ export class SecurityCCSchemeGet extends SecurityCC {
 	public serialize(ctx: CCEncodingContext): Bytes {
 		// Since it is unlikely that any more schemes will be added to S0, we hardcode the default scheme here (bit 0 = 0)
 		this.payload = Bytes.from([0]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -957,6 +1017,7 @@ export class SecurityCCSchemeInherit extends SecurityCC {
 	public serialize(ctx: CCEncodingContext): Bytes {
 		// Since it is unlikely that any more schemes will be added to S0, we hardcode the default scheme here (bit 0 = 0)
 		this.payload = Bytes.from([0]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1010,6 +1071,7 @@ export class SecurityCCNetworkKeySet extends SecurityCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.view(this.networkKey);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1102,6 +1164,7 @@ export class SecurityCCCommandsSupportedReport extends SecurityCC {
 			Bytes.from([this.reportsToFollow]),
 			encodeCCList(this.supportedCCs, this.controlledCCs),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/SoundSwitchCC.ts
+++ b/packages/cc/src/cc/SoundSwitchCC.ts
@@ -501,6 +501,7 @@ export class SoundSwitchCCTonesNumberReport extends SoundSwitchCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.toneCount]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -566,6 +567,7 @@ export class SoundSwitchCCToneInfoReport extends SoundSwitchCC {
 			Bytes.from(this.name, "utf8"),
 		]);
 		this.payload.writeUInt16BE(this.duration, 1);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -623,6 +625,7 @@ export class SoundSwitchCCToneInfoGet extends SoundSwitchCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.toneId]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -671,6 +674,7 @@ export class SoundSwitchCCConfigurationSet extends SoundSwitchCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.defaultVolume, this.defaultToneId]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -724,6 +728,7 @@ export class SoundSwitchCCConfigurationReport extends SoundSwitchCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.defaultVolume, this.defaultToneId]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -783,6 +788,7 @@ export class SoundSwitchCCTonePlaySet extends SoundSwitchCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.toneId, this.volume ?? 0]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -844,6 +850,7 @@ export class SoundSwitchCCTonePlayReport extends SoundSwitchCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.toneId, this.volume ?? 0]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/SupervisionCC.ts
+++ b/packages/cc/src/cc/SupervisionCC.ts
@@ -416,12 +416,34 @@ export class SupervisionCCGet extends SupervisionCC {
 		this.encapsulated.encapsulatingCC = this as any;
 	}
 
+	/** @deprecated Use {@link fromAsync} instead */
 	public static from(raw: CCRaw, ctx: CCParsingContext): SupervisionCCGet {
 		validatePayload(raw.payload.length >= 3);
 		const requestStatusUpdates = !!(raw.payload[0] & 0b1_0_000000);
 		const sessionId = raw.payload[0] & 0b111111;
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		const encapsulated = CommandClass.parse(raw.payload.subarray(2), ctx);
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			requestStatusUpdates,
+			sessionId,
+			encapsulated,
+		});
+	}
+
+	public static async fromAsync(
+		raw: CCRaw,
+		ctx: CCParsingContext,
+	): Promise<SupervisionCCGet> {
+		validatePayload(raw.payload.length >= 3);
+		const requestStatusUpdates = !!(raw.payload[0] & 0b1_0_000000);
+		const sessionId = raw.payload[0] & 0b111111;
+
+		const encapsulated = await CommandClass.parseAsync(
+			raw.payload.subarray(2),
+			ctx,
+		);
 		return new this({
 			nodeId: ctx.sourceNodeId,
 			requestStatusUpdates,

--- a/packages/cc/src/cc/SupervisionCC.ts
+++ b/packages/cc/src/cc/SupervisionCC.ts
@@ -355,6 +355,7 @@ export class SupervisionCCReport extends SupervisionCC {
 				Bytes.from([this.duration.serializeReport()]),
 			]);
 		}
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -456,7 +457,9 @@ export class SupervisionCCGet extends SupervisionCC {
 	public sessionId: number;
 	public encapsulated: CommandClass;
 
+	/** @deprecated Use {@link serializeAsync} instead */
 	public serialize(ctx: CCEncodingContext): Bytes {
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		const encapCC = this.encapsulated.serialize(ctx);
 		this.payload = Bytes.concat([
 			Bytes.from([
@@ -466,7 +469,21 @@ export class SupervisionCCGet extends SupervisionCC {
 			]),
 			encapCC,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
+	}
+
+	public async serializeAsync(ctx: CCEncodingContext): Promise<Bytes> {
+		const encapCC = await this.encapsulated.serializeAsync(ctx);
+		this.payload = Bytes.concat([
+			Bytes.from([
+				(this.requestStatusUpdates ? 0b10_000000 : 0)
+				| (this.sessionId & 0b111111),
+				encapCC.length,
+			]),
+			encapCC,
+		]);
+		return super.serializeAsync(ctx);
 	}
 
 	protected computeEncapsulationOverhead(): number {

--- a/packages/cc/src/cc/ThermostatFanModeCC.ts
+++ b/packages/cc/src/cc/ThermostatFanModeCC.ts
@@ -375,6 +375,7 @@ export class ThermostatFanModeCCSet extends ThermostatFanModeCC {
 			(this.off ? 0b1000_0000 : 0)
 			| (this.mode & 0b1111),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/ThermostatModeCC.ts
+++ b/packages/cc/src/cc/ThermostatModeCC.ts
@@ -376,6 +376,7 @@ export class ThermostatModeCCSet extends ThermostatModeCC {
 			]),
 			manufacturerData,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -502,6 +503,7 @@ export class ThermostatModeCCReport extends ThermostatModeCC {
 				1,
 			);
 		}
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -577,6 +579,7 @@ export class ThermostatModeCCSupportedReport extends ThermostatModeCC {
 			ThermostatMode["Manufacturer specific"],
 			ThermostatMode.Off,
 		);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/ThermostatSetbackCC.ts
+++ b/packages/cc/src/cc/ThermostatSetbackCC.ts
@@ -213,6 +213,7 @@ export class ThermostatSetbackCCSet extends ThermostatSetbackCC {
 			[this.setbackType & 0b11],
 			encodeSetbackState(this.setbackState),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -276,6 +277,7 @@ export class ThermostatSetbackCCReport extends ThermostatSetbackCC {
 			[this.setbackType & 0b11],
 			encodeSetbackState(this.setbackState),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/ThermostatSetpointCC.ts
+++ b/packages/cc/src/cc/ThermostatSetpointCC.ts
@@ -594,6 +594,7 @@ export class ThermostatSetpointCCSet extends ThermostatSetpointCC {
 			Bytes.from([this.setpointType & 0b1111]),
 			encodeFloatWithScale(this.value, this.scale, override),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -699,6 +700,7 @@ export class ThermostatSetpointCCReport extends ThermostatSetpointCC {
 			Bytes.from([this.type & 0b1111]),
 			encodeFloatWithScale(this.value, this.scale),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -760,6 +762,7 @@ export class ThermostatSetpointCCGet extends ThermostatSetpointCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.setpointType & 0b1111]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -853,6 +856,7 @@ export class ThermostatSetpointCCCapabilitiesReport
 		const min = encodeFloatWithScale(this.minValue, this.minValueScale);
 		const max = encodeFloatWithScale(this.maxValue, this.maxValueScale);
 		this.payload = Bytes.concat([Bytes.from([this.type]), min, max]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -905,6 +909,7 @@ export class ThermostatSetpointCCCapabilitiesGet extends ThermostatSetpointCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.setpointType & 0b1111]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -979,6 +984,7 @@ export class ThermostatSetpointCCSupportedReport extends ThermostatSetpointCC {
 			undefined,
 			ThermostatSetpointType["N/A"],
 		);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/TimeCC.ts
+++ b/packages/cc/src/cc/TimeCC.ts
@@ -278,6 +278,7 @@ export class TimeCCTimeReport extends TimeCC {
 			this.minute,
 			this.second,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -342,6 +343,7 @@ export class TimeCCDateReport extends TimeCC {
 			this.day,
 		]);
 		this.payload.writeUInt16BE(this.year, 0);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -417,6 +419,7 @@ export class TimeCCTimeOffsetSet extends TimeCC {
 				this.dstEndDate.getUTCHours(),
 			]),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -506,6 +509,7 @@ export class TimeCCTimeOffsetReport extends TimeCC {
 				this.dstEndDate.getUTCHours(),
 			]),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/TimeParametersCC.ts
+++ b/packages/cc/src/cc/TimeParametersCC.ts
@@ -408,6 +408,7 @@ export class TimeParametersCCSet extends TimeParametersCC {
 			dateSegments.second,
 		]);
 		this.payload.writeUInt16BE(dateSegments.year, 0);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/TransportServiceCC.ts
+++ b/packages/cc/src/cc/TransportServiceCC.ts
@@ -182,6 +182,7 @@ export class TransportServiceCCFirstSegment extends TransportServiceCC {
 		// Write the checksum into the last two bytes of the payload
 		this.payload.writeUInt16BE(crc, this.payload.length - 2);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -428,6 +429,7 @@ export class TransportServiceCCSubsequentSegment extends TransportServiceCC {
 		// Write the checksum into the last two bytes of the payload
 		this.payload.writeUInt16BE(crc, this.payload.length - 2);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -514,6 +516,7 @@ export class TransportServiceCCSegmentRequest extends TransportServiceCC {
 			| ((this.datagramOffset >>> 8) & 0b111),
 			this.datagramOffset & 0xff,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -559,6 +562,7 @@ export class TransportServiceCCSegmentComplete extends TransportServiceCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([(this.sessionId & 0b1111) << 4]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -601,6 +605,7 @@ export class TransportServiceCCSegmentWait extends TransportServiceCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.pendingSegments]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/TransportServiceCC.ts
+++ b/packages/cc/src/cc/TransportServiceCC.ts
@@ -336,6 +336,7 @@ export class TransportServiceCCSubsequentSegment extends TransportServiceCC {
 		return { ccCommand: undefined, sessionId: this.sessionId };
 	}
 
+	/** @deprecated Use {@link mergePartialCCsAsync} instead */
 	public mergePartialCCs(
 		partials: [
 			TransportServiceCCFirstSegment,
@@ -360,7 +361,36 @@ export class TransportServiceCCSubsequentSegment extends TransportServiceCC {
 		}
 
 		// and deserialize the CC
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		this._encapsulated = CommandClass.parse(datagram, ctx);
+		this._encapsulated.encapsulatingCC = this as any;
+	}
+
+	public async mergePartialCCsAsync(
+		partials: [
+			TransportServiceCCFirstSegment,
+			...TransportServiceCCSubsequentSegment[],
+		],
+		ctx: CCParsingContext,
+	): Promise<void> {
+		// Concat the CC buffers
+		const datagram = new Bytes(this.datagramSize);
+		for (const partial of [...partials, this]) {
+			// Ensure that we don't try to write out-of-bounds
+			const offset = partial instanceof TransportServiceCCFirstSegment
+				? 0
+				: partial.datagramOffset;
+			if (offset + partial.partialDatagram.length > datagram.length) {
+				throw new ZWaveError(
+					`The partial datagram offset and length in a segment are not compatible to the communicated datagram length`,
+					ZWaveErrorCodes.PacketFormat_InvalidPayload,
+				);
+			}
+			datagram.set(partial.partialDatagram, offset);
+		}
+
+		// and deserialize the CC
+		this._encapsulated = await CommandClass.parseAsync(datagram, ctx);
 		this._encapsulated.encapsulatingCC = this as any;
 	}
 

--- a/packages/cc/src/cc/UserCodeCC.ts
+++ b/packages/cc/src/cc/UserCodeCC.ts
@@ -1313,6 +1313,7 @@ export class UserCodeCCSet extends UserCodeCC {
 				? Bytes.from(this.userCode, "ascii")
 				: this.userCode,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1421,6 +1422,7 @@ export class UserCodeCCReport extends UserCodeCC
 			Bytes.from([this.userId, this.userIdStatus]),
 			userCodeBuffer,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1470,6 +1472,7 @@ export class UserCodeCCGet extends UserCodeCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.userId]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1526,6 +1529,7 @@ export class UserCodeCCUsersNumberReport extends UserCodeCC {
 		// If the node implements more than 255 users, this field MUST be set to 255
 		this.payload[0] = Math.min(255, this.supportedUsers);
 		this.payload.writeUInt16BE(this.supportedUsers, 1);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1717,6 +1721,7 @@ export class UserCodeCCCapabilitiesReport extends UserCodeCC {
 			Bytes.from([controlByte3]),
 			supportedKeysBitmask,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1783,6 +1788,7 @@ export class UserCodeCCKeypadModeSet extends UserCodeCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.keypadMode]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1847,6 +1853,7 @@ export class UserCodeCCKeypadModeReport extends UserCodeCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.keypadMode]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1903,6 +1910,7 @@ export class UserCodeCCAdminCodeSet extends UserCodeCC {
 			Bytes.from([this.adminCode.length & 0b1111]),
 			Bytes.from(this.adminCode, "ascii"),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1953,6 +1961,7 @@ export class UserCodeCCAdminCodeReport extends UserCodeCC {
 			Bytes.from([this.adminCode.length & 0b1111]),
 			Bytes.from(this.adminCode, "ascii"),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -2001,6 +2010,7 @@ export class UserCodeCCUserCodeChecksumReport extends UserCodeCC {
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = new Bytes(2);
 		this.payload.writeUInt16BE(this.userCodeChecksum, 0);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -2074,6 +2084,7 @@ export class UserCodeCCExtendedUserCodeSet extends UserCodeCC {
 			Bytes.from([this.userCodes.length]),
 			...userCodeBuffers,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -2210,6 +2221,7 @@ export class UserCodeCCExtendedUserCodeGet extends UserCodeCC {
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([0, 0, this.reportMore ? 1 : 0]);
 		this.payload.writeUInt16BE(this.userId, 0);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/VersionCC.ts
+++ b/packages/cc/src/cc/VersionCC.ts
@@ -752,6 +752,7 @@ export class VersionCCReport extends VersionCC {
 			this.payload = Bytes.concat([this.payload, firmwaresBuffer]);
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -814,6 +815,7 @@ export class VersionCCCommandClassReport extends VersionCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.requestedCC, this.ccVersion]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -871,6 +873,7 @@ export class VersionCCCommandClassGet extends VersionCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.requestedCC]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -921,6 +924,7 @@ export class VersionCCCapabilitiesReport extends VersionCC {
 		this.payload = Bytes.from([
 			(this.supportsZWaveSoftwareGet ? 0b100 : 0) | 0b11,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/WakeUpCC.ts
+++ b/packages/cc/src/cc/WakeUpCC.ts
@@ -394,6 +394,7 @@ export class WakeUpCCIntervalSet extends WakeUpCC {
 			this.controllerNodeId,
 		]);
 		this.payload.writeUIntBE(this.wakeUpInterval, 0, 3);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/WindowCoveringCC.ts
+++ b/packages/cc/src/cc/WindowCoveringCC.ts
@@ -733,6 +733,7 @@ export class WindowCoveringCCSupportedReport extends WindowCoveringCC {
 			bitmask.subarray(0, numBitmaskBytes),
 		]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -877,6 +878,7 @@ export class WindowCoveringCCGet extends WindowCoveringCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.parameter]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -964,6 +966,7 @@ export class WindowCoveringCCSet extends WindowCoveringCC {
 			this.duration ?? Duration.default()
 		).serializeSet();
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1035,6 +1038,7 @@ export class WindowCoveringCCStartLevelChange extends WindowCoveringCC {
 			this.parameter,
 			(this.duration ?? Duration.default()).serializeSet(),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1088,6 +1092,7 @@ export class WindowCoveringCCStopLevelChange extends WindowCoveringCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.parameter]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/ZWavePlusCC.ts
+++ b/packages/cc/src/cc/ZWavePlusCC.ts
@@ -235,6 +235,7 @@ export class ZWavePlusCCReport extends ZWavePlusCC {
 		]);
 		this.payload.writeUInt16BE(this.installerIcon, 3);
 		this.payload.writeUInt16BE(this.userIcon, 5);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/cc/ZWaveProtocolCC.ts
+++ b/packages/cc/src/cc/ZWaveProtocolCC.ts
@@ -123,6 +123,7 @@ export class ZWaveProtocolCCNodeInformationFrame extends ZWaveProtocolCC
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = encodeNodeInformationFrame(this);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -171,6 +172,7 @@ export class ZWaveProtocolCCAssignIDs extends ZWaveProtocolCC {
 		this.payload = new Bytes(5);
 		this.payload[0] = this.assignedNodeId;
 		this.payload.writeUInt32BE(this.homeId, 1);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -248,6 +250,7 @@ export class ZWaveProtocolCCFindNodesInRange extends ZWaveProtocolCC {
 			nodesBitmask,
 			Bytes.from([this.wakeUpTime, this.dataRate]),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -306,6 +309,7 @@ export class ZWaveProtocolCCRangeInfo extends ZWaveProtocolCC {
 				? Bytes.from([this.wakeUpTime])
 				: new Bytes(),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -345,6 +349,7 @@ export class ZWaveProtocolCCCommandComplete extends ZWaveProtocolCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.sequenceNumber]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -401,6 +406,7 @@ export class ZWaveProtocolCCTransferPresentation extends ZWaveProtocolCC {
 			| (this.excludeNode ? 0b0010 : 0)
 			| (this.includeNode ? 0b0100 : 0),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -479,6 +485,7 @@ export class ZWaveProtocolCCTransferNodeInformation extends ZWaveProtocolCC
 			Bytes.from([this.sequenceNumber, this.sourceNodeId]),
 			encodeNodeProtocolInfoAndDeviceClass(this),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -537,6 +544,7 @@ export class ZWaveProtocolCCTransferRangeInformation extends ZWaveProtocolCC {
 			]),
 			nodesBitmask,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -572,6 +580,7 @@ export class ZWaveProtocolCCTransferEnd extends ZWaveProtocolCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.status]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -646,6 +655,7 @@ export class ZWaveProtocolCCAssignReturnRoute extends ZWaveProtocolCC {
 			...this.repeaters,
 			speedByte,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -718,6 +728,7 @@ export class ZWaveProtocolCCNewNodeRegistered extends ZWaveProtocolCC
 			Bytes.from([this.newNodeId]),
 			encodeNodeInformationFrame(this),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -765,6 +776,7 @@ export class ZWaveProtocolCCNewRangeRegistered extends ZWaveProtocolCC {
 			Bytes.from([this.testedNodeId, nodesBitmask.length]),
 			nodesBitmask,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -804,6 +816,7 @@ export class ZWaveProtocolCCTransferNewPrimaryControllerComplete
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.genericDeviceClass]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -850,6 +863,7 @@ export class ZWaveProtocolCCSUCNodeID extends ZWaveProtocolCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.sucNodeId, this.isSIS ? 0b1 : 0]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -887,6 +901,7 @@ export class ZWaveProtocolCCSetSUC extends ZWaveProtocolCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([0x01, this.enableSIS ? 0b1 : 0]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -931,6 +946,7 @@ export class ZWaveProtocolCCSetSUCAck extends ZWaveProtocolCC {
 			this.accepted ? 0x01 : 0x00,
 			this.isSIS ? 0b1 : 0,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -982,6 +998,7 @@ export class ZWaveProtocolCCStaticRouteRequest extends ZWaveProtocolCC {
 		for (let i = 0; i < this.nodeIds.length && i < 5; i++) {
 			this.payload[i] = this.nodeIds[i];
 		}
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -1014,6 +1031,7 @@ export class ZWaveProtocolCCLost extends ZWaveProtocolCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.lostNodeId]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -1052,6 +1070,7 @@ export class ZWaveProtocolCCAcceptLost extends ZWaveProtocolCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.accepted ? 0x05 : 0x04]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -1119,6 +1138,7 @@ export class ZWaveProtocolCCNOPPower extends ZWaveProtocolCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([0, this.powerDampening]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -1161,6 +1181,7 @@ export class ZWaveProtocolCCReservedIDs extends ZWaveProtocolCC {
 			this.reservedNodeIDs.length,
 			...this.reservedNodeIDs,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -1197,6 +1218,7 @@ export class ZWaveProtocolCCReserveNodeIDs extends ZWaveProtocolCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.numNodeIDs]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -1240,6 +1262,7 @@ export class ZWaveProtocolCCNodesExistReply extends ZWaveProtocolCC {
 			this.nodeMaskType,
 			this.nodeListUpdated ? 0x01 : 0x00,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -1297,6 +1320,7 @@ export class ZWaveProtocolCCNodesExist extends ZWaveProtocolCC {
 			this.nodeIDs.length,
 			...this.nodeIDs,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -1340,6 +1364,7 @@ export class ZWaveProtocolCCSetNWIMode extends ZWaveProtocolCC {
 			this.enabled ? 0x01 : 0x00,
 			this.timeoutMinutes ?? 0x00,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -1385,6 +1410,7 @@ export class ZWaveProtocolCCAssignReturnRoutePriority extends ZWaveProtocolCC {
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from([this.targetNodeId, this.routeNumber]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -1435,6 +1461,7 @@ export class ZWaveProtocolCCSmartStartIncludedNodeInformation
 
 	public serialize(ctx: CCEncodingContext): Bytes {
 		this.payload = Bytes.from(this.nwiHomeId);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }

--- a/packages/cc/src/cc/manufacturerProprietary/FibaroCC.ts
+++ b/packages/cc/src/cc/manufacturerProprietary/FibaroCC.ts
@@ -237,6 +237,7 @@ export class FibaroCC extends ManufacturerProprietaryCC {
 			fibaroCCCommand,
 		);
 		if (FibaroConstructor) {
+			// eslint-disable-next-line @typescript-eslint/no-deprecated
 			return FibaroConstructor.from(
 				raw.withPayload(raw.payload.subarray(2)),
 				ctx,
@@ -299,6 +300,7 @@ export class FibaroCC extends ManufacturerProprietaryCC {
 			Bytes.from([this.fibaroCCId, this.fibaroCCCommand]),
 			this.payload,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -406,6 +408,7 @@ export class FibaroVenetianBlindCCSet extends FibaroVenetianBlindCC {
 			this.position ?? 0,
 			this.tilt ?? 0,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/cc/src/lib/CommandClass.ts
+++ b/packages/cc/src/lib/CommandClass.ts
@@ -350,6 +350,12 @@ export class CommandClass implements CCId {
 	): Promise<CommandClass> {
 		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return this.from(raw, ctx);
+
+		// TODO: Plan for next major release:
+		// - CommandClass ONLY exposes `public static async from` (renamed!)
+		// - CommandClass internally implements `protected static fromSync` and `protected static async fromAsync`
+		// - The default implementation of `fromAsync` just calls `fromSync`
+		// - Sub-classes override either `fromSync` OR `fromAsync` as needed
 	}
 
 	/** This CC's identifier */
@@ -423,6 +429,7 @@ export class CommandClass implements CCId {
 
 	/**
 	 * Serializes this CommandClass to be embedded in a message payload or another CC
+	 * @deprecated Use {@link serializeAsync} instead
 	 */
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	public serialize(ctx: CCEncodingContext): Bytes {
@@ -445,6 +452,21 @@ export class CommandClass implements CCId {
 			data.set(this.payload, 1 + ccIdLength);
 		}
 		return data;
+	}
+
+	/**
+	 * Serializes this CommandClass to be embedded in a message payload or another CC
+	 */
+	// eslint-disable-next-line @typescript-eslint/require-await
+	public async serializeAsync(ctx: CCEncodingContext): Promise<Bytes> {
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
+		return this.serialize(ctx);
+
+		// TODO: Plan for next major release:
+		// - CommandClass ONLY exposes `public async serialize` (renamed!)
+		// - CommandClass internally implements `protected serializeSync` and `protected async serializeAsync`
+		// - The default implementation of `serializeAsync` just calls `serializeSync`
+		// - Sub-classes override either `serializeSync` OR `serializeAsync` as needed
 	}
 
 	public prepareRetransmission(): void {

--- a/packages/maintenance/src/codefind.ts
+++ b/packages/maintenance/src/codefind.ts
@@ -2,14 +2,7 @@
  * This scripts helps find certain code patterns via the CLI
  */
 
-import {
-	blueBright,
-	bold,
-	gray,
-	greenBright,
-	redBright,
-	yellow,
-} from "ansi-colors";
+import c from "ansi-colors";
 import { fromJson as themeFromJson, highlight } from "cli-highlight";
 import esMain from "es-main";
 import globrex from "globrex";
@@ -18,6 +11,15 @@ import ts from "typescript";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { loadTSConfig, projectRoot } from "./tsAPITools.js";
+
+const {
+	blueBright,
+	bold,
+	gray,
+	greenBright,
+	redBright,
+	yellow,
+} = c;
 
 function relativeToProject(filename: string): string {
 	return path.relative(projectRoot, filename).replaceAll("\\", "/");

--- a/packages/maintenance/src/refactorTests.04.ts
+++ b/packages/maintenance/src/refactorTests.04.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs/promises";
+import { Project, SyntaxKind } from "ts-morph";
+
+async function main() {
+	const project = new Project();
+	project.addSourceFilesAtPaths("packages/**/*.test.ts");
+
+	const sourceFiles = project.getSourceFiles() /*.filter((f) =>
+		f.getFilePath().endsWith("JsonTemplate.test.ts")
+	) */;
+
+	for (const file of sourceFiles) {
+		// Find calls to `CommandClass.parse`
+		const ccParse = file.getDescendantsOfKind(
+			SyntaxKind.PropertyAccessExpression,
+		)
+			.filter((p) => p.getText() === "CommandClass.parse")
+			.map((p) => {
+				const callExpr = p.getParentIfKind(SyntaxKind.CallExpression);
+				if (!callExpr) return;
+				const parentFn = callExpr.getFirstAncestorByKind(
+					SyntaxKind.ArrowFunction,
+				);
+				if (!parentFn) return;
+				return [parentFn, callExpr, p] as const;
+			})
+			.filter((p) => p != undefined);
+
+		if (ccParse.length === 0) continue;
+
+		for (const [parentFn, callExpr, propAccess] of ccParse) {
+			parentFn.setIsAsync(true);
+			propAccess.replaceWithText("CommandClass.parseAsync");
+			callExpr.replaceWithText(`await ${callExpr.getText()}`);
+		}
+
+		await file.save();
+	}
+}
+
+void main().catch(async (e) => {
+	debugger;
+	await fs.writeFile(`${e.filePath}.old`, e.oldText);
+	await fs.writeFile(`${e.filePath}.new`, e.newText);
+	console.error(`Error refactoring file ${e.filePath}
+  old text: ${e.filePath}.old
+  new text: ${e.filePath}.new
+  
+Reason: ${e.message}`);
+
+	process.exit(1);
+});

--- a/packages/maintenance/src/refactorTests.05.ts
+++ b/packages/maintenance/src/refactorTests.05.ts
@@ -1,0 +1,76 @@
+import fs from "node:fs/promises";
+import { Project, SyntaxKind } from "ts-morph";
+
+async function main() {
+	const project = new Project();
+	project.addSourceFilesAtPaths("packages/**/*.test.ts");
+
+	const sourceFiles = project.getSourceFiles() /*.filter((f) =>
+		f.getFilePath().endsWith("JsonTemplate.test.ts")
+	) */;
+
+	for (const file of sourceFiles) {
+		// Find calls to `t.expect`
+		const tExpect = file.getDescendantsOfKind(
+			SyntaxKind.PropertyAccessExpression,
+		)
+			.filter((p) => p.getText() === "t.expect");
+
+		// Limit to those with a `.serialize` call
+		const withSerialize = tExpect
+			.map((p) => {
+				const call = p.getParentIfKind(
+					SyntaxKind.CallExpression,
+				);
+				if (!call) return;
+
+				const stmt = call.getFirstAncestorByKind(
+					SyntaxKind.ExpressionStatement,
+				);
+				if (!stmt) return;
+
+				const serialize = call.getDescendantsOfKind(
+					SyntaxKind.PropertyAccessExpression,
+				).filter((s) => s.getName() === "serialize");
+				if (serialize.length === 0) return;
+
+				return [
+					stmt,
+					call,
+					serialize.map((s) => s.getNameNode()),
+				] as const;
+			}).filter((x) => x != undefined);
+
+		const withParentFn = withSerialize.map(([expr, t, s]) => {
+			const parentFn = t.getFirstAncestorByKind(SyntaxKind.ArrowFunction);
+			if (!parentFn) return;
+			return [parentFn, expr, t, s] as const;
+		}).filter((x) => x != undefined);
+
+		if (withParentFn.length === 0) continue;
+
+		for (const [parentFn, expr, tExpect, serialize] of withParentFn) {
+			parentFn.setIsAsync(true);
+			serialize.forEach((s) => s.replaceWithText("serializeAsync"));
+			tExpect.replaceWithText(
+				`${tExpect.getText()}.resolves`,
+			);
+			expr.replaceWithText(`await ${expr.getText()}`);
+		}
+
+		await file.save();
+	}
+}
+
+void main().catch(async (e) => {
+	debugger;
+	await fs.writeFile(`${e.filePath}.old`, e.oldText);
+	await fs.writeFile(`${e.filePath}.new`, e.newText);
+	console.error(`Error refactoring file ${e.filePath}
+  old text: ${e.filePath}.old
+  new text: ${e.filePath}.new
+  
+Reason: ${e.message}`);
+
+	process.exit(1);
+});

--- a/packages/serial/src/message/Message.test.ts
+++ b/packages/serial/src/message/Message.test.ts
@@ -5,7 +5,7 @@ import { test } from "vitest";
 import { FunctionType, MessageType } from "./Constants.js";
 import { Message, messageTypes } from "./Message.js";
 
-test("should deserialize and serialize correctly", (t) => {
+test("should deserialize and serialize correctly", async (t) => {
 	// actual messages from OZW
 	const okayMessages = [
 		Bytes.from([
@@ -39,7 +39,7 @@ test("should deserialize and serialize correctly", (t) => {
 		]),
 	];
 	for (const original of okayMessages) {
-		const parsed = Message.parse(original, {} as any);
+		const parsed = await Message.parseAsync(original, {} as any);
 		t.expect(parsed.serialize({} as any)).toStrictEqual(original);
 	}
 });
@@ -54,7 +54,7 @@ test("should serialize correctly when the payload is null", (t) => {
 	t.expect(message.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("should throw the correct error when parsing a faulty message", (t) => {
+test("should throw the correct error when parsing a faulty message", async (t) => {
 	// fake messages to produce certain errors
 	const brokenMessages: [Bytes, string, ZWaveErrorCodes][] = [
 		// too short (<5 bytes)
@@ -89,9 +89,9 @@ test("should throw the correct error when parsing a faulty message", (t) => {
 		],
 	];
 	for (const [message, msg, code] of brokenMessages) {
-		assertZWaveError(
+		await assertZWaveError(
 			t.expect,
-			() => Message.parse(message, {} as any),
+			() => Message.parseAsync(message, {} as any),
 			{
 				messageMatches: msg,
 				errorCode: code,
@@ -154,11 +154,10 @@ test("toJSON() should return a semi-readable JSON representation", (t) => {
 	t.expect(msg4.toJSON()).toStrictEqual(json4);
 });
 
-test("Parsing a buffer with an unknown function type returns an unspecified `Message` instance", (t) => {
+test("Parsing a buffer with an unknown function type returns an unspecified `Message` instance", async (t) => {
 	const unknown = Bytes.from([0x01, 0x03, 0x00, 0x00, 0xfc]);
-	t.expect(
-		Message.parse(unknown, {} as any).constructor,
-	).toBe(Message);
+	const parsed = await Message.parseAsync(unknown, {} as any);
+	t.expect(parsed).toBeInstanceOf(Message);
 });
 
 test(`the constructor should throw when no message type is specified`, (t) => {

--- a/packages/serial/src/message/Message.test.ts
+++ b/packages/serial/src/message/Message.test.ts
@@ -39,7 +39,7 @@ test("should deserialize and serialize correctly", async (t) => {
 		]),
 	];
 	for (const original of okayMessages) {
-		const parsed = await Message.parseAsync(original, {} as any);
+		const parsed = Message.parse(original, {} as any);
 		await t.expect(parsed.serializeAsync({} as any)).resolves.toStrictEqual(
 			original,
 		);
@@ -93,9 +93,9 @@ test("should throw the correct error when parsing a faulty message", async (t) =
 		],
 	];
 	for (const [message, msg, code] of brokenMessages) {
-		await assertZWaveError(
+		assertZWaveError(
 			t.expect,
-			() => Message.parseAsync(message, {} as any),
+			() => Message.parse(message, {} as any),
 			{
 				messageMatches: msg,
 				errorCode: code,
@@ -160,7 +160,7 @@ test("toJSON() should return a semi-readable JSON representation", (t) => {
 
 test("Parsing a buffer with an unknown function type returns an unspecified `Message` instance", async (t) => {
 	const unknown = Bytes.from([0x01, 0x03, 0x00, 0x00, 0xfc]);
-	const parsed = await Message.parseAsync(unknown, {} as any);
+	const parsed = Message.parse(unknown, {} as any);
 	t.expect(parsed).toBeInstanceOf(Message);
 });
 

--- a/packages/serial/src/message/Message.test.ts
+++ b/packages/serial/src/message/Message.test.ts
@@ -40,18 +40,22 @@ test("should deserialize and serialize correctly", async (t) => {
 	];
 	for (const original of okayMessages) {
 		const parsed = await Message.parseAsync(original, {} as any);
-		t.expect(parsed.serialize({} as any)).toStrictEqual(original);
+		await t.expect(parsed.serializeAsync({} as any)).resolves.toStrictEqual(
+			original,
+		);
 	}
 });
 
-test("should serialize correctly when the payload is null", (t) => {
+test("should serialize correctly when the payload is null", async (t) => {
 	// synthetic message
 	const expected = Bytes.from([0x01, 0x03, 0x00, 0xff, 0x03]);
 	const message = new Message({
 		type: MessageType.Request,
 		functionType: 0xff as any,
 	});
-	t.expect(message.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(message.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("should throw the correct error when parsing a faulty message", async (t) => {

--- a/packages/serial/src/message/Message.ts
+++ b/packages/serial/src/message/Message.ts
@@ -190,7 +190,6 @@ export class Message {
 		this.payload = payload;
 	}
 
-	/** @deprecated Use {@link parseAsync} instead */
 	public static parse(
 		data: Uint8Array,
 		ctx: MessageParsingContext,
@@ -200,24 +199,10 @@ export class Message {
 		const Constructor = getMessageConstructor(raw.type, raw.functionType)
 			?? Message;
 
-		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return Constructor.from(raw, ctx);
 	}
 
-	public static async parseAsync(
-		data: Uint8Array,
-		ctx: MessageParsingContext,
-	): Promise<Message> {
-		const raw = MessageRaw.parse(data);
-
-		const Constructor = getMessageConstructor(raw.type, raw.functionType)
-			?? Message;
-
-		return Constructor.fromAsync(raw, ctx);
-	}
-
 	/** Creates an instance of the message that is serialized in the given buffer */
-	/** @deprecated Use {@link fromAsync} instead */
 	public static from(
 		raw: MessageRaw,
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -228,22 +213,6 @@ export class Message {
 			functionType: raw.functionType,
 			payload: raw.payload,
 		});
-	}
-
-	/** Creates an instance of the message that is serialized in the given buffer */
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public static async fromAsync(
-		raw: MessageRaw,
-		ctx: MessageParsingContext,
-	): Promise<Message> {
-		// eslint-disable-next-line @typescript-eslint/no-deprecated
-		return this.from(raw, ctx);
-
-		// TODO: Plan for next major release:
-		// - Message ONLY exposes `public static async from` (renamed!)
-		// - Message internally implements `protected static fromSync` and `protected static async fromAsync`
-		// - The default implementation of `fromAsync` just calls `fromSync`
-		// - Sub-classes override either `fromSync` OR `fromAsync` as needed
 	}
 
 	public type: MessageType;

--- a/packages/serial/src/message/Message.ts
+++ b/packages/serial/src/message/Message.ts
@@ -238,6 +238,12 @@ export class Message {
 	): Promise<Message> {
 		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return this.from(raw, ctx);
+
+		// TODO: Plan for next major release:
+		// - Message ONLY exposes `public static async from` (renamed!)
+		// - Message internally implements `protected static fromSync` and `protected static async fromAsync`
+		// - The default implementation of `fromAsync` just calls `fromSync`
+		// - Sub-classes override either `fromSync` OR `fromAsync` as needed
 	}
 
 	public type: MessageType;
@@ -292,7 +298,10 @@ export class Message {
 		return;
 	}
 
-	/** Serializes this message into a Buffer */
+	/**
+	 * Serializes this message into a Buffer
+	 * @deprecated Use {@link serializeAsync} instead
+	 */
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		const ret = new Bytes(this.payload.length + 5);
@@ -306,6 +315,19 @@ export class Message {
 		// followed by the checksum
 		ret[ret.length - 1] = computeChecksum(ret);
 		return ret;
+	}
+
+	/** Serializes this message into a Buffer */
+	// eslint-disable-next-line @typescript-eslint/require-await
+	public async serializeAsync(ctx: MessageEncodingContext): Promise<Bytes> {
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
+		return this.serialize(ctx);
+
+		// TODO: Plan for next major release:
+		// - Message ONLY exposes `public async serialize` (renamed!)
+		// - Message internally implements `protected serializeSync` and `protected async serializeAsync`
+		// - The default implementation of `serializeAsync` just calls `serializeSync`
+		// - Sub-classes override either `serializeSync` OR `serializeAsync` as needed
 	}
 
 	/** Generates a representation of this Message for the log */

--- a/packages/serial/src/message/Message.ts
+++ b/packages/serial/src/message/Message.ts
@@ -190,6 +190,7 @@ export class Message {
 		this.payload = payload;
 	}
 
+	/** @deprecated Use {@link parseAsync} instead */
 	public static parse(
 		data: Uint8Array,
 		ctx: MessageParsingContext,
@@ -199,10 +200,24 @@ export class Message {
 		const Constructor = getMessageConstructor(raw.type, raw.functionType)
 			?? Message;
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return Constructor.from(raw, ctx);
 	}
 
+	public static async parseAsync(
+		data: Uint8Array,
+		ctx: MessageParsingContext,
+	): Promise<Message> {
+		const raw = MessageRaw.parse(data);
+
+		const Constructor = getMessageConstructor(raw.type, raw.functionType)
+			?? Message;
+
+		return Constructor.fromAsync(raw, ctx);
+	}
+
 	/** Creates an instance of the message that is serialized in the given buffer */
+	/** @deprecated Use {@link fromAsync} instead */
 	public static from(
 		raw: MessageRaw,
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -213,6 +228,16 @@ export class Message {
 			functionType: raw.functionType,
 			payload: raw.payload,
 		});
+	}
+
+	/** Creates an instance of the message that is serialized in the given buffer */
+	// eslint-disable-next-line @typescript-eslint/require-await
+	public static async fromAsync(
+		raw: MessageRaw,
+		ctx: MessageParsingContext,
+	): Promise<Message> {
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
+		return this.from(raw, ctx);
 	}
 
 	public type: MessageType;

--- a/packages/serial/src/serialapi/application/ApplicationCommandRequest.ts
+++ b/packages/serial/src/serialapi/application/ApplicationCommandRequest.ts
@@ -155,6 +155,7 @@ export class ApplicationCommandRequest extends Message
 	}
 
 	public serializedCC: Uint8Array | undefined;
+	/** @deprecated Use {@link serializeCCAsync} instead */
 	public serializeCC(ctx: CCEncodingContext): Uint8Array {
 		if (!this.serializedCC) {
 			if (!this.command) {
@@ -163,11 +164,26 @@ export class ApplicationCommandRequest extends Message
 					ZWaveErrorCodes.Argument_Invalid,
 				);
 			}
+			// eslint-disable-next-line @typescript-eslint/no-deprecated
 			this.serializedCC = this.command.serialize(ctx);
 		}
 		return this.serializedCC;
 	}
 
+	public async serializeCCAsync(ctx: CCEncodingContext): Promise<Uint8Array> {
+		if (!this.serializedCC) {
+			if (!this.command) {
+				throw new ZWaveError(
+					`Cannot serialize a ${this.constructor.name} without a command`,
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
+			this.serializedCC = await this.command.serializeAsync(ctx);
+		}
+		return this.serializedCC;
+	}
+
+	/** @deprecated Use {@link serializeAsync} instead */
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		const statusByte = (this.frameType === "broadcast"
 			? ApplicationCommandStatusFlags.TypeBroad
@@ -176,6 +192,7 @@ export class ApplicationCommandRequest extends Message
 			: 0)
 			| (this.routedBusy ? ApplicationCommandStatusFlags.RoutedBusy : 0);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		const serializedCC = this.serializeCC(ctx);
 		const nodeId = encodeNodeID(
 			this.getNodeId() ?? ctx.ownNodeId,
@@ -188,7 +205,31 @@ export class ApplicationCommandRequest extends Message
 			serializedCC,
 		]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
+	}
+
+	public async serializeAsync(ctx: MessageEncodingContext): Promise<Bytes> {
+		const statusByte = (this.frameType === "broadcast"
+			? ApplicationCommandStatusFlags.TypeBroad
+			: this.frameType === "multicast"
+			? ApplicationCommandStatusFlags.TypeMulti
+			: 0)
+			| (this.routedBusy ? ApplicationCommandStatusFlags.RoutedBusy : 0);
+
+		const serializedCC = await this.serializeCCAsync(ctx);
+		const nodeId = encodeNodeID(
+			this.getNodeId() ?? ctx.ownNodeId,
+			ctx.nodeIdType,
+		);
+		this.payload = Bytes.concat([
+			[statusByte],
+			nodeId,
+			[serializedCC.length],
+			serializedCC,
+		]);
+
+		return super.serializeAsync(ctx);
 	}
 
 	public toLogEntry(): MessageOrCCLogEntry {

--- a/packages/serial/src/serialapi/application/ApplicationUpdateRequest.ts
+++ b/packages/serial/src/serialapi/application/ApplicationUpdateRequest.ts
@@ -96,6 +96,7 @@ export class ApplicationUpdateRequest extends Message {
 			Bytes.from([this.updateType]),
 			this.payload,
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -140,6 +141,7 @@ export class ApplicationUpdateRequestWithNodeInfo
 			this.nodeInformation,
 			ctx.nodeIdType,
 		);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }

--- a/packages/serial/src/serialapi/application/BridgeApplicationCommandRequest.test.ts
+++ b/packages/serial/src/serialapi/application/BridgeApplicationCommandRequest.test.ts
@@ -5,13 +5,11 @@ import { test } from "vitest";
 
 test("BridgeApplicationCommandRequest can be parsed without RSSI", async (t) => {
 	// Repro for https://github.com/zwave-js/node-zwave-js/issues/4335
-	t.expect(() =>
-		Message.parse(
-			Bytes.from(
-				"011200a80001020a320221340000000000000069",
-				"hex",
-			),
-			{} as any,
-		)
-	).not.toThrow();
+	await Message.parseAsync(
+		Bytes.from(
+			"011200a80001020a320221340000000000000069",
+			"hex",
+		),
+		{} as any,
+	);
 });

--- a/packages/serial/src/serialapi/application/BridgeApplicationCommandRequest.test.ts
+++ b/packages/serial/src/serialapi/application/BridgeApplicationCommandRequest.test.ts
@@ -5,7 +5,7 @@ import { test } from "vitest";
 
 test("BridgeApplicationCommandRequest can be parsed without RSSI", async (t) => {
 	// Repro for https://github.com/zwave-js/node-zwave-js/issues/4335
-	await Message.parseAsync(
+	Message.parse(
 		Bytes.from(
 			"011200a80001020a320221340000000000000069",
 			"hex",

--- a/packages/serial/src/serialapi/application/BridgeApplicationCommandRequest.ts
+++ b/packages/serial/src/serialapi/application/BridgeApplicationCommandRequest.ts
@@ -169,6 +169,7 @@ export class BridgeApplicationCommandRequest extends Message
 	public readonly ownNodeId: number;
 
 	public serializedCC: Uint8Array | undefined;
+	/** @deprecated Use {@link serializeCCAsync} instead */
 	public serializeCC(ctx: CCEncodingContext): Uint8Array {
 		if (!this.serializedCC) {
 			if (!this.command) {
@@ -177,7 +178,21 @@ export class BridgeApplicationCommandRequest extends Message
 					ZWaveErrorCodes.Argument_Invalid,
 				);
 			}
+			// eslint-disable-next-line @typescript-eslint/no-deprecated
 			this.serializedCC = this.command.serialize(ctx);
+		}
+		return this.serializedCC;
+	}
+
+	public async serializeCCAsync(ctx: CCEncodingContext): Promise<Uint8Array> {
+		if (!this.serializedCC) {
+			if (!this.command) {
+				throw new ZWaveError(
+					`Cannot serialize a ${this.constructor.name} without a command`,
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
+			this.serializedCC = await this.command.serializeAsync(ctx);
 		}
 		return this.serializedCC;
 	}
@@ -193,6 +208,7 @@ export class BridgeApplicationCommandRequest extends Message
 		return this._nodeId ?? super.getNodeId();
 	}
 
+	/** @deprecated Use {@link serializeAsync} instead */
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		let rxStatus = 0;
 		if (this.routedBusy) {
@@ -225,6 +241,7 @@ export class BridgeApplicationCommandRequest extends Message
 			this.getNodeId() ?? 0,
 			ctx.nodeIdType,
 		);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		const serializedCC = this.serializeCC(ctx);
 		const multicastNodeMask = typeof this.targetNodeId === "number"
 			? Uint8Array.from([0])
@@ -244,7 +261,62 @@ export class BridgeApplicationCommandRequest extends Message
 			this.payload.writeInt8(this.rssi, this.payload.length - 1);
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
+	}
+
+	public async serializeAsync(ctx: MessageEncodingContext): Promise<Bytes> {
+		let rxStatus = 0;
+		if (this.routedBusy) {
+			rxStatus |= ApplicationCommandStatusFlags.RoutedBusy;
+		}
+		switch (this.frameType) {
+			case "multicast":
+				rxStatus |= ApplicationCommandStatusFlags.TypeMulti;
+				break;
+			case "broadcast":
+				rxStatus |= ApplicationCommandStatusFlags.TypeBroad;
+				break;
+			default:
+				rxStatus |= ApplicationCommandStatusFlags.TypeSingle;
+		}
+		if (this.isExploreFrame) {
+			rxStatus |= ApplicationCommandStatusFlags.Explore;
+		}
+		if (this.isForeignFrame) {
+			rxStatus |= ApplicationCommandStatusFlags.ForeignFrame;
+		}
+		if (this.fromForeignHomeId) {
+			rxStatus |= ApplicationCommandStatusFlags.ForeignHomeId;
+		}
+		const destinationNodeId = encodeNodeID(
+			typeof this.targetNodeId === "number" ? this.targetNodeId : 0,
+			ctx.nodeIdType,
+		);
+		const sourceNodeId = encodeNodeID(
+			this.getNodeId() ?? 0,
+			ctx.nodeIdType,
+		);
+		const serializedCC = await this.serializeCCAsync(ctx);
+		const multicastNodeMask = typeof this.targetNodeId === "number"
+			? Uint8Array.from([0])
+			: Uint8Array.from([this.targetNodeId.length, ...this.targetNodeId]);
+
+		this.payload = Bytes.concat([
+			[rxStatus],
+			destinationNodeId,
+			sourceNodeId,
+			[serializedCC.length],
+			serializedCC,
+			multicastNodeMask,
+			[RssiError.NotAvailable],
+		]);
+
+		if (this.rssi != undefined) {
+			this.payload.writeInt8(this.rssi, this.payload.length - 1);
+		}
+
+		return super.serializeAsync(ctx);
 	}
 
 	public toLogEntry(): MessageOrCCLogEntry {

--- a/packages/serial/src/serialapi/application/SerialAPIStartedRequest.ts
+++ b/packages/serial/src/serialapi/application/SerialAPIStartedRequest.ts
@@ -132,6 +132,7 @@ export class SerialAPIStartedRequest extends Message {
 		this.payload.set(ccList, 6);
 		this.payload[6 + numCCBytes] = this.supportsLongRange ? 0b1 : 0;
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/capability/GetControllerCapabilitiesMessages.ts
+++ b/packages/serial/src/serialapi/capability/GetControllerCapabilitiesMessages.ts
@@ -101,6 +101,7 @@ export class GetControllerCapabilitiesResponse extends Message {
 				? ControllerCapabilityFlags.NoNodesIncluded
 				: 0),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }

--- a/packages/serial/src/serialapi/capability/GetControllerVersionMessages.ts
+++ b/packages/serial/src/serialapi/capability/GetControllerVersionMessages.ts
@@ -58,6 +58,7 @@ export class GetControllerVersionResponse extends Message {
 			Bytes.from([this.controllerType]),
 		]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }

--- a/packages/serial/src/serialapi/capability/GetLongRangeNodesMessages.ts
+++ b/packages/serial/src/serialapi/capability/GetLongRangeNodesMessages.ts
@@ -54,6 +54,7 @@ export class GetLongRangeNodesRequest extends Message {
 
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.payload = Bytes.from([this.segmentNumber]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -126,6 +127,7 @@ export class GetLongRangeNodesResponse extends Message {
 		);
 		this.payload.set(nodeBitMask, 3);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }

--- a/packages/serial/src/serialapi/capability/GetSerialApiCapabilitiesMessages.ts
+++ b/packages/serial/src/serialapi/capability/GetSerialApiCapabilitiesMessages.ts
@@ -96,6 +96,7 @@ export class GetSerialApiCapabilitiesResponse extends Message {
 		);
 		this.payload.set(functionBitMask, 8);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }

--- a/packages/serial/src/serialapi/capability/GetSerialApiInitDataMessages.ts
+++ b/packages/serial/src/serialapi/capability/GetSerialApiInitDataMessages.ts
@@ -167,6 +167,7 @@ export class GetSerialApiInitDataResponse extends Message {
 			this.payload[3 + NUM_NODEMASK_BYTES + 1] = chipType.version;
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/capability/HardResetRequest.ts
+++ b/packages/serial/src/serialapi/capability/HardResetRequest.ts
@@ -34,6 +34,7 @@ export class HardResetRequest extends HardResetRequestBase {
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.assertCallbackId();
 		this.payload = Bytes.from([this.callbackId]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/capability/LongRangeChannelMessages.ts
+++ b/packages/serial/src/serialapi/capability/LongRangeChannelMessages.ts
@@ -111,6 +111,7 @@ export class SetLongRangeChannelRequest extends Message {
 
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.payload = Bytes.from([this.channel]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/capability/SerialAPISetupMessages.test.ts
+++ b/packages/serial/src/serialapi/capability/SerialAPISetupMessages.test.ts
@@ -3,13 +3,13 @@ import { Bytes } from "@zwave-js/shared/safe";
 import { test } from "vitest";
 import { SerialAPISetup_GetSupportedCommandsResponse } from "./SerialAPISetupMessages.js";
 
-test("GetSupportedCommandsResponse with extended bitmask parses correctly (pre-7.19.1 encoding)", (t) => {
+test("GetSupportedCommandsResponse with extended bitmask parses correctly (pre-7.19.1 encoding)", async (t) => {
 	const data = Bytes.from(
 		"0116010b01fe160103000100000001000000000000000109",
 		"hex",
 	);
 
-	const msg = Message.parse(
+	const msg = await Message.parseAsync(
 		data,
 		{ sdkVersion: "7.19.0" } as any,
 	);
@@ -24,13 +24,13 @@ test("GetSupportedCommandsResponse with extended bitmask parses correctly (pre-7
 	).toStrictEqual([0x01, 0x02, 0x04, 0x08, 0x10, 0x11, 0x20, 0x40, 0x80]);
 });
 
-test("GetSupportedCommandsResponse with extended bitmask parses correctly (post-7.19.1 encoding)", (t) => {
+test("GetSupportedCommandsResponse with extended bitmask parses correctly (post-7.19.1 encoding)", async (t) => {
 	const data = Bytes.from(
 		"0116010b01ff8b8001800000008000000000000000800097",
 		"hex",
 	);
 
-	const msg = Message.parse(
+	const msg = await Message.parseAsync(
 		data,
 		{ sdkVersion: "7.19.1" } as any,
 	);

--- a/packages/serial/src/serialapi/capability/SerialAPISetupMessages.test.ts
+++ b/packages/serial/src/serialapi/capability/SerialAPISetupMessages.test.ts
@@ -9,7 +9,7 @@ test("GetSupportedCommandsResponse with extended bitmask parses correctly (pre-7
 		"hex",
 	);
 
-	const msg = await Message.parseAsync(
+	const msg = Message.parse(
 		data,
 		{ sdkVersion: "7.19.0" } as any,
 	);
@@ -30,7 +30,7 @@ test("GetSupportedCommandsResponse with extended bitmask parses correctly (post-
 		"hex",
 	);
 
-	const msg = await Message.parseAsync(
+	const msg = Message.parse(
 		data,
 		{ sdkVersion: "7.19.1" } as any,
 	);

--- a/packages/serial/src/serialapi/capability/SerialAPISetupMessages.ts
+++ b/packages/serial/src/serialapi/capability/SerialAPISetupMessages.ts
@@ -129,6 +129,7 @@ export class SerialAPISetupRequest extends Message {
 			this.payload,
 		]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -355,6 +356,7 @@ export class SerialAPISetup_SetTXStatusReportRequest
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.payload = Bytes.from([this.enabled ? 0xff : 0x00]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -443,6 +445,7 @@ export class SerialAPISetup_SetNodeIDTypeRequest extends SerialAPISetupRequest {
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.payload = Bytes.from([this.nodeIdType]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -570,6 +573,7 @@ export class SerialAPISetup_SetRFRegionRequest extends SerialAPISetupRequest {
 
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.payload = Bytes.from([this.region]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -733,6 +737,7 @@ export class SerialAPISetup_SetPowerlevelRequest extends SerialAPISetupRequest {
 		this.payload.writeInt8(Math.round(this.powerlevel * 10), 0);
 		this.payload.writeInt8(Math.round(this.measured0dBm * 10), 1);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -904,6 +909,7 @@ export class SerialAPISetup_SetPowerlevel16BitRequest
 		this.payload.writeInt16BE(Math.round(this.powerlevel * 10), 0);
 		this.payload.writeInt16BE(Math.round(this.measured0dBm * 10), 2);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1063,6 +1069,7 @@ export class SerialAPISetup_SetLongRangeMaximumTxPowerRequest
 		// The values are in 0.1 dBm, signed
 		this.payload.writeInt16BE(Math.round(this.limit * 10), 0);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -1287,6 +1294,7 @@ export class SerialAPISetup_GetRegionInfoRequest extends SerialAPISetupRequest {
 
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.payload = Bytes.from([this.region]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/capability/SetApplicationNodeInformationRequest.ts
+++ b/packages/serial/src/serialapi/capability/SetApplicationNodeInformationRequest.ts
@@ -57,6 +57,7 @@ export class SetApplicationNodeInformationRequest extends Message {
 			...ccList.subarray(0, ccListLength),
 		]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/capability/SetLongRangeShadowNodeIDsRequest.ts
+++ b/packages/serial/src/serialapi/capability/SetLongRangeShadowNodeIDsRequest.ts
@@ -56,6 +56,7 @@ export class SetLongRangeShadowNodeIDsRequest extends Message {
 			LONG_RANGE_SHADOW_NODE_IDS_START,
 		);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }

--- a/packages/serial/src/serialapi/memory/GetControllerIdMessages.ts
+++ b/packages/serial/src/serialapi/memory/GetControllerIdMessages.ts
@@ -62,6 +62,7 @@ export class GetControllerIdResponse extends Message {
 
 		this.payload = Bytes.concat([homeId, nodeId]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/misc/SetRFReceiveModeMessages.ts
+++ b/packages/serial/src/serialapi/misc/SetRFReceiveModeMessages.ts
@@ -54,6 +54,7 @@ export class SetRFReceiveModeRequest extends Message {
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.payload = Bytes.from([this.enabled ? 0x01 : 0x00]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/misc/SetSerialApiTimeoutsMessages.ts
+++ b/packages/serial/src/serialapi/misc/SetSerialApiTimeoutsMessages.ts
@@ -38,6 +38,7 @@ export class SetSerialApiTimeoutsRequest extends Message {
 			Math.round(this.ackTimeout / 10),
 			Math.round(this.byteTimeout / 10),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }

--- a/packages/serial/src/serialapi/network-mgmt/AddNodeToNetworkRequest.ts
+++ b/packages/serial/src/serialapi/network-mgmt/AddNodeToNetworkRequest.ts
@@ -180,6 +180,7 @@ export class AddNodeToNetworkRequest extends AddNodeToNetworkRequestBase {
 
 		this.payload = Bytes.from([data, this.callbackId]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -216,6 +217,7 @@ export class EnableSmartStartListenRequest extends AddNodeToNetworkRequestBase {
 		this.callbackId = 0;
 
 		this.payload = Bytes.from([control, this.callbackId]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -267,6 +269,7 @@ export class AddNodeDSKToNetworkRequest extends AddNodeToNetworkRequestBase {
 			this.authHomeId,
 		]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -391,6 +394,7 @@ export class AddNodeToNetworkRequestStatusReport
 				),
 			]);
 		}
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/network-mgmt/AssignPriorityReturnRouteMessages.ts
+++ b/packages/serial/src/serialapi/network-mgmt/AssignPriorityReturnRouteMessages.ts
@@ -119,6 +119,7 @@ export class AssignPriorityReturnRouteRequest
 			]),
 		]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/network-mgmt/AssignPrioritySUCReturnRouteMessages.ts
+++ b/packages/serial/src/serialapi/network-mgmt/AssignPrioritySUCReturnRouteMessages.ts
@@ -107,6 +107,7 @@ export class AssignPrioritySUCReturnRouteRequest
 			]),
 		]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/network-mgmt/AssignReturnRouteMessages.ts
+++ b/packages/serial/src/serialapi/network-mgmt/AssignReturnRouteMessages.ts
@@ -91,6 +91,7 @@ export class AssignReturnRouteRequest extends AssignReturnRouteRequestBase {
 			Bytes.from([this.callbackId]),
 		]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }

--- a/packages/serial/src/serialapi/network-mgmt/AssignSUCReturnRouteMessages.ts
+++ b/packages/serial/src/serialapi/network-mgmt/AssignSUCReturnRouteMessages.ts
@@ -87,6 +87,7 @@ export class AssignSUCReturnRouteRequest
 		const nodeId = encodeNodeID(this.nodeId, ctx.nodeIdType);
 		this.payload = Bytes.concat([nodeId, Bytes.from([this.callbackId])]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -125,6 +126,7 @@ export class AssignSUCReturnRouteResponse extends Message
 
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.payload = Bytes.from([this.wasExecuted ? 0x01 : 0]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -180,6 +182,7 @@ export class AssignSUCReturnRouteRequestTransmitReport
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.assertCallbackId();
 		this.payload = Bytes.from([this.callbackId, this.transmitStatus]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/network-mgmt/DeleteReturnRouteMessages.ts
+++ b/packages/serial/src/serialapi/network-mgmt/DeleteReturnRouteMessages.ts
@@ -73,6 +73,7 @@ export class DeleteReturnRouteRequest extends DeleteReturnRouteRequestBase {
 		const nodeId = encodeNodeID(this.nodeId, ctx.nodeIdType);
 		this.payload = Bytes.concat([nodeId, Bytes.from([this.callbackId])]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }

--- a/packages/serial/src/serialapi/network-mgmt/DeleteSUCReturnRouteMessages.ts
+++ b/packages/serial/src/serialapi/network-mgmt/DeleteSUCReturnRouteMessages.ts
@@ -89,6 +89,7 @@ export class DeleteSUCReturnRouteRequest
 		const nodeId = encodeNodeID(this.nodeId, ctx.nodeIdType);
 		this.payload = Bytes.concat([nodeId, Bytes.from([this.callbackId])]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -127,6 +128,7 @@ export class DeleteSUCReturnRouteResponse extends Message
 
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.payload = Bytes.from([this.wasExecuted ? 0x01 : 0]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -182,6 +184,7 @@ export class DeleteSUCReturnRouteRequestTransmitReport
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.assertCallbackId();
 		this.payload = Bytes.from([this.callbackId, this.transmitStatus]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/network-mgmt/GetNodeProtocolInfoMessages.ts
+++ b/packages/serial/src/serialapi/network-mgmt/GetNodeProtocolInfoMessages.ts
@@ -60,6 +60,7 @@ export class GetNodeProtocolInfoRequest extends Message {
 
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.payload = encodeNodeID(this.requestedNodeId, ctx.nodeIdType);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -189,6 +190,7 @@ export class GetNodeProtocolInfoResponse extends Message {
 			]),
 		]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }

--- a/packages/serial/src/serialapi/network-mgmt/GetPriorityRouteMessages.ts
+++ b/packages/serial/src/serialapi/network-mgmt/GetPriorityRouteMessages.ts
@@ -59,6 +59,7 @@ export class GetPriorityRouteRequest extends Message {
 			ctx.nodeIdType,
 		);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/network-mgmt/GetRoutingInfoMessages.ts
+++ b/packages/serial/src/serialapi/network-mgmt/GetRoutingInfoMessages.ts
@@ -53,6 +53,7 @@ export class GetRoutingInfoRequest extends Message {
 				0, // callbackId - this must be 0 as per the docs
 			]),
 		]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/network-mgmt/GetSUCNodeIdMessages.ts
+++ b/packages/serial/src/serialapi/network-mgmt/GetSUCNodeIdMessages.ts
@@ -52,6 +52,7 @@ export class GetSUCNodeIdResponse extends Message {
 
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.payload = encodeNodeID(this.sucNodeId, ctx.nodeIdType);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }

--- a/packages/serial/src/serialapi/network-mgmt/IsFailedNodeMessages.ts
+++ b/packages/serial/src/serialapi/network-mgmt/IsFailedNodeMessages.ts
@@ -34,6 +34,7 @@ export class IsFailedNodeRequest extends Message {
 
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.payload = encodeNodeID(this.failedNodeId, ctx.nodeIdType);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }

--- a/packages/serial/src/serialapi/network-mgmt/RemoveFailedNodeMessages.ts
+++ b/packages/serial/src/serialapi/network-mgmt/RemoveFailedNodeMessages.ts
@@ -82,6 +82,7 @@ export class RemoveFailedNodeRequest extends RemoveFailedNodeRequestBase {
 		this.assertCallbackId();
 		const nodeId = encodeNodeID(this.failedNodeId, ctx.nodeIdType);
 		this.payload = Bytes.concat([nodeId, Bytes.from([this.callbackId])]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }

--- a/packages/serial/src/serialapi/network-mgmt/RemoveNodeFromNetworkRequest.ts
+++ b/packages/serial/src/serialapi/network-mgmt/RemoveNodeFromNetworkRequest.ts
@@ -140,6 +140,7 @@ export class RemoveNodeFromNetworkRequest
 
 		this.payload = Bytes.from([data, this.callbackId]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }
@@ -232,6 +233,7 @@ export class RemoveNodeFromNetworkRequestStatusReport
 			]);
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }

--- a/packages/serial/src/serialapi/network-mgmt/ReplaceFailedNodeRequest.ts
+++ b/packages/serial/src/serialapi/network-mgmt/ReplaceFailedNodeRequest.ts
@@ -81,6 +81,7 @@ export class ReplaceFailedNodeRequest extends ReplaceFailedNodeRequestBase {
 		this.assertCallbackId();
 		const nodeId = encodeNodeID(this.failedNodeId, ctx.nodeIdType);
 		this.payload = Bytes.concat([nodeId, Bytes.from([this.callbackId])]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 }

--- a/packages/serial/src/serialapi/network-mgmt/RequestNodeInfoMessages.ts
+++ b/packages/serial/src/serialapi/network-mgmt/RequestNodeInfoMessages.ts
@@ -58,6 +58,7 @@ export class RequestNodeInfoResponse extends Message
 
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.payload = Bytes.from([this.wasSent ? 0x01 : 0]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -120,6 +121,7 @@ export class RequestNodeInfoRequest extends Message {
 
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.payload = encodeNodeID(this.nodeId, ctx.nodeIdType);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/network-mgmt/RequestNodeNeighborUpdateMessages.ts
+++ b/packages/serial/src/serialapi/network-mgmt/RequestNodeNeighborUpdateMessages.ts
@@ -65,6 +65,7 @@ export class RequestNodeNeighborUpdateRequest
 		this.assertCallbackId();
 		const nodeId = encodeNodeID(this.nodeId, ctx.nodeIdType);
 		this.payload = Bytes.concat([nodeId, Bytes.from([this.callbackId])]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/network-mgmt/SetLearnModeMessages.ts
+++ b/packages/serial/src/serialapi/network-mgmt/SetLearnModeMessages.ts
@@ -94,6 +94,7 @@ export class SetLearnModeRequest extends SetLearnModeRequestBase {
 			this.callbackId,
 		]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/network-mgmt/SetPriorityRouteMessages.ts
+++ b/packages/serial/src/serialapi/network-mgmt/SetPriorityRouteMessages.ts
@@ -103,6 +103,7 @@ export class SetPriorityRouteRequest extends Message {
 			]);
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/network-mgmt/SetSUCNodeIDMessages.ts
+++ b/packages/serial/src/serialapi/network-mgmt/SetSUCNodeIDMessages.ts
@@ -100,6 +100,7 @@ export class SetSUCNodeIdRequest extends SetSUCNodeIdRequestBase {
 			]),
 		]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/nvm/ExtNVMReadLongBufferMessages.ts
+++ b/packages/serial/src/serialapi/nvm/ExtNVMReadLongBufferMessages.ts
@@ -67,6 +67,7 @@ export class ExtNVMReadLongBufferRequest extends Message {
 		this.payload = new Bytes(5);
 		this.payload.writeUIntBE(this.offset, 0, 3);
 		this.payload.writeUInt16BE(this.length, 3);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/nvm/ExtNVMReadLongByteMessages.ts
+++ b/packages/serial/src/serialapi/nvm/ExtNVMReadLongByteMessages.ts
@@ -56,6 +56,7 @@ export class ExtNVMReadLongByteRequest extends Message {
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.payload = new Bytes(3);
 		this.payload.writeUIntBE(this.offset, 0, 3);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/nvm/ExtNVMWriteLongBufferMessages.ts
+++ b/packages/serial/src/serialapi/nvm/ExtNVMWriteLongBufferMessages.ts
@@ -67,6 +67,7 @@ export class ExtNVMWriteLongBufferRequest extends Message {
 		this.payload.writeUIntBE(this.offset, 0, 3);
 		this.payload.writeUInt16BE(this.buffer.length, 3);
 		this.payload.set(this.buffer, 5);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/nvm/ExtNVMWriteLongByteMessages.ts
+++ b/packages/serial/src/serialapi/nvm/ExtNVMWriteLongByteMessages.ts
@@ -66,6 +66,7 @@ export class ExtNVMWriteLongByteRequest extends Message {
 		this.payload = new Bytes(4);
 		this.payload.writeUIntBE(this.offset, 0, 3);
 		this.payload[3] = this.byte;
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/nvm/ExtendedNVMOperationsMessages.ts
+++ b/packages/serial/src/serialapi/nvm/ExtendedNVMOperationsMessages.ts
@@ -52,6 +52,7 @@ export class ExtendedNVMOperationsRequest extends Message {
 			this.payload,
 		]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -144,6 +145,7 @@ export class ExtendedNVMOperationsReadRequest
 		this.payload[0] = this.length;
 		this.payload.writeUInt32BE(this.offset, 1);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -213,6 +215,7 @@ export class ExtendedNVMOperationsWriteRequest
 		this.payload[0] = this.buffer.length;
 		this.payload.writeUInt32BE(this.offset, 1);
 		this.payload.set(this.buffer, 5);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/nvm/FirmwareUpdateNVMMessages.ts
+++ b/packages/serial/src/serialapi/nvm/FirmwareUpdateNVMMessages.ts
@@ -111,6 +111,7 @@ export class FirmwareUpdateNVMRequest extends Message {
 			this.payload,
 		]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -258,6 +259,7 @@ export class FirmwareUpdateNVM_SetNewImageRequest
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.payload = Bytes.from([this.newImage ? 1 : 0]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -412,6 +414,7 @@ export class FirmwareUpdateNVM_UpdateCRC16Request
 		this.payload.writeUInt16BE(this.blockLength, 3);
 		this.payload.writeUInt16BE(this.crcSeed, 5);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -561,6 +564,7 @@ export class FirmwareUpdateNVM_WriteRequest extends FirmwareUpdateNVMRequest {
 		this.payload.writeUInt16BE(this.buffer.length, 3);
 		this.payload.set(this.buffer, 5);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/nvm/NVMOperationsMessages.ts
+++ b/packages/serial/src/serialapi/nvm/NVMOperationsMessages.ts
@@ -49,6 +49,7 @@ export class NVMOperationsRequest extends Message {
 			this.payload,
 		]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -132,6 +133,7 @@ export class NVMOperationsReadRequest extends NVMOperationsRequest {
 		this.payload[0] = this.length;
 		this.payload.writeUInt16BE(this.offset, 1);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -199,6 +201,7 @@ export class NVMOperationsWriteRequest extends NVMOperationsRequest {
 		this.payload[0] = this.buffer.length;
 		this.payload.writeUInt16BE(this.offset, 1);
 		this.payload.set(this.buffer, 3);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/transport/SendDataMessages.ts
+++ b/packages/serial/src/serialapi/transport/SendDataMessages.ts
@@ -160,6 +160,7 @@ export class SendDataRequest<CCType extends CommandClass = CommandClass>
 	}
 
 	public serializedCC: Uint8Array | undefined;
+	/** @deprecated Use {@link serializeCCAsync} instead */
 	public serializeCC(ctx: CCEncodingContext): Uint8Array {
 		if (!this.serializedCC) {
 			if (!this.command) {
@@ -168,7 +169,21 @@ export class SendDataRequest<CCType extends CommandClass = CommandClass>
 					ZWaveErrorCodes.Argument_Invalid,
 				);
 			}
+			// eslint-disable-next-line @typescript-eslint/no-deprecated
 			this.serializedCC = this.command.serialize(ctx);
+		}
+		return this.serializedCC;
+	}
+
+	public async serializeCCAsync(ctx: CCEncodingContext): Promise<Uint8Array> {
+		if (!this.serializedCC) {
+			if (!this.command) {
+				throw new ZWaveError(
+					`Cannot serialize a ${this.constructor.name} without a command`,
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
+			this.serializedCC = await this.command.serializeAsync(ctx);
 		}
 		return this.serializedCC;
 	}
@@ -179,12 +194,14 @@ export class SendDataRequest<CCType extends CommandClass = CommandClass>
 		this.callbackId = undefined;
 	}
 
+	/** @deprecated Use {@link serializeAsync} instead */
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.assertCallbackId();
 		const nodeId = encodeNodeID(
 			this.command?.nodeId ?? this._nodeId,
 			ctx.nodeIdType,
 		);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		const serializedCC = this.serializeCC(ctx);
 		this.payload = Bytes.concat([
 			nodeId,
@@ -193,7 +210,25 @@ export class SendDataRequest<CCType extends CommandClass = CommandClass>
 			Bytes.from([this.transmitOptions, this.callbackId]),
 		]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
+	}
+
+	public async serializeAsync(ctx: MessageEncodingContext): Promise<Bytes> {
+		this.assertCallbackId();
+		const nodeId = encodeNodeID(
+			this.command?.nodeId ?? this._nodeId,
+			ctx.nodeIdType,
+		);
+		const serializedCC = await this.serializeCCAsync(ctx);
+		this.payload = Bytes.concat([
+			nodeId,
+			Bytes.from([serializedCC.length]),
+			serializedCC,
+			Bytes.from([this.transmitOptions, this.callbackId]),
+		]);
+
+		return super.serializeAsync(ctx);
 	}
 
 	public toLogEntry(): MessageOrCCLogEntry {
@@ -284,6 +319,7 @@ export class SendDataRequestTransmitReport extends SendDataRequestBase
 			]);
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -337,6 +373,7 @@ export class SendDataResponse extends Message implements SuccessIndicator {
 
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.payload = Bytes.from([this.wasSent ? 1 : 0]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -480,6 +517,7 @@ export class SendDataMulticastRequest<
 	}
 
 	public serializedCC: Uint8Array | undefined;
+	/** @deprecated Use {@link serializeCCAsync} instead */
 	public serializeCC(ctx: CCEncodingContext): Uint8Array {
 		if (!this.serializedCC) {
 			if (!this.command) {
@@ -488,7 +526,21 @@ export class SendDataMulticastRequest<
 					ZWaveErrorCodes.Argument_Invalid,
 				);
 			}
+			// eslint-disable-next-line @typescript-eslint/no-deprecated
 			this.serializedCC = this.command.serialize(ctx);
+		}
+		return this.serializedCC;
+	}
+
+	public async serializeCCAsync(ctx: CCEncodingContext): Promise<Uint8Array> {
+		if (!this.serializedCC) {
+			if (!this.command) {
+				throw new ZWaveError(
+					`Cannot serialize a ${this.constructor.name} without a command`,
+					ZWaveErrorCodes.Argument_Invalid,
+				);
+			}
+			this.serializedCC = await this.command.serializeAsync(ctx);
 		}
 		return this.serializedCC;
 	}
@@ -499,8 +551,10 @@ export class SendDataMulticastRequest<
 		this.callbackId = undefined;
 	}
 
+	/** @deprecated Use {@link serializeAsync} instead */
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.assertCallbackId();
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		const serializedCC = this.serializeCC(ctx);
 		const destinationNodeIDs = (this.command?.nodeId ?? this.nodeIds)
 			.map((id) => encodeNodeID(id, ctx.nodeIdType));
@@ -514,7 +568,26 @@ export class SendDataMulticastRequest<
 			Bytes.from([this.transmitOptions, this.callbackId]),
 		]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
+	}
+
+	public async serializeAsync(ctx: MessageEncodingContext): Promise<Bytes> {
+		this.assertCallbackId();
+		const serializedCC = await this.serializeCCAsync(ctx);
+		const destinationNodeIDs = (this.command?.nodeId ?? this.nodeIds)
+			.map((id) => encodeNodeID(id, ctx.nodeIdType));
+		this.payload = Bytes.concat([
+			// # of target nodes, not # of bytes
+			Bytes.from([destinationNodeIDs.length]),
+			...destinationNodeIDs,
+			Bytes.from([serializedCC.length]),
+			// payload
+			serializedCC,
+			Bytes.from([this.transmitOptions, this.callbackId]),
+		]);
+
+		return super.serializeAsync(ctx);
 	}
 
 	public toLogEntry(): MessageOrCCLogEntry {
@@ -568,6 +641,7 @@ export class SendDataMulticastRequestTransmitReport
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.assertCallbackId();
 		this.payload = Bytes.from([this.callbackId, this.transmitStatus]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 
@@ -619,6 +693,7 @@ export class SendDataMulticastResponse extends Message
 
 	public serialize(ctx: MessageEncodingContext): Bytes {
 		this.payload = Bytes.from([this.wasSent ? 1 : 0]);
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/serial/src/serialapi/transport/SendTestFrameMessages.ts
+++ b/packages/serial/src/serialapi/transport/SendTestFrameMessages.ts
@@ -89,6 +89,7 @@ export class SendTestFrameRequest extends SendTestFrameRequestBase {
 			]),
 		]);
 
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		return super.serialize(ctx);
 	}
 

--- a/packages/testing/src/MockController.ts
+++ b/packages/testing/src/MockController.ts
@@ -395,14 +395,14 @@ export class MockController {
 	): Promise<void> {
 		let data: Uint8Array;
 		if (fromNode) {
-			data = msg.serialize({
+			data = await msg.serializeAsync({
 				nodeIdType: this.encodingContext.nodeIdType,
 				...fromNode.encodingContext,
 			});
 			// Simulate the frame being transmitted via radio
 			await wait(fromNode.capabilities.txDelay);
 		} else {
-			data = msg.serialize(this.encodingContext);
+			data = await msg.serializeAsync(this.encodingContext);
 		}
 		this.serial.emitData(data);
 		// TODO: make the timeout match the configured ACK timeout

--- a/packages/testing/src/MockController.ts
+++ b/packages/testing/src/MockController.ts
@@ -240,7 +240,7 @@ export class MockController {
 
 		let msg: Message;
 		try {
-			msg = Message.parse(data, {
+			msg = await Message.parseAsync(data, {
 				...this.parsingContext,
 				origin: MessageOrigin.Host,
 			});

--- a/packages/testing/src/MockController.ts
+++ b/packages/testing/src/MockController.ts
@@ -240,7 +240,7 @@ export class MockController {
 
 		let msg: Message;
 		try {
-			msg = await Message.parseAsync(data, {
+			msg = Message.parse(data, {
 				...this.parsingContext,
 				origin: MessageOrigin.Host,
 			});
@@ -530,7 +530,7 @@ export class MockController {
 
 				await wait(node.capabilities.txDelay);
 
-				const unlazy = unlazyMockZWaveFrame(frame);
+				const unlazy = await unlazyMockZWaveFrame(frame);
 				onTransmit?.(unlazy);
 				node.onControllerFrame(unlazy).catch((e) => {
 					console.error(e);
@@ -542,7 +542,7 @@ export class MockController {
 
 				await wait(node.capabilities.txDelay);
 
-				const unlazy = unlazyMockZWaveFrame(frame);
+				const unlazy = await unlazyMockZWaveFrame(frame);
 				onTransmit?.(unlazy);
 				this.onNodeFrame(node, unlazy).catch((e) => {
 					console.error(e);

--- a/packages/testing/src/MockZWaveFrame.ts
+++ b/packages/testing/src/MockZWaveFrame.ts
@@ -25,7 +25,7 @@ export interface LazyMockZWaveRequestFrame {
 	/** Whether an ACK is requested from the destination */
 	ackRequested: boolean;
 	/** The Command Class contained in the frame */
-	payload: CommandClass | (() => CommandClass);
+	payload: CommandClass | (() => Promise<CommandClass>);
 }
 
 export interface MockZWaveAckFrame {
@@ -44,7 +44,7 @@ export enum MockZWaveFrameType {
 }
 
 export function createMockZWaveRequestFrame(
-	payload: CommandClass | (() => CommandClass),
+	payload: CommandClass | (() => Promise<CommandClass>),
 	options: Partial<Omit<MockZWaveRequestFrame, "direction" | "payload">> = {},
 ): LazyMockZWaveRequestFrame {
 	const { repeaters = [], ackRequested = true } = options;
@@ -68,13 +68,13 @@ export function createMockZWaveAckFrame(
 	};
 }
 
-export function unlazyMockZWaveFrame(
+export async function unlazyMockZWaveFrame(
 	frame: LazyMockZWaveFrame,
-): MockZWaveFrame {
+): Promise<MockZWaveFrame> {
 	if (frame.type === MockZWaveFrameType.ACK) return frame;
 	let payload = frame.payload;
 	if (typeof payload === "function") {
-		payload = payload();
+		payload = await payload();
 	}
 	return {
 		...frame,

--- a/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
+++ b/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
@@ -109,10 +109,10 @@ function createLazySendDataPayload(
 	controller: MockController,
 	node: MockNode,
 	msg: SendDataMessage,
-): () => CommandClass {
-	return () => {
+): () => Promise<CommandClass> {
+	return async () => {
 		try {
-			const cmd = CommandClass.parse(msg.serializedCC!, {
+			const cmd = await CommandClass.parseAsync(msg.serializedCC!, {
 				sourceNodeId: controller.ownNodeId,
 				__internalIsMockNode: true,
 				...node.encodingContext,

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -3542,7 +3542,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks>
 		try {
 			// Parse the message while remembering potential decoding errors in embedded CCs
 			// This way we can log the invalid CC contents
-			msg = await Message.parseAsync(
+			msg = Message.parse(
 				data,
 				this.getMessageParsingContext(),
 			);

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -5860,7 +5860,7 @@ ${handlers.length} left`,
 
 		const machine = createSerialAPICommandMachine(
 			msg,
-			msg.serialize(this.getEncodingContext()),
+			await msg.serializeAsync(this.getEncodingContext()),
 			{
 				sendData: (data) => this.writeSerial(data),
 				sendDataAbort: () => this.abortSendData(),
@@ -6425,7 +6425,7 @@ ${handlers.length} left`,
 		try {
 			const abort = new SendDataAbort();
 			await this.writeSerial(
-				abort.serialize(this.getEncodingContext()),
+				await abort.serializeAsync(this.getEncodingContext()),
 			);
 			this.driverLog.logMessage(abort, {
 				direction: "outbound",
@@ -7118,9 +7118,13 @@ ${handlers.length} left`,
 		}
 	}
 
-	public exceedsMaxPayloadLength(msg: SendDataMessage): boolean {
-		return msg.serializeCC(this.getEncodingContext()).length
-			> this.getMaxPayloadLength(msg);
+	public async exceedsMaxPayloadLength(
+		msg: SendDataMessage,
+	): Promise<boolean> {
+		const serializedCC = await msg.serializeCCAsync(
+			this.getEncodingContext(),
+		);
+		return serializedCC.length > this.getMaxPayloadLength(msg);
 	}
 
 	/** Determines time in milliseconds to wait for a report from a node */

--- a/packages/zwave-js/src/lib/driver/SerialAPICommandMachine.test.ts
+++ b/packages/zwave-js/src/lib/driver/SerialAPICommandMachine.test.ts
@@ -440,7 +440,7 @@ testPlans.forEach((plan) => {
 			const message: Message = messages[msgSelector.resp][msgSelector.cb];
 			const machine = createSerialAPICommandMachine(
 				message,
-				message.serialize({} as any),
+				await message.serializeAsync({} as any),
 				implementations,
 				machineParams,
 			);

--- a/packages/zwave-js/src/lib/test/cc/AssociationCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/AssociationCC.test.ts
@@ -33,14 +33,14 @@ test("the SupportedGroupingsGet command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the SupportedGroupingsReport command should be deserialized correctly", (t) => {
+test("the SupportedGroupingsReport command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			AssociationCommand.SupportedGroupingsReport, // CC Command
 			7, // # of groups
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 2 } as any,
 	) as AssociationCCSupportedGroupingsReport;
@@ -81,7 +81,7 @@ test("the Get command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the Report command should be deserialized correctly", (t) => {
+test("the Report command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			AssociationCommand.Report, // CC Command
@@ -94,7 +94,7 @@ test("the Report command should be deserialized correctly", (t) => {
 			5,
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as AssociationCCReport;

--- a/packages/zwave-js/src/lib/test/cc/AssociationCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/AssociationCC.test.ts
@@ -21,7 +21,7 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the SupportedGroupingsGet command should serialize correctly", (t) => {
+test("the SupportedGroupingsGet command should serialize correctly", async (t) => {
 	const cc = new AssociationCCSupportedGroupingsGet({
 		nodeId: 1,
 	});
@@ -30,7 +30,9 @@ test("the SupportedGroupingsGet command should serialize correctly", (t) => {
 			AssociationCommand.SupportedGroupingsGet, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the SupportedGroupingsReport command should be deserialized correctly", async (t) => {
@@ -49,7 +51,7 @@ test("the SupportedGroupingsReport command should be deserialized correctly", as
 	t.expect(cc.groupCount).toBe(7);
 });
 
-test("the Set command should serialize correctly", (t) => {
+test("the Set command should serialize correctly", async (t) => {
 	const cc = new AssociationCCSet({
 		nodeId: 2,
 		groupId: 5,
@@ -65,9 +67,11 @@ test("the Set command should serialize correctly", (t) => {
 			5,
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
-test("the Get command should serialize correctly", (t) => {
+test("the Get command should serialize correctly", async (t) => {
 	const cc = new AssociationCCGet({
 		nodeId: 1,
 		groupId: 9,
@@ -78,7 +82,9 @@ test("the Get command should serialize correctly", (t) => {
 			9, // group ID
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the Report command should be deserialized correctly", async (t) => {
@@ -106,7 +112,7 @@ test("the Report command should be deserialized correctly", async (t) => {
 	t.expect(cc.nodeIds).toStrictEqual([1, 2, 5]);
 });
 
-test("the Remove command should serialize correctly", (t) => {
+test("the Remove command should serialize correctly", async (t) => {
 	const cc = new AssociationCCRemove({
 		nodeId: 2,
 		groupId: 5,
@@ -122,10 +128,12 @@ test("the Remove command should serialize correctly", (t) => {
 			5,
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Remove command should serialize correctly (empty node list)", (t) => {
+test("the Remove command should serialize correctly (empty node list)", async (t) => {
 	const cc = new AssociationCCRemove({
 		nodeId: 2,
 		groupId: 5,
@@ -136,7 +144,9 @@ test("the Remove command should serialize correctly (empty node list)", (t) => {
 			5, // group id
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 // test("deserializing an unsupported command should return an unspecified version of AssociationCC", (t) => {

--- a/packages/zwave-js/src/lib/test/cc/AssociationGroupInfoCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/AssociationGroupInfoCC.test.ts
@@ -24,7 +24,7 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the NameGet command should serialize correctly", (t) => {
+test("the NameGet command should serialize correctly", async (t) => {
 	const cc = new AssociationGroupInfoCCNameGet({
 		nodeId: 1,
 		groupId: 7,
@@ -35,7 +35,9 @@ test("the NameGet command should serialize correctly", (t) => {
 			7, // group id
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the NameReport command should be deserialized correctly", async (t) => {
@@ -63,7 +65,7 @@ test("the NameReport command should be deserialized correctly", async (t) => {
 	t.expect(cc.name).toBe("foobar");
 });
 
-test("the InfoGet command should serialize correctly (no flag set)", (t) => {
+test("the InfoGet command should serialize correctly (no flag set)", async (t) => {
 	const cc = new AssociationGroupInfoCCInfoGet({
 		nodeId: 1,
 		groupId: 7,
@@ -77,10 +79,12 @@ test("the InfoGet command should serialize correctly (no flag set)", (t) => {
 			7, // group id
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the InfoGet command should serialize correctly (refresh cache flag set)", (t) => {
+test("the InfoGet command should serialize correctly (refresh cache flag set)", async (t) => {
 	const cc = new AssociationGroupInfoCCInfoGet({
 		nodeId: 1,
 		groupId: 7,
@@ -94,10 +98,12 @@ test("the InfoGet command should serialize correctly (refresh cache flag set)", 
 			7, // group id
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the InfoGet command should serialize correctly (list mode flag set)", (t) => {
+test("the InfoGet command should serialize correctly (list mode flag set)", async (t) => {
 	const cc = new AssociationGroupInfoCCInfoGet({
 		nodeId: 1,
 		groupId: 7,
@@ -111,7 +117,9 @@ test("the InfoGet command should serialize correctly (list mode flag set)", (t) 
 			0, // group id is ignored
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the Info Report command should be deserialized correctly", async (t) => {
@@ -157,7 +165,7 @@ test("the Info Report command should be deserialized correctly", async (t) => {
 	);
 });
 
-test("the CommandListGet command should serialize correctly", (t) => {
+test("the CommandListGet command should serialize correctly", async (t) => {
 	const cc = new AssociationGroupInfoCCCommandListGet({
 		nodeId: 1,
 		groupId: 6,
@@ -170,7 +178,9 @@ test("the CommandListGet command should serialize correctly", (t) => {
 			6, // group id
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the CommandListReport command should be deserialized correctly", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/AssociationGroupInfoCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/AssociationGroupInfoCC.test.ts
@@ -38,7 +38,7 @@ test("the NameGet command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the NameReport command should be deserialized correctly", (t) => {
+test("the NameReport command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			AssociationGroupInfoCommand.NameReport, // CC Command
@@ -53,7 +53,7 @@ test("the NameReport command should be deserialized correctly", (t) => {
 			0x72,
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as AssociationGroupInfoCCNameReport;
@@ -114,7 +114,7 @@ test("the InfoGet command should serialize correctly (list mode flag set)", (t) 
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the Info Report command should be deserialized correctly", (t) => {
+test("the Info Report command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			AssociationGroupInfoCommand.InfoReport, // CC Command
@@ -140,7 +140,7 @@ test("the Info Report command should be deserialized correctly", (t) => {
 			0,
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as AssociationGroupInfoCCInfoReport;
@@ -173,7 +173,7 @@ test("the CommandListGet command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the CommandListReport command should be deserialized correctly", (t) => {
+test("the CommandListReport command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			AssociationGroupInfoCommand.CommandListReport, // CC Command
@@ -187,7 +187,7 @@ test("the CommandListReport command should be deserialized correctly", (t) => {
 			0x05,
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as AssociationGroupInfoCCCommandListReport;
@@ -203,11 +203,11 @@ test("the CommandListReport command should be deserialized correctly", (t) => {
 	]]);
 });
 
-test("deserializing an unsupported command should return an unspecified version of AssociationGroupInfoCC", (t) => {
+test("deserializing an unsupported command should return an unspecified version of AssociationGroupInfoCC", async (t) => {
 	const serializedCC = buildCCBuffer(
 		Uint8Array.from([255]), // not a valid command
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		serializedCC,
 		{ sourceNodeId: 1 } as any,
 	) as AssociationGroupInfoCC;

--- a/packages/zwave-js/src/lib/test/cc/BasicCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/BasicCC.test.ts
@@ -26,14 +26,16 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the Get command should serialize correctly", (t) => {
+test("the Get command should serialize correctly", async (t) => {
 	const basicCC = new BasicCCGet({ nodeId: 1 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
 			BasicCommand.Get, // CC Command
 		]),
 	);
-	t.expect(basicCC.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(basicCC.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the Get command should be deserialized correctly", async (t) => {
@@ -50,7 +52,7 @@ test("the Get command should be deserialized correctly", async (t) => {
 	t.expect(basicCC.nodeId).toBe(2);
 });
 
-test("the Set command should serialize correctly", (t) => {
+test("the Set command should serialize correctly", async (t) => {
 	const basicCC = new BasicCCSet({
 		nodeId: 2,
 		targetValue: 55,
@@ -61,7 +63,9 @@ test("the Set command should serialize correctly", (t) => {
 			55, // target value
 		]),
 	);
-	t.expect(basicCC.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(basicCC.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the Report command (v1) should be deserialized correctly", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/BasicCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/BasicCC.test.ts
@@ -36,13 +36,13 @@ test("the Get command should serialize correctly", (t) => {
 	t.expect(basicCC.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the Get command should be deserialized correctly", (t) => {
+test("the Get command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			BasicCommand.Get, // CC Command
 		]),
 	);
-	const basicCC = CommandClass.parse(
+	const basicCC = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 2 } as any,
 	) as BasicCCGet;
@@ -64,14 +64,14 @@ test("the Set command should serialize correctly", (t) => {
 	t.expect(basicCC.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the Report command (v1) should be deserialized correctly", (t) => {
+test("the Report command (v1) should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			BasicCommand.Report, // CC Command
 			55, // current value
 		]),
 	);
-	const basicCC = CommandClass.parse(
+	const basicCC = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 2 } as any,
 	) as BasicCCReport;
@@ -82,7 +82,7 @@ test("the Report command (v1) should be deserialized correctly", (t) => {
 	t.expect(basicCC.duration).toBeUndefined();
 });
 
-test("the Report command (v2) should be deserialized correctly", (t) => {
+test("the Report command (v2) should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			BasicCommand.Report, // CC Command
@@ -91,7 +91,7 @@ test("the Report command (v2) should be deserialized correctly", (t) => {
 			1, // duration
 		]),
 	);
-	const basicCC = CommandClass.parse(
+	const basicCC = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 2 } as any,
 	) as BasicCCReport;
@@ -103,11 +103,11 @@ test("the Report command (v2) should be deserialized correctly", (t) => {
 	t.expect(basicCC.duration!.value).toBe(1);
 });
 
-test("deserializing an unsupported command should return an unspecified version of BasicCC", (t) => {
+test("deserializing an unsupported command should return an unspecified version of BasicCC", async (t) => {
 	const serializedCC = buildCCBuffer(
 		Uint8Array.from([255]), // not a valid command
 	);
-	const basicCC = CommandClass.parse(
+	const basicCC = await CommandClass.parseAsync(
 		serializedCC,
 		{ sourceNodeId: 2 } as any,
 	) as BasicCCReport;

--- a/packages/zwave-js/src/lib/test/cc/BatteryCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/BatteryCC.test.ts
@@ -11,13 +11,15 @@ import { CommandClasses } from "@zwave-js/core";
 import { Bytes } from "@zwave-js/shared";
 import { test } from "vitest";
 
-test("the Get command should serialize correctly", (t) => {
+test("the Get command should serialize correctly", async (t) => {
 	const batteryCC = new BatteryCCGet({ nodeId: 1 });
 	const expected = Bytes.from([
 		CommandClasses.Battery, // CC
 		BatteryCommand.Get, // CC Command
 	]);
-	t.expect(batteryCC.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(batteryCC.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the Report command (v1) should be deserialized correctly: when the battery is not low", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/BatteryCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/BatteryCC.test.ts
@@ -20,13 +20,13 @@ test("the Get command should serialize correctly", (t) => {
 	t.expect(batteryCC.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the Report command (v1) should be deserialized correctly: when the battery is not low", (t) => {
+test("the Report command (v1) should be deserialized correctly: when the battery is not low", async (t) => {
 	const ccData = Uint8Array.from([
 		CommandClasses.Battery, // CC
 		BatteryCommand.Report, // CC Command
 		55, // current value
 	]);
-	const batteryCC = CommandClass.parse(
+	const batteryCC = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 7 } as any,
 	) as BatteryCCReport;
@@ -36,13 +36,13 @@ test("the Report command (v1) should be deserialized correctly: when the battery
 	t.expect(batteryCC.isLow).toBe(false);
 });
 
-test("the Report command (v1) should be deserialized correctly: when the battery is low", (t) => {
+test("the Report command (v1) should be deserialized correctly: when the battery is low", async (t) => {
 	const ccData = Uint8Array.from([
 		CommandClasses.Battery, // CC
 		BatteryCommand.Report, // CC Command
 		0xff, // current value
 	]);
-	const batteryCC = CommandClass.parse(
+	const batteryCC = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 7 } as any,
 	) as BatteryCCReport;
@@ -52,7 +52,7 @@ test("the Report command (v1) should be deserialized correctly: when the battery
 	t.expect(batteryCC.isLow).toBe(true);
 });
 
-test("the Report command (v2) should be deserialized correctly: all flags set", (t) => {
+test("the Report command (v2) should be deserialized correctly: all flags set", async (t) => {
 	const ccData = Uint8Array.from([
 		CommandClasses.Battery, // CC
 		BatteryCommand.Report, // CC Command
@@ -60,7 +60,7 @@ test("the Report command (v2) should be deserialized correctly: all flags set", 
 		0b00_1111_00,
 		1, // disconnected
 	]);
-	const batteryCC = CommandClass.parse(
+	const batteryCC = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 7 } as any,
 	) as BatteryCCReport;
@@ -73,7 +73,7 @@ test("the Report command (v2) should be deserialized correctly: all flags set", 
 	t.expect(batteryCC.disconnected).toBe(true);
 });
 
-test("the Report command (v2) should be deserialized correctly: charging status", (t) => {
+test("the Report command (v2) should be deserialized correctly: charging status", async (t) => {
 	const ccData = Uint8Array.from([
 		CommandClasses.Battery, // CC
 		BatteryCommand.Report, // CC Command
@@ -81,7 +81,7 @@ test("the Report command (v2) should be deserialized correctly: charging status"
 		0b10_000000, // Maintaining
 		0,
 	]);
-	const batteryCC = CommandClass.parse(
+	const batteryCC = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 7 } as any,
 	) as BatteryCCReport;
@@ -90,7 +90,7 @@ test("the Report command (v2) should be deserialized correctly: charging status"
 	t.expect(batteryCC.chargingStatus).toBe(BatteryChargingStatus.Maintaining);
 });
 
-test("the Report command (v2) should be deserialized correctly: recharge or replace", (t) => {
+test("the Report command (v2) should be deserialized correctly: recharge or replace", async (t) => {
 	const ccData = Uint8Array.from([
 		CommandClasses.Battery, // CC
 		BatteryCommand.Report, // CC Command
@@ -98,7 +98,7 @@ test("the Report command (v2) should be deserialized correctly: recharge or repl
 		0b11, // Maintaining
 		0,
 	]);
-	const batteryCC = CommandClass.parse(
+	const batteryCC = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 7 } as any,
 	) as BatteryCCReport;
@@ -107,12 +107,12 @@ test("the Report command (v2) should be deserialized correctly: recharge or repl
 	t.expect(batteryCC.rechargeOrReplace).toBe(BatteryReplacementStatus.Now);
 });
 
-test("deserializing an unsupported command should return an unspecified version of BatteryCC", (t) => {
+test("deserializing an unsupported command should return an unspecified version of BatteryCC", async (t) => {
 	const serializedCC = Uint8Array.from([
 		CommandClasses.Battery, // CC
 		255, // not a valid command
 	]);
-	const batteryCC = CommandClass.parse(
+	const batteryCC = await CommandClass.parseAsync(
 		serializedCC,
 		{ sourceNodeId: 7 } as any,
 	) as BatteryCCReport;

--- a/packages/zwave-js/src/lib/test/cc/BinarySensorCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/BinarySensorCC.test.ts
@@ -21,7 +21,7 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the Get command should serialize correctly (no sensor type)", (t) => {
+test("the Get command should serialize correctly (no sensor type)", async (t) => {
 	const cc = new BinarySensorCCGet({ nodeId: 1 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
@@ -29,10 +29,12 @@ test("the Get command should serialize correctly (no sensor type)", (t) => {
 			BinarySensorType.Any, // sensor type
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Get command should serialize correctly", (t) => {
+test("the Get command should serialize correctly", async (t) => {
 	const cc = new BinarySensorCCGet({
 		nodeId: 1,
 		sensorType: BinarySensorType.CO,
@@ -40,7 +42,9 @@ test("the Get command should serialize correctly", (t) => {
 	const expected = buildCCBuffer(
 		Uint8Array.from([BinarySensorCommand.Get, BinarySensorType.CO]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the Report command (v1) should be deserialized correctly", async (t) => {
@@ -77,14 +81,16 @@ test("the Report command (v2) should be deserialized correctly", async (t) => {
 	t.expect(cc.type).toBe(BinarySensorType.CO2);
 });
 
-test("the SupportedGet command should serialize correctly", (t) => {
+test("the SupportedGet command should serialize correctly", async (t) => {
 	const cc = new BinarySensorCCSupportedGet({ nodeId: 1 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
 			BinarySensorCommand.SupportedGet, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the SupportedReport command should be deserialized correctly", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/BinarySensorCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/BinarySensorCC.test.ts
@@ -43,14 +43,14 @@ test("the Get command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the Report command (v1) should be deserialized correctly", (t) => {
+test("the Report command (v1) should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			BinarySensorCommand.Report, // CC Command
 			0xff, // current value
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as BinarySensorCCReport;
@@ -59,7 +59,7 @@ test("the Report command (v1) should be deserialized correctly", (t) => {
 	t.expect(cc.value).toBe(true);
 });
 
-test("the Report command (v2) should be deserialized correctly", (t) => {
+test("the Report command (v2) should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			BinarySensorCommand.Report, // CC Command
@@ -67,7 +67,7 @@ test("the Report command (v2) should be deserialized correctly", (t) => {
 			BinarySensorType.CO2,
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as BinarySensorCCReport;
@@ -87,7 +87,7 @@ test("the SupportedGet command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the SupportedReport command should be deserialized correctly", (t) => {
+test("the SupportedReport command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			BinarySensorCommand.SupportedReport, // CC Command
@@ -95,7 +95,7 @@ test("the SupportedReport command should be deserialized correctly", (t) => {
 			0b10,
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as BinarySensorCCSupportedReport;
@@ -110,11 +110,11 @@ test("the SupportedReport command should be deserialized correctly", (t) => {
 	]);
 });
 
-test("deserializing an unsupported command should return an unspecified version of BinarySensorCC", (t) => {
+test("deserializing an unsupported command should return an unspecified version of BinarySensorCC", async (t) => {
 	const serializedCC = buildCCBuffer(
 		Uint8Array.from([255]), // not a valid command
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		serializedCC,
 		{ sourceNodeId: 1 } as any,
 	) as BinarySensorCC;

--- a/packages/zwave-js/src/lib/test/cc/BinarySwitchCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/BinarySwitchCC.test.ts
@@ -74,14 +74,14 @@ test("the Set command should serialize correctly", (t) => {
 	t.expect(cc.serialize(ctx)).toStrictEqual(expected);
 });
 
-test("the Report command (v1) should be deserialized correctly", (t) => {
+test("the Report command (v1) should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			BinarySwitchCommand.Report, // CC Command
 			0xff, // current value
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 2 } as any,
 	) as BinarySwitchCCReport;
@@ -92,7 +92,7 @@ test("the Report command (v1) should be deserialized correctly", (t) => {
 	t.expect(cc.duration).toBeUndefined();
 });
 
-test("the Report command (v2) should be deserialized correctly", (t) => {
+test("the Report command (v2) should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			BinarySwitchCommand.Report, // CC Command
@@ -101,7 +101,7 @@ test("the Report command (v2) should be deserialized correctly", (t) => {
 			1, // duration
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 2 } as any,
 	) as BinarySwitchCCReport;
@@ -113,11 +113,11 @@ test("the Report command (v2) should be deserialized correctly", (t) => {
 	t.expect(cc.duration!.value).toBe(1);
 });
 
-test("deserializing an unsupported command should return an unspecified version of BinarySwitchCC", (t) => {
+test("deserializing an unsupported command should return an unspecified version of BinarySwitchCC", async (t) => {
 	const serializedCC = buildCCBuffer(
 		Uint8Array.from([255]), // not a valid command
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		serializedCC,
 		{ sourceNodeId: 2 } as any,
 	) as BinarySwitchCC;

--- a/packages/zwave-js/src/lib/test/cc/BinarySwitchCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/BinarySwitchCC.test.ts
@@ -20,17 +20,19 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the Get command should serialize correctly", (t) => {
+test("the Get command should serialize correctly", async (t) => {
 	const cc = new BinarySwitchCCGet({ nodeId: 1 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
 			BinarySwitchCommand.Get, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Set command should serialize correctly (no duration)", (t) => {
+test("the Set command should serialize correctly (no duration)", async (t) => {
 	const cc = new BinarySwitchCCSet({
 		nodeId: 2,
 		targetValue: false,
@@ -48,10 +50,10 @@ test("the Set command should serialize correctly (no duration)", (t) => {
 		},
 	} satisfies GetSupportedCCVersion as any;
 
-	t.expect(cc.serialize(ctx)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync(ctx)).resolves.toStrictEqual(expected);
 });
 
-test("the Set command should serialize correctly", (t) => {
+test("the Set command should serialize correctly", async (t) => {
 	const duration = new Duration(2, "minutes");
 	const cc = new BinarySwitchCCSet({
 		nodeId: 2,
@@ -71,7 +73,7 @@ test("the Set command should serialize correctly", (t) => {
 		},
 	} satisfies GetSupportedCCVersion as any;
 
-	t.expect(cc.serialize(ctx)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync(ctx)).resolves.toStrictEqual(expected);
 });
 
 test("the Report command (v1) should be deserialized correctly", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/CRC16CC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/CRC16CC.test.ts
@@ -28,7 +28,7 @@ test("should match the specs", (t) => {
 	t.expect(serialized).toStrictEqual(expected);
 });
 
-test("serialization and deserialization should be compatible", (t) => {
+test("serialization and deserialization should be compatible", async (t) => {
 	const basicCCSet = new BasicCCSet({
 		nodeId: 3,
 		targetValue: 89,
@@ -38,7 +38,7 @@ test("serialization and deserialization should be compatible", (t) => {
 	t.expect(crc16.encapsulated).toBe(basicCCSet);
 	const serialized = crc16.serialize({} as any);
 
-	const deserialized = CommandClass.parse(
+	const deserialized = await CommandClass.parseAsync(
 		serialized,
 		{ sourceNodeId: basicCCSet.nodeId as number } as any,
 	);
@@ -50,7 +50,7 @@ test("serialization and deserialization should be compatible", (t) => {
 	t.expect(deserializedPayload.targetValue).toBe(basicCCSet.targetValue);
 });
 
-test("deserializing a CC with a wrong checksum should result in an invalid CC", (t) => {
+test("deserializing a CC with a wrong checksum should result in an invalid CC", async (t) => {
 	const basicCCSet = new BasicCCSet({
 		nodeId: 3,
 		targetValue: 89,
@@ -61,7 +61,7 @@ test("deserializing a CC with a wrong checksum should result in an invalid CC", 
 	const serialized = crc16.serialize({} as any);
 	serialized[serialized.length - 1] ^= 0xff;
 
-	const deserialized = CommandClass.parse(
+	const deserialized = await CommandClass.parseAsync(
 		serialized,
 		{ sourceNodeId: basicCCSet.nodeId as number } as any,
 	);

--- a/packages/zwave-js/src/lib/test/cc/CRC16CC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/CRC16CC.test.ts
@@ -19,11 +19,11 @@ test("should be detected as an encapsulating CC", (t) => {
 	t.expect(isEncapsulatingCommandClass(crc16)).toBe(true);
 });
 
-test("should match the specs", (t) => {
+test("should match the specs", async (t) => {
 	// SDS13783 contains the following sample encapsulated command:
 	const basicCCGet = new BasicCCGet({ nodeId: 1 });
 	const crc16 = CRC16CC.encapsulate(basicCCGet);
-	const serialized = crc16.serialize({} as any);
+	const serialized = await crc16.serializeAsync({} as any);
 	const expected = Bytes.from("560120024d26", "hex");
 	t.expect(serialized).toStrictEqual(expected);
 });
@@ -36,7 +36,7 @@ test("serialization and deserialization should be compatible", async (t) => {
 	const crc16 = CRC16CC.encapsulate(basicCCSet);
 	t.expect(crc16.nodeId).toBe(basicCCSet.nodeId);
 	t.expect(crc16.encapsulated).toBe(basicCCSet);
-	const serialized = crc16.serialize({} as any);
+	const serialized = await crc16.serializeAsync({} as any);
 
 	const deserialized = await CommandClass.parseAsync(
 		serialized,
@@ -58,7 +58,7 @@ test("deserializing a CC with a wrong checksum should result in an invalid CC", 
 	const crc16 = CRC16CC.encapsulate(basicCCSet);
 	t.expect(crc16.nodeId).toBe(basicCCSet.nodeId);
 	t.expect(crc16.encapsulated).toBe(basicCCSet);
-	const serialized = crc16.serialize({} as any);
+	const serialized = await crc16.serializeAsync({} as any);
 	serialized[serialized.length - 1] ^= 0xff;
 
 	const deserialized = await CommandClass.parseAsync(

--- a/packages/zwave-js/src/lib/test/cc/CentralSceneCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/CentralSceneCC.test.ts
@@ -23,7 +23,7 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the ConfigurationGet command should serialize correctly", (t) => {
+test("the ConfigurationGet command should serialize correctly", async (t) => {
 	const cc = new CentralSceneCCConfigurationGet({
 		nodeId: 1,
 	});
@@ -32,10 +32,12 @@ test("the ConfigurationGet command should serialize correctly", (t) => {
 			CentralSceneCommand.ConfigurationGet, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the ConfigurationSet command should serialize correctly (flags set)", (t) => {
+test("the ConfigurationSet command should serialize correctly (flags set)", async (t) => {
 	const cc = new CentralSceneCCConfigurationSet({
 		nodeId: 2,
 		slowRefresh: true,
@@ -46,10 +48,12 @@ test("the ConfigurationSet command should serialize correctly (flags set)", (t) 
 			0b1000_0000,
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the ConfigurationSet command should serialize correctly (flags not set)", (t) => {
+test("the ConfigurationSet command should serialize correctly (flags not set)", async (t) => {
 	const cc = new CentralSceneCCConfigurationSet({
 		nodeId: 2,
 		slowRefresh: false,
@@ -60,7 +64,9 @@ test("the ConfigurationSet command should serialize correctly (flags not set)", 
 			0,
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the ConfigurationReport command should be deserialized correctly", async (t) => {
@@ -79,7 +85,7 @@ test("the ConfigurationReport command should be deserialized correctly", async (
 	t.expect(cc.slowRefresh).toBe(true);
 });
 
-test("the SupportedGet command should serialize correctly", (t) => {
+test("the SupportedGet command should serialize correctly", async (t) => {
 	const cc = new CentralSceneCCSupportedGet({
 		nodeId: 1,
 	});
@@ -88,7 +94,9 @@ test("the SupportedGet command should serialize correctly", (t) => {
 			CentralSceneCommand.SupportedGet, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the SupportedReport command should be deserialized correctly", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/CentralSceneCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/CentralSceneCC.test.ts
@@ -63,14 +63,14 @@ test("the ConfigurationSet command should serialize correctly (flags not set)", 
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the ConfigurationReport command should be deserialized correctly", (t) => {
+test("the ConfigurationReport command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			CentralSceneCommand.ConfigurationReport, // CC Command
 			0b1000_0000,
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as CentralSceneCCConfigurationReport;
@@ -91,7 +91,7 @@ test("the SupportedGet command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the SupportedReport command should be deserialized correctly", (t) => {
+test("the SupportedReport command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			CentralSceneCommand.SupportedReport, // CC Command
@@ -103,7 +103,7 @@ test("the SupportedReport command should be deserialized correctly", (t) => {
 			0,
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as CentralSceneCCSupportedReport;
@@ -117,7 +117,7 @@ test("the SupportedReport command should be deserialized correctly", (t) => {
 	t.expect(cc.supportedKeyAttributes.get(2)).toStrictEqual([0, 2, 4]);
 });
 
-test("the Notification command should be deserialized correctly", (t) => {
+test("the Notification command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			CentralSceneCommand.Notification, // CC Command
@@ -126,7 +126,7 @@ test("the Notification command should be deserialized correctly", (t) => {
 			8, // scene number
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as CentralSceneCCNotification;
@@ -139,7 +139,7 @@ test("the Notification command should be deserialized correctly", (t) => {
 	t.expect(cc.sceneNumber).toBe(8);
 });
 
-test("the Notification command should be deserialized correctly (KeyHeldDown)", (t) => {
+test("the Notification command should be deserialized correctly (KeyHeldDown)", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			CentralSceneCommand.Notification, // CC Command
@@ -148,7 +148,7 @@ test("the Notification command should be deserialized correctly (KeyHeldDown)", 
 			8, // scene number
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as CentralSceneCCNotification;
@@ -160,11 +160,11 @@ test("the Notification command should be deserialized correctly (KeyHeldDown)", 
 	t.expect(cc.sceneNumber).toBe(8);
 });
 
-test("deserializing an unsupported command should return an unspecified version of CentralSceneCC", (t) => {
+test("deserializing an unsupported command should return an unspecified version of CentralSceneCC", async (t) => {
 	const serializedCC = buildCCBuffer(
 		Uint8Array.from([255]), // not a valid command
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		serializedCC,
 		{ sourceNodeId: 1 } as any,
 	) as CentralSceneCC;

--- a/packages/zwave-js/src/lib/test/cc/ColorSwitchCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/ColorSwitchCC.test.ts
@@ -42,7 +42,7 @@ test("the SupportedGet command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the SupportedReport command should deserialize correctly", (t) => {
+test("the SupportedReport command should deserialize correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			ColorSwitchCommand.SupportedReport, // CC Command
@@ -50,7 +50,7 @@ test("the SupportedReport command should deserialize correctly", (t) => {
 			0b0000_0001,
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as ColorSwitchCCSupportedReport;
@@ -85,7 +85,7 @@ test("the Get command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the Report command should deserialize correctly (version 1)", (t) => {
+test("the Report command should deserialize correctly (version 1)", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			ColorSwitchCommand.Report, // CC Command
@@ -93,7 +93,7 @@ test("the Report command should deserialize correctly (version 1)", (t) => {
 			0b1111_1111, // value: 255
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as ColorSwitchCCReport;
@@ -105,7 +105,7 @@ test("the Report command should deserialize correctly (version 1)", (t) => {
 	t.expect(cc.duration).toBeUndefined();
 });
 
-test("the Report command should deserialize correctly (version 3)", (t) => {
+test("the Report command should deserialize correctly (version 3)", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			ColorSwitchCommand.Report, // CC Command
@@ -115,7 +115,7 @@ test("the Report command should deserialize correctly (version 3)", (t) => {
 			0b0000_0001, // duration: 1
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as ColorSwitchCCReport;

--- a/packages/zwave-js/src/lib/test/cc/ColorSwitchCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/ColorSwitchCC.test.ts
@@ -30,7 +30,7 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the SupportedGet command should serialize correctly", (t) => {
+test("the SupportedGet command should serialize correctly", async (t) => {
 	const cc = new ColorSwitchCCSupportedGet({
 		nodeId: 1,
 	});
@@ -39,7 +39,9 @@ test("the SupportedGet command should serialize correctly", (t) => {
 			ColorSwitchCommand.SupportedGet, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the SupportedReport command should deserialize correctly", async (t) => {
@@ -71,7 +73,7 @@ test("the SupportedReport command should deserialize correctly", async (t) => {
 	// ]);
 });
 
-test("the Get command should serialize correctly", (t) => {
+test("the Get command should serialize correctly", async (t) => {
 	const cc = new ColorSwitchCCGet({
 		nodeId: 1,
 		colorComponent: ColorComponent.Red,
@@ -82,7 +84,9 @@ test("the Get command should serialize correctly", (t) => {
 			2, // Color Component
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the Report command should deserialize correctly (version 1)", async (t) => {
@@ -128,7 +132,7 @@ test("the Report command should deserialize correctly (version 3)", async (t) =>
 	t.expect(cc.duration!.unit).toBe("seconds");
 });
 
-test("the Set command should serialize correctly (without duration)", (t) => {
+test("the Set command should serialize correctly (without duration)", async (t) => {
 	const cc = new ColorSwitchCCSet({
 		nodeId: 1,
 		red: 128,
@@ -154,10 +158,10 @@ test("the Set command should serialize correctly (without duration)", (t) => {
 		},
 	} satisfies GetSupportedCCVersion as any;
 
-	t.expect(cc.serialize(ctx)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync(ctx)).resolves.toStrictEqual(expected);
 });
 
-test("the Set command should serialize correctly (version 2)", (t) => {
+test("the Set command should serialize correctly (version 2)", async (t) => {
 	const cc = new ColorSwitchCCSet({
 		nodeId: 1,
 		red: 128,
@@ -183,10 +187,10 @@ test("the Set command should serialize correctly (version 2)", (t) => {
 		},
 	} satisfies GetSupportedCCVersion as any;
 
-	t.expect(cc.serialize(ctx)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync(ctx)).resolves.toStrictEqual(expected);
 });
 
-test("the StartLevelChange command should serialize correctly", (t) => {
+test("the StartLevelChange command should serialize correctly", async (t) => {
 	const cc = new ColorSwitchCCStartLevelChange({
 		nodeId: 1,
 		startLevel: 5,
@@ -210,10 +214,10 @@ test("the StartLevelChange command should serialize correctly", (t) => {
 		},
 	} satisfies GetSupportedCCVersion as any;
 
-	t.expect(cc.serialize(ctx)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync(ctx)).resolves.toStrictEqual(expected);
 });
 
-test("the StopLevelChange command should serialize correctly", (t) => {
+test("the StopLevelChange command should serialize correctly", async (t) => {
 	const cc = new ColorSwitchCCStopLevelChange({
 		nodeId: 1,
 		colorComponent: ColorComponent.Red,
@@ -225,7 +229,9 @@ test("the StopLevelChange command should serialize correctly", (t) => {
 			0b0000_0010, // color: red
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the setValue API verifies that targetColor isn't set with non-numeric keys", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/CommandClass.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/CommandClass.test.ts
@@ -25,7 +25,7 @@ class DummyCCSubClass2 extends DummyCC {
 	private y: any;
 }
 
-test(`creating and serializing should work for unspecified commands`, (t) => {
+test(`creating and serializing should work for unspecified commands`, async (t) => {
 	// Repro for #1219
 	const cc = new CommandClass({
 		nodeId: 2,
@@ -37,9 +37,9 @@ test(`creating and serializing should work for unspecified commands`, (t) => {
 		command: cc,
 		callbackId: 0xfe,
 	});
-	t.expect(
-		msg.serialize({} as any),
-	).toStrictEqual(Bytes.from("010c001302055d0201020325fe63", "hex"));
+	await t.expect(
+		msg.serializeAsync({} as any),
+	).resolves.toStrictEqual(Bytes.from("010c001302055d0201020325fe63", "hex"));
 });
 
 test("parse() returns an un-specialized instance when receiving a non-implemented CC", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/CommandClass.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/CommandClass.test.ts
@@ -42,9 +42,9 @@ test(`creating and serializing should work for unspecified commands`, (t) => {
 	).toStrictEqual(Bytes.from("010c001302055d0201020325fe63", "hex"));
 });
 
-test("parse() returns an un-specialized instance when receiving a non-implemented CC", (t) => {
+test("parse() returns an un-specialized instance when receiving a non-implemented CC", async (t) => {
 	// This is a Node Provisioning CC. Change it when that CC is implemented
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		Bytes.from("78030100", "hex"),
 		{ sourceNodeId: 5 } as any,
 	);
@@ -56,9 +56,9 @@ test("parse() returns an un-specialized instance when receiving a non-implemente
 });
 
 test("parse() does not throw when the CC is implemented", (t) => {
-	t.expect(() =>
+	t.expect(async () =>
 		// CRC-16 with BasicCC
-		CommandClass.parse(
+		await CommandClass.parseAsync(
 			Bytes.from("560120024d26", "hex"),
 			{ sourceNodeId: 5 } as any,
 		)

--- a/packages/zwave-js/src/lib/test/cc/DoorLockCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/DoorLockCC.test.ts
@@ -65,7 +65,7 @@ test("the OperationSet command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the OperationReport command (v1-v3) should be deserialized correctly", (t) => {
+test("the OperationReport command (v1-v3) should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			DoorLockCommand.OperationReport, // CC Command
@@ -76,7 +76,7 @@ test("the OperationReport command (v1-v3) should be deserialized correctly", (t)
 			20, // timeout seconds
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as DoorLockCCOperationReport;
@@ -103,7 +103,7 @@ test("the OperationReport command (v1-v3) should be deserialized correctly", (t)
 	t.expect(cc.duration).toBeUndefined();
 });
 
-test("the OperationReport command (v4) should be deserialized correctly", (t) => {
+test("the OperationReport command (v4) should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			DoorLockCommand.OperationReport, // CC Command
@@ -116,7 +116,7 @@ test("the OperationReport command (v4) should be deserialized correctly", (t) =>
 			0x01, // 1 second left
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 2 } as any,
 	) as DoorLockCCOperationReport;
@@ -160,7 +160,7 @@ test("the ConfigurationGet command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the ConfigurationReport command (v1-v3) should be deserialized correctly", (t) => {
+test("the ConfigurationReport command (v1-v3) should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			DoorLockCommand.ConfigurationReport, // CC Command
@@ -170,7 +170,7 @@ test("the ConfigurationReport command (v1-v3) should be deserialized correctly",
 			20, // timeout seconds
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as DoorLockCCConfigurationReport;
@@ -196,7 +196,7 @@ test("the ConfigurationReport command (v1-v3) should be deserialized correctly",
 	t.expect(cc.blockToBlock).toBeUndefined();
 });
 
-test("the ConfigurationReport command must ignore invalid timeouts (constant)", (t) => {
+test("the ConfigurationReport command must ignore invalid timeouts (constant)", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			DoorLockCommand.ConfigurationReport, // CC Command
@@ -206,7 +206,7 @@ test("the ConfigurationReport command must ignore invalid timeouts (constant)", 
 			20, // timeout seconds
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as DoorLockCCConfigurationReport;
@@ -215,7 +215,7 @@ test("the ConfigurationReport command must ignore invalid timeouts (constant)", 
 	t.expect(cc.lockTimeoutConfiguration).toBeUndefined();
 });
 
-test("the ConfigurationReport command must ignore invalid timeouts (invalid minutes)", (t) => {
+test("the ConfigurationReport command must ignore invalid timeouts (invalid minutes)", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			DoorLockCommand.ConfigurationReport, // CC Command
@@ -225,7 +225,7 @@ test("the ConfigurationReport command must ignore invalid timeouts (invalid minu
 			20, // timeout seconds
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as DoorLockCCConfigurationReport;
@@ -234,7 +234,7 @@ test("the ConfigurationReport command must ignore invalid timeouts (invalid minu
 	t.expect(cc.lockTimeoutConfiguration).toBeUndefined();
 });
 
-test("the ConfigurationReport command must ignore invalid timeouts (invalid seconds)", (t) => {
+test("the ConfigurationReport command must ignore invalid timeouts (invalid seconds)", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			DoorLockCommand.ConfigurationReport, // CC Command
@@ -244,7 +244,7 @@ test("the ConfigurationReport command must ignore invalid timeouts (invalid seco
 			0xff, // timeout seconds
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as DoorLockCCConfigurationReport;
@@ -253,7 +253,7 @@ test("the ConfigurationReport command must ignore invalid timeouts (invalid seco
 	t.expect(cc.lockTimeoutConfiguration).toBeUndefined();
 });
 
-test("the ConfigurationReport command (v4) should be deserialized correctly", (t) => {
+test("the ConfigurationReport command (v4) should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			DoorLockCommand.ConfigurationReport, // CC Command
@@ -269,7 +269,7 @@ test("the ConfigurationReport command (v4) should be deserialized correctly", (t
 			0b01, // flags
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as DoorLockCCConfigurationReport;
@@ -320,7 +320,7 @@ test("the CapabilitiesGet command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the CapabilitiesReport command should be deserialized correctly", (t) => {
+test("the CapabilitiesReport command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			DoorLockCommand.CapabilitiesReport, // CC Command
@@ -335,7 +335,7 @@ test("the CapabilitiesReport command should be deserialized correctly", (t) => {
 			0b1010, // feature flags
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as DoorLockCCCapabilitiesReport;

--- a/packages/zwave-js/src/lib/test/cc/DoorLockCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/DoorLockCC.test.ts
@@ -41,17 +41,19 @@ valueDB2.setValue(DoorLockCCValues.doorSupported.id, false);
 valueDB2.setValue(DoorLockCCValues.boltSupported.id, true);
 valueDB2.setValue(DoorLockCCValues.latchSupported.id, true);
 
-test("the OperationGet command should serialize correctly", (t) => {
+test("the OperationGet command should serialize correctly", async (t) => {
 	const cc = new DoorLockCCOperationGet({ nodeId: 1 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
 			DoorLockCommand.OperationGet, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the OperationSet command should serialize correctly", (t) => {
+test("the OperationSet command should serialize correctly", async (t) => {
 	const cc = new DoorLockCCOperationSet({
 		nodeId: 2,
 		mode: DoorLockMode.OutsideUnsecured,
@@ -62,7 +64,9 @@ test("the OperationSet command should serialize correctly", (t) => {
 			0x20, // target value
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the OperationReport command (v1-v3) should be deserialized correctly", async (t) => {
@@ -150,14 +154,16 @@ test("the OperationReport command (v4) should be deserialized correctly", async 
 	t.expect(cc.duration).toStrictEqual(new Duration(1, "seconds"));
 });
 
-test("the ConfigurationGet command should serialize correctly", (t) => {
+test("the ConfigurationGet command should serialize correctly", async (t) => {
 	const cc = new DoorLockCCConfigurationGet({ nodeId: 1 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
 			DoorLockCommand.ConfigurationGet, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the ConfigurationReport command (v1-v3) should be deserialized correctly", async (t) => {
@@ -281,7 +287,7 @@ test("the ConfigurationReport command (v4) should be deserialized correctly", as
 	t.expect(cc.blockToBlock).toBe(false);
 });
 
-test("the ConfigurationSet command (v4) should serialize correctly", (t) => {
+test("the ConfigurationSet command (v4) should serialize correctly", async (t) => {
 	const cc = new DoorLockCCConfigurationSet({
 		nodeId: 2,
 		operationType: DoorLockOperationType.Timed,
@@ -307,17 +313,21 @@ test("the ConfigurationSet command (v4) should serialize correctly", (t) => {
 			0b1,
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the CapabilitiesGet command should serialize correctly", (t) => {
+test("the CapabilitiesGet command should serialize correctly", async (t) => {
 	const cc = new DoorLockCCCapabilitiesGet({ nodeId: 1 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
 			DoorLockCommand.CapabilitiesGet, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the CapabilitiesReport command should be deserialized correctly", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/DoorLockLoggingCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/DoorLockLoggingCC.test.ts
@@ -32,14 +32,14 @@ test("the RecordsCountGet command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the RecordsCountReport command should be deserialized correctly", (t) => {
+test("the RecordsCountReport command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			DoorLockLoggingCommand.RecordsSupportedReport, // CC Command
 			0x14, // max records supported (20)
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as DoorLockLoggingCCRecordsSupportedReport;
@@ -62,7 +62,7 @@ test("the RecordGet command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the RecordReport command should be deserialized correctly", (t) => {
+test("the RecordReport command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			DoorLockLoggingCommand.RecordReport, // CC Command
@@ -81,7 +81,7 @@ test("the RecordReport command should be deserialized correctly", (t) => {
 		]),
 	);
 
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as DoorLockLoggingCCRecordReport;

--- a/packages/zwave-js/src/lib/test/cc/DoorLockLoggingCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/DoorLockLoggingCC.test.ts
@@ -20,7 +20,7 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the RecordsCountGet command should serialize correctly", (t) => {
+test("the RecordsCountGet command should serialize correctly", async (t) => {
 	const cc = new DoorLockLoggingCCRecordsSupportedGet({
 		nodeId: 1,
 	});
@@ -29,7 +29,9 @@ test("the RecordsCountGet command should serialize correctly", (t) => {
 			DoorLockLoggingCommand.RecordsSupportedGet, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the RecordsCountReport command should be deserialized correctly", async (t) => {
@@ -48,7 +50,7 @@ test("the RecordsCountReport command should be deserialized correctly", async (t
 	t.expect(cc.recordsCount).toBe(20);
 });
 
-test("the RecordGet command should serialize correctly", (t) => {
+test("the RecordGet command should serialize correctly", async (t) => {
 	const cc = new DoorLockLoggingCCRecordGet({
 		nodeId: 1,
 		recordNumber: 1,
@@ -59,7 +61,9 @@ test("the RecordGet command should serialize correctly", (t) => {
 			1, // Record Number
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the RecordReport command should be deserialized correctly", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/EntryControlCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/EntryControlCC.test.ts
@@ -56,7 +56,7 @@ test("the Notification command should deserialize correctly", async (t) => {
 	t.expect(cc.eventData).toStrictEqual("1234");
 });
 
-test("the ConfigurationGet command should serialize correctly", (t) => {
+test("the ConfigurationGet command should serialize correctly", async (t) => {
 	const cc = new EntryControlCCConfigurationGet({
 		nodeId: 1,
 	});
@@ -65,10 +65,12 @@ test("the ConfigurationGet command should serialize correctly", (t) => {
 			EntryControlCommand.ConfigurationGet, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the ConfigurationSet command should serialize correctly", (t) => {
+test("the ConfigurationSet command should serialize correctly", async (t) => {
 	const cc = new EntryControlCCConfigurationSet({
 		nodeId: 1,
 		keyCacheSize: 1,
@@ -81,7 +83,9 @@ test("the ConfigurationSet command should serialize correctly", (t) => {
 			0x2,
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the ConfigurationReport command should be deserialize correctly", async (t) => {
@@ -103,7 +107,7 @@ test("the ConfigurationReport command should be deserialize correctly", async (t
 	t.expect(cc.keyCacheTimeout).toStrictEqual(2);
 });
 
-test("the EventSupportedGet command should serialize correctly", (t) => {
+test("the EventSupportedGet command should serialize correctly", async (t) => {
 	const cc = new EntryControlCCEventSupportedGet({
 		nodeId: 1,
 	});
@@ -112,7 +116,9 @@ test("the EventSupportedGet command should serialize correctly", (t) => {
 			EntryControlCommand.EventSupportedGet, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the EventSupportedReport command should be deserialize correctly", async (t) => {
@@ -154,14 +160,16 @@ test("the EventSupportedReport command should be deserialize correctly", async (
 	t.expect(cc.maxKeyCacheTimeout).toStrictEqual(9);
 });
 
-test("the KeySupportedGet command should serialize correctly", (t) => {
+test("the KeySupportedGet command should serialize correctly", async (t) => {
 	const cc = new EntryControlCCKeySupportedGet({ nodeId: 1 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
 			EntryControlCommand.KeySupportedGet, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the KeySupportedReport command should be deserialize correctly", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/EntryControlCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/EntryControlCC.test.ts
@@ -25,7 +25,7 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the Notification command should deserialize correctly", (t) => {
+test("the Notification command should deserialize correctly", async (t) => {
 	const data = buildCCBuffer(
 		Bytes.concat([
 			Uint8Array.from([
@@ -44,7 +44,7 @@ test("the Notification command should deserialize correctly", (t) => {
 		]),
 	);
 
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		data,
 		{ sourceNodeId: 1 } as any,
 	) as EntryControlCCNotification;
@@ -84,7 +84,7 @@ test("the ConfigurationSet command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the ConfigurationReport command should be deserialize correctly", (t) => {
+test("the ConfigurationReport command should be deserialize correctly", async (t) => {
 	const data = buildCCBuffer(
 		Uint8Array.from([
 			EntryControlCommand.ConfigurationReport, // CC Command
@@ -93,7 +93,7 @@ test("the ConfigurationReport command should be deserialize correctly", (t) => {
 		]),
 	);
 
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		data,
 		{ sourceNodeId: 1 } as any,
 	) as EntryControlCCConfigurationReport;
@@ -115,7 +115,7 @@ test("the EventSupportedGet command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the EventSupportedReport command should be deserialize correctly", (t) => {
+test("the EventSupportedReport command should be deserialize correctly", async (t) => {
 	const data = buildCCBuffer(
 		Uint8Array.from([
 			EntryControlCommand.EventSupportedReport, // CC Command
@@ -133,7 +133,7 @@ test("the EventSupportedReport command should be deserialize correctly", (t) => 
 		]),
 	);
 
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		data,
 		{ sourceNodeId: 1 } as any,
 	) as EntryControlCCEventSupportedReport;
@@ -164,7 +164,7 @@ test("the KeySupportedGet command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the KeySupportedReport command should be deserialize correctly", (t) => {
+test("the KeySupportedReport command should be deserialize correctly", async (t) => {
 	const data = buildCCBuffer(
 		Uint8Array.from([
 			EntryControlCommand.KeySupportedReport, // CC Command
@@ -173,7 +173,7 @@ test("the KeySupportedReport command should be deserialize correctly", (t) => {
 		]),
 	);
 
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		data,
 		{ sourceNodeId: 1 } as any,
 	) as EntryControlCCKeySupportedReport;

--- a/packages/zwave-js/src/lib/test/cc/FibaroCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/FibaroCC.test.ts
@@ -23,7 +23,7 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the Set Tilt command should serialize correctly", (t) => {
+test("the Set Tilt command should serialize correctly", async (t) => {
 	const cc = new FibaroVenetianBlindCCSet({
 		nodeId: 2,
 		tilt: 99,
@@ -36,7 +36,9 @@ test("the Set Tilt command should serialize correctly", (t) => {
 			0x63, // Tilt
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the Report command should be deserialized correctly", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/FibaroCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/FibaroCC.test.ts
@@ -39,7 +39,7 @@ test("the Set Tilt command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the Report command should be deserialized correctly", (t) => {
+test("the Report command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			FibaroVenetianBlindCCCommand.Report,
@@ -48,7 +48,7 @@ test("the Report command should be deserialized correctly", (t) => {
 			0x00, // Tilt
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 2 } as any,
 	) as FibaroVenetianBlindCCReport;
@@ -72,12 +72,12 @@ test("FibaroVenetianBlindCCGet should expect a response", (t) => {
 	t.expect(cc.expectsCCResponse()).toBe(true);
 });
 
-test("FibaroVenetianBlindCCSet => FibaroVenetianBlindCCReport = unexpected", (t) => {
+test("FibaroVenetianBlindCCSet => FibaroVenetianBlindCCReport = unexpected", async (t) => {
 	const ccRequest = new FibaroVenetianBlindCCSet({
 		nodeId: 2,
 		tilt: 7,
 	});
-	const ccResponse = CommandClass.parse(
+	const ccResponse = await CommandClass.parseAsync(
 		buildCCBuffer(
 			Uint8Array.from([
 				FibaroVenetianBlindCCCommand.Report,
@@ -92,11 +92,11 @@ test("FibaroVenetianBlindCCSet => FibaroVenetianBlindCCReport = unexpected", (t)
 	t.expect(ccRequest.isExpectedCCResponse(ccResponse)).toBe(false);
 });
 
-test("FibaroVenetianBlindCCGet => FibaroVenetianBlindCCReport = expected", (t) => {
+test("FibaroVenetianBlindCCGet => FibaroVenetianBlindCCReport = expected", async (t) => {
 	const ccRequest = new FibaroVenetianBlindCCGet({
 		nodeId: 2,
 	});
-	const ccResponse = CommandClass.parse(
+	const ccResponse = await CommandClass.parseAsync(
 		buildCCBuffer(
 			Uint8Array.from([
 				FibaroVenetianBlindCCCommand.Report,

--- a/packages/zwave-js/src/lib/test/cc/HumidityControlModeCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/HumidityControlModeCC.test.ts
@@ -26,7 +26,7 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the Get command should serialize correctly", (t) => {
+test("the Get command should serialize correctly", async (t) => {
 	const cc = new HumidityControlModeCCGet({
 		nodeId,
 	});
@@ -35,10 +35,12 @@ test("the Get command should serialize correctly", (t) => {
 			HumidityControlModeCommand.Get, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Set command should serialize correctly", (t) => {
+test("the Set command should serialize correctly", async (t) => {
 	const cc = new HumidityControlModeCCSet({
 		nodeId,
 		mode: HumidityControlMode.Auto,
@@ -49,7 +51,9 @@ test("the Set command should serialize correctly", (t) => {
 			0x03, // target value
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the Report command should be deserialized correctly", async (t) => {
@@ -111,7 +115,7 @@ test("the Report command should set the correct metadata", async (t) => {
 	});
 });
 
-test("the SupportedGet command should serialize correctly", (t) => {
+test("the SupportedGet command should serialize correctly", async (t) => {
 	const cc = new HumidityControlModeCCSupportedGet({
 		nodeId,
 	});
@@ -120,7 +124,9 @@ test("the SupportedGet command should serialize correctly", (t) => {
 			HumidityControlModeCommand.SupportedGet, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the SupportedReport command should be deserialized correctly", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/HumidityControlModeCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/HumidityControlModeCC.test.ts
@@ -52,14 +52,14 @@ test("the Set command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the Report command should be deserialized correctly", (t) => {
+test("the Report command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			HumidityControlModeCommand.Report, // CC Command
 			HumidityControlMode.Auto, // current value
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: nodeId } as any,
 	) as HumidityControlModeCCReport;
@@ -68,14 +68,14 @@ test("the Report command should be deserialized correctly", (t) => {
 	t.expect(cc.mode).toBe(HumidityControlMode.Auto);
 });
 
-test("the Report command should set the correct value", (t) => {
+test("the Report command should set the correct value", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			HumidityControlModeCommand.Report, // CC Command
 			HumidityControlMode.Auto, // current value
 		]),
 	);
-	const report = CommandClass.parse(
+	const report = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: nodeId } as any,
 	) as HumidityControlModeCCReport;
@@ -88,14 +88,14 @@ test("the Report command should set the correct value", (t) => {
 	t.expect(currentValue).toStrictEqual(HumidityControlMode.Auto);
 });
 
-test("the Report command should set the correct metadata", (t) => {
+test("the Report command should set the correct metadata", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			HumidityControlModeCommand.Report, // CC Command
 			HumidityControlMode.Auto, // current value
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: nodeId } as any,
 	) as HumidityControlModeCCReport;
@@ -123,14 +123,14 @@ test("the SupportedGet command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the SupportedReport command should be deserialized correctly", (t) => {
+test("the SupportedReport command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			HumidityControlModeCommand.SupportedReport, // CC Command
 			(1 << HumidityControlMode.Off) | (1 << HumidityControlMode.Auto),
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: nodeId } as any,
 	) as HumidityControlModeCCSupportedReport;
@@ -142,14 +142,14 @@ test("the SupportedReport command should be deserialized correctly", (t) => {
 	]);
 });
 
-test("the SupportedReport command should set the correct metadata", (t) => {
+test("the SupportedReport command should set the correct metadata", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			HumidityControlModeCommand.SupportedReport, // CC Command
 			(1 << HumidityControlMode.Off) | (1 << HumidityControlMode.Auto),
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: nodeId } as any,
 	) as HumidityControlModeCCSupportedReport;

--- a/packages/zwave-js/src/lib/test/cc/HumidityControlOperatingStateCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/HumidityControlOperatingStateCC.test.ts
@@ -30,14 +30,14 @@ test("the Get command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the Report command should be deserialized correctly", (t) => {
+test("the Report command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			HumidityControlOperatingStateCommand.Report, // CC Command
 			HumidityControlOperatingState.Humidifying, // state
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as HumidityControlOperatingStateCCReport;

--- a/packages/zwave-js/src/lib/test/cc/HumidityControlOperatingStateCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/HumidityControlOperatingStateCC.test.ts
@@ -18,7 +18,7 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the Get command should serialize correctly", (t) => {
+test("the Get command should serialize correctly", async (t) => {
 	const cc = new HumidityControlOperatingStateCCGet({
 		nodeId: 1,
 	});
@@ -27,7 +27,9 @@ test("the Get command should serialize correctly", (t) => {
 			HumidityControlOperatingStateCommand.Get, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the Report command should be deserialized correctly", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/HumidityControlSetpointCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/HumidityControlSetpointCC.test.ts
@@ -29,7 +29,7 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 const host = createTestingHost();
 const nodeId = 2;
 
-test("the Get command should serialize correctly", (t) => {
+test("the Get command should serialize correctly", async (t) => {
 	const cc = new HumidityControlSetpointCCGet({
 		nodeId: nodeId,
 		setpointType: HumidityControlSetpointType.Humidifier,
@@ -40,10 +40,12 @@ test("the Get command should serialize correctly", (t) => {
 			HumidityControlSetpointType.Humidifier, // type
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Set command should serialize correctly", (t) => {
+test("the Set command should serialize correctly", async (t) => {
 	const cc = new HumidityControlSetpointCCSet({
 		nodeId: nodeId,
 		setpointType: HumidityControlSetpointType.Humidifier,
@@ -59,7 +61,9 @@ test("the Set command should serialize correctly", (t) => {
 			encodeFloatWithScale(57, 1),
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the Report command should be deserialized correctly", async (t) => {
@@ -148,7 +152,7 @@ test("the Report command should set the correct metadata", async (t) => {
 	});
 });
 
-test("the SupportedGet command should serialize correctly", (t) => {
+test("the SupportedGet command should serialize correctly", async (t) => {
 	const cc = new HumidityControlSetpointCCSupportedGet({
 		nodeId: nodeId,
 	});
@@ -157,7 +161,9 @@ test("the SupportedGet command should serialize correctly", (t) => {
 			HumidityControlSetpointCommand.SupportedGet, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the SupportedReport command should be deserialized correctly", async (t) => {
@@ -204,7 +210,7 @@ test("the SupportedReport command should set the correct value", async (t) => {
 	]);
 });
 
-test("the ScaleSupportedGet command should serialize correctly", (t) => {
+test("the ScaleSupportedGet command should serialize correctly", async (t) => {
 	const cc = new HumidityControlSetpointCCScaleSupportedGet({
 		nodeId: nodeId,
 		setpointType: HumidityControlSetpointType.Auto,
@@ -215,7 +221,9 @@ test("the ScaleSupportedGet command should serialize correctly", (t) => {
 			HumidityControlSetpointType.Auto, // type
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the ScaleSupportedReport command should be deserialized correctly", async (t) => {
@@ -245,7 +253,7 @@ test("the ScaleSupportedReport command should be deserialized correctly", async 
 	// ]);
 });
 
-test("the CapabilitiesGet command should serialize correctly", (t) => {
+test("the CapabilitiesGet command should serialize correctly", async (t) => {
 	const cc = new HumidityControlSetpointCCCapabilitiesGet({
 		nodeId: nodeId,
 		setpointType: HumidityControlSetpointType.Auto,
@@ -256,7 +264,9 @@ test("the CapabilitiesGet command should serialize correctly", (t) => {
 			HumidityControlSetpointType.Auto, // type
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the CapabilitiesReport command should be deserialized correctly", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/HumidityControlSetpointCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/HumidityControlSetpointCC.test.ts
@@ -62,7 +62,7 @@ test("the Set command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the Report command should be deserialized correctly", (t) => {
+test("the Report command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Bytes.concat([
 			Uint8Array.from([
@@ -72,7 +72,7 @@ test("the Report command should be deserialized correctly", (t) => {
 			encodeFloatWithScale(12, 1),
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: nodeId } as any,
 	) as HumidityControlSetpointCCReport;
@@ -88,7 +88,7 @@ test("the Report command should be deserialized correctly", (t) => {
 	t.expect(cc.value).toBe(12);
 });
 
-test("the Report command should set the correct value", (t) => {
+test("the Report command should set the correct value", async (t) => {
 	const ccData = buildCCBuffer(
 		Bytes.concat([
 			Uint8Array.from([
@@ -98,7 +98,7 @@ test("the Report command should set the correct value", (t) => {
 			encodeFloatWithScale(12, 1),
 		]),
 	);
-	const report = CommandClass.parse(
+	const report = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: nodeId } as any,
 	) as HumidityControlSetpointCCReport;
@@ -119,7 +119,7 @@ test("the Report command should set the correct value", (t) => {
 	t.expect(scaleValue).toStrictEqual(1);
 });
 
-test("the Report command should set the correct metadata", (t) => {
+test("the Report command should set the correct metadata", async (t) => {
 	const ccData = buildCCBuffer(
 		Bytes.concat([
 			Uint8Array.from([
@@ -129,7 +129,7 @@ test("the Report command should set the correct metadata", (t) => {
 			encodeFloatWithScale(12, 1),
 		]),
 	);
-	const report = CommandClass.parse(
+	const report = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: nodeId } as any,
 	) as HumidityControlSetpointCCReport;
@@ -160,7 +160,7 @@ test("the SupportedGet command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the SupportedReport command should be deserialized correctly", (t) => {
+test("the SupportedReport command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			HumidityControlSetpointCommand.SupportedReport, // CC Command
@@ -168,7 +168,7 @@ test("the SupportedReport command should be deserialized correctly", (t) => {
 			| (1 << HumidityControlSetpointType.Auto),
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: nodeId } as any,
 	) as HumidityControlSetpointCCSupportedReport;
@@ -180,7 +180,7 @@ test("the SupportedReport command should be deserialized correctly", (t) => {
 	]);
 });
 
-test("the SupportedReport command should set the correct value", (t) => {
+test("the SupportedReport command should set the correct value", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			HumidityControlSetpointCommand.SupportedReport, // CC Command
@@ -188,7 +188,7 @@ test("the SupportedReport command should set the correct value", (t) => {
 			| (1 << HumidityControlSetpointType.Auto),
 		]),
 	);
-	const report = CommandClass.parse(
+	const report = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: nodeId } as any,
 	) as HumidityControlSetpointCCSupportedReport;
@@ -218,14 +218,14 @@ test("the ScaleSupportedGet command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the ScaleSupportedReport command should be deserialized correctly", (t) => {
+test("the ScaleSupportedReport command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			HumidityControlSetpointCommand.ScaleSupportedReport, // CC Command
 			0b11, // percent + absolute
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: nodeId } as any,
 	) as HumidityControlSetpointCCScaleSupportedReport;
@@ -259,7 +259,7 @@ test("the CapabilitiesGet command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the CapabilitiesReport command should be deserialized correctly", (t) => {
+test("the CapabilitiesReport command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Bytes.concat([
 			Uint8Array.from([
@@ -270,7 +270,7 @@ test("the CapabilitiesReport command should be deserialized correctly", (t) => {
 			encodeFloatWithScale(90, 1),
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: nodeId } as any,
 	) as HumidityControlSetpointCCCapabilitiesReport;
@@ -283,7 +283,7 @@ test("the CapabilitiesReport command should be deserialized correctly", (t) => {
 	t.expect(cc.maxValueScale).toStrictEqual(1);
 });
 
-test("the CapabilitiesReport command should set the correct metadata", (t) => {
+test("the CapabilitiesReport command should set the correct metadata", async (t) => {
 	const ccData = buildCCBuffer(
 		Bytes.concat([
 			Uint8Array.from([
@@ -294,7 +294,7 @@ test("the CapabilitiesReport command should set the correct metadata", (t) => {
 			encodeFloatWithScale(90, 1),
 		]),
 	);
-	const report = CommandClass.parse(
+	const report = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: nodeId } as any,
 	) as HumidityControlSetpointCCCapabilitiesReport;

--- a/packages/zwave-js/src/lib/test/cc/IndicatorCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/IndicatorCC.test.ts
@@ -94,14 +94,14 @@ test("the Set command (v2) should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the Report command (v1) should be deserialized correctly", (t) => {
+test("the Report command (v1) should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			IndicatorCommand.Report, // CC Command
 			55, // value
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as IndicatorCCReport;
@@ -111,7 +111,7 @@ test("the Report command (v1) should be deserialized correctly", (t) => {
 	t.expect(cc.values).toBeUndefined();
 });
 
-test("the Report command (v2) should be deserialized correctly", (t) => {
+test("the Report command (v2) should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			IndicatorCommand.Report, // CC Command
@@ -125,7 +125,7 @@ test("the Report command (v2) should be deserialized correctly", (t) => {
 			1, // value
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as IndicatorCCReport;
@@ -148,11 +148,11 @@ test("the Report command (v2) should be deserialized correctly", (t) => {
 	]);
 });
 
-test("deserializing an unsupported command should return an unspecified version of IndicatorCC", (t) => {
+test("deserializing an unsupported command should return an unspecified version of IndicatorCC", async (t) => {
 	const serializedCC = buildCCBuffer(
 		Uint8Array.from([255]), // not a valid command
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		serializedCC,
 		{ sourceNodeId: 1 } as any,
 	) as IndicatorCC;

--- a/packages/zwave-js/src/lib/test/cc/IndicatorCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/IndicatorCC.test.ts
@@ -24,17 +24,19 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 
 const host = createTestingHost();
 
-test("the Get command (V1) should serialize correctly", (t) => {
+test("the Get command (V1) should serialize correctly", async (t) => {
 	const cc = new IndicatorCCGet({ nodeId: 1 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
 			IndicatorCommand.Get, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Get command (V2) should serialize correctly", (t) => {
+test("the Get command (V2) should serialize correctly", async (t) => {
 	const cc = new IndicatorCCGet({
 		nodeId: 1,
 		indicatorId: 5,
@@ -45,10 +47,12 @@ test("the Get command (V2) should serialize correctly", (t) => {
 			5,
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Set command (v1) should serialize correctly", (t) => {
+test("the Set command (v1) should serialize correctly", async (t) => {
 	const cc = new IndicatorCCSet({
 		nodeId: 2,
 		value: 23,
@@ -59,10 +63,12 @@ test("the Set command (v1) should serialize correctly", (t) => {
 			23, // value
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Set command (v2) should serialize correctly", (t) => {
+test("the Set command (v2) should serialize correctly", async (t) => {
 	const cc = new IndicatorCCSet({
 		nodeId: 2,
 		values: [
@@ -91,7 +97,9 @@ test("the Set command (v2) should serialize correctly", (t) => {
 			1, // value
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the Report command (v1) should be deserialized correctly", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/LanguageCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/LanguageCC.test.ts
@@ -67,7 +67,7 @@ test("the Set command should serialize correctly (w/ country code)", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the Report command should be deserialized correctly (w/o country code)", (t) => {
+test("the Report command should be deserialized correctly (w/o country code)", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			LanguageCommand.Report, // CC Command
@@ -77,7 +77,7 @@ test("the Report command should be deserialized correctly (w/o country code)", (
 			0x75,
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 4 } as any,
 	) as LanguageCCReport;
@@ -87,7 +87,7 @@ test("the Report command should be deserialized correctly (w/o country code)", (
 	t.expect(cc.country).toBeUndefined();
 });
 
-test("the Report command should be deserialized correctly (w/ country code)", (t) => {
+test("the Report command should be deserialized correctly (w/ country code)", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			LanguageCommand.Report, // CC Command
@@ -100,7 +100,7 @@ test("the Report command should be deserialized correctly (w/ country code)", (t
 			0x45,
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 4 } as any,
 	) as LanguageCCReport;
@@ -110,11 +110,11 @@ test("the Report command should be deserialized correctly (w/ country code)", (t
 	t.expect(cc.country).toBe("DE");
 });
 
-test("deserializing an unsupported command should return an unspecified version of LanguageCC", (t) => {
+test("deserializing an unsupported command should return an unspecified version of LanguageCC", async (t) => {
 	const serializedCC = buildCCBuffer(
 		Uint8Array.from([255]), // not a valid command
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		serializedCC,
 		{ sourceNodeId: 4 } as any,
 	) as LanguageCC;

--- a/packages/zwave-js/src/lib/test/cc/LanguageCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/LanguageCC.test.ts
@@ -19,17 +19,19 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the Get command should serialize correctly", (t) => {
+test("the Get command should serialize correctly", async (t) => {
 	const cc = new LanguageCCGet({ nodeId: 1 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
 			LanguageCommand.Get, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Set command should serialize correctly (w/o country code)", (t) => {
+test("the Set command should serialize correctly (w/o country code)", async (t) => {
 	const cc = new LanguageCCSet({
 		nodeId: 2,
 		language: "deu",
@@ -43,10 +45,12 @@ test("the Set command should serialize correctly (w/o country code)", (t) => {
 			0x75,
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Set command should serialize correctly (w/ country code)", (t) => {
+test("the Set command should serialize correctly (w/ country code)", async (t) => {
 	const cc = new LanguageCCSet({
 		nodeId: 2,
 		language: "deu",
@@ -64,7 +68,9 @@ test("the Set command should serialize correctly (w/ country code)", (t) => {
 			0x45,
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the Report command should be deserialized correctly (w/o country code)", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/ManufacturerSpecificCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/ManufacturerSpecificCC.test.ts
@@ -17,14 +17,16 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the Get command should serialize correctly", (t) => {
+test("the Get command should serialize correctly", async (t) => {
 	const cc = new ManufacturerSpecificCCGet({ nodeId: 1 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
 			ManufacturerSpecificCommand.Get, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the Report command (v1) should be deserialized correctly", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/ManufacturerSpecificCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/ManufacturerSpecificCC.test.ts
@@ -27,7 +27,7 @@ test("the Get command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the Report command (v1) should be deserialized correctly", (t) => {
+test("the Report command (v1) should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			ManufacturerSpecificCommand.Report, // CC Command
@@ -39,7 +39,7 @@ test("the Report command (v1) should be deserialized correctly", (t) => {
 			0x06,
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 2 } as any,
 	) as ManufacturerSpecificCCReport;

--- a/packages/zwave-js/src/lib/test/cc/MeterCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/MeterCC.test.ts
@@ -32,7 +32,7 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 const host = createTestingHost();
 const node2 = createTestNode(host, { id: 2 });
 
-test("the Get command (V1) should serialize correctly", (t) => {
+test("the Get command (V1) should serialize correctly", async (t) => {
 	const cc = new MeterCCGet({ nodeId: 1 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
@@ -45,10 +45,10 @@ test("the Get command (V1) should serialize correctly", (t) => {
 		},
 	} satisfies GetSupportedCCVersion as any;
 
-	t.expect(cc.serialize(ctx)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync(ctx)).resolves.toStrictEqual(expected);
 });
 
-test("the Get command (V2) should serialize correctly", (t) => {
+test("the Get command (V2) should serialize correctly", async (t) => {
 	const cc = new MeterCCGet({ nodeId: 1, scale: 0x03 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
@@ -62,10 +62,10 @@ test("the Get command (V2) should serialize correctly", (t) => {
 		},
 	} satisfies GetSupportedCCVersion as any;
 
-	t.expect(cc.serialize(ctx)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync(ctx)).resolves.toStrictEqual(expected);
 });
 
-test("the Get command (V3) should serialize correctly", (t) => {
+test("the Get command (V3) should serialize correctly", async (t) => {
 	const cc = new MeterCCGet({ nodeId: 1, scale: 0x06 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
@@ -79,10 +79,10 @@ test("the Get command (V3) should serialize correctly", (t) => {
 		},
 	} satisfies GetSupportedCCVersion as any;
 
-	t.expect(cc.serialize(ctx)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync(ctx)).resolves.toStrictEqual(expected);
 });
 
-test("the Get command (V4) should serialize correctly", (t) => {
+test("the Get command (V4) should serialize correctly", async (t) => {
 	const cc = new MeterCCGet({ nodeId: 1, scale: 0x0f });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
@@ -97,30 +97,34 @@ test("the Get command (V4) should serialize correctly", (t) => {
 		},
 	} satisfies GetSupportedCCVersion as any;
 
-	t.expect(cc.serialize(ctx)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync(ctx)).resolves.toStrictEqual(expected);
 });
 
-test("the SupportedGet command should serialize correctly", (t) => {
+test("the SupportedGet command should serialize correctly", async (t) => {
 	const cc = new MeterCCSupportedGet({ nodeId: 1 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
 			MeterCommand.SupportedGet, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Reset command (V2) should serialize correctly", (t) => {
+test("the Reset command (V2) should serialize correctly", async (t) => {
 	const cc = new MeterCCReset({ nodeId: 1 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
 			MeterCommand.Reset, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Reset command (V6) should serialize correctly", (t) => {
+test("the Reset command (V6) should serialize correctly", async (t) => {
 	const cc = new MeterCCReset({
 		nodeId: 1,
 		type: 7,
@@ -136,7 +140,9 @@ test("the Reset command (V6) should serialize correctly", (t) => {
 			123, // 12.3
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the Report command (V1) should be deserialized correctly", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/MeterCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/MeterCC.test.ts
@@ -139,7 +139,7 @@ test("the Reset command (V6) should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the Report command (V1) should be deserialized correctly", (t) => {
+test("the Report command (V1) should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			MeterCommand.Report, // CC Command
@@ -148,7 +148,7 @@ test("the Report command (V1) should be deserialized correctly", (t) => {
 			55, // value
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as MeterCCReport;
@@ -162,7 +162,7 @@ test("the Report command (V1) should be deserialized correctly", (t) => {
 	t.expect(cc.previousValue).toBeUndefined();
 });
 
-test("the Report command (V2) should be deserialized correctly (no time delta)", (t) => {
+test("the Report command (V2) should be deserialized correctly (no time delta)", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			MeterCommand.Report, // CC Command
@@ -173,7 +173,7 @@ test("the Report command (V2) should be deserialized correctly (no time delta)",
 			0,
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as MeterCCReport;
@@ -187,7 +187,7 @@ test("the Report command (V2) should be deserialized correctly (no time delta)",
 	t.expect(cc.previousValue).toBeUndefined();
 });
 
-test("the Report command (V2) should be deserialized correctly (with time delta)", (t) => {
+test("the Report command (V2) should be deserialized correctly (with time delta)", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			MeterCommand.Report, // CC Command
@@ -199,7 +199,7 @@ test("the Report command (V2) should be deserialized correctly (with time delta)
 			54, // previous value
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as MeterCCReport;
@@ -213,7 +213,7 @@ test("the Report command (V2) should be deserialized correctly (with time delta)
 	t.expect(cc.previousValue).toBe(5.4);
 });
 
-test("the Report command (V3) should be deserialized correctly", (t) => {
+test("the Report command (V3) should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			MeterCommand.Report, // CC Command
@@ -225,7 +225,7 @@ test("the Report command (V3) should be deserialized correctly", (t) => {
 			54, // previous value
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as MeterCCReport;
@@ -234,7 +234,7 @@ test("the Report command (V3) should be deserialized correctly", (t) => {
 	t.expect(cc.scale).toBe(6);
 });
 
-test("the Report command (V4) should be deserialized correctly", (t) => {
+test("the Report command (V4) should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			MeterCommand.Report, // CC Command
@@ -247,7 +247,7 @@ test("the Report command (V4) should be deserialized correctly", (t) => {
 			0b01, // Scale2
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as MeterCCReport;
@@ -256,7 +256,7 @@ test("the Report command (V4) should be deserialized correctly", (t) => {
 	t.expect(cc.scale).toBe(8);
 });
 
-test("the Report command should validate that a known meter type is given", (t) => {
+test("the Report command should validate that a known meter type is given", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			MeterCommand.Report, // CC Command
@@ -270,7 +270,7 @@ test("the Report command should validate that a known meter type is given", (t) 
 		]),
 	);
 
-	const report = CommandClass.parse(
+	const report = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as MeterCCReport;
@@ -282,7 +282,7 @@ test("the Report command should validate that a known meter type is given", (t) 
 	});
 });
 
-test("the Report command should validate that a known meter scale is given", (t) => {
+test("the Report command should validate that a known meter scale is given", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			MeterCommand.Report, // CC Command
@@ -296,7 +296,7 @@ test("the Report command should validate that a known meter scale is given", (t)
 		]),
 	);
 
-	const report = CommandClass.parse(
+	const report = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as MeterCCReport;
@@ -320,7 +320,7 @@ test("the value IDs should be translated correctly", (t) => {
 	});
 });
 
-test("the SupportedReport command (V2/V3) should be deserialized correctly", (t) => {
+test("the SupportedReport command (V2/V3) should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			MeterCommand.SupportedReport, // CC Command
@@ -328,7 +328,7 @@ test("the SupportedReport command (V2/V3) should be deserialized correctly", (t)
 			0b01101110, // supported scales
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as MeterCCSupportedReport;
@@ -340,7 +340,7 @@ test("the SupportedReport command (V2/V3) should be deserialized correctly", (t)
 	t.expect(cc.supportedScales).toStrictEqual([1, 2, 3, 5, 6]);
 });
 
-test("the SupportedReport command (V4/V5) should be deserialized correctly", (t) => {
+test("the SupportedReport command (V4/V5) should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			MeterCommand.SupportedReport, // CC Command
@@ -351,7 +351,7 @@ test("the SupportedReport command (V4/V5) should be deserialized correctly", (t)
 			1,
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as MeterCCSupportedReport;
@@ -385,11 +385,11 @@ test("the SupportedReport command (V4/V5) should be deserialized correctly", (t)
 // 	t.deepEqual(cc.supportedScales, [0, 7, 15]);
 // });
 
-test("deserializing an unsupported command should return an unspecified version of MeterCC", (t) => {
+test("deserializing an unsupported command should return an unspecified version of MeterCC", async (t) => {
 	const serializedCC = buildCCBuffer(
 		Uint8Array.from([255]), // not a valid command
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		serializedCC,
 		{ sourceNodeId: 1 } as any,
 	) as MeterCC;

--- a/packages/zwave-js/src/lib/test/cc/MultiChannelAssociationCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/MultiChannelAssociationCC.test.ts
@@ -21,7 +21,7 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the SupportedGroupingsGet command should serialize correctly", (t) => {
+test("the SupportedGroupingsGet command should serialize correctly", async (t) => {
 	const cc = new MultiChannelAssociationCCSupportedGroupingsGet({
 		nodeId: 1,
 	});
@@ -30,7 +30,9 @@ test("the SupportedGroupingsGet command should serialize correctly", (t) => {
 			MultiChannelAssociationCommand.SupportedGroupingsGet, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the SupportedGroupingsReport command should be deserialized correctly", async (t) => {
@@ -51,7 +53,7 @@ test("the SupportedGroupingsReport command should be deserialized correctly", as
 	t.expect(cc.groupCount).toBe(7);
 });
 
-test("the Set command should serialize correctly (node IDs only)", (t) => {
+test("the Set command should serialize correctly (node IDs only)", async (t) => {
 	const cc = new MultiChannelAssociationCCSet({
 		nodeId: 2,
 		groupId: 5,
@@ -67,10 +69,12 @@ test("the Set command should serialize correctly (node IDs only)", (t) => {
 			5,
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Set command should serialize correctly (endpoint addresses only)", (t) => {
+test("the Set command should serialize correctly (endpoint addresses only)", async (t) => {
 	const cc = new MultiChannelAssociationCCSet({
 		nodeId: 2,
 		groupId: 5,
@@ -98,10 +102,12 @@ test("the Set command should serialize correctly (endpoint addresses only)", (t)
 			0b11010111,
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Set command should serialize correctly (both options)", (t) => {
+test("the Set command should serialize correctly (both options)", async (t) => {
 	const cc = new MultiChannelAssociationCCSet({
 		nodeId: 2,
 		groupId: 5,
@@ -134,10 +140,12 @@ test("the Set command should serialize correctly (both options)", (t) => {
 			0b11010111,
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Get command should serialize correctly", (t) => {
+test("the Get command should serialize correctly", async (t) => {
 	const cc = new MultiChannelAssociationCCGet({
 		nodeId: 1,
 		groupId: 9,
@@ -148,7 +156,9 @@ test("the Get command should serialize correctly", (t) => {
 			9, // group ID
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the Report command should be deserialized correctly (node IDs only)", async (t) => {
@@ -250,7 +260,7 @@ test("the Report command should be deserialized correctly (both options)", async
 	]);
 });
 
-test("the Remove command should serialize correctly (node IDs only)", (t) => {
+test("the Remove command should serialize correctly (node IDs only)", async (t) => {
 	const cc = new MultiChannelAssociationCCRemove({
 		nodeId: 2,
 		groupId: 5,
@@ -266,10 +276,12 @@ test("the Remove command should serialize correctly (node IDs only)", (t) => {
 			5,
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Remove command should serialize correctly (endpoint addresses only)", (t) => {
+test("the Remove command should serialize correctly (endpoint addresses only)", async (t) => {
 	const cc = new MultiChannelAssociationCCRemove({
 		nodeId: 2,
 		groupId: 5,
@@ -297,10 +309,12 @@ test("the Remove command should serialize correctly (endpoint addresses only)", 
 			0b11010111,
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Remove command should serialize correctly (both options)", (t) => {
+test("the Remove command should serialize correctly (both options)", async (t) => {
 	const cc = new MultiChannelAssociationCCRemove({
 		nodeId: 2,
 		groupId: 5,
@@ -333,10 +347,12 @@ test("the Remove command should serialize correctly (both options)", (t) => {
 			0b11010111,
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Remove command should serialize correctly (both empty)", (t) => {
+test("the Remove command should serialize correctly (both empty)", async (t) => {
 	const cc = new MultiChannelAssociationCCRemove({
 		nodeId: 2,
 		groupId: 5,
@@ -347,7 +363,9 @@ test("the Remove command should serialize correctly (both empty)", (t) => {
 			5, // group id
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 // test("deserializing an unsupported command should return an unspecified version of MultiChannelAssociationCC", (t) => {

--- a/packages/zwave-js/src/lib/test/cc/MultiChannelAssociationCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/MultiChannelAssociationCC.test.ts
@@ -33,14 +33,14 @@ test("the SupportedGroupingsGet command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the SupportedGroupingsReport command should be deserialized correctly", (t) => {
+test("the SupportedGroupingsReport command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			MultiChannelAssociationCommand.SupportedGroupingsReport, // CC Command
 			7, // # of groups
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 4 } as any,
 	) as MultiChannelAssociationCCSupportedGroupingsReport;
@@ -151,7 +151,7 @@ test("the Get command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the Report command should be deserialized correctly (node IDs only)", (t) => {
+test("the Report command should be deserialized correctly (node IDs only)", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			MultiChannelAssociationCommand.Report, // CC Command
@@ -164,7 +164,7 @@ test("the Report command should be deserialized correctly (node IDs only)", (t) 
 			5,
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 4 } as any,
 	) as MultiChannelAssociationCCReport;
@@ -177,7 +177,7 @@ test("the Report command should be deserialized correctly (node IDs only)", (t) 
 	t.expect(cc.endpoints).toStrictEqual([]);
 });
 
-test("the Report command should be deserialized correctly (endpoint addresses only)", (t) => {
+test("the Report command should be deserialized correctly (endpoint addresses only)", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			MultiChannelAssociationCommand.Report, // CC Command
@@ -193,7 +193,7 @@ test("the Report command should be deserialized correctly (endpoint addresses on
 			0b11010111,
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 4 } as any,
 	) as MultiChannelAssociationCCReport;
@@ -212,7 +212,7 @@ test("the Report command should be deserialized correctly (endpoint addresses on
 	]);
 });
 
-test("the Report command should be deserialized correctly (both options)", (t) => {
+test("the Report command should be deserialized correctly (both options)", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			MultiChannelAssociationCommand.Report, // CC Command
@@ -231,7 +231,7 @@ test("the Report command should be deserialized correctly (both options)", (t) =
 			0b11010111,
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 4 } as any,
 	) as MultiChannelAssociationCCReport;

--- a/packages/zwave-js/src/lib/test/cc/MultiChannelCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/MultiChannelCC.test.ts
@@ -37,17 +37,19 @@ test("is an encapsulating CommandClass", (t) => {
 	t.expect(isEncapsulatingCommandClass(cc)).toBe(true);
 });
 
-test("the EndPointGet command should serialize correctly", (t) => {
+test("the EndPointGet command should serialize correctly", async (t) => {
 	const cc = new MultiChannelCCEndPointGet({ nodeId: 1 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
 			MultiChannelCommand.EndPointGet, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the CapabilityGet command should serialize correctly", (t) => {
+test("the CapabilityGet command should serialize correctly", async (t) => {
 	const cc = new MultiChannelCCCapabilityGet({
 		nodeId: 2,
 		requestedEndpoint: 7,
@@ -58,10 +60,12 @@ test("the CapabilityGet command should serialize correctly", (t) => {
 			7, // EndPoint
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the EndPointFind command should serialize correctly", (t) => {
+test("the EndPointFind command should serialize correctly", async (t) => {
 	const cc = new MultiChannelCCEndPointFind({
 		nodeId: 2,
 		genericClass: 0x01,
@@ -74,10 +78,12 @@ test("the EndPointFind command should serialize correctly", (t) => {
 			0x02, // specificClass
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the CommandEncapsulation command should serialize correctly", (t) => {
+test("the CommandEncapsulation command should serialize correctly", async (t) => {
 	let cc: CommandClass = new BasicCCSet({
 		nodeId: 2,
 		targetValue: 5,
@@ -94,10 +100,12 @@ test("the CommandEncapsulation command should serialize correctly", (t) => {
 			5, // target value
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the AggregatedMembersGet command should serialize correctly", (t) => {
+test("the AggregatedMembersGet command should serialize correctly", async (t) => {
 	const cc = new MultiChannelCCAggregatedMembersGet({
 		nodeId: 2,
 		requestedEndpoint: 6,
@@ -108,7 +116,9 @@ test("the AggregatedMembersGet command should serialize correctly", (t) => {
 			6, // EndPoint
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the CommandEncapsulation command should also accept V1CommandEncapsulation as a response", (t) => {

--- a/packages/zwave-js/src/lib/test/cc/MultiChannelCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/MultiChannelCC.test.ts
@@ -147,11 +147,11 @@ test("the CommandEncapsulation command should also accept V1CommandEncapsulation
 // 	t.is(cc.duration!.value, 1);
 // });
 
-test("deserializing an unsupported command should return an unspecified version of MultiChannelCC", (t) => {
+test("deserializing an unsupported command should return an unspecified version of MultiChannelCC", async (t) => {
 	const serializedCC = buildCCBuffer(
 		Uint8Array.from([255]), // not a valid command
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		serializedCC,
 		{ sourceNodeId: 1 } as any,
 	) as MultiChannelCC;

--- a/packages/zwave-js/src/lib/test/cc/MultilevelSwitchCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/MultilevelSwitchCC.test.ts
@@ -23,17 +23,19 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the Get command should serialize correctly", (t) => {
+test("the Get command should serialize correctly", async (t) => {
 	const cc = new MultilevelSwitchCCGet({ nodeId: 1 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
 			MultilevelSwitchCommand.Get, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Set command should serialize correctly (no duration)", (t) => {
+test("the Set command should serialize correctly (no duration)", async (t) => {
 	const cc = new MultilevelSwitchCCSet({
 		nodeId: 2,
 		targetValue: 55,
@@ -51,10 +53,10 @@ test("the Set command should serialize correctly (no duration)", (t) => {
 		},
 	} satisfies GetSupportedCCVersion as any;
 
-	t.expect(cc.serialize(ctx)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync(ctx)).resolves.toStrictEqual(expected);
 });
 
-test("the Set command (V2) should serialize correctly", (t) => {
+test("the Set command (V2) should serialize correctly", async (t) => {
 	const cc = new MultilevelSwitchCCSet({
 		nodeId: 2,
 		targetValue: 55,
@@ -73,7 +75,7 @@ test("the Set command (V2) should serialize correctly", (t) => {
 		},
 	} satisfies GetSupportedCCVersion as any;
 
-	t.expect(cc.serialize(ctx)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync(ctx)).resolves.toStrictEqual(expected);
 });
 
 test("the Report command (V1) should be deserialized correctly", async (t) => {
@@ -115,7 +117,7 @@ test("the Report command (v4) should be deserialized correctly", async (t) => {
 	t.expect(cc.duration!.value).toBe(1);
 });
 
-test("the StopLevelChange command should serialize correctly", (t) => {
+test("the StopLevelChange command should serialize correctly", async (t) => {
 	const cc = new MultilevelSwitchCCStopLevelChange({
 		nodeId: 1,
 	});
@@ -124,10 +126,12 @@ test("the StopLevelChange command should serialize correctly", (t) => {
 			MultilevelSwitchCommand.StopLevelChange, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the StartLevelChange command (V2) should serialize correctly (down, ignore start level, with duration)", (t) => {
+test("the StartLevelChange command (V2) should serialize correctly (down, ignore start level, with duration)", async (t) => {
 	const cc = new MultilevelSwitchCCStartLevelChange({
 		nodeId: 2,
 		direction: "down",
@@ -149,10 +153,10 @@ test("the StartLevelChange command (V2) should serialize correctly (down, ignore
 		},
 	} satisfies GetSupportedCCVersion as any;
 
-	t.expect(cc.serialize(ctx)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync(ctx)).resolves.toStrictEqual(expected);
 });
 
-test("the SupportedGet command should serialize correctly", (t) => {
+test("the SupportedGet command should serialize correctly", async (t) => {
 	const cc = new MultilevelSwitchCCSupportedGet({
 		nodeId: 1,
 	});
@@ -161,7 +165,9 @@ test("the SupportedGet command should serialize correctly", (t) => {
 			MultilevelSwitchCommand.SupportedGet, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("deserializing an unsupported command should return an unspecified version of MultilevelSwitchCC", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/MultilevelSwitchCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/MultilevelSwitchCC.test.ts
@@ -76,14 +76,14 @@ test("the Set command (V2) should serialize correctly", (t) => {
 	t.expect(cc.serialize(ctx)).toStrictEqual(expected);
 });
 
-test("the Report command (V1) should be deserialized correctly", (t) => {
+test("the Report command (V1) should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			MultilevelSwitchCommand.Report, // CC Command
 			55, // current value
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 2 } as any,
 	) as MultilevelSwitchCCReport;
@@ -94,7 +94,7 @@ test("the Report command (V1) should be deserialized correctly", (t) => {
 	t.expect(cc.duration).toBeUndefined();
 });
 
-test("the Report command (v4) should be deserialized correctly", (t) => {
+test("the Report command (v4) should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			MultilevelSwitchCommand.Report, // CC Command
@@ -103,7 +103,7 @@ test("the Report command (v4) should be deserialized correctly", (t) => {
 			1, // duration
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 2 } as any,
 	) as MultilevelSwitchCCReport;
@@ -164,11 +164,11 @@ test("the SupportedGet command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("deserializing an unsupported command should return an unspecified version of MultilevelSwitchCC", (t) => {
+test("deserializing an unsupported command should return an unspecified version of MultilevelSwitchCC", async (t) => {
 	const serializedCC = buildCCBuffer(
 		Uint8Array.from([255]), // not a valid command
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		serializedCC,
 		{ sourceNodeId: 2 } as any,
 	) as MultilevelSwitchCC;

--- a/packages/zwave-js/src/lib/test/cc/NoOperationCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/NoOperationCC.test.ts
@@ -12,12 +12,14 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the CC should serialize correctly", (t) => {
+test("the CC should serialize correctly", async (t) => {
 	const cc = new NoOperationCC({ nodeId: 1 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([]), // No command!
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the CC should be deserialized correctly", (t) => {

--- a/packages/zwave-js/src/lib/test/cc/PowerlevelCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/PowerlevelCC.test.ts
@@ -77,7 +77,7 @@ test("the Set Custom power command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the Report command should be deserialized correctly (NormalPower)", (t) => {
+test("the Report command should be deserialized correctly (NormalPower)", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			PowerlevelCommand.Report, // CC Command
@@ -85,7 +85,7 @@ test("the Report command should be deserialized correctly (NormalPower)", (t) =>
 			50, // timeout (ignored because NormalPower)
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 5 } as any,
 	) as PowerlevelCCReport;
@@ -95,7 +95,7 @@ test("the Report command should be deserialized correctly (NormalPower)", (t) =>
 	t.expect(cc.timeout).toBeUndefined(); // timeout does not apply to NormalPower
 });
 
-test("the Report command should be deserialized correctly (custom power)", (t) => {
+test("the Report command should be deserialized correctly (custom power)", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			PowerlevelCommand.Report, // CC Command
@@ -103,7 +103,7 @@ test("the Report command should be deserialized correctly (custom power)", (t) =
 			50, // timeout (ignored because NormalPower)
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 5 } as any,
 	) as PowerlevelCCReport;
@@ -113,11 +113,11 @@ test("the Report command should be deserialized correctly (custom power)", (t) =
 	t.expect(cc.timeout).toBe(50); // timeout does not apply to NormalPower
 });
 
-test("deserializing an unsupported command should return an unspecified version of PowerlevelCC", (t) => {
+test("deserializing an unsupported command should return an unspecified version of PowerlevelCC", async (t) => {
 	const serializedCC = buildCCBuffer(
 		Uint8Array.from([255]), // not a valid command
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		serializedCC,
 		{ sourceNodeId: 1 } as any,
 	) as PowerlevelCC;

--- a/packages/zwave-js/src/lib/test/cc/PowerlevelCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/PowerlevelCC.test.ts
@@ -20,17 +20,19 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the Get command should serialize correctly", (t) => {
+test("the Get command should serialize correctly", async (t) => {
 	const cc = new PowerlevelCCGet({ nodeId: 1 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
 			PowerlevelCommand.Get, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Set NormalPower command should serialize correctly", (t) => {
+test("the Set NormalPower command should serialize correctly", async (t) => {
 	const cc = new PowerlevelCCSet({
 		nodeId: 2,
 		powerlevel: Powerlevel["Normal Power"],
@@ -42,10 +44,12 @@ test("the Set NormalPower command should serialize correctly", (t) => {
 			0, // timeout (ignored)
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Set NormalPower command with timeout should serialize correctly", (t) => {
+test("the Set NormalPower command with timeout should serialize correctly", async (t) => {
 	const cc = new PowerlevelCCSet({
 		nodeId: 2,
 		powerlevel: Powerlevel["Normal Power"],
@@ -58,10 +62,12 @@ test("the Set NormalPower command with timeout should serialize correctly", (t) 
 			0x00, // timeout ignored
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Set Custom power command should serialize correctly", (t) => {
+test("the Set Custom power command should serialize correctly", async (t) => {
 	const cc = new PowerlevelCCSet({
 		nodeId: 2,
 		powerlevel: Powerlevel["-1 dBm"],
@@ -74,7 +80,9 @@ test("the Set Custom power command should serialize correctly", (t) => {
 			50, // timeout
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the Report command should be deserialized correctly (NormalPower)", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/SceneActivationCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/SceneActivationCC.test.ts
@@ -17,7 +17,7 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the Set command (without Duration) should serialize correctly", (t) => {
+test("the Set command (without Duration) should serialize correctly", async (t) => {
 	const cc = new SceneActivationCCSet({
 		nodeId: 2,
 		sceneId: 55,
@@ -29,10 +29,12 @@ test("the Set command (without Duration) should serialize correctly", (t) => {
 			0xff, // default duration
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Set command (with Duration) should serialize correctly", (t) => {
+test("the Set command (with Duration) should serialize correctly", async (t) => {
 	const cc = new SceneActivationCCSet({
 		nodeId: 2,
 		sceneId: 56,
@@ -45,7 +47,9 @@ test("the Set command (with Duration) should serialize correctly", (t) => {
 			0x80, // 1 minute
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the Set command should be deserialized correctly", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/SceneActivationCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/SceneActivationCC.test.ts
@@ -48,7 +48,7 @@ test("the Set command (with Duration) should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the Set command should be deserialized correctly", (t) => {
+test("the Set command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			SceneActivationCommand.Set, // CC Command
@@ -56,7 +56,7 @@ test("the Set command should be deserialized correctly", (t) => {
 			0x00, // 0 seconds
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 2 } as any,
 	) as SceneActivationCCSet;
@@ -66,11 +66,11 @@ test("the Set command should be deserialized correctly", (t) => {
 	t.expect(cc.dimmingDuration).toStrictEqual(new Duration(0, "seconds"));
 });
 
-test("deserializing an unsupported command should return an unspecified version of SceneActivationCC", (t) => {
+test("deserializing an unsupported command should return an unspecified version of SceneActivationCC", async (t) => {
 	const serializedCC = buildCCBuffer(
 		Uint8Array.from([255]), // not a valid command
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		serializedCC,
 		{ sourceNodeId: 2 } as any,
 	) as SceneActivationCC;

--- a/packages/zwave-js/src/lib/test/cc/SceneActuatorConfigurationCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/SceneActuatorConfigurationCC.test.ts
@@ -71,7 +71,7 @@ test("the Set command should serialize correctly with undefined level", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the Report command (v1) should be deserialized correctly", (t) => {
+test("the Report command (v1) should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			SceneActuatorConfigurationCommand.Report, // CC Command
@@ -80,7 +80,7 @@ test("the Report command (v1) should be deserialized correctly", (t) => {
 			0x05, // dimmingDuration
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 2 } as any,
 	) as SceneActuatorConfigurationCCReport;
@@ -91,11 +91,11 @@ test("the Report command (v1) should be deserialized correctly", (t) => {
 	t.expect(cc.dimmingDuration).toStrictEqual(Duration.parseReport(0x05)!);
 });
 
-test("deserializing an unsupported command should return an unspecified version of SceneActuatorConfigurationCC", (t) => {
+test("deserializing an unsupported command should return an unspecified version of SceneActuatorConfigurationCC", async (t) => {
 	const serializedCC = buildCCBuffer(
 		Uint8Array.from([255]), // not a valid command
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		serializedCC,
 		{ sourceNodeId: 2 } as any,
 	) as SceneActuatorConfigurationCC;

--- a/packages/zwave-js/src/lib/test/cc/SceneActuatorConfigurationCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/SceneActuatorConfigurationCC.test.ts
@@ -19,7 +19,7 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the Get command should serialize correctly", (t) => {
+test("the Get command should serialize correctly", async (t) => {
 	const cc = new SceneActuatorConfigurationCCGet({
 		nodeId: 2,
 		sceneId: 1,
@@ -30,10 +30,12 @@ test("the Get command should serialize correctly", (t) => {
 			1,
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Set command should serialize correctly with level", (t) => {
+test("the Set command should serialize correctly with level", async (t) => {
 	const cc = new SceneActuatorConfigurationCCSet({
 		nodeId: 2,
 		sceneId: 2,
@@ -49,10 +51,12 @@ test("the Set command should serialize correctly with level", (t) => {
 			0x00, // level
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Set command should serialize correctly with undefined level", (t) => {
+test("the Set command should serialize correctly with undefined level", async (t) => {
 	const cc = new SceneActuatorConfigurationCCSet({
 		nodeId: 2,
 		sceneId: 2,
@@ -68,7 +72,9 @@ test("the Set command should serialize correctly with undefined level", (t) => {
 			0xff, // level
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the Report command (v1) should be deserialized correctly", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/SceneControllerConfigurationCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/SceneControllerConfigurationCC.test.ts
@@ -19,7 +19,7 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the Get command should serialize correctly", (t) => {
+test("the Get command should serialize correctly", async (t) => {
 	const cc = new SceneControllerConfigurationCCGet({
 		nodeId: 2,
 		groupId: 1,
@@ -30,10 +30,12 @@ test("the Get command should serialize correctly", (t) => {
 			0b0000_0001,
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Set command should serialize correctly", (t) => {
+test("the Set command should serialize correctly", async (t) => {
 	const cc = new SceneControllerConfigurationCCSet({
 		nodeId: 2,
 		groupId: 3,
@@ -48,10 +50,12 @@ test("the Set command should serialize correctly", (t) => {
 			0x05, // dimming duration
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Set command should serialize correctly with undefined duration", (t) => {
+test("the Set command should serialize correctly with undefined duration", async (t) => {
 	const cc = new SceneControllerConfigurationCCSet({
 		nodeId: 2,
 		groupId: 3,
@@ -66,7 +70,9 @@ test("the Set command should serialize correctly with undefined duration", (t) =
 			0xff, // dimming duration
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the Report command (v1) should be deserialized correctly", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/SceneControllerConfigurationCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/SceneControllerConfigurationCC.test.ts
@@ -69,7 +69,7 @@ test("the Set command should serialize correctly with undefined duration", (t) =
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the Report command (v1) should be deserialized correctly", (t) => {
+test("the Report command (v1) should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			SceneControllerConfigurationCommand.Report, // CC Command
@@ -78,7 +78,7 @@ test("the Report command (v1) should be deserialized correctly", (t) => {
 			0x05, // dimming duration
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 2 } as any,
 	) as SceneControllerConfigurationCCReport;
@@ -89,11 +89,11 @@ test("the Report command (v1) should be deserialized correctly", (t) => {
 	t.expect(cc.dimmingDuration).toStrictEqual(Duration.parseReport(0x05)!);
 });
 
-test("deserializing an unsupported command should return an unspecified version of SceneControllerConfigurationCC", (t) => {
+test("deserializing an unsupported command should return an unspecified version of SceneControllerConfigurationCC", async (t) => {
 	const serializedCC = buildCCBuffer(
 		Uint8Array.from([255]), // not a valid command
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		serializedCC,
 		{ sourceNodeId: 1 } as any,
 	) as SceneControllerConfigurationCC;

--- a/packages/zwave-js/src/lib/test/cc/ThermostatFanModeCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/ThermostatFanModeCC.test.ts
@@ -19,17 +19,19 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the Get command should serialize correctly", (t) => {
+test("the Get command should serialize correctly", async (t) => {
 	const cc = new ThermostatFanModeCCGet({ nodeId: 5 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
 			ThermostatFanModeCommand.Get, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Set command should serialize correctly (off = false)", (t) => {
+test("the Set command should serialize correctly (off = false)", async (t) => {
 	const cc = new ThermostatFanModeCCSet({
 		nodeId: 5,
 		mode: ThermostatFanMode["Auto medium"],
@@ -41,10 +43,12 @@ test("the Set command should serialize correctly (off = false)", (t) => {
 			0x04, // target value
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
-test("the Set command should serialize correctly (off = true)", (t) => {
+test("the Set command should serialize correctly (off = true)", async (t) => {
 	const cc = new ThermostatFanModeCCSet({
 		nodeId: 5,
 		mode: ThermostatFanMode["Auto medium"],
@@ -56,7 +60,9 @@ test("the Set command should serialize correctly (off = true)", (t) => {
 			0b1000_0100, // target value
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the Report command should be deserialized correctly", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/ThermostatFanModeCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/ThermostatFanModeCC.test.ts
@@ -59,14 +59,14 @@ test("the Set command should serialize correctly (off = true)", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the Report command should be deserialized correctly", (t) => {
+test("the Report command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			ThermostatFanModeCommand.Report, // CC Command
 			0b1000_0010, // Off bit set to 1 and Auto high mode
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 5 } as any,
 	) as ThermostatFanModeCCReport;

--- a/packages/zwave-js/src/lib/test/cc/ThermostatFanStateCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/ThermostatFanStateCC.test.ts
@@ -29,14 +29,14 @@ test("the Get command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the Report command (v1 - v2) should be deserialized correctly", (t) => {
+test("the Report command (v1 - v2) should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			ThermostatFanStateCommand.Report, // CC Command
 			ThermostatFanState["Idle / off"], // state
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 1 } as any,
 	) as ThermostatFanStateCCReport;
@@ -45,11 +45,11 @@ test("the Report command (v1 - v2) should be deserialized correctly", (t) => {
 	t.expect(cc.state).toBe(ThermostatFanState["Idle / off"]);
 });
 
-test("deserializing an unsupported command should return an unspecified version of ThermostatFanStateCC", (t) => {
+test("deserializing an unsupported command should return an unspecified version of ThermostatFanStateCC", async (t) => {
 	const serializedCC = buildCCBuffer(
 		Uint8Array.from([255]), // not a valid command
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		serializedCC,
 		{ sourceNodeId: 1 } as any,
 	) as ThermostatFanStateCC;

--- a/packages/zwave-js/src/lib/test/cc/ThermostatFanStateCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/ThermostatFanStateCC.test.ts
@@ -19,14 +19,16 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the Get command should serialize correctly", (t) => {
+test("the Get command should serialize correctly", async (t) => {
 	const cc = new ThermostatFanStateCCGet({ nodeId: 1 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
 			ThermostatFanStateCommand.Get, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the Report command (v1 - v2) should be deserialized correctly", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/TimeCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/TimeCC.test.ts
@@ -20,14 +20,16 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("the TimeGet command should serialize correctly", (t) => {
+test("the TimeGet command should serialize correctly", async (t) => {
 	const cc = new TimeCCTimeGet({ nodeId: 1 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
 			TimeCommand.TimeGet, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the TimeReport command should be deserialized correctly", async (t) => {
@@ -50,14 +52,16 @@ test("the TimeReport command should be deserialized correctly", async (t) => {
 	t.expect(cc.second).toBe(59);
 });
 
-test("the DateGet command should serialize correctly", (t) => {
+test("the DateGet command should serialize correctly", async (t) => {
 	const cc = new TimeCCDateGet({ nodeId: 1 });
 	const expected = buildCCBuffer(
 		Uint8Array.from([
 			TimeCommand.DateGet, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 test("the DateReport command should be deserialized correctly", async (t) => {

--- a/packages/zwave-js/src/lib/test/cc/TimeCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/TimeCC.test.ts
@@ -30,7 +30,7 @@ test("the TimeGet command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the TimeReport command should be deserialized correctly", (t) => {
+test("the TimeReport command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			TimeCommand.TimeReport, // CC Command
@@ -39,7 +39,7 @@ test("the TimeReport command should be deserialized correctly", (t) => {
 			59,
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 8 } as any,
 	) as TimeCCTimeReport;
@@ -60,7 +60,7 @@ test("the DateGet command should serialize correctly", (t) => {
 	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
 });
 
-test("the DateReport command should be deserialized correctly", (t) => {
+test("the DateReport command should be deserialized correctly", async (t) => {
 	const ccData = buildCCBuffer(
 		Uint8Array.from([
 			TimeCommand.DateReport, // CC Command
@@ -70,7 +70,7 @@ test("the DateReport command should be deserialized correctly", (t) => {
 			17,
 		]),
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		ccData,
 		{ sourceNodeId: 8 } as any,
 	) as TimeCCDateReport;
@@ -81,11 +81,11 @@ test("the DateReport command should be deserialized correctly", (t) => {
 	t.expect(cc.day).toBe(17);
 });
 
-test("deserializing an unsupported command should return an unspecified version of TimeCC", (t) => {
+test("deserializing an unsupported command should return an unspecified version of TimeCC", async (t) => {
 	const serializedCC = buildCCBuffer(
 		Uint8Array.from([255]), // not a valid command
 	);
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		serializedCC,
 		{ sourceNodeId: 8 } as any,
 	) as TimeCC;

--- a/packages/zwave-js/src/lib/test/cc/ZWavePlusCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/ZWavePlusCC.test.ts
@@ -12,7 +12,7 @@ function buildCCBuffer(payload: Uint8Array): Uint8Array {
 	]);
 }
 
-test("The Get command should serialize correctly", (t) => {
+test("The Get command should serialize correctly", async (t) => {
 	const cc = new ZWavePlusCCGet({
 		nodeId: 1,
 	});
@@ -21,7 +21,9 @@ test("The Get command should serialize correctly", (t) => {
 			ZWavePlusCommand.Get, // CC Command
 		]),
 	);
-	t.expect(cc.serialize({} as any)).toStrictEqual(expected);
+	await t.expect(cc.serializeAsync({} as any)).resolves.toStrictEqual(
+		expected,
+	);
 });
 
 // describe.skip(`interview()`, () => {

--- a/packages/zwave-js/src/lib/test/compliance/decodeLowerS2Keys.test.ts
+++ b/packages/zwave-js/src/lib/test/compliance/decodeLowerS2Keys.test.ts
@@ -68,9 +68,8 @@ integrationTest(
 				driver.options.securityKeys!.S2_Unauthenticated!,
 			);
 			controller.securityManagers.securityManager2 = smCtrlr;
-			controller.parsingContext.getHighestSecurityClass =
-				controller.encodingContext.getHighestSecurityClass =
-					() => SecurityClass.S2_Unauthenticated;
+			controller.encodingContext.getHighestSecurityClass = () =>
+				SecurityClass.S2_Unauthenticated;
 
 			// Respond to S2 Nonce Get
 			const respondToS2NonceGet: MockNodeBehavior = {

--- a/packages/zwave-js/src/lib/test/compliance/secureNodeSecureEndpoint.test.ts
+++ b/packages/zwave-js/src/lib/test/compliance/secureNodeSecureEndpoint.test.ts
@@ -115,9 +115,8 @@ integrationTest(
 				driver.options.securityKeys!.S2_Unauthenticated!,
 			);
 			controller.securityManagers.securityManager2 = smCtrlr;
-			controller.parsingContext.getHighestSecurityClass =
-				controller.encodingContext.getHighestSecurityClass =
-					() => SecurityClass.S2_Unauthenticated;
+			controller.encodingContext.getHighestSecurityClass = () =>
+				SecurityClass.S2_Unauthenticated;
 
 			// Respond to Nonce Get
 			const respondToNonceGet: MockNodeBehavior = {

--- a/packages/zwave-js/src/lib/test/driver/assemblePartialCCs.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/assemblePartialCCs.test.ts
@@ -182,7 +182,7 @@ test("supports nested partial/non-partial CCs", async ({ context, expect }) => {
 		encapsulated: {} as any,
 	});
 	cc.encapsulated = undefined as any;
-	cc["decryptedCCBytes"] = cc1.serialize({} as any);
+	cc["decryptedCCBytes"] = await cc1.serializeAsync({} as any);
 	const msg = new ApplicationCommandRequest({
 		command: cc,
 	});

--- a/packages/zwave-js/src/lib/test/driver/assemblePartialCCs.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/assemblePartialCCs.test.ts
@@ -57,20 +57,20 @@ const test = baseTest.extend<LocalTestContext>({
 	],
 });
 
-test.sequential("returns true when a non-partial CC is received", ({ context, expect }) => {
+test("returns true when a non-partial CC is received", async ({ context, expect }) => {
 	const { driver } = context;
 	const cc = new BasicCCSet({ nodeId: 2, targetValue: 50 });
 	const msg = new ApplicationCommandRequest({
 		command: cc,
 	});
-	expect(driver["assemblePartialCCs"](msg)).toBe(true);
+	expect(await driver["assemblePartialCCs"](msg)).toBe(true);
 });
 
-test.sequential(
+test(
 	"returns true when a partial CC is received that expects no more reports",
-	({ context, expect }) => {
+	async ({ context, expect }) => {
 		const { driver } = context;
-		const cc = CommandClass.parse(
+		const cc = await CommandClass.parseAsync(
 			Uint8Array.from([
 				CommandClasses.Association,
 				AssociationCommand.Report,
@@ -86,15 +86,15 @@ test.sequential(
 		const msg = new ApplicationCommandRequest({
 			command: cc,
 		});
-		expect(driver["assemblePartialCCs"](msg)).toBe(true);
+		expect(await driver["assemblePartialCCs"](msg)).toBe(true);
 	},
 );
 
-test.sequential(
+test(
 	"returns false when a partial CC is received that expects more reports",
-	({ context, expect }) => {
+	async ({ context, expect }) => {
 		const { driver } = context;
-		const cc = CommandClass.parse(
+		const cc = await CommandClass.parseAsync(
 			Uint8Array.from([
 				CommandClasses.Association,
 				AssociationCommand.Report,
@@ -110,15 +110,15 @@ test.sequential(
 		const msg = new ApplicationCommandRequest({
 			command: cc,
 		});
-		expect(driver["assemblePartialCCs"](msg)).toBe(false);
+		expect(await driver["assemblePartialCCs"](msg)).toBe(false);
 	},
 );
 
-test.sequential(
+test(
 	"returns true when the final partial CC is received and merges its data",
-	({ context, expect }) => {
+	async ({ context, expect }) => {
 		const { driver } = context;
-		const cc1 = CommandClass.parse(
+		const cc1 = await CommandClass.parseAsync(
 			Uint8Array.from([
 				CommandClasses.Association,
 				AssociationCommand.Report,
@@ -131,7 +131,7 @@ test.sequential(
 			]),
 			{ sourceNodeId: 2 } as any,
 		) as AssociationCCReport;
-		const cc2 = CommandClass.parse(
+		const cc2 = await CommandClass.parseAsync(
 			Uint8Array.from([
 				CommandClasses.Association,
 				AssociationCommand.Report,
@@ -147,12 +147,12 @@ test.sequential(
 		const msg1 = new ApplicationCommandRequest({
 			command: cc1,
 		});
-		expect(driver["assemblePartialCCs"](msg1)).toBe(false);
+		await expect(driver["assemblePartialCCs"](msg1)).resolves.toBe(false);
 
 		const msg2 = new ApplicationCommandRequest({
 			command: cc2,
 		});
-		expect(driver["assemblePartialCCs"](msg2)).toBe(true);
+		await expect(driver["assemblePartialCCs"](msg2)).resolves.toBe(true);
 
 		expect(
 			(msg2.command as AssociationCCReport).nodeIds,
@@ -160,7 +160,7 @@ test.sequential(
 	},
 );
 
-test.sequential("does not crash when receiving a Multi Command CC", ({ context, expect }) => {
+test("does not crash when receiving a Multi Command CC", async ({ context, expect }) => {
 	const { driver } = context;
 	const cc1 = new BasicCCSet({ nodeId: 2, targetValue: 25 });
 	const cc2 = new BasicCCSet({ nodeId: 2, targetValue: 50 });
@@ -171,10 +171,10 @@ test.sequential("does not crash when receiving a Multi Command CC", ({ context, 
 	const msg = new ApplicationCommandRequest({
 		command: cc,
 	});
-	expect(driver["assemblePartialCCs"](msg)).toBe(true);
+	expect(await driver["assemblePartialCCs"](msg)).toBe(true);
 });
 
-test.sequential("supports nested partial/non-partial CCs", ({ context, expect }) => {
+test("supports nested partial/non-partial CCs", async ({ context, expect }) => {
 	const { driver } = context;
 	const cc1 = new BasicCCSet({ nodeId: 2, targetValue: 25 });
 	const cc = new SecurityCCCommandEncapsulation({
@@ -186,10 +186,10 @@ test.sequential("supports nested partial/non-partial CCs", ({ context, expect })
 	const msg = new ApplicationCommandRequest({
 		command: cc,
 	});
-	expect(driver["assemblePartialCCs"](msg)).toBe(true);
+	expect(await driver["assemblePartialCCs"](msg)).toBe(true);
 });
 
-test.sequential("supports nested partial/partial CCs (part 1)", ({ context, expect }) => {
+test("supports nested partial/partial CCs (part 1)", async ({ context, expect }) => {
 	const { driver } = context;
 	const cc = new SecurityCCCommandEncapsulation({
 		nodeId: 2,
@@ -209,10 +209,10 @@ test.sequential("supports nested partial/partial CCs (part 1)", ({ context, expe
 	const msg = new ApplicationCommandRequest({
 		command: cc,
 	});
-	expect(driver["assemblePartialCCs"](msg)).toBe(false);
+	expect(await driver["assemblePartialCCs"](msg)).toBe(false);
 });
 
-test.sequential("supports nested partial/partial CCs (part 2)", ({ context, expect }) => {
+test("supports nested partial/partial CCs (part 2)", async ({ context, expect }) => {
 	const { driver } = context;
 	const cc = new SecurityCCCommandEncapsulation({
 		nodeId: 2,
@@ -232,14 +232,14 @@ test.sequential("supports nested partial/partial CCs (part 2)", ({ context, expe
 	const msg = new ApplicationCommandRequest({
 		command: cc,
 	});
-	expect(driver["assemblePartialCCs"](msg)).toBe(true);
+	expect(await driver["assemblePartialCCs"](msg)).toBe(true);
 });
 
-test.sequential(
+test(
 	"returns false when a partial CC throws Deserialization_NotImplemented during merging",
-	({ context, expect }) => {
+	async ({ context, expect }) => {
 		const { driver } = context;
-		const cc = CommandClass.parse(
+		const cc = await CommandClass.parseAsync(
 			Uint8Array.from([
 				CommandClasses.Association,
 				AssociationCommand.Report,
@@ -252,7 +252,7 @@ test.sequential(
 			]),
 			{ sourceNodeId: 2 } as any,
 		) as AssociationCCReport;
-		cc.mergePartialCCs = () => {
+		cc.mergePartialCCsAsync = async () => {
 			throw new ZWaveError(
 				"not implemented",
 				ZWaveErrorCodes.Deserialization_NotImplemented,
@@ -261,15 +261,15 @@ test.sequential(
 		const msg = new ApplicationCommandRequest({
 			command: cc,
 		});
-		expect(driver["assemblePartialCCs"](msg)).toBe(false);
+		expect(await driver["assemblePartialCCs"](msg)).toBe(false);
 	},
 );
 
-test.sequential(
+test(
 	"returns false when a partial CC throws CC_NotImplemented during merging",
-	({ context, expect }) => {
+	async ({ context, expect }) => {
 		const { driver } = context;
-		const cc = CommandClass.parse(
+		const cc = await CommandClass.parseAsync(
 			Uint8Array.from([
 				CommandClasses.Association,
 				AssociationCommand.Report,
@@ -282,7 +282,7 @@ test.sequential(
 			]),
 			{ sourceNodeId: 2 } as any,
 		) as AssociationCCReport;
-		cc.mergePartialCCs = () => {
+		cc.mergePartialCCsAsync = async () => {
 			throw new ZWaveError(
 				"not implemented",
 				ZWaveErrorCodes.CC_NotImplemented,
@@ -291,15 +291,15 @@ test.sequential(
 		const msg = new ApplicationCommandRequest({
 			command: cc,
 		});
-		expect(driver["assemblePartialCCs"](msg)).toBe(false);
+		expect(await driver["assemblePartialCCs"](msg)).toBe(false);
 	},
 );
 
-test.sequential(
+test(
 	"returns false when a partial CC throws PacketFormat_InvalidPayload during merging",
-	({ context, expect }) => {
+	async ({ context, expect }) => {
 		const { driver } = context;
-		const cc = CommandClass.parse(
+		const cc = await CommandClass.parseAsync(
 			Uint8Array.from([
 				CommandClasses.Association,
 				AssociationCommand.Report,
@@ -312,7 +312,7 @@ test.sequential(
 			]),
 			{ sourceNodeId: 2 } as any,
 		) as AssociationCCReport;
-		cc.mergePartialCCs = () => {
+		cc.mergePartialCCsAsync = async () => {
 			throw new ZWaveError(
 				"not implemented",
 				ZWaveErrorCodes.PacketFormat_InvalidPayload,
@@ -321,13 +321,13 @@ test.sequential(
 		const msg = new ApplicationCommandRequest({
 			command: cc,
 		});
-		expect(driver["assemblePartialCCs"](msg)).toBe(false);
+		expect(await driver["assemblePartialCCs"](msg)).toBe(false);
 	},
 );
 
-test.sequential("passes other errors during merging through", ({ context, expect }) => {
+test("passes other errors during merging through", async ({ context, expect }) => {
 	const { driver } = context;
-	const cc = CommandClass.parse(
+	const cc = await CommandClass.parseAsync(
 		Uint8Array.from([
 			CommandClasses.Association,
 			AssociationCommand.Report,
@@ -340,12 +340,12 @@ test.sequential("passes other errors during merging through", ({ context, expect
 		]),
 		{ sourceNodeId: 2 } as any,
 	) as AssociationCCReport;
-	cc.mergePartialCCs = () => {
+	cc.mergePartialCCsAsync = async () => {
 		throw new ZWaveError("invalid", ZWaveErrorCodes.Argument_Invalid);
 	};
 	const msg = new ApplicationCommandRequest({
 		command: cc,
 	});
-	expect(() => driver["assemblePartialCCs"](msg))
-		.toThrow("invalid");
+	await expect(() => driver["assemblePartialCCs"](msg))
+		.rejects.toThrow("invalid");
 });

--- a/packages/zwave-js/src/lib/test/driver/ignoreCCVersion0ForKnownSupportedCCs.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/ignoreCCVersion0ForKnownSupportedCCs.test.ts
@@ -66,9 +66,8 @@ integrationTest(
 				driver.options.securityKeys!.S2_Unauthenticated!,
 			);
 			controller.securityManagers.securityManager2 = smCtrlr;
-			controller.parsingContext.getHighestSecurityClass =
-				controller.encodingContext.getHighestSecurityClass =
-					() => SecurityClass.S2_Unauthenticated;
+			controller.encodingContext.getHighestSecurityClass = () =>
+				SecurityClass.S2_Unauthenticated;
 
 			// Respond to Nonce Get
 			const respondToNonceGet: MockNodeBehavior = {
@@ -342,12 +341,13 @@ integrationTest(
 
 			// Parse Security CC commands
 			const parseS0CC: MockNodeBehavior = {
-				handleCC(controller, self, receivedCC) {
+				async handleCC(controller, self, receivedCC) {
 					// We don't support sequenced commands here
 					if (receivedCC instanceof SecurityCCCommandEncapsulation) {
-						receivedCC.mergePartialCCs([], {
+						await receivedCC.mergePartialCCsAsync([], {
 							sourceNodeId: controller.ownNodeId,
 							__internalIsMockNode: true,
+							frameType: "singlecast",
 							...self.encodingContext,
 							...self.securityManagers,
 						});

--- a/packages/zwave-js/src/lib/test/driver/multiStageResponseNoTimeout.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/multiStageResponseNoTimeout.test.ts
@@ -107,7 +107,9 @@ integrationTest(
 								"Veeeeeeeeeeeeeeeeeeeeeeeeery loooooooooooooooooong parameter name",
 							reportsToFollow: 0,
 						});
-						const serialized = configCC.serialize();
+						const serialized = await configCC.serializeAsync(
+							mockNode.encodingContext,
+						);
 						const segment1 = serialized.subarray(
 							0,
 							MAX_SEGMENT_SIZE,

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepBlockNonceReport.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepBlockNonceReport.test.ts
@@ -61,12 +61,13 @@ integrationTest(
 
 			// Parse Security CC commands. This MUST be defined last, since defineBehavior will prepend it to the list
 			const parseS0CC: MockNodeBehavior = {
-				handleCC(controller, self, receivedCC) {
+				async handleCC(controller, self, receivedCC) {
 					// We don't support sequenced commands here
 					if (receivedCC instanceof SecurityCCCommandEncapsulation) {
-						receivedCC.mergePartialCCs([], {
+						await receivedCC.mergePartialCCsAsync([], {
 							sourceNodeId: controller.ownNodeId,
 							__internalIsMockNode: true,
+							frameType: "singlecast",
 							...self.encodingContext,
 							...self.securityManagers,
 						});

--- a/packages/zwave-js/src/lib/test/driver/receiveMessages.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/receiveMessages.test.ts
@@ -55,7 +55,7 @@ test.sequential(
 			}),
 		});
 		controller.serial.emitData(
-			req.serialize(driver["getEncodingContext"]()),
+			await req.serializeAsync(driver["getEncodingContext"]()),
 		);
 		await controller.expectHostACK(1000);
 	},

--- a/packages/zwave-js/src/lib/test/driver/s0AndS2Encapsulation.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s0AndS2Encapsulation.test.ts
@@ -76,9 +76,8 @@ integrationTest("S0 commands are S0-encapsulated, even when S2 is supported", {
 			driver.options.securityKeys!.S2_Unauthenticated!,
 		);
 		controller.securityManagers.securityManager2 = smCtrlr;
-		controller.parsingContext.getHighestSecurityClass =
-			controller.encodingContext.getHighestSecurityClass =
-				() => SecurityClass.S2_Unauthenticated;
+		controller.encodingContext.getHighestSecurityClass = () =>
+			SecurityClass.S2_Unauthenticated;
 
 		const sm0Ctrlr = new SecurityManager({
 			ownNodeId: controller.ownNodeId,
@@ -107,16 +106,18 @@ integrationTest("S0 commands are S0-encapsulated, even when S2 is supported", {
 
 		// Parse Security CC commands
 		const parseS0CC: MockNodeBehavior = {
-			handleCC(controller, self, receivedCC) {
+			async handleCC(controller, self, receivedCC) {
 				// We don't support sequenced commands here
 				if (receivedCC instanceof SecurityCCCommandEncapsulation) {
-					receivedCC.mergePartialCCs([], {
+					await receivedCC.mergePartialCCsAsync([], {
 						sourceNodeId: controller.ownNodeId,
 						__internalIsMockNode: true,
+						frameType: "singlecast",
 						...self.encodingContext,
 						...self.securityManagers,
 					});
 				}
+				// This just decodes - we need to call further handlers
 				return undefined;
 			},
 		};

--- a/packages/zwave-js/src/lib/test/driver/s0Encapsulation.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s0Encapsulation.test.ts
@@ -167,12 +167,13 @@ integrationTest("Communication via Security S0 works", {
 
 		// Parse Security CC commands. This MUST be defined last, since defineBehavior will prepend it to the list
 		const parseS0CC: MockNodeBehavior = {
-			handleCC(controller, self, receivedCC) {
+			async handleCC(controller, self, receivedCC) {
 				// We don't support sequenced commands here
 				if (receivedCC instanceof SecurityCCCommandEncapsulation) {
-					receivedCC.mergePartialCCs([], {
+					await receivedCC.mergePartialCCsAsync([], {
 						sourceNodeId: controller.ownNodeId,
 						__internalIsMockNode: true,
+						frameType: "singlecast",
 						...self.encodingContext,
 						...self.securityManagers,
 					});

--- a/packages/zwave-js/src/lib/test/driver/s0EncapsulationTwoNodes.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s0EncapsulationTwoNodes.test.ts
@@ -202,14 +202,15 @@ integrationTest(
 
 				// Parse Security CC commands. This MUST be defined last, since defineBehavior will prepend it to the list
 				const parseS0CC: MockNodeBehavior = {
-					handleCC(controller, self, receivedCC) {
+					async handleCC(controller, self, receivedCC) {
 						// We don't support sequenced commands here
 						if (
 							receivedCC instanceof SecurityCCCommandEncapsulation
 						) {
-							receivedCC.mergePartialCCs([], {
+							await receivedCC.mergePartialCCsAsync([], {
 								sourceNodeId: controller.ownNodeId,
 								__internalIsMockNode: true,
+								frameType: "singlecast",
 								...self.encodingContext,
 								...self.securityManagers,
 							});

--- a/packages/zwave-js/src/lib/test/driver/s2Collisions.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s2Collisions.test.ts
@@ -29,10 +29,10 @@ import { wait } from "alcalzone-shared/async";
 import path from "node:path";
 import { integrationTest } from "../integrationTestSuite.js";
 
-integrationTest.only(
+integrationTest(
 	"S2 Collisions: Both nodes send at the same time, with supervision",
 	{
-		debug: true,
+		// debug: true,
 
 		// We need the cache to skip the CC interviews and mark S2 as supported
 		provisioningDirectory: path.join(

--- a/packages/zwave-js/src/lib/test/driver/s2Collisions.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s2Collisions.test.ts
@@ -29,10 +29,10 @@ import { wait } from "alcalzone-shared/async";
 import path from "node:path";
 import { integrationTest } from "../integrationTestSuite.js";
 
-integrationTest(
+integrationTest.only(
 	"S2 Collisions: Both nodes send at the same time, with supervision",
 	{
-		// debug: true,
+		debug: true,
 
 		// We need the cache to skip the CC interviews and mark S2 as supported
 		provisioningDirectory: path.join(
@@ -76,9 +76,8 @@ integrationTest(
 				driver.options.securityKeys!.S2_Unauthenticated!,
 			);
 			controller.securityManagers.securityManager2 = smCtrlr;
-			controller.parsingContext.getHighestSecurityClass =
-				controller.encodingContext.getHighestSecurityClass =
-					() => SecurityClass.S2_Unauthenticated;
+			controller.encodingContext.getHighestSecurityClass = () =>
+				SecurityClass.S2_Unauthenticated;
 
 			// Respond to Nonce Get
 			const respondToNonceGet: MockNodeBehavior = {
@@ -244,9 +243,8 @@ integrationTest(
 				driver.options.securityKeys!.S2_Unauthenticated!,
 			);
 			controller.securityManagers.securityManager2 = smCtrlr;
-			controller.parsingContext.getHighestSecurityClass =
-				controller.encodingContext.getHighestSecurityClass =
-					() => SecurityClass.S2_Unauthenticated;
+			controller.encodingContext.getHighestSecurityClass = () =>
+				SecurityClass.S2_Unauthenticated;
 
 			// Respond to Nonce Get
 			const respondToNonceGet: MockNodeBehavior = {
@@ -379,9 +377,8 @@ integrationTest(
 				SecurityClass.S2_Unauthenticated,
 				driver.options.securityKeys!.S2_Unauthenticated!,
 			);
-			controller.parsingContext.getHighestSecurityClass =
-				controller.encodingContext.getHighestSecurityClass =
-					() => SecurityClass.S2_Unauthenticated;
+			controller.encodingContext.getHighestSecurityClass = () =>
+				SecurityClass.S2_Unauthenticated;
 
 			// Respond to Nonce Get
 			const respondToNonceGet: MockNodeBehavior = {

--- a/packages/zwave-js/src/lib/test/messages.ts
+++ b/packages/zwave-js/src/lib/test/messages.ts
@@ -3,7 +3,7 @@ import { MessageType } from "@zwave-js/serial";
 import { Bytes } from "@zwave-js/shared";
 
 const defaultImplementations = {
-	serialize: () => Bytes.from([1, 2, 3]),
+	serializeAsync: () => Promise.resolve(Bytes.from([1, 2, 3])),
 	tryGetNode: () => undefined,
 	getNodeId: () => undefined,
 	toLogEntry: () => ({ tags: [] }),

--- a/packages/zwave-js/src/lib/test/node/Node.handleCommand.test.ts
+++ b/packages/zwave-js/src/lib/test/node/Node.handleCommand.test.ts
@@ -113,7 +113,7 @@ test.sequential(
 			new Uint8Array(12).fill(0xff),
 		]);
 
-		const command = CommandClass.parse(
+		const command = await CommandClass.parseAsync(
 			buf,
 			{ sourceNodeId: node.id } as any,
 		) as EntryControlCCNotification;

--- a/packages/zwave-js/src/lib/zniffer/Zniffer.ts
+++ b/packages/zwave-js/src/lib/zniffer/Zniffer.ts
@@ -455,9 +455,9 @@ supported frequencies: ${
 	/**
 	 * Is called when the serial port has received a Zniffer frame
 	 */
-	private serialport_onData(
+	private async serialport_onData(
 		data: Uint8Array,
-	): void {
+	): Promise<void> {
 		let msg: ZnifferMessage | undefined;
 		try {
 			msg = ZnifferMessage.parse(data);
@@ -482,7 +482,7 @@ supported frequencies: ${
 			) {
 				this._capturedFrames.shift();
 			}
-			this.handleDataMessage(dataMsg, capture);
+			await this.handleDataMessage(dataMsg, capture);
 		}
 	}
 
@@ -503,10 +503,10 @@ supported frequencies: ${
 	/**
 	 * Is called when a Request-type message was received
 	 */
-	private handleDataMessage(
+	private async handleDataMessage(
 		msg: ZnifferDataMessage,
 		capture: CapturedData,
-	): void {
+	): Promise<void> {
 		try {
 			let convertedRSSI: RSSI | undefined;
 			if (this._options.convertRSSI && this._chipType) {
@@ -577,7 +577,7 @@ supported frequencies: ${
 						? "broadcast"
 						: "singlecast";
 				try {
-					cc = CommandClass.parse(
+					cc = await CommandClass.parseAsync(
 						mpdu.payload,
 						{
 							homeId: mpdu.homeId,

--- a/test/decodeMessage.ts
+++ b/test/decodeMessage.ts
@@ -96,7 +96,7 @@ import { containsCC } from "zwave-js";
 		getHighestSecurityClass: () => SecurityClass.S2_AccessControl,
 		hasSecurityClass: () => true,
 	};
-	const msg = Message.parse(data, ctx as any);
+	const msg = await Message.parseAsync(data, ctx as any);
 
 	if (containsCC(msg)) {
 		msg.command.mergePartialCCs([], {} as any);


### PR DESCRIPTION
With this PR, parsing and serializing CCs, as well as serializing messages is now done asynchronously. For this purpose, new `async` variants `parseAsync`, `fromAsync`, `serializeAsync` and `mergePartialCCsAsync` have been added.
For backwards compatibility, the synchronous versions of `.parse()`, `.from()`, `.serialize()`, `.mergePartialCCs()` will be kept around until the next major release, after which the `...Async` versions will take their place.

This change allows using asynchronous APIs while parsing and serializing, e.g. the portable WebCrypto API as a replacement for `node:crypto`.