### PR TITLE
fix(config): correct Fibaro FGMS001 association groups

### DIFF
--- a/packages/config/config/devices/0x010f/fgms001.json
+++ b/packages/config/config/devices/0x010f/fgms001.json
@@ -68,23 +68,28 @@
 	"associations": {
 		"1": {
 			"label": "Lifeline",
+			"description": "Reports the device status and allows for assigning single device only (main controller by default).",
 			"maxNodes": 1,
 			"isLifeline": true
 		},
 		"2": {
 			"label": "Motion",
+			"description": "Sends motion detection and alarm cancellation frames to the associated devices.",
 			"maxNodes": 5
 		},
 		"3": {
 			"label": "Tamper",
+			"description": "Sends tamper alarm and alarm cancellation frames to the associated devices.",
 			"maxNodes": 5
 		},
 		"4": {
 			"label": "Motion BC",
+			"description": "Sends motion detection and alarm cancellation frames to the associated devices. Provides backward compatibility with controllers not supporting Z-Wave+ protocol.",
 			"maxNodes": 5
 		},
 		"5": {
 			"label": "Tamper BC",
+			"description": "Sends tamper alarm and alarm cancellation frames to the associated devices. Provides backward compatibility with controllers not supporting Z-Wave+ protocol.",
 			"maxNodes": 5
 		}
 	},

--- a/packages/config/config/devices/0x010f/fgms001.json
+++ b/packages/config/config/devices/0x010f/fgms001.json
@@ -74,18 +74,18 @@
 		"2": {
 			"label": "Motion",
 			"maxNodes": 5
-		},		
+		},
 		"3": {
 			"label": "Tamper",
 			"maxNodes": 5
 		},
 		"4": {
 			"label": "Motion BC",
-			"maxNodes": 5,
+			"maxNodes": 5
 		},
 		"5": {
 			"label": "Tamper BC",
-			"maxNodes": 5,
+			"maxNodes": 5
 		}
 	},
 	"paramInformation": [

--- a/packages/config/config/devices/0x010f/fgms001.json
+++ b/packages/config/config/devices/0x010f/fgms001.json
@@ -67,18 +67,25 @@
 	},
 	"associations": {
 		"1": {
-			"label": "Motion Sensor Status",
-			"maxNodes": 16
-		},
-		"2": {
-			"label": "Tamper Alarm",
-			"maxNodes": 16,
-			"isLifeline": true
-		},
-		"3": {
-			"label": "Controller Updates",
+			"label": "Lifeline",
 			"maxNodes": 1,
 			"isLifeline": true
+		},
+		"2": {
+			"label": "Motion",
+			"maxNodes": 5
+		},		
+		"3": {
+			"label": "Tamper",
+			"maxNodes": 5
+		},
+		"4": {
+			"label": "Motion BC",
+			"maxNodes": 5,
+		},
+		"5": {
+			"label": "Tamper BC",
+			"maxNodes": 5,
 		}
 	},
 	"paramInformation": [


### PR DESCRIPTION
I had a lot of trouble with setting up associations with my FGMS001 motion sensor from Fibaro.
Turns out the configuration in the documentation was incorrect. After reviewing the documentation at https://manuals.fibaro.com/motion-sensor/ I came to the conclusion ZwaveJS was reporting the associations groups incorrectly. 

ZwaveJS documentation link: https://devices.zwave-js.io/?jumpTo=0x010f:0x0800:0x1001:0.0#

This PR corrects the association group names and limits.

Group information:

1st Association Group – “Lifeline” reports the device status and allows for assigning single device only (main controller by default). 
2nd Association Group – “Motion” is assigned to the motion sensor – sends motion detection and alarm cancellation frames to the associated devices. 
3rd Association Group – “Tamper” is assigned to the tamper – sends tamper alarm and alarm cancellation frames to the associated devices. 
4th Association Group – “Motion BC” is assigned to the motion sensor – sends motion detection and alarm cancellation frames to the associated devices. Provides backward compatibility with controllers not supporting Z-Wave+ protocol. 
5th Association Group – “Tamper BC” is assigned to the tamper – sends tamper alarm and alarm cancellation frames to the associated devices. Provides backward compatibility with controllers not supporting Z-Wave+ protocol.