### PR TITLE
fix(config): updates to AEON Labs Minimote

### DIFF
--- a/packages/config/config/devices/0x0086/dsa03202.json
+++ b/packages/config/config/devices/0x0086/dsa03202.json
@@ -87,6 +87,10 @@
 	"compat": {
 		"commandClasses": {
 			"add": {
+				"Scene Activation": {
+					"isControlled": true,
+					"version": 1
+				},
 				"Wake Up": {
 					// To fix issue #1536
 					"isSupported": true,

--- a/packages/config/config/devices/0x0086/dsa03202.json
+++ b/packages/config/config/devices/0x0086/dsa03202.json
@@ -39,42 +39,42 @@
 	"paramInformation": [
 		{
 			"#": "241",
-			"$import": "templates/aeotec_template.json#base_remote_mode_5",
+			"$import": "~/0x0086/templates/aeotec_template.json#base_remote_mode_5",
 			"label": "Button 1 (Upper Left) Mode"
 		},
 		{
 			"#": "242",
-			"$import": "templates/aeotec_template.json#base_remote_mode_5",
+			"$import": "~/0x0086/templates/aeotec_template.json#base_remote_mode_5",
 			"label": "Button 2 (Upper Right) Mode"
 		},
 		{
 			"#": "243",
-			"$import": "templates/aeotec_template.json#base_remote_mode_5",
+			"$import": "~/0x0086/templates/aeotec_template.json#base_remote_mode_5",
 			"label": "Button 3 (Lower Left) Mode"
 		},
 		{
 			"#": "244",
-			"$import": "templates/aeotec_template.json#base_remote_mode_5",
+			"$import": "~/0x0086/templates/aeotec_template.json#base_remote_mode_5",
 			"label": "Button 4 (Lower Right) Mode"
 		},
 		{
 			"#": "245",
-			"$import": "templates/aeotec_template.json#base_remote_mode_5",
+			"$import": "~/0x0086/templates/aeotec_template.json#base_remote_mode_5",
 			"label": "Button 5 (Include) Mode"
 		},
 		{
 			"#": "246",
-			"$import": "templates/aeotec_template.json#base_remote_mode_5",
+			"$import": "~/0x0086/templates/aeotec_template.json#base_remote_mode_5",
 			"label": "Button 6 (Exclude) Mode"
 		},
 		{
 			"#": "247",
-			"$import": "templates/aeotec_template.json#base_remote_mode_5",
+			"$import": "~/0x0086/templates/aeotec_template.json#base_remote_mode_5",
 			"label": "Button 7 (Association) Mode"
 		},
 		{
 			"#": "248",
-			"$import": "templates/aeotec_template.json#base_remote_mode_5",
+			"$import": "~/0x0086/templates/aeotec_template.json#base_remote_mode_5",
 			"label": "Button 8 (Learn) Mode"
 		},
 		{

--- a/packages/config/config/devices/0x0086/dsa03202.json
+++ b/packages/config/config/devices/0x0086/dsa03202.json
@@ -39,42 +39,42 @@
 	"paramInformation": [
 		{
 			"#": "241",
-			"$import": "~/0x0086/templates/aeotec_template.json#base_remote_mode_5",
+			"$import": "templates/aeotec_template.json#base_remote_mode_5",
 			"label": "Button 1 (Upper Left) Mode"
 		},
 		{
 			"#": "242",
-			"$import": "~/0x0086/templates/aeotec_template.json#base_remote_mode_5",
+			"$import": "templates/aeotec_template.json#base_remote_mode_5",
 			"label": "Button 2 (Upper Right) Mode"
 		},
 		{
 			"#": "243",
-			"$import": "~/0x0086/templates/aeotec_template.json#base_remote_mode_5",
+			"$import": "templates/aeotec_template.json#base_remote_mode_5",
 			"label": "Button 3 (Lower Left) Mode"
 		},
 		{
 			"#": "244",
-			"$import": "~/0x0086/templates/aeotec_template.json#base_remote_mode_5",
+			"$import": "templates/aeotec_template.json#base_remote_mode_5",
 			"label": "Button 4 (Lower Right) Mode"
 		},
 		{
 			"#": "245",
-			"$import": "~/0x0086/templates/aeotec_template.json#base_remote_mode_5",
+			"$import": "templates/aeotec_template.json#base_remote_mode_5",
 			"label": "Button 5 (Include) Mode"
 		},
 		{
 			"#": "246",
-			"$import": "~/0x0086/templates/aeotec_template.json#base_remote_mode_5",
+			"$import": "templates/aeotec_template.json#base_remote_mode_5",
 			"label": "Button 6 (Exclude) Mode"
 		},
 		{
 			"#": "247",
-			"$import": "~/0x0086/templates/aeotec_template.json#base_remote_mode_5",
+			"$import": "templates/aeotec_template.json#base_remote_mode_5",
 			"label": "Button 7 (Association) Mode"
 		},
 		{
 			"#": "248",
-			"$import": "~/0x0086/templates/aeotec_template.json#base_remote_mode_5",
+			"$import": "templates/aeotec_template.json#base_remote_mode_5",
 			"label": "Button 8 (Learn) Mode"
 		},
 		{

--- a/packages/config/config/devices/0x0086/dsa03202.json
+++ b/packages/config/config/devices/0x0086/dsa03202.json
@@ -98,5 +98,8 @@
 				}
 			}
 		}
+	},
+	"metadata": {
+		"wakeup": "Press and hold the Learn Button (or Join Button) for 3 seconds, then let go. This should keep the Minimote awake for 30 seconds."
 	}
 }

--- a/packages/config/config/devices/0x0086/dsa03202.json
+++ b/packages/config/config/devices/0x0086/dsa03202.json
@@ -80,7 +80,8 @@
 		{
 			"#": "250",
 			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Scene Mode (Secondary Controller)"
+			"label": "Scene Mode (Secondary Controller)",
+			"writeOnly": true
 		}
 	],
 	"compat": {


### PR DESCRIPTION
Updates to fix https://github.com/zwave-js/zwave-js-ui/issues/4088:

- Parameter 250 should be write-only as device does not respond to queries (params 241-249 already write-only)
- Force support for Scene Activation CC so static value IDs are persisted

Additionally:

- ~Import manufacturer templates via root directory~
- Add wakeup instructions

