### PR TITLE
fix: don't recover from bootloader to flash firmware

### DIFF
--- a/packages/flash/src/cli.ts
+++ b/packages/flash/src/cli.ts
@@ -39,8 +39,7 @@ const driver = new Driver(port, {
 		cacheDir: path.join(process.cwd(), "cache"),
 		lockDir: path.join(process.cwd(), "cache/locks"),
 	},
-	forceBootloaderOnly: true,
-	// allowBootloaderOnly: true,
+	bootloaderMode: "stay",
 })
 	.on("error", (e) => {
 		if (isZWaveError(e) && e.code === ZWaveErrorCodes.Driver_Failed) {

--- a/packages/flash/src/cli.ts
+++ b/packages/flash/src/cli.ts
@@ -39,7 +39,8 @@ const driver = new Driver(port, {
 		cacheDir: path.join(process.cwd(), "cache"),
 		lockDir: path.join(process.cwd(), "cache/locks"),
 	},
-	allowBootloaderOnly: true,
+	forceBootloaderOnly: true,
+	// allowBootloaderOnly: true,
 })
 	.on("error", (e) => {
 		if (isZWaveError(e) && e.code === ZWaveErrorCodes.Driver_Failed) {

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1449,30 +1449,48 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 				// If we are, the bootloader will reply with its menu.
 				await wait(1000);
 				if (this._bootloader) {
-					this.driverLog.print(
-						"Controller is in bootloader, attempting to recover...",
-						"warn",
-					);
-					await this.leaveBootloaderInternal();
-
-					// Wait a short time again. If we're in bootloader mode again, we're stuck
-					await wait(1000);
-					if (this._bootloader) {
-						if (this._options.allowBootloaderOnly) {
-							this.driverLog.print(
-								"Failed to recover from bootloader. Staying in bootloader mode as requested.",
-								"warn",
-							);
-							// Needed for the OTW feature to be available
-							this._controller = new ZWaveController(this, true);
-							this.emit("bootloader ready");
-						} else {
-							void this.destroyWithMessage(
-								"Failed to recover from bootloader. Please flash a new firmware to continue...",
-							);
-						}
+					if (this._options.forceBootloaderOnly) {
+						this.driverLog.print(
+							"Controller is in bootloader mode. Staying in bootloader as requested.",
+							"warn",
+						);
+						// Needed for the OTW feature to be available
+						this._controller = new ZWaveController(
+							this,
+							true,
+						);
+						this.emit("bootloader ready");
 
 						return;
+					} else {
+						this.driverLog.print(
+							"Controller is in bootloader, attempting to recover...",
+							"warn",
+						);
+						await this.leaveBootloaderInternal();
+
+						// Wait a short time again. If we're in bootloader mode again, we're stuck
+						await wait(1000);
+						if (this._bootloader) {
+							if (this._options.allowBootloaderOnly) {
+								this.driverLog.print(
+									"Failed to recover from bootloader. Staying in bootloader mode as requested.",
+									"warn",
+								);
+								// Needed for the OTW feature to be available
+								this._controller = new ZWaveController(
+									this,
+									true,
+								);
+								this.emit("bootloader ready");
+							} else {
+								void this.destroyWithMessage(
+									"Failed to recover from bootloader. Please flash a new firmware to continue...",
+								);
+							}
+
+							return;
+						}
 					}
 				}
 			}

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1436,7 +1436,7 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 				typeof this._options.testingHooks?.onSerialPortOpen
 					=== "function"
 			) {
-				await this._options.testingHooks.onSerialPortOpen(this.serial);
+				await this._options.testingHooks.onSerialPortOpen(this.serial!);
 			}
 
 			// Perform initialization sequence

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -362,6 +362,8 @@ export interface ZWaveOptions {
 	 */
 	allowBootloaderOnly?: boolean;
 
+	forceBootloaderOnly?: boolean;
+
 	/**
 	 * An object with application/module/component names and their versions.
 	 * This will be used to build a user-agent string for requests to Z-Wave JS webservices.

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -351,18 +351,28 @@ export interface ZWaveOptions {
 	};
 
 	/**
-	 * Normally, the driver expects to start in Serial API mode and enter the bootloader on demand. If in bootloader,
-	 * it will try to exit it and enter Serial API mode again.
-	 *
-	 * However there are situations where a controller may be stuck in bootloader mode and no Serial API is available.
-	 * In this case, the driver startup will fail, unless this option is set to `true`.
-	 *
-	 * If it is, the driver instance will only be good for interacting with the bootloader, e.g. for flashing a new image.
-	 * Commands attempting to talk to the serial API will fail.
+	 * @deprecated
+	 * To allow bootloader only mode, set `bootloaderMode` to `allow` instead.
 	 */
 	allowBootloaderOnly?: boolean;
 
-	forceBootloaderOnly?: boolean;
+	/**
+	 * Determines how the driver should be have when it encounters a controller that is in bootloader mode
+	 * and when the Serial API is not available (yet).
+	 * This can be useful when a controller may be stuck in bootloader mode, or when the application
+	 * wants to operate in bootloader mode anyways.
+	 *
+	 * The following options exist:
+	 * - `recover`: Z-Wave JS will attempt to recover the controller from bootloader mode.
+	 *   If this does not succeed, the driver startup will fail.
+	 * - `allow`: Z-Wave JS will attempt to recover the controller from bootloader mode.
+	 *   If this does not succeed, the driver will continue to operate in bootloader mode,
+	 *   e.g. for flashing a new image. Commands attempting to talk to the serial API will fail.
+	 * - `stay`: Z-Wave JS will NOT attempt to recover the controller from bootlaoder mode.
+	 *
+	 * Default: `recover`
+	 */
+	bootloaderMode?: "recover" | "allow" | "stay";
 
 	/**
 	 * An object with application/module/component names and their versions.

--- a/packages/zwave-js/src/lib/test/driver/bootloaderDetection.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/bootloaderDetection.test.ts
@@ -10,7 +10,7 @@ integrationTest(
 		// debug: true,
 
 		additionalDriverOptions: {
-			allowBootloaderOnly: true,
+			bootloaderMode: "allow",
 		},
 
 		async customSetup(driver, mockController, mockNode) {

--- a/packages/zwave-js/src/lib/test/integrationTestSuite.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuite.ts
@@ -149,7 +149,10 @@ function suite(
 				}
 			});
 
-			if (options.additionalDriverOptions?.allowBootloaderOnly) {
+			if (
+				options.additionalDriverOptions?.bootloaderMode === "stay"
+				|| options.additionalDriverOptions?.bootloaderMode === "allow"
+			) {
 				driver.once("bootloader ready", () => {
 					process.nextTick(resolve);
 				});

--- a/packages/zwave-js/src/lib/test/integrationTestSuiteShared.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuiteShared.ts
@@ -28,8 +28,9 @@ export function prepareDriver(
 ): Promise<CreateAndStartDriverWithMockPortResult> {
 	// Skipping the bootloader check speeds up tests a lot
 	additionalOptions.testingHooks ??= {};
-	additionalOptions.testingHooks.skipBootloaderCheck = !additionalOptions
-		.allowBootloaderOnly;
+	additionalOptions.testingHooks.skipBootloaderCheck =
+		additionalOptions.bootloaderMode === "recover"
+		|| additionalOptions.bootloaderMode == undefined;
 
 	const logConfig = additionalOptions.logConfig ?? {};
 	if (logToFile) {


### PR DESCRIPTION
With this PR, the driver can now stay in bootloader mode when necessary.