### PR TITLE
refactor: move OTW firmware updates to `Driver` class

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -1215,36 +1215,7 @@ Returns whether an OTA firmware update is in progress for any node.
 
 ### Updating the firmware of the controller (OTW)
 
-```ts
-firmwareUpdateOTW(data: Buffer): Promise<ControllerFirmwareUpdateResult>
-```
-
-> [!WARNING] We don't take any responsibility if devices upgraded using Z-Wave JS don't work after an update. Always double-check that the correct update is about to be installed.
-
-Performs an over-the-wire (OTW) firmware update for the controller using the given firmware image. To do so, the controller gets put in bootloader mode where a new firmware image can be uploaded.
-
-> [!WARNING] A failure during this process may leave your controller in recovery mode, rendering it unusable until a correct firmware image is uploaded.
-
-To keep track of the update progress, use the [`"firmware update progress"` and `"firmware update finished"` events](api/controller#quotfirmware-update-progressquot) of the controller.
-
-The return value indicates whether the update was successful and includes an error code that can be used to determine the reason for a failure. This is the same information that is emitted using the `"firmware update finished"` event:
-
-<!-- #import ControllerFirmwareUpdateResult from "zwave-js" -->
-
-```ts
-interface ControllerFirmwareUpdateResult {
-	success: boolean;
-	status: ControllerFirmwareUpdateStatus;
-}
-```
-
-### `isFirmwareUpdateInProgress`
-
-```ts
-isFirmwareUpdateInProgress(): boolean;
-```
-
-Return whether a firmware update is in progress for the controller.
+See [`driver.firmwareUpdateOTW`](api/driver#updating-the-firmware-of-the-z-wave-module-otw).
 
 ### Joining and leaving a network
 
@@ -1784,62 +1755,6 @@ interface ControllerStatistics {
 			current: number;
 		};
 	};
-}
-```
-
-### `"firmware update progress"`
-
-```ts
-(progress: ControllerFirmwareUpdateProgress) => void
-```
-
-Firmware update progress has been made. The callback arguments gives information about the progress of the update:
-
-<!-- #import ControllerFirmwareUpdateProgress from "zwave-js" -->
-
-```ts
-interface ControllerFirmwareUpdateProgress {
-	/** How many fragments of the firmware update have been transmitted. Together with `totalFragments` this can be used to display progress. */
-	sentFragments: number;
-	/** How many fragments the firmware update consists of. */
-	totalFragments: number;
-	/** The total progress of the firmware update in %, rounded to two digits. */
-	progress: number;
-}
-```
-
-### `"firmware update finished"`
-
-```ts
-(result: ControllerFirmwareUpdateResult) => void;
-```
-
-The firmware update process is finished. The `result` argument looks like this indicates whether the update was successful:
-
-<!-- #import ControllerFirmwareUpdateResult from "zwave-js" -->
-
-```ts
-interface ControllerFirmwareUpdateResult {
-	success: boolean;
-	status: ControllerFirmwareUpdateStatus;
-}
-```
-
-Its `status` property contains more details on potential errors.
-
-<!-- #import ControllerFirmwareUpdateStatus from "zwave-js" -->
-
-```ts
-enum ControllerFirmwareUpdateStatus {
-	Error_Timeout = 0,
-	/** The maximum number of retry attempts for a firmware fragments were reached */
-	Error_RetryLimitReached,
-	/** The update was aborted by the bootloader */
-	Error_Aborted,
-	/** This controller does not support firmware updates */
-	Error_NotSupported,
-
-	OK = 0xff,
 }
 ```
 

--- a/docs/getting-started/migrating/v15.md
+++ b/docs/getting-started/migrating/v15.md
@@ -25,6 +25,21 @@ As of this release, Z-Wave JS supports communicating with the text-based CLI exp
 - The `driver.isInBootloader()` method has been removed. Use the new `driver.mode` property instead, which allows distinguishing between controller firmware, end device CLI firmware and the bootloader.
 - The `allowBootloaderOnly` driver option has been removed. To achieve the same behavior as before, set the new `bootloaderMode` option to `allow`.
 
+## Moved OTW firmware update functionality from `Controller` to `Driver` class
+
+To properly support OTW firmware updates in the different firmware types, the OTW firmware update functionality has been moved from the `Controller` class to the `Driver` class.
+
+- The `Controller.firmwareUpdateOTW` method has been removed. Use the new `Driver.firmwareUpdateOTW` method instead. The function signature is unchanged.
+- The `Controller.isFirmwareUpdateInProgress` method has been removed. Use the new `Driver.isOTWFirmwareUpdateInProgress` method instead. The function signature is unchanged.
+- The following types have been renamed:
+  - `ControllerFirmwareUpdateProgress` to `OTWFirmwareUpdateProgress`
+  - `ControllerFirmwareUpdateStatus` to `OTWFirmwareUpdateStatus`
+  - `ControllerFirmwareUpdateResult` to `OTWFirmwareUpdateResult`
+
+  ...and are no longer exported from the `zwave-js/Controller` or `zwave-js/Controller/safe` entry points. Import them from `zwave-js` or `zwave-js/Driver` instead.
+- The `"firmware update progress"` and `"firmware update finished"` events have been moved from the `Controller` class to the `Driver` class. Their signature is unchanged, except for the renamed types, see above.
+- In bootloader mode, the `driver.controller` property is now `undefined`, since it is no longer necessary to access the OTW firmware update functionality.
+
 ## Deprecated `isDocker` method has been removed
 
 Use the [`is-docker` package](https://github.com/sindresorhus/is-docker) instead or copy its code into your project.

--- a/packages/flash/src/cli.ts
+++ b/packages/flash/src/cli.ts
@@ -5,8 +5,8 @@ import path from "pathe";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import {
-	ControllerFirmwareUpdateStatus,
 	Driver,
+	OTWFirmwareUpdateStatus,
 	extractFirmware,
 	getEnumMemberName,
 	guessFirmwareFileFormat,
@@ -62,7 +62,7 @@ function clearLastLine() {
 async function flash() {
 	console.log("Flashing firmware...");
 	let lastProgress = 0;
-	driver.controller.on("firmware update progress", (p) => {
+	driver.on("firmware update progress", (p) => {
 		const rounded = Math.round(p.progress);
 		if (rounded > lastProgress) {
 			lastProgress = rounded;
@@ -72,7 +72,7 @@ async function flash() {
 			);
 		}
 	});
-	driver.controller.on("firmware update finished", async (r) => {
+	driver.on("firmware update finished", async (r) => {
 		if (r.success) {
 			console.log("Firmware update successful");
 			await wait(1000);
@@ -81,7 +81,7 @@ async function flash() {
 			console.log(
 				`Firmware update failed: ${
 					getEnumMemberName(
-						ControllerFirmwareUpdateStatus,
+						OTWFirmwareUpdateStatus,
 						r.status,
 					)
 				}`,
@@ -92,7 +92,7 @@ async function flash() {
 	});
 
 	try {
-		await driver.controller.firmwareUpdateOTW(firmware);
+		await driver.firmwareUpdateOTW(firmware);
 	} catch (e: any) {
 		console.error("Failed to update firmware:", e.message);
 		process.exit(1);

--- a/packages/web/src/flasher.ts
+++ b/packages/web/src/flasher.ts
@@ -13,9 +13,9 @@ import {
 	createDeferredPromise,
 } from "alcalzone-shared/deferred-promise";
 import {
-	ControllerFirmwareUpdateStatus,
 	Driver,
 	DriverMode,
+	OTWFirmwareUpdateStatus,
 	getEnumMemberName,
 } from "zwave-js";
 
@@ -136,20 +136,15 @@ function failed() {
 }
 
 function ready() {
-	try {
-		driver.controller.on("firmware update progress", (progress) => {
-			flashProgress.value = progress.progress;
-		});
-		driver.controller.on("firmware update finished", (_result) => {
-			flashProgress.style.display = "none";
-		});
-		fileInput.disabled = false;
-		recreateWhenInBootloader = false;
-	} catch {
-		recreateWhenInBootloader = true;
-		flashError.innerText =
-			"Firmware update currently not available for devices in CLI mode. Enter bootloader first!";
-	}
+	driver.on("firmware update progress", (progress) => {
+		flashProgress.value = progress.progress;
+	});
+	driver.on("firmware update finished", (_result) => {
+		flashProgress.style.display = "none";
+	});
+	fileInput.disabled = false;
+	recreateWhenInBootloader = false;
+
 	btnEraseNVM.disabled = false;
 	btnBootloaderHw.disabled = false; // This always works
 
@@ -203,7 +198,7 @@ async function flash() {
 	try {
 		flashProgress.style.display = "initial";
 
-		const result = await driver.controller.firmwareUpdateOTW(
+		const result = await driver.firmwareUpdateOTW(
 			new Uint8Array(firmwareFileContent),
 		);
 		if (result.success) {
@@ -218,7 +213,7 @@ async function flash() {
 		alert(
 			`Failed to flash firmware: ${
 				getEnumMemberName(
-					ControllerFirmwareUpdateStatus,
+					OTWFirmwareUpdateStatus,
 					result.status,
 				)
 			}`,

--- a/packages/zwave-js/src/Controller.ts
+++ b/packages/zwave-js/src/Controller.ts
@@ -18,10 +18,7 @@ export type { ControllerEvents } from "./lib/controller/Controller.js";
 export type { ControllerStatistics } from "./lib/controller/ControllerStatistics.js";
 export { ZWaveFeature } from "./lib/controller/Features.js";
 export * from "./lib/controller/Inclusion.js";
-export { ControllerFirmwareUpdateStatus } from "./lib/controller/_Types.js";
 export type {
-	ControllerFirmwareUpdateProgress,
-	ControllerFirmwareUpdateResult,
 	FirmwareUpdateDeviceID,
 	FirmwareUpdateFileInfo,
 	FirmwareUpdateInfo,

--- a/packages/zwave-js/src/Controller_safe.ts
+++ b/packages/zwave-js/src/Controller_safe.ts
@@ -9,10 +9,7 @@ export type { ZWaveLibraryTypes } from "@zwave-js/core/safe";
 export type { ControllerStatistics } from "./lib/controller/ControllerStatistics.js";
 export { ZWaveFeature } from "./lib/controller/Features.js";
 export * from "./lib/controller/Inclusion.js";
-export { ControllerFirmwareUpdateStatus } from "./lib/controller/_Types.js";
 export type {
-	ControllerFirmwareUpdateProgress,
-	ControllerFirmwareUpdateResult,
 	FirmwareUpdateDeviceID,
 	GetFirmwareUpdatesOptions,
 	RebuildRoutesOptions,

--- a/packages/zwave-js/src/Driver.ts
+++ b/packages/zwave-js/src/Driver.ts
@@ -24,4 +24,9 @@ export type {
 	PartialZWaveOptions,
 	ZWaveOptions,
 } from "./lib/driver/ZWaveOptions.js";
+export { OTWFirmwareUpdateStatus } from "./lib/driver/_Types.js";
+export type {
+	OTWFirmwareUpdateProgress,
+	OTWFirmwareUpdateResult,
+} from "./lib/driver/_Types.js";
 export type { DriverLogContext } from "./lib/log/Driver.js";

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -113,12 +113,9 @@ import {
 	migrateNVM,
 } from "@zwave-js/nvmedit";
 import {
-	type BootloaderChunk,
-	BootloaderChunkType,
 	FunctionType,
 	type Message,
 	type SuccessIndicator,
-	XModemMessageHeaders,
 } from "@zwave-js/serial";
 import {
 	type ApplicationUpdateRequest,
@@ -374,10 +371,8 @@ import {
 	type DeferredPromise,
 	createDeferredPromise,
 } from "alcalzone-shared/deferred-promise";
-import { roundTo } from "alcalzone-shared/math";
 import { isObject } from "alcalzone-shared/typeguards";
 import type { Driver } from "../driver/Driver.js";
-import { DriverMode } from "../driver/DriverMode.js";
 import { cacheKeyUtils, cacheKeys } from "../driver/NetworkCache.js";
 import type { StatisticsEventCallbacks } from "../driver/Statistics.js";
 import { type TaskBuilder, TaskPriority } from "../driver/Task.js";
@@ -430,9 +425,6 @@ import {
 } from "./ProxyInclusionMachine.js";
 import { protocolVersionToSDKVersion } from "./ZWaveSDKVersions.js";
 import {
-	type ControllerFirmwareUpdateProgress,
-	type ControllerFirmwareUpdateResult,
-	ControllerFirmwareUpdateStatus,
 	type FirmwareUpdateDeviceID,
 	type FirmwareUpdateInfo,
 	type GetFirmwareUpdatesOptions,
@@ -467,12 +459,6 @@ interface ControllerEventCallbacks
 	"rebuild routes done": (
 		result: ReadonlyMap<number, RebuildRoutesStatus>,
 	) => void;
-	"firmware update progress": (
-		progress: ControllerFirmwareUpdateProgress,
-	) => void;
-	"firmware update finished": (
-		result: ControllerFirmwareUpdateResult,
-	) => void;
 	identify: (node: ZWaveNode) => void;
 	"status changed": (status: ControllerStatus) => void;
 }
@@ -487,11 +473,12 @@ export class ZWaveController
 	extends TypedEventTarget<ControllerEventCallbacks>
 {
 	/** @internal */
-	public constructor(
-		private readonly driver: Driver,
-		bootloaderOnly: boolean = false,
-	) {
+	public constructor(driver: Driver) {
 		super();
+
+		debugger;
+
+		this.driver = driver;
 
 		this._nodes = createThrowingMap((nodeId) => {
 			throw new ZWaveError(
@@ -500,9 +487,6 @@ export class ZWaveController
 				nodeId,
 			);
 		});
-
-		// Limit interaction with the controller in bootloader-only mode
-		if (bootloaderOnly) return;
 
 		// register message handlers
 		driver.registerRequestHandler(
@@ -522,6 +506,8 @@ export class ZWaveController
 			this.handleLearnModeCallback.bind(this),
 		);
 	}
+
+	private readonly driver: Driver;
 
 	private _type: MaybeNotKnown<ZWaveLibraryTypes>;
 	public get type(): MaybeNotKnown<ZWaveLibraryTypes> {
@@ -7277,8 +7263,9 @@ export class ZWaveController
 	 * **Z-Wave 500 series only**
 	 *
 	 * Initialize the Firmware Update functionality and determine if the firmware can be updated.
+	 * @internal
 	 */
-	private async firmwareUpdateNVMInit(): Promise<boolean> {
+	public async firmwareUpdateNVMInit(): Promise<boolean> {
 		const ret = await this.driver.sendMessage<
 			FirmwareUpdateNVM_InitResponse
 		>(
@@ -7291,8 +7278,9 @@ export class ZWaveController
 	 * **Z-Wave 500 series only**
 	 *
 	 * Set the NEWIMAGE marker in the NVM (to the given value), which is used to signal that a new firmware image is present
+	 * @internal
 	 */
-	private async firmwareUpdateNVMSetNewImage(
+	public async firmwareUpdateNVMSetNewImage(
 		value: boolean = true,
 	): Promise<void> {
 		await this.driver.sendMessage<FirmwareUpdateNVM_SetNewImageResponse>(
@@ -7342,8 +7330,9 @@ export class ZWaveController
 	 * **Z-Wave 500 series only**
 	 *
 	 * Writes the given data into the firmware update region of the NVM.
+	 * @internal
 	 */
-	private async firmwareUpdateNVMWrite(
+	public async firmwareUpdateNVMWrite(
 		offset: number,
 		buffer: Uint8Array,
 	): Promise<void> {
@@ -7359,8 +7348,9 @@ export class ZWaveController
 	 * **Z-Wave 500 series only**
 	 *
 	 * Checks if the firmware present in the NVM is valid
+	 * @internal
 	 */
-	private async firmwareUpdateNVMIsValidCRC16(): Promise<boolean> {
+	public async firmwareUpdateNVMIsValidCRC16(): Promise<boolean> {
 		const ret = await this.driver.sendMessage<
 			FirmwareUpdateNVM_IsValidCRC16Response
 		>(
@@ -8387,8 +8377,9 @@ export class ZWaveController
 				ZWaveErrorCodes.FirmwareUpdateCC_NetworkBusy,
 			);
 		}
+
 		// Don't allow updating firmware when the controller is currently updating its own firmware
-		if (this.isFirmwareUpdateInProgress()) {
+		if (this.driver.isOTWFirmwareUpdateInProgress()) {
 			const message =
 				`Failed to start the update: The controller is currently being updated!`;
 			this.driver.controllerLog.print(message, "error");
@@ -8483,375 +8474,6 @@ export class ZWaveController
 		}
 
 		return node.updateFirmware(firmwares, options);
-	}
-
-	private _firmwareUpdateInProgress: boolean = false;
-
-	/**
-	 * Returns whether a firmware update is in progress for the controller.
-	 */
-	public isFirmwareUpdateInProgress(): boolean {
-		return this._firmwareUpdateInProgress;
-	}
-
-	/**
-	 * Updates the firmware of the controller using the given firmware file.
-	 *
-	 * The return value indicates whether the update was successful.
-	 * **WARNING:** After a successful update, the Z-Wave driver will destroy itself so it can be restarted.
-	 *
-	 * **WARNING:** A failure during this process may put your controller in recovery mode, rendering it unusable until a correct firmware image is uploaded. Use at your own risk!
-	 */
-	public async firmwareUpdateOTW(
-		data: Uint8Array,
-	): Promise<ControllerFirmwareUpdateResult> {
-		// Don't let two firmware updates happen in parallel
-		if (this.isAnyOTAFirmwareUpdateInProgress()) {
-			const message =
-				`Failed to start the update: A firmware update is already in progress on this network!`;
-			this.driver.controllerLog.print(message, "error");
-			throw new ZWaveError(message, ZWaveErrorCodes.OTW_Update_Busy);
-		}
-		// Don't allow updating firmware when the controller is currently updating its own firmware
-		if (this.isFirmwareUpdateInProgress()) {
-			const message =
-				`Failed to start the update: The controller is currently being updated!`;
-			this.driver.controllerLog.print(message, "error");
-			throw new ZWaveError(message, ZWaveErrorCodes.OTW_Update_Busy);
-		}
-
-		if (
-			this.driver.mode === DriverMode.Bootloader
-			|| this.sdkVersionGte("7.0")
-		) {
-			// If the controller is stuck in bootloader mode, always use the 700 series update method
-			return this.firmwareUpdateOTW700(data);
-		} else if (
-			this.sdkVersionGte("6.50.0")
-			&& this.supportedFunctionTypes?.includes(
-				FunctionType.FirmwareUpdateNVM,
-			)
-		) {
-			// This is 500 series
-			const wasUpdated = await this.firmwareUpdateOTW500(data);
-			if (wasUpdated.success) {
-				// After updating the firmware on 500 series sticks, we MUST soft-reset them
-				await this.driver.softResetAndRestart(
-					"Activating new firmware and restarting driver...",
-					"Controller firmware updates require a driver restart!",
-				);
-			}
-			return wasUpdated;
-		} else {
-			throw new ZWaveError(
-				`Firmware updates are not supported on this controller`,
-				ZWaveErrorCodes.Controller_NotSupported,
-			);
-		}
-	}
-
-	private async firmwareUpdateOTW500(
-		data: Uint8Array,
-	): Promise<ControllerFirmwareUpdateResult> {
-		this._firmwareUpdateInProgress = true;
-		let turnedRadioOff = false;
-		try {
-			this.driver.controllerLog.print("Beginning firmware update");
-
-			const canUpdate = await this.firmwareUpdateNVMInit();
-			if (!canUpdate) {
-				this.driver.controllerLog.print(
-					"OTW update failed: This controller does not support firmware updates",
-					"error",
-				);
-
-				const result: ControllerFirmwareUpdateResult = {
-					success: false,
-					status: ControllerFirmwareUpdateStatus.Error_NotSupported,
-				};
-				this.emit("firmware update finished", result);
-				return result;
-			}
-
-			// Avoid interruption by incoming messages
-			await this.toggleRF(false);
-			turnedRadioOff = true;
-
-			// Upload the firmware data
-			const BLOCK_SIZE = 64;
-			const numFragments = Math.ceil(data.length / BLOCK_SIZE);
-			for (let fragment = 0; fragment < numFragments; fragment++) {
-				const fragmentData = data.subarray(
-					fragment * BLOCK_SIZE,
-					(fragment + 1) * BLOCK_SIZE,
-				);
-				await this.firmwareUpdateNVMWrite(
-					fragment * BLOCK_SIZE,
-					fragmentData,
-				);
-
-				// This progress is technically too low, but we can keep 100% for after CRC checking this way
-				const progress: ControllerFirmwareUpdateProgress = {
-					sentFragments: fragment,
-					totalFragments: numFragments,
-					progress: roundTo((fragment / numFragments) * 100, 2),
-				};
-				this.emit("firmware update progress", progress);
-			}
-
-			// Check if a valid image was written
-			const isValidCRC = await this.firmwareUpdateNVMIsValidCRC16();
-			if (!isValidCRC) {
-				this.driver.controllerLog.print(
-					"OTW update failed: The firmware image is invalid",
-					"error",
-				);
-
-				const result: ControllerFirmwareUpdateResult = {
-					success: false,
-					status: ControllerFirmwareUpdateStatus.Error_Aborted,
-				};
-				this.emit("firmware update finished", result);
-				return result;
-			}
-
-			this.emit("firmware update progress", {
-				sentFragments: numFragments,
-				totalFragments: numFragments,
-				progress: 100,
-			});
-
-			// Enable the image
-			await this.firmwareUpdateNVMSetNewImage();
-
-			this.driver.controllerLog.print("Firmware update succeeded");
-
-			const result: ControllerFirmwareUpdateResult = {
-				success: true,
-				status: ControllerFirmwareUpdateStatus.OK,
-			};
-			this.emit("firmware update finished", result);
-			return result;
-		} finally {
-			this._firmwareUpdateInProgress = false;
-			if (turnedRadioOff) await this.toggleRF(true);
-		}
-	}
-
-	private async firmwareUpdateOTW700(
-		data: Uint8Array,
-	): Promise<ControllerFirmwareUpdateResult> {
-		this._firmwareUpdateInProgress = true;
-		let destroy = false;
-
-		try {
-			await this.driver.enterBootloader();
-
-			// Start the update process
-			this.driver.controllerLog.print("Beginning firmware upload");
-			await this.driver.bootloader.beginUpload();
-
-			// Wait for the bootloader to accept fragments
-			try {
-				await this.driver.waitForBootloaderChunk(
-					(c) =>
-						c.type === BootloaderChunkType.Message
-						&& c.message === "begin upload",
-					5000,
-				);
-				await this.driver.waitForBootloaderChunk(
-					(c) =>
-						c.type === BootloaderChunkType.FlowControl
-						&& c.command === XModemMessageHeaders.C,
-					1000,
-				);
-			} catch {
-				this.driver.controllerLog.print(
-					"OTW update failed: Expected response not received from the bootloader",
-					"error",
-				);
-				const result: ControllerFirmwareUpdateResult = {
-					success: false,
-					status: ControllerFirmwareUpdateStatus.Error_Timeout,
-				};
-				this.emit("firmware update finished", result);
-				return result;
-			}
-
-			const BLOCK_SIZE = 128;
-			if (data.length % BLOCK_SIZE !== 0) {
-				// Pad the data to a multiple of BLOCK_SIZE
-				data = Bytes.concat([
-					data,
-					new Bytes(BLOCK_SIZE - (data.length % BLOCK_SIZE)).fill(
-						0xff,
-					),
-				]);
-			}
-			const numFragments = Math.ceil(data.length / BLOCK_SIZE);
-
-			let aborted = false;
-
-			transfer: for (
-				let fragment = 1;
-				fragment <= numFragments;
-				fragment++
-			) {
-				const fragmentData = data.subarray(
-					(fragment - 1) * BLOCK_SIZE,
-					fragment * BLOCK_SIZE,
-				);
-
-				retry: for (let retry = 0; retry < 3; retry++) {
-					await this.driver.bootloader.uploadFragment(
-						fragment,
-						fragmentData,
-					);
-					let result: BootloaderChunk & {
-						type: BootloaderChunkType.FlowControl;
-					};
-					try {
-						result = await this.driver.waitForBootloaderChunk(
-							(c) => c.type === BootloaderChunkType.FlowControl,
-							1000,
-						);
-					} catch {
-						this.driver.controllerLog.print(
-							"OTW update failed: The bootloader did not acknowledge the start of transfer.",
-							"error",
-						);
-
-						const result: ControllerFirmwareUpdateResult = {
-							success: false,
-							status:
-								ControllerFirmwareUpdateStatus.Error_Timeout,
-						};
-						this.emit("firmware update finished", result);
-						return result;
-					}
-
-					switch (result.command) {
-						case XModemMessageHeaders.ACK: {
-							// The fragment was accepted
-							const progress: ControllerFirmwareUpdateProgress = {
-								sentFragments: fragment,
-								totalFragments: numFragments,
-								progress: roundTo(
-									(fragment / numFragments) * 100,
-									2,
-								),
-							};
-							this.emit("firmware update progress", progress);
-
-							// we've transmitted at least one fragment, so we need to destroy the driver afterwards
-							destroy = true;
-
-							continue transfer;
-						}
-						case XModemMessageHeaders.NAK:
-							// The fragment was rejected, try again
-							continue retry;
-						case XModemMessageHeaders.CAN:
-							// The bootloader aborted the update. We'll receive the reason afterwards as a message
-							aborted = true;
-							break transfer;
-					}
-				}
-
-				this.driver.controllerLog.print(
-					"OTW update failed: Maximum retry attempts reached",
-					"error",
-				);
-				const result: ControllerFirmwareUpdateResult = {
-					success: false,
-					status:
-						ControllerFirmwareUpdateStatus.Error_RetryLimitReached,
-				};
-				this.emit("firmware update finished", result);
-				return result;
-			}
-
-			if (aborted) {
-				// wait for the reason to craft a good error message
-				const error = await this.driver
-					.waitForBootloaderChunk<
-						BootloaderChunk & { type: BootloaderChunkType.Message }
-					>(
-						(c) =>
-							c.type === BootloaderChunkType.Message
-							&& c.message.includes("error 0x"),
-						1000,
-					)
-					.catch(() => undefined);
-
-				// wait for the menu screen so it doesn't show up in logs
-				await this.driver
-					.waitForBootloaderChunk(
-						(c) => c.type === BootloaderChunkType.Menu,
-						1000,
-					)
-					.catch(() => undefined);
-
-				let message = `OTW update was aborted by the bootloader.`;
-				if (error) {
-					message += ` ${error.message}`;
-					// TODO: parse error code
-				}
-				this.driver.controllerLog.print(message, "error");
-
-				const result: ControllerFirmwareUpdateResult = {
-					success: false,
-					status: ControllerFirmwareUpdateStatus.Error_Aborted,
-				};
-				this.emit("firmware update finished", result);
-				return result;
-			} else {
-				// We're done, send EOT and wait for the menu screen
-				await this.driver.bootloader.finishUpload();
-				try {
-					// The bootloader sends the confirmation and the menu screen very quickly.
-					// Waiting for them separately can cause us to miss the menu screen and
-					// incorrectly assume the update timed out.
-
-					await Promise.all([
-						this.driver.waitForBootloaderChunk(
-							(c) =>
-								c.type === BootloaderChunkType.Message
-								&& c.message.includes("upload complete"),
-							1000,
-						),
-
-						this.driver.waitForBootloaderChunk(
-							(c) => c.type === BootloaderChunkType.Menu,
-							1000,
-						),
-					]);
-				} catch {
-					this.driver.controllerLog.print(
-						"OTW update failed: The bootloader did not acknowledge the end of transfer.",
-						"error",
-					);
-					const result: ControllerFirmwareUpdateResult = {
-						success: false,
-						status: ControllerFirmwareUpdateStatus.Error_Timeout,
-					};
-					this.emit("firmware update finished", result);
-					return result;
-				}
-			}
-
-			this.driver.controllerLog.print("Firmware update succeeded");
-
-			const result: ControllerFirmwareUpdateResult = {
-				success: true,
-				status: ControllerFirmwareUpdateStatus.OK,
-			};
-			this.emit("firmware update finished", result);
-			return result;
-		} finally {
-			await this.driver.leaveBootloader(destroy);
-			this._firmwareUpdateInProgress = false;
-		}
 	}
 
 	private _currentLearnMode: LearnModeIntent | undefined;

--- a/packages/zwave-js/src/lib/controller/_Types.ts
+++ b/packages/zwave-js/src/lib/controller/_Types.ts
@@ -63,30 +63,3 @@ export interface GetFirmwareUpdatesOptions {
 	 */
 	rfRegion?: RFRegion;
 }
-
-export interface ControllerFirmwareUpdateProgress {
-	/** How many fragments of the firmware update have been transmitted. Together with `totalFragments` this can be used to display progress. */
-	sentFragments: number;
-	/** How many fragments the firmware update consists of. */
-	totalFragments: number;
-	/** The total progress of the firmware update in %, rounded to two digits. */
-	progress: number;
-}
-
-export enum ControllerFirmwareUpdateStatus {
-	// An expected response was not received from the controller in time
-	Error_Timeout = 0,
-	/** The maximum number of retry attempts for a firmware fragments were reached */
-	Error_RetryLimitReached,
-	/** The update was aborted by the bootloader */
-	Error_Aborted,
-	/** This controller does not support firmware updates */
-	Error_NotSupported,
-
-	OK = 0xff,
-}
-
-export interface ControllerFirmwareUpdateResult {
-	success: boolean;
-	status: ControllerFirmwareUpdateStatus;
-}

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -208,6 +208,7 @@ import {
 	type DeferredPromise,
 	createDeferredPromise,
 } from "alcalzone-shared/deferred-promise";
+import { roundTo } from "alcalzone-shared/math";
 import { isArray, isObject } from "alcalzone-shared/typeguards";
 import path from "pathe";
 import { PACKAGE_NAME, PACKAGE_VERSION } from "../_version.js";
@@ -269,6 +270,11 @@ import type {
 	PartialZWaveOptions,
 	ZWaveOptions,
 } from "./ZWaveOptions.js";
+import {
+	type OTWFirmwareUpdateProgress,
+	type OTWFirmwareUpdateResult,
+	OTWFirmwareUpdateStatus,
+} from "./_Types.js";
 import { discoverRemoteSerialPorts } from "./mDNSDiscovery.js";
 
 export const libVersion: string = PACKAGE_VERSION;
@@ -656,6 +662,12 @@ export interface DriverEventCallbacks extends PrefixedNodeEvents {
 	"bootloader ready": () => void;
 	"cli ready": () => void;
 	"all nodes ready": () => void;
+	"firmware update progress": (
+		progress: OTWFirmwareUpdateProgress,
+	) => void;
+	"firmware update finished": (
+		result: OTWFirmwareUpdateResult,
+	) => void;
 	error: (err: Error) => void;
 }
 
@@ -1480,11 +1492,6 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 							"Controller is in bootloader mode. Staying in bootloader as requested.",
 							"warn",
 						);
-						// Needed for the OTW feature to be available
-						this._controller = new ZWaveController(
-							this,
-							true,
-						);
 						this.emit("bootloader ready");
 						return;
 					}
@@ -1505,11 +1512,6 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 							this.driverLog.print(
 								"Failed to recover from bootloader. Staying in bootloader mode as requested.",
 								"warn",
-							);
-							// Needed for the OTW feature to be available
-							this._controller = new ZWaveController(
-								this,
-								true,
 							);
 							this.emit("bootloader ready");
 						} else {
@@ -7601,6 +7603,382 @@ ${handlers.length} left`,
 		return true;
 	}
 
