### PR TITLE
fix(config): correct config JSON syntax for Zooz ZSE70 800LR 

### DIFF
--- a/packages/config/config/devices/0x027a/zse70_800lr.json
+++ b/packages/config/config/devices/0x027a/zse70_800lr.json
@@ -29,37 +29,32 @@
 		{
 			"#": "1",
 			"label": "Motion Sensitivity",
-			"description": "0",
+			"description": "Adjust motion sensitivity where 8 is the most sensitive setting.",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 8,
-			"defaultValue": 6,
-			"unsigned": true
+			"defaultValue": 6
 		},
 		{
 			"#": "2",
 			"label": "Motion Untrigger Time",
-			"description": "0",
+			"description": "Set motion clear time for the delay before the sensor reports no motion to the hub and associated devices are detecting the last motion activity.",
 			"valueSize": 2,
 			"minValue": 10,
 			"maxValue": 3600,
-			"defaultValue": 30,
-			"unsigned": true
+			"defaultValue": 30
 		},
 		{
 			"#": "3",
 			"label": "Motion Group Control",
-			"description": "0",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 7,
-			"defaultValue": 7,
-			"unsigned": true
+			"defaultValue": 7
 		},
 		{
 			"#": "4",
 			"label": "Motion Group Value Setting",
-			"description": "0",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 65535,
@@ -69,77 +64,64 @@
 		{
 			"#": "5",
 			"label": "Temperature Report Scale",
-			"description": "0",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
-			"defaultValue": 1,
-			"unsigned": true
+			"defaultValue": 1
 		},
 		{
 			"#": "6",
-			"label": "Led Activity",
-			"description": "0",
+			"label": "LED Activity",
+			"description": "Enable or disable LED indicator for motion alerts.",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 1,
-			"defaultValue": 1,
-			"unsigned": true
+			"defaultValue": 1
 		},
 		{
 			"#": "7",
 			"label": "Low Battery Threshold",
-			"description": "0",
 			"valueSize": 1,
 			"minValue": 10,
 			"maxValue": 50,
-			"defaultValue": 10,
-			"unsigned": true
+			"defaultValue": 10
 		},
 		{
 			"#": "8",
 			"label": "Battery Power Checking Interval",
-			"description": "0",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 744,
-			"defaultValue": 4,
-			"unsigned": true
+			"defaultValue": 4
 		},
 		{
 			"#": "9",
 			"label": "Temperature Threshold Check Time",
-			"description": "0",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 600,
-			"defaultValue": 30,
-			"unsigned": true
+			"defaultValue": 30
 		},
 		{
 			"#": "10",
 			"label": "Light Threshold Check Time",
-			"description": "0",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 600,
-			"defaultValue": 10,
-			"unsigned": true
+			"defaultValue": 10
 		},
 		{
 			"#": "11",
 			"label": "Battery Threshold",
-			"description": "0",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 50,
-			"defaultValue": 2,
-			"unsigned": true
+			"defaultValue": 2
 		},
 		{
 			"#": "12",
 			"label": "Temperature Threshold",
-			"description": "0",
+			"description": "Set the reporting threshold for temperature. The sensor will report new temperature value to the hub whenever temperature changes by the number of degrees entered as value.",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 144,
@@ -149,17 +131,15 @@
 		{
 			"#": "13",
 			"label": "Light Threshold",
-			"description": "0",
+			"description": "Set the reporting threshold for lux. The sensor will report new lux value to the hub whenever the brightness level changes by the number of lux entered as value.",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 30000,
-			"defaultValue": 50,
-			"unsigned": true
+			"defaultValue": 50
 		},
 		{
 			"#": "14",
 			"label": "Temperature Calibrate Offset",
-			"description": "0",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 200,
@@ -169,7 +149,6 @@
 		{
 			"#": "15",
 			"label": "Light Calibrate Offset",
-			"description": "0",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 200,
@@ -179,17 +158,16 @@
 		{
 			"#": "16",
 			"label": "Dusk to Dawn",
-			"description": "0",
+			"description": "Program the dusk to dawn feature. The sensor will report motion to the hub only when the lux level goes below the value set in this parameter",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 30000,
-			"defaultValue": 0,
-			"unsigned": true
+			"defaultValue": 0
 		},
 		{
 			"#": "17",
-			"label": "Automatic Report Interval Time For Temp",
-			"description": "0",
+			"label": "Automatic Report Interval Time for Temp",
+			"description": "Set the reporting frequency for temperature. This is the minimum interval in which the sensor will send updates to the hub even if the reporting threshold isn’t met. The values entered correspond to the number of seconds.",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 43200,
@@ -198,8 +176,7 @@
 		},
 		{
 			"#": "18",
-			"label": "Automatic Report Interval Time For Light",
-			"description": "0",
+			"label": "Automatic Report Interval Time for Light",
 			"valueSize": 2,
 			"minValue": 0,
 			"maxValue": 43200,
@@ -210,6 +187,7 @@
 	"metadata": {
 		"inclusion": "Put your Z-Wave® hub into inclusion mode and click\nthe Z-Wave® button 3 times as quickly as possible. The\nLED indicator will start blinking to confirm inclusion\nmode and turn off once inclusion is completed",
 		"exclusion": "1. Bring the sensor within direct range of your Z-Wave®\ngateway (hub).\n2. Put the Z-Wave® hub into exclusion mode (not sure\nhow to do that? ask@getzooz.com).\n3. Click the Z-Wave® button 3 times quickly.\n4. Your hub will confirm exclusion and the sensor will\ndisappear from your controller''s device list",
-		"reset": "When your network’s primary controller is missing or\notherwise inoperable, you may need to reset the device\nto factory settings manually. In order to complete the\nprocess, make sure the sensor is powered, then hold\nthe Z-Wave® button down for at least 10 seconds.\nThe LED indicator will start flashing blue and turn solid\nblue for a couple of seconds to indicate successful reset.\nNOTE: All previously recorded activity and custom settings will be\nerased from the device’s memory"
+		"reset": "When your network’s primary controller is missing or\notherwise inoperable, you may need to reset the device\nto factory settings manually. In order to complete the\nprocess, make sure the sensor is powered, then hold\nthe Z-Wave® button down for at least 10 seconds.\nThe LED indicator will start flashing blue and turn solid\nblue for a couple of seconds to indicate successful reset.\nNOTE: All previously recorded activity and custom settings will be\nerased from the device’s memory",
+		"manual": "https://cdn.shopify.com/s/files/1/0218/7704/files/zooz-zse70-800lr-manual.pdf"
 	}
 }


### PR DESCRIPTION
Updated the initial imported config file for the new ZooZ ZSE70 800LR outdoor sensor with meaningful descriptions, along with removing blank entries that failed linting.

Due to the new parameter types of this sensor, and slight variations compared to existing templates, I was only able to find a single meaningful template to include, and since it was just one, deliberately didn't include any templates.