### PR TITLE
fix(config): corrected productType/productId for Z-TRV-V01

### DIFF
--- a/packages/config/config/devices/0x045a/Z-TRV-V01.json
+++ b/packages/config/config/devices/0x045a/Z-TRV-V01.json
@@ -5,8 +5,8 @@
 	"description": "Thermostatic Radiator Valve",
 	"devices": [
 		{
-			"productType": "0x0000",
-			"productId": "0x0400"
+			"productType": "0x0400",
+			"productId": "0x0501"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
Corrected productType/productId as per [https://products.z-wavealliance.org/products/4819](https://products.z-wavealliance.org/products/4819) so it can be properly recognized. 