+	// region OTW Firmware Updates
+
+	private _otwFirmwareUpdateInProgress: boolean = false;
+
+	/**
+	 * Returns whether a firmware update is in progress for the Z-Wave module.
+	 */
+	public isOTWFirmwareUpdateInProgress(): boolean {
+		return this._otwFirmwareUpdateInProgress;
+	}
+
+	/**
+	 * Updates the firmware of the controller using the given firmware file.
+	 *
+	 * The return value indicates whether the update was successful.
+	 * **WARNING:** After a successful update, the Z-Wave driver will destroy itself so it can be restarted.
+	 *
+	 * **WARNING:** A failure during this process may put your controller in recovery mode, rendering it unusable until a correct firmware image is uploaded. Use at your own risk!
+	 */
+	public async firmwareUpdateOTW(
+		data: Uint8Array,
+	): Promise<OTWFirmwareUpdateResult> {
+		// Don't interrupt ongoing OTA firmware updates
+		if (this._controller?.isAnyOTAFirmwareUpdateInProgress()) {
+			const message =
+				`Failed to start the update: A firmware update is already in progress on this network!`;
+			this.controllerLog.print(message, "error");
+			throw new ZWaveError(message, ZWaveErrorCodes.OTW_Update_Busy);
+		}
+
+		// Don't allow updating firmware when the controller is currently updating its own firmware
+		if (this.isOTWFirmwareUpdateInProgress()) {
+			const message =
+				`Failed to start the update: The controller is currently being updated!`;
+			this.controllerLog.print(message, "error");
+			throw new ZWaveError(message, ZWaveErrorCodes.OTW_Update_Busy);
+		}
+
+		// When in bootloader mode, we can use the 700 series update method
+		if (this.mode === DriverMode.Bootloader) {
+			return this.firmwareUpdateOTW700(data);
+		} else if (this.mode === DriverMode.SerialAPI) {
+			if (this.controller.sdkVersionGte("7.0")) {
+				// This is at least a 700 series controller, so we can use the 700 series update method
+				return this.firmwareUpdateOTW700(data);
+			} else if (
+				this.controller.sdkVersionGte("6.50.0")
+				&& this.controller.supportedFunctionTypes
+					?.includes(FunctionType.FirmwareUpdateNVM)
+			) {
+				// This is a 500 series controller, use the 500 series update method
+				const wasUpdated = await this.firmwareUpdateOTW500(data);
+				if (wasUpdated.success) {
+					// After updating the firmware on 500 series sticks, we MUST soft-reset them
+					await this.softResetAndRestart(
+						"Activating new firmware and restarting driver...",
+						"Controller firmware updates require a driver restart!",
+					);
+				}
+				return wasUpdated;
+			}
+		} else if (this.mode === DriverMode.CLI) {
+			// If the CLI has an option to enter bootloader, we can use the 700 series update method,
+			// since it tries to execute that.
+			return this.firmwareUpdateOTW700(data);
+		}
+
+		throw new ZWaveError(
+			`Firmware updates are not supported on this Z-Wave module`,
+			ZWaveErrorCodes.Controller_NotSupported,
+		);
+	}
+
+	private async firmwareUpdateOTW500(
+		data: Uint8Array,
+	): Promise<OTWFirmwareUpdateResult> {
+		this._otwFirmwareUpdateInProgress = true;
+		let turnedRadioOff = false;
+		try {
+			this.controllerLog.print("Beginning firmware update");
+
+			const canUpdate = await this.controller.firmwareUpdateNVMInit();
+			if (!canUpdate) {
+				this.controllerLog.print(
+					"OTW update failed: This controller does not support firmware updates",
+					"error",
+				);
+
+				const result: OTWFirmwareUpdateResult = {
+					success: false,
+					status: OTWFirmwareUpdateStatus.Error_NotSupported,
+				};
+				this.emit("firmware update finished", result);
+				return result;
+			}
+
+			// Avoid interruption by incoming messages
+			await this.controller.toggleRF(false);
+			turnedRadioOff = true;
+
+			// Upload the firmware data
+			const BLOCK_SIZE = 64;
+			const numFragments = Math.ceil(data.length / BLOCK_SIZE);
+			for (let fragment = 0; fragment < numFragments; fragment++) {
+				const fragmentData = data.subarray(
+					fragment * BLOCK_SIZE,
+					(fragment + 1) * BLOCK_SIZE,
+				);
+				await this.controller.firmwareUpdateNVMWrite(
+					fragment * BLOCK_SIZE,
+					fragmentData,
+				);
+
+				// This progress is technically too low, but we can keep 100% for after CRC checking this way
+				const progress: OTWFirmwareUpdateProgress = {
+					sentFragments: fragment,
+					totalFragments: numFragments,
+					progress: roundTo((fragment / numFragments) * 100, 2),
+				};
+				this.emit("firmware update progress", progress);
+			}
+
+			// Check if a valid image was written
+			const isValidCRC = await this.controller
+				.firmwareUpdateNVMIsValidCRC16();
+			if (!isValidCRC) {
+				this.controllerLog.print(
+					"OTW update failed: The firmware image is invalid",
+					"error",
+				);
+
+				const result: OTWFirmwareUpdateResult = {
+					success: false,
+					status: OTWFirmwareUpdateStatus.Error_Aborted,
+				};
+				this.emit("firmware update finished", result);
+				return result;
+			}
+
+			this.emit("firmware update progress", {
+				sentFragments: numFragments,
+				totalFragments: numFragments,
+				progress: 100,
+			});
+
+			// Enable the image
+			await this.controller.firmwareUpdateNVMSetNewImage();
+
+			this.controllerLog.print("Firmware update succeeded");
+
+			const result: OTWFirmwareUpdateResult = {
+				success: true,
+				status: OTWFirmwareUpdateStatus.OK,
+			};
+			this.emit("firmware update finished", result);
+			return result;
+		} finally {
+			this._otwFirmwareUpdateInProgress = false;
+			if (turnedRadioOff) await this.controller.toggleRF(true);
+		}
+	}
+
+	private async firmwareUpdateOTW700(
+		data: Uint8Array,
+	): Promise<OTWFirmwareUpdateResult> {
+		this._otwFirmwareUpdateInProgress = true;
+		let destroy = false;
+
+		try {
+			await this.enterBootloader();
+
+			// Start the update process
+			this.controllerLog.print("Beginning firmware upload");
+			await this.bootloader.beginUpload();
+
+			// Wait for the bootloader to accept fragments
+			try {
+				await this.waitForBootloaderChunk(
+					(c) =>
+						c.type === BootloaderChunkType.Message
+						&& c.message === "begin upload",
+					5000,
+				);
+				await this.waitForBootloaderChunk(
+					(c) =>
+						c.type === BootloaderChunkType.FlowControl
+						&& c.command === XModemMessageHeaders.C,
+					1000,
+				);
+			} catch {
+				this.controllerLog.print(
+					"OTW update failed: Expected response not received from the bootloader",
+					"error",
+				);
+				const result: OTWFirmwareUpdateResult = {
+					success: false,
+					status: OTWFirmwareUpdateStatus.Error_Timeout,
+				};
+				this.emit("firmware update finished", result);
+				return result;
+			}
+
+			const BLOCK_SIZE = 128;
+			if (data.length % BLOCK_SIZE !== 0) {
+				// Pad the data to a multiple of BLOCK_SIZE
+				data = Bytes.concat([
+					data,
+					new Bytes(BLOCK_SIZE - (data.length % BLOCK_SIZE)).fill(
+						0xff,
+					),
+				]);
+			}
+			const numFragments = Math.ceil(data.length / BLOCK_SIZE);
+
+			let aborted = false;
+
+			transfer: for (
+				let fragment = 1;
+				fragment <= numFragments;
+				fragment++
+			) {
+				const fragmentData = data.subarray(
+					(fragment - 1) * BLOCK_SIZE,
+					fragment * BLOCK_SIZE,
+				);
+
+				retry: for (let retry = 0; retry < 3; retry++) {
+					await this.bootloader.uploadFragment(
+						fragment,
+						fragmentData,
+					);
+					let result: BootloaderChunk & {
+						type: BootloaderChunkType.FlowControl;
+					};
+					try {
+						result = await this.waitForBootloaderChunk(
+							(c) => c.type === BootloaderChunkType.FlowControl,
+							1000,
+						);
+					} catch {
+						this.controllerLog.print(
+							"OTW update failed: The bootloader did not acknowledge the start of transfer.",
+							"error",
+						);
+
+						const result: OTWFirmwareUpdateResult = {
+							success: false,
+							status: OTWFirmwareUpdateStatus.Error_Timeout,
+						};
+						this.emit("firmware update finished", result);
+						return result;
+					}
+
+					switch (result.command) {
+						case XModemMessageHeaders.ACK: {
+							// The fragment was accepted
+							const progress: OTWFirmwareUpdateProgress = {
+								sentFragments: fragment,
+								totalFragments: numFragments,
+								progress: roundTo(
+									(fragment / numFragments) * 100,
+									2,
+								),
+							};
+							this.emit("firmware update progress", progress);
+
+							// we've transmitted at least one fragment, so we need to destroy the driver afterwards
+							destroy = true;
+
+							continue transfer;
+						}
+						case XModemMessageHeaders.NAK:
+							// The fragment was rejected, try again
+							continue retry;
+						case XModemMessageHeaders.CAN:
+							// The bootloader aborted the update. We'll receive the reason afterwards as a message
+							aborted = true;
+							break transfer;
+					}
+				}
+
+				this.controllerLog.print(
+					"OTW update failed: Maximum retry attempts reached",
+					"error",
+				);
+				const result: OTWFirmwareUpdateResult = {
+					success: false,
+					status: OTWFirmwareUpdateStatus.Error_RetryLimitReached,
+				};
+				this.emit("firmware update finished", result);
+				return result;
+			}
+
+			if (aborted) {
+				// wait for the reason to craft a good error message
+				const error = await this.waitForBootloaderChunk<
+					BootloaderChunk & { type: BootloaderChunkType.Message }
+				>(
+					(c) =>
+						c.type === BootloaderChunkType.Message
+						&& c.message.includes("error 0x"),
+					1000,
+				)
+					.catch(() => undefined);
+
+				// wait for the menu screen so it doesn't show up in logs
+				await this.waitForBootloaderChunk(
+					(c) => c.type === BootloaderChunkType.Menu,
+					1000,
+				)
+					.catch(() => undefined);
+
+				let message = `OTW update was aborted by the bootloader.`;
+				if (error) {
+					message += ` ${error.message}`;
+					// TODO: parse error code
+				}
+				this.controllerLog.print(message, "error");
+
+				const result: OTWFirmwareUpdateResult = {
+					success: false,
+					status: OTWFirmwareUpdateStatus.Error_Aborted,
+				};
+				this.emit("firmware update finished", result);
+				return result;
+			} else {
+				// We're done, send EOT and wait for the menu screen
+				await this.bootloader.finishUpload();
+				try {
+					// The bootloader sends the confirmation and the menu screen very quickly.
+					// Waiting for them separately can cause us to miss the menu screen and
+					// incorrectly assume the update timed out.
+
+					await Promise.all([
+						this.waitForBootloaderChunk(
+							(c) =>
+								c.type === BootloaderChunkType.Message
+								&& c.message.includes("upload complete"),
+							1000,
+						),
+
+						this.waitForBootloaderChunk(
+							(c) => c.type === BootloaderChunkType.Menu,
+							1000,
+						),
+					]);
+				} catch {
+					this.controllerLog.print(
+						"OTW update failed: The bootloader did not acknowledge the end of transfer.",
+						"error",
+					);
+					const result: OTWFirmwareUpdateResult = {
+						success: false,
+						status: OTWFirmwareUpdateStatus.Error_Timeout,
+					};
+					this.emit("firmware update finished", result);
+					return result;
+				}
+			}
+
+			this.controllerLog.print("Firmware update succeeded");
+
+			const result: OTWFirmwareUpdateResult = {
+				success: true,
+				status: OTWFirmwareUpdateStatus.OK,
+			};
+			this.emit("firmware update finished", result);
+			return result;
+		} finally {
+			await this.leaveBootloader(destroy);
+			this._otwFirmwareUpdateInProgress = false;
+		}
+	}
+
+	// region Bootloader
+
 	private _enteringBootloader: boolean = false;
 	private _enterBootloaderPromise: DeferredPromise<void> | undefined;
 
