### PR TITLE
feat: expose manufacturer name as a node property with fallback

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -1163,6 +1163,15 @@ readonly productType: number
 
 These three properties together identify the actual device this node is.
 
+### `manufacturer`, `label`
+
+```ts
+readonly manufacturer: string | undefined
+readonly label: string | undefined
+```
+
+The human-readable manufacturer/brand name and device label of this node.
+
 ### `deviceConfig`
 
 ```ts

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -474,6 +474,20 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 		return this._deviceConfig;
 	}
 
+	/**
+	 * Returns the manufacturer/brand name defined in the device configuration,
+	 * or looks it up from the manufacturer database if no config is available
+	 */
+	public get manufacturer(): string | undefined {
+		if (this._deviceConfig) return this._deviceConfig.manufacturer;
+		if (this.manufacturerId != undefined) {
+			return this.driver.lookupManufacturer(this.manufacturerId);
+		}
+	}
+
+	/**
+	 * Returns the device label defined in the device configuration.
+	 */
 	public get label(): string | undefined {
 		return this._deviceConfig?.label;
 	}

--- a/packages/zwave-js/src/lib/test/node/manufacturerNameWithoutConfigFile.test.ts
+++ b/packages/zwave-js/src/lib/test/node/manufacturerNameWithoutConfigFile.test.ts
@@ -1,0 +1,21 @@
+import { CommandClasses } from "@zwave-js/core";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest(
+	"Nodes without a config file but known manufacturer ID have a manufacturer name",
+	{
+		nodeCapabilities: {
+			manufacturerId: 0x0000,
+			productType: 0xdead,
+			productId: 0xbeef,
+
+			commandClasses: [
+				CommandClasses["Manufacturer Specific"],
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			t.expect(node.manufacturer).toBe("Silicon Labs");
+		},
+	},
+);


### PR DESCRIPTION
fixes: #7548