### PR TITLE
feat(config): ZEN04 800LR added new param 14 and 15

### DIFF
--- a/packages/config/config/devices/0x027a/zen04.json
+++ b/packages/config/config/devices/0x027a/zen04.json
@@ -142,6 +142,24 @@
 					"value": 0
 				}
 			]
+		},
+		{
+			"#": "14",
+			"$if": "firmwareVersion >= 2.10",
+			"label": "kWh Report Frequency (800 Series Only)",
+			"valueSize": 4,
+			"unit": "minutes",
+			"minValue": 1,
+			"maxValue": 65535,
+			"defaultValue": 60
+			]
+		},
+		{
+			"#": "15",
+			"$if": "firmwareVersion >= 2.10",
+			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
+			"label": "Disable kWh Reports (800 Series Only)",
+			"defaultValue": 0
 		}
 	]
 }


### PR DESCRIPTION
Per manufacturer doc: https://www.support.getzooz.com/kb/article/1114-zen04-smart-plug-advanced-settings/

Parameter 14: kWh Report Frequency (800 Series Only)

The number entered as a value corresponds to the number of minutes. So if 60 is entered by default, the Plug will report energy consumption (kWh) every 60 minutes.

Values: 1 - 65535. Default: 60

Size: 4 byte dec

Parameter 15: Disable kWh Reports (800 Series Only)

Disable or enable kWh reports sent from the plug. No kWh reports from the device connected to the plug will be sent back to the hub if kWh monitoring is disabled. Use this option to minimize the amount of reports you want the receive from the smart plug

Values: 0 – kWh reports enabled (Default); 1 – kWh reports disabled.

Size: 1 byte dec
