### PR TITLE
feat(config): add params for Enbrighten 58436

### DIFF
--- a/packages/config/config/devices/0x0063/58436_59334_zwa4012.json
+++ b/packages/config/config/devices/0x0063/58436_59334_zwa4012.json
@@ -12,6 +12,68 @@
 	"firmwareVersion": {
 		"min": "0.0",
 		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "Single Press",
+			"maxNodes": 5
+		},
+		"3": {
+			"label": "Double Press",
+			"maxNodes": 5
+		}
+	},
+	"paramInformation": [
+		{
+			"#": "3",
+			"$import": "~/templates/master_template.json#led_indicator_four_options"
+		},
+		{
+			"#": "4",
+			"$import": "~/templates/master_template.json#orientation"
+		},
+		{
+			"#": "5",
+			"$import": "templates/jasco_template.json#three_way_setup"
+		},
+		{
+			"#": "19",
+			"$import": "templates/jasco_template.json#alternate_exclusion"
+		},
+		{
+			"#": "34",
+			"$import": "templates/jasco_template.json#led_indicator_color"
+		},
+		{
+			"#": "35",
+			"$import": "templates/jasco_template.json#led_indicator_intensity"
+		},
+		{
+			"#": "36",
+			"$import": "templates/jasco_template.json#led_indicator_intensity",
+			"label": "Guidelight Mode Intensity"
+		},
+		{
+			"#": "39",
+			"$import": "templates/jasco_template.json#control_groups"
+		},
+		{
+			"#": "84",
+			"$import": "templates/jasco_template.json#factory_default"
+		}
+	],
+	"compat": {
+		// Enables Basic Set via Group 3 as an alternative way to detect double taps (instead of Central Scene)
+		"mapBasicSet": "event"
+	},
+	"metadata": {
+		"inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press up and release the toggle",
+		"exclusion": "1. Follow the instructions for your Z-Wave certified controller to remove a device from the Z-Wave network.\n2. Once the controller is ready to remove your device, press up and release the toggle",
+		"reset": "1. Quickly press ON (top) button three times, then immediately press the OFF (bottom) button three times. The LED will flash ON/OFF five times when completed successfully"
 	}
-	// TODO: Add configuration parameters
 }


### PR DESCRIPTION
Add params for the Enbrighten 58436 In-Wall Smart Switch. These are the same as the 58433, so I copied from there. The only real changes I made were to the inclusion/exclusion instructions, as 58436 is a toggle and not a dimmer switch.