### PR TITLE
feat(config): update Zooz ZEN32 with button press blinking param for fw v2.40

### DIFF
--- a/packages/config/config/devices/0x027a/zen32.json
+++ b/packages/config/config/devices/0x027a/zen32.json
@@ -281,7 +281,7 @@
 			"#": "27",
 			"$if": "firmwareVersion >= 2.40 && firmwareVersion < 10.0",
 			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
-			"label": "LED Blinking When Buttons Are Pressed",
+			"label": "LED Indication: Button Pressed",
 			"description": "Choose if you want the LED indicators to flash whenever a button is pressed on the device to confirm scene activation.",
 			"defaultValue": 0
 		}

--- a/packages/config/config/devices/0x027a/zen32.json
+++ b/packages/config/config/devices/0x027a/zen32.json
@@ -276,6 +276,14 @@
 			"label": "Send Status Change Report: Timer",
 			"description": "Determine whether a trigger of this type should prompt a status change report to associated devices.",
 			"defaultValue": 1
+		},
+		{
+			"#": "27",
+			"$if": "firmwareVersion >= 2.40 && firmwareVersion < 10.0",
+			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
+			"label": "LED Blinking When Buttons Are Pressed",
+			"description": "Choose if you want the LED indicators to flash whenever a button is pressed on the device to confirm scene activation.",
+			"defaultValue": 0
 		}
 	],
 	"compat": {


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

Firmware [2.40](https://www.support.getzooz.com/kb/article/706-zen32-scene-controller-change-log/) for the 800LR version of the Zooz ZEN32 scene controller switch [added](https://www.support.getzooz.com/kb/article/608-zen32-scene-controller-advanced-settings/) parameter 27 to control the LED blinking behavior (enable/disable) when buttons are pressed.  It is similar to the LED blinking behavior control on configuration change as defined parameter 23.
