### PR TITLE
refactor: allow switching out the DB bindings

### DIFF
--- a/packages/core/src/bindings/db/jsonl.ts
+++ b/packages/core/src/bindings/db/jsonl.ts
@@ -1,0 +1,16 @@
+import { JsonlDB } from "@alcalzone/jsonl-db";
+import {
+	type Database,
+	type DatabaseFactory,
+	type DatabaseOptions,
+} from "@zwave-js/shared/bindings";
+
+/** An implementation of the Database bindings for Node.js based on JsonlDB */
+export const db: DatabaseFactory = {
+	createInstance<V>(
+		filename: string,
+		options?: DatabaseOptions<V>,
+	): Database<V> {
+		return new JsonlDB(filename, options);
+	},
+};

--- a/packages/core/src/values/CacheBackedMap.ts
+++ b/packages/core/src/values/CacheBackedMap.ts
@@ -1,4 +1,4 @@
-import type { JsonlDB } from "@alcalzone/jsonl-db";
+import { type Database } from "@zwave-js/shared/bindings";
 
 export interface CacheBackedMapKeys<K extends string | number> {
 	/** The common prefix all keys start with */
@@ -12,7 +12,7 @@ export interface CacheBackedMapKeys<K extends string | number> {
 /** Wrapper class which allows storing a Map as a subset of a JsonlDB */
 export class CacheBackedMap<K extends string | number, V> implements Map<K, V> {
 	constructor(
-		private readonly cache: JsonlDB<any>,
+		private readonly cache: Database<any>,
 		private readonly cacheKeys: CacheBackedMapKeys<K>,
 	) {
 		this.map = new Map();

--- a/packages/core/src/values/ValueDB.ts
+++ b/packages/core/src/values/ValueDB.ts
@@ -1,5 +1,5 @@
-import type { JsonlDB } from "@alcalzone/jsonl-db";
 import { TypedEventTarget } from "@zwave-js/shared";
+import { type Database } from "@zwave-js/shared/bindings";
 import type { CommandClasses } from "../definitions/CommandClasses.js";
 import {
 	ZWaveError,
@@ -106,8 +106,8 @@ export class ValueDB extends TypedEventTarget<ValueDBEventCallbacks> {
 	 */
 	public constructor(
 		nodeId: number,
-		valueDB: JsonlDB,
-		metadataDB: JsonlDB<ValueMetadata>,
+		valueDB: Database<unknown>,
+		metadataDB: Database<ValueMetadata>,
 		ownKeys?: Set<string>,
 	) {
 		super();
@@ -119,8 +119,8 @@ export class ValueDB extends TypedEventTarget<ValueDBEventCallbacks> {
 	}
 
 	private nodeId: number;
-	private _db: JsonlDB<unknown>;
-	private _metadata: JsonlDB<ValueMetadata>;
+	private _db: Database<unknown>;
+	private _metadata: Database<ValueMetadata>;
 	private _index: Set<string>;
 
 	private buildIndex(): Set<string> {
@@ -603,7 +603,9 @@ function compareDBKeyFast(
 }
 
 /** Extracts an index for each node from one or more JSONL DBs */
-export function indexDBsByNode(databases: JsonlDB[]): Map<number, Set<string>> {
+export function indexDBsByNode(
+	databases: Database<unknown>[],
+): Map<number, Set<string>> {
 	const indexes = new Map<number, Set<string>>();
 	for (const db of databases) {
 		for (const key of db.keys()) {

--- a/packages/shared/src/bindings.ts
+++ b/packages/shared/src/bindings.ts
@@ -135,3 +135,42 @@ export interface FileSystem
 {}
 
 export type Platform = "linux" | "darwin" | "win32" | "browser" | "other";
+
+export type DatabaseOptions<V> = {
+	/**
+	 * An optional reviver function (similar to JSON.parse) to transform parsed values before they are accessible in the database.
+	 * If this function is defined, it must always return a value.
+	 */
+	reviver?: (key: string, value: any) => V;
+	/**
+	 * An optional serializer function (similar to JSON.serialize) to transform values before they are written to the database file.
+	 * If this function is defined, it must always return a value.
+	 */
+	serializer?: (key: string, value: V) => any;
+	/** Whether timestamps should be recorded when setting values. Default: false */
+	enableTimestamps?: boolean;
+};
+
+export interface DatabaseFactory {
+	createInstance<V>(
+		filename: string,
+		options?: DatabaseOptions<V>,
+	): Database<V>;
+}
+
+export interface Database<V> {
+	open(): Promise<void>;
+	close(): Promise<void>;
+
+	has: Map<string, V>["has"];
+	get: Map<string, V>["get"];
+	set(key: string, value: V, updateTimestamp?: boolean): this;
+	delete(key: string): boolean;
+	clear(): void;
+
+	getTimestamp(key: string): number | undefined;
+	get size(): number;
+
+	keys: Map<string, V>["keys"];
+	entries: Map<string, V>["entries"];
+}

--- a/packages/zwave-js/src/lib/driver/Host.ts
+++ b/packages/zwave-js/src/lib/driver/Host.ts
@@ -1,11 +1,16 @@
 // FIXME: This should eventually live in @zwave-js/host
 
 import { type Serial } from "@zwave-js/serial";
-import { type FileSystem, type Platform } from "@zwave-js/shared/bindings";
+import {
+	type DatabaseFactory,
+	type FileSystem,
+	type Platform,
+} from "@zwave-js/shared/bindings";
 
 /** Abstractions for a host system Z-Wave JS is running on */
 export interface Host {
 	fs: FileSystem;
 	platform: Platform;
 	serial: Serial;
+	db: DatabaseFactory;
 }

--- a/packages/zwave-js/src/lib/driver/NetworkCache.ts
+++ b/packages/zwave-js/src/lib/driver/NetworkCache.ts
@@ -1,4 +1,3 @@
-import type { JsonlDB } from "@alcalzone/jsonl-db";
 import { type AssociationAddress } from "@zwave-js/cc";
 import {
 	type CommandClasses,
@@ -12,7 +11,11 @@ import {
 	securityClassOrder,
 } from "@zwave-js/core";
 import { Bytes, getEnumMemberName, num2hex, pickDeep } from "@zwave-js/shared";
-import type { ReadFile, ReadFileSystemInfo } from "@zwave-js/shared/bindings";
+import type {
+	Database,
+	ReadFile,
+	ReadFileSystemInfo,
+} from "@zwave-js/shared/bindings";
 import { isArray, isObject } from "alcalzone-shared/typeguards";
 import path from "pathe";
 import {
@@ -621,8 +624,8 @@ const legacyPaths = {
 
 export async function migrateLegacyNetworkCache(
 	homeId: number,
-	networkCache: JsonlDB,
-	valueDB: JsonlDB,
+	networkCache: Database<any>,
+	valueDB: Database<unknown>,
 	fs: ReadFileSystemInfo & ReadFile,
 	cacheDir: string,
 ): Promise<void> {

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -6,7 +6,7 @@ import type {
 } from "@zwave-js/core";
 import { type Serial, type ZWaveSerialStream } from "@zwave-js/serial";
 import { type DeepPartial, type Expand } from "@zwave-js/shared";
-import type { FileSystem } from "@zwave-js/shared/bindings";
+import type { DatabaseFactory, FileSystem } from "@zwave-js/shared/bindings";
 import type {
 	InclusionUserCallbacks,
 	JoinNetworkUserCallbacks,
@@ -137,6 +137,11 @@ export interface ZWaveOptions {
 		 * Specifies which bindings are used interact with serial ports.
 		 */
 		serial?: Serial;
+
+		/**
+		 * Specifies which bindings are used to interact with the database used to store the cache.
+		 */
+		db?: DatabaseFactory;
 	};
 
 	storage: {

--- a/packages/zwave-js/src/lib/zniffer/Zniffer.ts
+++ b/packages/zwave-js/src/lib/zniffer/Zniffer.ts
@@ -279,7 +279,12 @@ export class Zniffer extends TypedEventTarget<ZnifferEventCallbacks> {
 	 * The host bindings used to access file system etc.
 	 */
 	// This is set during `init()` and should not be accessed before
-	private bindings!: Required<NonNullable<ZWaveOptions["host"]>>;
+	private bindings!: Omit<
+		Required<
+			NonNullable<ZWaveOptions["host"]>
+		>,
+		"db"
+	>;
 
 	private serialFactory: ZnifferSerialStreamFactory | undefined;
 	/** The serial port instance */


### PR DESCRIPTION
This PR adds an abstraction for the underlying storage of the network and value caches. This allows using other storage backends than `jsonl-db`, for example a light wrapper around `window.localStorage`.