### PR TITLE
fix: treat "ascii" buffer encoding as "utf-8"

### DIFF
--- a/packages/cc/src/cc/EntryControlCC.ts
+++ b/packages/cc/src/cc/EntryControlCC.ts
@@ -459,14 +459,21 @@ export class EntryControlCCNotification extends EntryControlCC {
 							eventDataLength === 16 || eventDataLength === 32,
 						);
 					}
-					eventData = eventData.toString("ascii");
-					if (!noStrictValidation) {
-						validatePayload(
-							/^[\u0000-\u007f]+[\u00ff]*$/.test(eventData),
-						);
-					}
 					// Trim 0xff padding bytes
-					eventData = eventData.replace(/[\u00ff]*$/, "");
+					let paddingStart = eventDataLength;
+					while (
+						paddingStart > 0
+						&& eventData[paddingStart - 1] === 0xff
+					) {
+						paddingStart--;
+					}
+					eventData = eventData.subarray(0, paddingStart).toString(
+						"ascii",
+					);
+
+					if (!noStrictValidation) {
+						validatePayload(/^[\u0000-\u007f]+$/.test(eventData));
+					}
 					break;
 				case EntryControlDataTypes.MD5:
 					// MD5 16 byte binary data encoded as a MD5 hash value.

--- a/packages/shared/src/Bytes.ts
+++ b/packages/shared/src/Bytes.ts
@@ -132,7 +132,6 @@ export class Bytes extends Uint8Array {
 				return uint8ArrayToBase64(this);
 			case "base64url":
 				return uint8ArrayToBase64(this, { urlSafe: true });
-				return uint8ArrayToString(this, "utf8");
 			case "ucs-2":
 			case "ucs2":
 			case "utf16le":

--- a/packages/shared/src/Bytes.ts
+++ b/packages/shared/src/Bytes.ts
@@ -132,8 +132,20 @@ export class Bytes extends Uint8Array {
 				return uint8ArrayToBase64(this);
 			case "base64url":
 				return uint8ArrayToBase64(this, { urlSafe: true });
+				return uint8ArrayToString(this, "utf8");
+			case "ucs-2":
+			case "ucs2":
+			case "utf16le":
+				return uint8ArrayToString(this, "utf-16le");
+			case "ascii":
+			case "latin1":
+			case "binary":
+			// For TextDecoder, these are aliases for "windows-1252"
+			// which is not supported with small-icu or without ICU.
+			// When dealing with actual ASCII data, there is no difference
+			// to simply using "utf8" instead.
 			default:
-				return uint8ArrayToString(this, encoding);
+				return uint8ArrayToString(this, "utf-8");
 		}
 	}
 


### PR DESCRIPTION
Fixes the issue reported in https://github.com/zwave-js/zwave-js-ui/issues/3994