### PR TITLE
feat(config): add alarmType 132 mapping for Yale YRD4x0 locks

### DIFF
--- a/packages/config/config/devices/0x0129/templates/yale_template.json
+++ b/packages/config/config/devices/0x0129/templates/yale_template.json
@@ -578,6 +578,18 @@
 			}
 		}
 	},
+	"alarm_map_outside_schedule": {
+		"from": {
+			"alarmType": 132
+		},
+		"to": {
+			"notificationType": 6, // Access Control
+			"notificationEvent": 254, // Valid user but outside of schedule
+			"eventParameters": {
+				"userId": "alarmLevel"
+			}
+		}
+	},
 	"assure_zw3_metadata": {
 		"inclusion": "1. Enter the 4-8 digit master PIN code followed by the gear key\n2. Press the 7 key followed by the gear key\n3. Press the 1 key followed by the gear key\n4. Enter the first 5 digits of the DSK when prompted",
 		"exclusion": "1. Enter the 4-8 digit master PIN code, followed by the gear key.\n2. Press the 7 key followed by the gear key.\n3. Press the 3 key followed by the gear key.",

--- a/packages/config/config/devices/0x0129/yrd4x0-f-zw3.json
+++ b/packages/config/config/devices/0x0129/yrd4x0-f-zw3.json
@@ -104,7 +104,7 @@
 	"compat": {
 		"alarmMapping": [
 			{
-				import": "templates/yale_template.json#alarm_map_outside_schedule"
+				"$import": "templates/yale_template.json#alarm_map_outside_schedule"
 			},
 		],
 	},

--- a/packages/config/config/devices/0x0129/yrd4x0-f-zw3.json
+++ b/packages/config/config/devices/0x0129/yrd4x0-f-zw3.json
@@ -101,6 +101,13 @@
 			"$import": "templates/yale_template.json#expiring_pin_lifetime"
 		}
 	],
+	"compat": {
+		"alarmMapping": [
+			{
+				import": "templates/yale_template.json#alarm_map_outside_schedule"
+			},
+		],
+	},
 	"metadata": {
 		"$import": "templates/yale_template.json#assure2_zw3_metadata",
 		"reset": "Please use this procedure only when the network primary controller is missing or otherwise inoperable.\n1. Remove the inside lever with the lever removal tool.\n2. Remove battery cover using hex wrench provided with lock.\n3. Remove four (4) AA batteries.\n4. Remove the 10-32 x 3/4\" pan head screw from the center of the battery housing into the barrel nut of the outside assembly.\n5. Remove inside escutcheon. Cables may stay connected.\n6. Reinstall batteries \n7. On the back of the PC board, push and hold the Reset Button with the lever removal tool for 3 seconds.\n8. While continuing the press the reset button, temporarily remove one AA battery.\n9. Reinstall the battery\n10. Release reset button and wait 15 seconds. Speaker will announce \"Welcome to Yale\"\n11. Reassemble escutcheon",

--- a/packages/config/config/devices/0x0129/yrd4x0-f-zw3.json
+++ b/packages/config/config/devices/0x0129/yrd4x0-f-zw3.json
@@ -105,8 +105,8 @@
 		"alarmMapping": [
 			{
 				"$import": "templates/yale_template.json#alarm_map_outside_schedule"
-			},
-		],
+			}
+		]
 	},
 	"metadata": {
 		"$import": "templates/yale_template.json#assure2_zw3_metadata",


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

Adds the correct notification events for Yale Locks when alarmType 132 fires.