### PR TITLE
feat: end device CLI support

### DIFF
--- a/packages/bindings-browser/src/serial/browser.ts
+++ b/packages/bindings-browser/src/serial/browser.ts
@@ -5,6 +5,7 @@ export function createWebSerialPortFactory(
 ): ZWaveSerialBindingFactory {
 	const sink: UnderlyingSink<Uint8Array> = {
 		close() {
+			console.log("sink.close()");
 			port.close();
 		},
 		async write(chunk) {
@@ -17,9 +18,11 @@ export function createWebSerialPortFactory(
 		},
 	};
 
+	let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+
 	const source: UnderlyingDefaultSource<Uint8Array> = {
 		async start(controller) {
-			const reader = port.readable!.getReader();
+			reader = port.readable!.getReader();
 			try {
 				while (true) {
 					const { value, done } = await reader.read();
@@ -31,6 +34,9 @@ export function createWebSerialPortFactory(
 			} finally {
 				reader.releaseLock();
 			}
+		},
+		async cancel() {
+			await reader?.cancel();
 		},
 	};
 

--- a/packages/serial/src/log/Logger.ts
+++ b/packages/serial/src/log/Logger.ts
@@ -129,12 +129,12 @@ export class SerialLogger extends ZWaveLoggerBase<SerialLogContext> {
 	 * Logs a message
 	 * @param message The message to output
 	 */
-	public message(message: string): void {
+	public message(message: string, direction: DataDirection = "none"): void {
 		if (this.isVisible()) {
 			this.logger.log({
 				level: SERIAL_LOGLEVEL,
 				message,
-				direction: getDirectionPrefix("none"),
+				direction: getDirectionPrefix(direction),
 				context: {
 					source: "serial",
 					direction: "none",

--- a/packages/serial/src/parsers/CLIParser.ts
+++ b/packages/serial/src/parsers/CLIParser.ts
@@ -1,0 +1,115 @@
+import { Bytes } from "@zwave-js/shared";
+import { type Transformer } from "node:stream/web";
+import type { SerialLogger } from "../log/Logger.js";
+import { XModemMessageHeaders } from "../message/MessageHeaders.js";
+import {
+	type CLIChunk,
+	CLIChunkType,
+	type ZWaveSerialFrame,
+	ZWaveSerialFrameType,
+} from "./ZWaveSerialFrame.js";
+
+function isFlowControl(byte: number): boolean {
+	return (
+		byte === XModemMessageHeaders.ACK
+		|| byte === XModemMessageHeaders.NAK
+		|| byte === XModemMessageHeaders.CAN
+		|| byte === XModemMessageHeaders.C
+	);
+}
+
+export class CLIParser extends TransformStream<
+	Uint8Array,
+	ZWaveSerialFrame & { type: ZWaveSerialFrameType.CLI }
+> {
+	constructor(private logger?: SerialLogger) {
+		let receiveBuffer = "";
+		let flushTimeout: NodeJS.Timeout | undefined;
+
+		function wrapChunk(
+			chunk: CLIChunk,
+		): ZWaveSerialFrame & { type: ZWaveSerialFrameType.CLI } {
+			return {
+				type: ZWaveSerialFrameType.CLI,
+				data: chunk,
+			};
+		}
+
+		const transformer: Transformer<
+			Uint8Array,
+			ZWaveSerialFrame & { type: ZWaveSerialFrameType.CLI }
+		> = {
+			transform(chunk, controller) {
+				if (flushTimeout) {
+					clearTimeout(flushTimeout);
+					flushTimeout = undefined;
+				}
+
+				receiveBuffer += Bytes.view(chunk).toString("utf8");
+
+				// Emit single flow-control bytes
+				while (receiveBuffer.length > 0) {
+					const charCode = receiveBuffer.charCodeAt(0);
+					if (!isFlowControl(charCode)) break;
+
+					logger?.data("inbound", Uint8Array.from([charCode]));
+					controller.enqueue(wrapChunk({
+						type: CLIChunkType.FlowControl,
+						command: charCode,
+					}));
+					receiveBuffer = receiveBuffer.slice(1);
+				}
+
+				// Essentially, each interaction with the CLI outputs 1 or more lines of text, followed by "> " to indicate
+				// that it's time for the user to input a command.
+				// Logging typically begins with [I] (or possibly other characters inside square brackets)
+				// When logging is involved, the log line may be output after the prompt due to a delay, e.g. "> [I] some log"
+
+				// We emit this as a message, followed by a prompt
+				if (receiveBuffer.includes("> ")) {
+					// There is a prompt input, that means the output is complete
+					const output = receiveBuffer.split("\n").map(
+						(line) => line.startsWith("> ") ? line.slice(2) : line,
+					).join("\n").trim();
+
+					if (output) {
+						logger?.message(output, "inbound");
+						controller.enqueue(wrapChunk({
+							type: CLIChunkType.Message,
+							message: output,
+						}));
+					}
+
+					controller.enqueue(wrapChunk({
+						type: CLIChunkType.Prompt,
+					}));
+
+					receiveBuffer = "";
+				} else if (/^\[[A-Z]\] /.test(receiveBuffer)) {
+					// This is an "unsolicited" log message
+					logger?.message(receiveBuffer, "inbound");
+					controller.enqueue(wrapChunk({
+						type: CLIChunkType.Message,
+						message: receiveBuffer,
+					}));
+					receiveBuffer = "";
+				}
+
+				// If a partial output is kept for a certain amount of time, emit it as a message
+				if (receiveBuffer) {
+					flushTimeout = setTimeout(() => {
+						flushTimeout = undefined;
+						logger?.message(receiveBuffer, "inbound");
+						controller.enqueue(wrapChunk({
+							type: CLIChunkType.Message,
+							message: receiveBuffer,
+						}));
+						receiveBuffer = "";
+					}, 500);
+				}
+			},
+		};
+
+		super(transformer);
+	}
+}

--- a/packages/serial/src/parsers/ZWaveSerialFrame.ts
+++ b/packages/serial/src/parsers/ZWaveSerialFrame.ts
@@ -7,6 +7,7 @@ import {
 export enum ZWaveSerialFrameType {
 	SerialAPI = 0,
 	Bootloader = 1,
+	CLI = 2,
 	Discarded = 0xff,
 }
 
@@ -16,6 +17,9 @@ export type ZWaveSerialFrame = {
 } | {
 	type: ZWaveSerialFrameType.Bootloader;
 	data: BootloaderChunk;
+} | {
+	type: ZWaveSerialFrameType.CLI;
+	data: CLIChunk;
 } | {
 	type: ZWaveSerialFrameType.Discarded;
 	data: Uint8Array;
@@ -53,6 +57,29 @@ export type BootloaderChunk =
 	}
 	| {
 		type: BootloaderChunkType.FlowControl;
+		command:
+			| XModemMessageHeaders.ACK
+			| XModemMessageHeaders.NAK
+			| XModemMessageHeaders.CAN
+			| XModemMessageHeaders.C;
+	};
+
+export enum CLIChunkType {
+	Prompt, // >
+	Message,
+	FlowControl,
+}
+
+export type CLIChunk =
+	| {
+		type: CLIChunkType.Prompt;
+	}
+	| {
+		type: CLIChunkType.Message;
+		message: string;
+	}
+	| {
+		type: CLIChunkType.FlowControl;
 		command:
 			| XModemMessageHeaders.ACK
 			| XModemMessageHeaders.NAK

--- a/packages/serial/src/plumbing/SerialModeSwitch.ts
+++ b/packages/serial/src/plumbing/SerialModeSwitch.ts
@@ -93,7 +93,6 @@ export class SerialModeSwitch extends WritableStream<Uint8Array> {
 						await this.#cliWriter.write(chunk);
 						await this.#cliWriter.ready;
 					} else {
-						console.log("writing to serial api", chunk);
 						await this.#serialAPIWriter.write(chunk);
 						await this.#serialAPIWriter.ready;
 					}

--- a/packages/serial/src/plumbing/SerialModeSwitch.ts
+++ b/packages/serial/src/plumbing/SerialModeSwitch.ts
@@ -51,7 +51,8 @@ export class SerialModeSwitch extends WritableStream<Uint8Array> {
 							this.mode = ZWaveSerialMode.Bootloader;
 						} else if (
 							str.split("\n").some((line) =>
-								line.startsWith("> ")
+								line === ">"
+								|| line.startsWith("> ")
 							)
 						) {
 							// We're sure we're in CLI mode

--- a/packages/serial/src/plumbing/SerialModeSwitch.ts
+++ b/packages/serial/src/plumbing/SerialModeSwitch.ts
@@ -8,7 +8,16 @@ const IS_TEST = process.env.NODE_ENV === "test" || !!getenv("CI");
 // active at the same time
 
 export class SerialModeSwitch extends WritableStream<Uint8Array> {
-	public mode: ZWaveSerialMode | undefined;
+	private possiblyCLI = false;
+
+	#mode: ZWaveSerialMode | undefined;
+	public get mode(): ZWaveSerialMode | undefined {
+		return this.#mode;
+	}
+	public set mode(mode: ZWaveSerialMode | undefined) {
+		this.#mode = mode;
+		this.possiblyCLI = false;
+	}
 
 	// The output sides of the stream
 	#serialAPIWriter: WritableStreamDefaultWriter<Uint8Array>;
@@ -17,36 +26,57 @@ export class SerialModeSwitch extends WritableStream<Uint8Array> {
 	#bootloaderWriter: WritableStreamDefaultWriter<Uint8Array>;
 	public readonly toBootloader: ReadableStream<Uint8Array>;
 
+	#cliWriter: WritableStreamDefaultWriter<Uint8Array>;
+	public readonly toCLI: ReadableStream<Uint8Array>;
+
 	public constructor() {
 		// Set up a writable stream for the input side of the public interface
 		// which also handles dispatching the data to the correct output
 		super({
 			write: async (chunk) => {
 				if (this.mode == undefined) {
-					const buffer = Bytes.view(chunk);
-					// If we haven't figured out the startup mode yet,
-					// inspect the chunk to see if it contains the bootloader preamble
-					const str = buffer.toString("ascii")
-						// like .trim(), but including null bytes
-						.replaceAll(/^[\s\0]+|[\s\0]+$/g, "");
-
-					if (str.startsWith(bootloaderMenuPreamble)) {
-						// We're sure we're in bootloader mode
-						this.mode = ZWaveSerialMode.Bootloader;
-					} else if (
-						buffer.every((b) =>
-							b === 0x00
-							|| b === 0x0a
-							|| b === 0x0d
-							|| (b >= 0x20 && b <= 0x7e)
-						) && buffer.some((b) => b >= 0x20 && b <= 0x7e)
-					) {
-						// Only printable line breaks, null bytes and at least one printable ASCII character
-						// --> We're pretty sure we're in bootloader mode
-						this.mode = ZWaveSerialMode.Bootloader;
+					if (chunk.length === 1 && chunk[0] === 0x15) {
+						// The CLI answers a NAK with a NAK, but this could also be the Serial API being unable to read a frame
+						this.possiblyCLI = true;
 					} else {
-						// We're in Serial API mode
-						this.mode = ZWaveSerialMode.SerialAPI;
+						const buffer = Bytes.view(chunk);
+						// If we haven't figured out the startup mode yet,
+						// inspect the chunk to see if it contains the bootloader preamble
+						const str = buffer.toString("ascii")
+							// like .trim(), but including null bytes
+							.replaceAll(/^[\s\0]+|[\s\0]+$/g, "");
+
+						if (str.startsWith(bootloaderMenuPreamble)) {
+							// We're sure we're in bootloader mode
+							this.mode = ZWaveSerialMode.Bootloader;
+						} else if (
+							str.split("\n").some((line) =>
+								line.startsWith("> ")
+							)
+						) {
+							// We're sure we're in CLI mode
+							this.mode = ZWaveSerialMode.CLI;
+						} else if (
+							buffer.every((b) =>
+								b === 0x00
+								|| b === 0x0a
+								|| b === 0x0d
+								|| (b >= 0x20 && b <= 0x7e)
+							) && buffer.some((b) => b >= 0x20 && b <= 0x7e)
+						) {
+							// Only printable line breaks, null bytes and at least one printable ASCII character
+
+							// If we've previously seen CLI behavior, we're pretty sure we're in CLI mode
+							if (this.possiblyCLI) {
+								this.mode = ZWaveSerialMode.CLI;
+							} else {
+								// We're pretty sure we're in bootloader mode
+								this.mode = ZWaveSerialMode.Bootloader;
+							}
+						} else {
+							// We're in Serial API mode
+							this.mode = ZWaveSerialMode.SerialAPI;
+						}
 					}
 				}
 
@@ -58,7 +88,11 @@ export class SerialModeSwitch extends WritableStream<Uint8Array> {
 					if (this.mode === ZWaveSerialMode.Bootloader) {
 						await this.#bootloaderWriter.write(chunk);
 						await this.#bootloaderWriter.ready;
+					} else if (this.mode === ZWaveSerialMode.CLI) {
+						await this.#cliWriter.write(chunk);
+						await this.#cliWriter.ready;
 					} else {
+						console.log("writing to serial api", chunk);
 						await this.#serialAPIWriter.write(chunk);
 						await this.#serialAPIWriter.ready;
 					}
@@ -82,6 +116,11 @@ export class SerialModeSwitch extends WritableStream<Uint8Array> {
 				} catch {
 					// Don't care
 				}
+				try {
+					await this.#cliWriter.abort(reason);
+				} catch {
+					// Don't care
+				}
 			},
 		});
 
@@ -90,9 +129,12 @@ export class SerialModeSwitch extends WritableStream<Uint8Array> {
 			new TransformStream();
 		const { readable: toBootloader, writable: outputBootloader } =
 			new TransformStream();
+		const { readable: toCLI, writable: outputCLI } = new TransformStream();
 		this.toSerialAPI = toSerialAPI;
 		this.#serialAPIWriter = outputSerialAPI.getWriter();
 		this.toBootloader = toBootloader;
 		this.#bootloaderWriter = outputBootloader.getWriter();
+		this.toCLI = toCLI;
+		this.#cliWriter = outputCLI.getWriter();
 	}
 }

--- a/packages/serial/src/serialport/definitions.ts
+++ b/packages/serial/src/serialport/definitions.ts
@@ -7,6 +7,10 @@ export type ZWaveSerialChunk =
 	| Uint8Array;
 
 export enum ZWaveSerialMode {
+	// Controller or end device Serial API
 	SerialAPI,
+	// OTW Bootloader
 	Bootloader,
+	// Text-based SoC end device CLI
+	CLI,
 }

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -12,12 +12,34 @@
 
 		<div>
 			<button id="connect">Connect</button>
+			<span style="margin-left: 1rem;">Current application: </span>
+			<span id="app">unknown</span>
 		</div>
 
-		<div style="margin-top: 2em;">
-			<input type="file" id="file" accept=".bin,.hex,.gbl" disabled />
+		<hr style="margin: 1em 0" />
+
+		<div>
+			<h2>Flash firmware</h2>
+			<div id="flash_error" style="color: red"></div>
+			<input type="file" id="file" accept=".gbl" disabled />
 			<button id="flash" disabled>Flash</button><br />
-			<progress id="progress" value="0" max="100" style="display: none;"></progress>
+			<progress
+				id="progress"
+				value="0"
+				max="100"
+				style="display: none"
+			></progress>
+		</div>
+
+		<hr style="margin: 1em 0" />
+
+		<div>
+			<h2>Controls</h2>
+			<button id="run_application" disabled>Run Application</button> 
+			<button id="bootloader" disabled>Enter Bootloader</button>
+			<button id="erase_nvm" disabled>Erase NVM</button> 
+			<button id="get_dsk" disabled>Get DSK</button> 
+			<button id="get_region" disabled>Get Region</button> 
 		</div>
 
 		<script type="module" src="build/flasher.js"></script>

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -37,6 +37,7 @@
 			<h2>Controls</h2>
 			<button id="run_application" disabled>Run Application</button> 
 			<button id="bootloader" disabled>Enter Bootloader</button>
+			<button id="bootloader_hw" disabled>HW Reset to Bootloader</button>
 			<button id="erase_nvm" disabled>Erase NVM</button> 
 			<button id="get_dsk" disabled>Get DSK</button> 
 			<button id="get_region" disabled>Get Region</button> 

--- a/packages/web/src/flasher.ts
+++ b/packages/web/src/flasher.ts
@@ -116,10 +116,7 @@ async function eraseNVM() {
 		return;
 	}
 
-	if (!driver.isInBootloader()) {
-		console.error("Driver is not in bootloader mode");
-		return;
-	}
+	await driver.enterBootloader();
 
 	const option = driver.bootloader.findOption((o) => o === "erase nvm");
 	if (option === undefined) {

--- a/packages/web/src/flasher.ts
+++ b/packages/web/src/flasher.ts
@@ -39,8 +39,10 @@ async function init() {
 			filters: [
 				// CP2102
 				{ usbVendorId: 0x10c4, usbProductId: 0xea60 },
-				// Nabu Casa ESP bridge
+				// Nabu Casa ESP bridge, first EVT revision
 				{ usbVendorId: 0x1234, usbProductId: 0x5678 },
+				// Nabu Casa ESP bridge, uses Espressif VID/PID
+				{ usbVendorId: 0x303a, usbProductId: 0x4001 },
 			],
 		});
 		await port.open({ baudRate: 115200 });

--- a/packages/zwave-js/src/Driver.ts
+++ b/packages/zwave-js/src/Driver.ts
@@ -18,6 +18,7 @@ export {
 	isMessageWithCC,
 } from "@zwave-js/serial/serialapi";
 export { Driver, libName, libVersion } from "./lib/driver/Driver.js";
+export * from "./lib/driver/DriverMode.js";
 export type {
 	EditableZWaveOptions,
 	PartialZWaveOptions,

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -7681,7 +7681,6 @@ ${handlers.length} left`,
 	}
 
 	/**
-	 * @internal
 	 * Leaves the bootloader and destroys the driver instance if desired
 	 */
 	public async leaveBootloader(destroy: boolean = false): Promise<void> {

--- a/packages/zwave-js/src/lib/driver/DriverMock.ts
+++ b/packages/zwave-js/src/lib/driver/DriverMock.ts
@@ -104,7 +104,7 @@ export interface CreateAndStartTestingDriverOptions {
 	/**
 	 * Set this to true to skip checking if the controller is in bootloader mode (default: true)
 	 */
-	skipBootloaderCheck?: boolean;
+	skipFirmwareIdentification?: boolean;
 
 	/**
 	 * Whether configuration files should be loaded (default: true)
@@ -123,7 +123,7 @@ export async function createAndStartTestingDriver(
 	const {
 		beforeStartup,
 		skipControllerIdentification = false,
-		skipBootloaderCheck = true,
+		skipFirmwareIdentification = true,
 		skipNodeInterview = false,
 		loadConfiguration = true,
 		fs = (await import("@zwave-js/core/bindings/fs/node")).fs,
@@ -148,9 +148,9 @@ export async function createAndStartTestingDriver(
 		internalOptions.testingHooks ??= {};
 		internalOptions.testingHooks.loadConfiguration = false;
 	}
-	if (skipBootloaderCheck) {
+	if (skipFirmwareIdentification) {
 		internalOptions.testingHooks ??= {};
-		internalOptions.testingHooks.skipBootloaderCheck = true;
+		internalOptions.testingHooks.skipFirmwareIdentification = true;
 	}
 
 	// TODO: Make sure we delete this from time to time

--- a/packages/zwave-js/src/lib/driver/DriverMock.ts
+++ b/packages/zwave-js/src/lib/driver/DriverMock.ts
@@ -102,7 +102,7 @@ export interface CreateAndStartTestingDriverOptions {
 	skipNodeInterview?: boolean;
 
 	/**
-	 * Set this to true to skip checking if the controller is in bootloader mode (default: true)
+	 * Set this to true to skip checking if the controller is in bootloader, serial API, or CLI mode (default: true)
 	 */
 	skipFirmwareIdentification?: boolean;
 

--- a/packages/zwave-js/src/lib/driver/DriverMode.ts
+++ b/packages/zwave-js/src/lib/driver/DriverMode.ts
@@ -1,0 +1,7 @@
+/** Determines which kind of Z-Wave application the driver is communicating with */
+export enum DriverMode {
+	Unknown,
+	SerialAPI,
+	Bootloader,
+	CLI,
+}

--- a/packages/zwave-js/src/lib/driver/EndDeviceCLI.ts
+++ b/packages/zwave-js/src/lib/driver/EndDeviceCLI.ts
@@ -1,0 +1,67 @@
+import { ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared/safe";
+
+/** Encapsulates information about the currently active bootloader */
+export class EndDeviceCLI {
+	public constructor(
+		writeSerial: (data: Uint8Array) => Promise<void>,
+		expectMessage: (timeoutMs?: number) => Promise<string | undefined>,
+	) {
+		this.writeSerial = writeSerial;
+		this.expectMessage = expectMessage;
+		this._commands = new Map();
+	}
+
+	public readonly writeSerial: (data: Uint8Array) => Promise<void>;
+	public readonly expectMessage: () => Promise<string | undefined>;
+
+	private _commands: Map<string, string>;
+	public get commands(): ReadonlyMap<string, string> {
+		return this._commands;
+	}
+
+	public async executeCommand(command: string): Promise<string | undefined> {
+		if (!this.commands.has(command)) {
+			throw new ZWaveError(
+				`Unknown CLI command ${command}`,
+				ZWaveErrorCodes.Driver_NotSupported,
+			);
+		}
+		const response = this.expectMessage();
+		await this.writeSerial(Bytes.from(command.trim() + "\r\n", "ascii"));
+		let ret = await response;
+		if (!ret) return;
+
+		// Successful commands echo the command itself, followed by a line break
+		if (ret.startsWith(command.trim() + "\r\n")) {
+			ret = ret.slice(command.length + 2);
+		}
+		ret = ret.trim();
+		// Most commands prefix their response with the log level, usually "[I] "
+		ret = ret.replace(/^\[[A-Z]\] /, "");
+		return ret;
+	}
+
+	public async detectCommands(): Promise<void> {
+		const response = this.expectMessage();
+		await this.writeSerial(Bytes.from("help\r\n", "ascii"));
+		const commandList = await response;
+		if (!commandList) {
+			throw new ZWaveError(
+				"Failed to detect CLI commands",
+				ZWaveErrorCodes.Driver_NotSupported,
+			);
+		}
+		const commands = commandList.trim()
+			.split("\n")
+			.map((line) => line.trim())
+			.map((line) =>
+				line.split(/\s+/, 2).map((part) => part.trim()) as [
+					string,
+					string,
+				]
+			)
+			.filter((parts) => parts.every((part) => !!part));
+		this._commands = new Map(commands);
+	}
+}

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -416,9 +416,10 @@ export interface ZWaveOptions {
 		skipNodeInterview?: boolean;
 
 		/**
-		 * Set this to true to skip checking if the controller is in bootloader mode
+		 * Set this to true to skip checking if the Z-Wave is in bootloader mode,
+		 * running a Serial API, or an end device CLI.
 		 */
-		skipBootloaderCheck?: boolean;
+		skipFirmwareIdentification?: boolean;
 
 		/**
 		 * Set this to false to skip loading the configuration files. Default: `true`..

--- a/packages/zwave-js/src/lib/test/driver/bootloaderDetection.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/bootloaderDetection.test.ts
@@ -1,6 +1,7 @@
 import { Bytes } from "@zwave-js/shared";
 import { type MockControllerBehavior } from "@zwave-js/testing";
 import { wait } from "alcalzone-shared/async";
+import { DriverMode } from "../../driver/DriverMode.js";
 import { integrationTest } from "../integrationTestSuite.js";
 
 integrationTest(
@@ -41,7 +42,7 @@ BL >\0`,
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			t.expect(driver.isInBootloader()).toBe(true);
+			t.expect(driver.mode).toBe(DriverMode.Bootloader);
 		},
 	},
 );

--- a/packages/zwave-js/src/lib/test/driver/handleUnsolicited.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/handleUnsolicited.test.ts
@@ -16,7 +16,7 @@ integrationTest(
 
 		additionalDriverOptions: {
 			testingHooks: {
-				skipBootloaderCheck: true,
+				skipFirmwareIdentification: true,
 				skipNodeInterview: true,
 			},
 		},
@@ -53,7 +53,7 @@ integrationTest(
 
 		additionalDriverOptions: {
 			testingHooks: {
-				skipBootloaderCheck: true,
+				skipFirmwareIdentification: true,
 				skipNodeInterview: true,
 			},
 		},
@@ -104,7 +104,7 @@ integrationTest(
 
 		additionalDriverOptions: {
 			testingHooks: {
-				skipBootloaderCheck: true,
+				skipFirmwareIdentification: true,
 				skipNodeInterview: true,
 			},
 		},

--- a/packages/zwave-js/src/lib/test/integrationTestSuiteShared.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuiteShared.ts
@@ -28,7 +28,7 @@ export function prepareDriver(
 ): Promise<CreateAndStartDriverWithMockPortResult> {
 	// Skipping the bootloader check speeds up tests a lot
 	additionalOptions.testingHooks ??= {};
-	additionalOptions.testingHooks.skipBootloaderCheck =
+	additionalOptions.testingHooks.skipFirmwareIdentification =
 		additionalOptions.bootloaderMode === "recover"
 		|| additionalOptions.bootloaderMode == undefined;
 


### PR DESCRIPTION
This PR adds support for communicating with the text-based CLI exposed by some SoC end device firmwares. To do so, the new `driver.cli` property can be used. Since the Z-Wave module we're communicating with can now be something else than the bootloader or a controller firmware, a breaking change is required:

- The `driver.isInBootloader()` method has been removed. Use the new `driver.mode` property instead, which allows distinguishing between controller firmware, end device CLI firmware and the bootloader.