@@ -7750,6 +8128,8 @@ ${handlers.length} left`,
 
 		if (!this._bootloader && data.type === BootloaderChunkType.Menu) {
 			// We just entered the bootloader
+			this._controller?.destroy();
+			this._controller = undefined;
 			this._cli = undefined;
 
 			this.controllerLog.print(

--- a/packages/zwave-js/src/lib/driver/_Types.ts
+++ b/packages/zwave-js/src/lib/driver/_Types.ts
@@ -1,0 +1,26 @@
+export interface OTWFirmwareUpdateProgress {
+	/** How many fragments of the firmware update have been transmitted. Together with `totalFragments` this can be used to display progress. */
+	sentFragments: number;
+	/** How many fragments the firmware update consists of. */
+	totalFragments: number;
+	/** The total progress of the firmware update in %, rounded to two digits. */
+	progress: number;
+}
+
+export enum OTWFirmwareUpdateStatus {
+	// An expected response was not received from the controller in time
+	Error_Timeout = 0,
+	/** The maximum number of retry attempts for a firmware fragments were reached */
+	Error_RetryLimitReached,
+	/** The update was aborted by the bootloader */
+	Error_Aborted,
+	/** This controller does not support firmware updates */
+	Error_NotSupported,
+
+	OK = 0xff,
+}
+
+export interface OTWFirmwareUpdateResult {
+	success: boolean;
+	status: OTWFirmwareUpdateStatus;
+}

--- a/packages/zwave-js/src/lib/node/mixins/70_FirmwareUpdate.ts
+++ b/packages/zwave-js/src/lib/node/mixins/70_FirmwareUpdate.ts
@@ -137,7 +137,7 @@ export abstract class FirmwareUpdateMixin extends SchedulePollMixin
 		}
 
 		// Don't start the process twice
-		if (this.driver.controller.isFirmwareUpdateInProgress()) {
+		if (this.driver.isOTWFirmwareUpdateInProgress()) {
 			throw new ZWaveError(
 				`Failed to start the update: An OTW upgrade of the controller is in progress!`,
 				ZWaveErrorCodes.FirmwareUpdateCC_Busy,


### PR DESCRIPTION
This PR clears up the inconsistency that OTW firmware updates were attached to the `Controller` instance, but we have to work around that in bootloader mode. All OTW functionality has been moved to the `Driver` instance instead, which is always available.