### PR TITLE
fix(config): disable Supervision for Everspring SP817 Motion Sensor

### DIFF
--- a/packages/config/config/devices/0x0060/sp817.json
+++ b/packages/config/config/devices/0x0060/sp817.json
@@ -57,5 +57,15 @@
 			"maxValue": 3600,
 			"defaultValue": 15
 		}
-	]
+	],
+	"compat": {
+		"commandClasses": {
+			"remove": {
+				// Supervised commands always result in a status of "Fail"
+				"Supervision": {
+					"endpoints": "*"
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
disable Supervision for Everspring SP817 Motion Sensor: setting configuration parameters always fails.

similar to issue discussed in https://github.com/zwave-js/node-zwave-js/issues/5157

