### PR TITLE
fix: treat EU_LR as EU for FW update service calls

### DIFF
--- a/packages/zwave-js/src/lib/controller/FirmwareUpdateService.ts
+++ b/packages/zwave-js/src/lib/controller/FirmwareUpdateService.ts
@@ -140,6 +140,7 @@ function rfRegionToUpdateServiceRegion(
 	switch (rfRegion) {
 		case RFRegion["Default (EU)"]:
 		case RFRegion.Europe:
+		case RFRegion["Europe (Long Range)"]:
 			return "europe";
 		case RFRegion.USA:
 		case RFRegion["USA (Long Range)"]:


### PR DESCRIPTION
fixes an issue where no firmware updates would show as available when the region is set to EU_LR.