### PR TITLE
docs: remove extraneous word in v15 migration guide

### DIFF
--- a/docs/getting-started/migrating/v15.md
+++ b/docs/getting-started/migrating/v15.md
@@ -1,6 +1,6 @@
 # Migrating to v15 <!-- {docsify-ignore-all} -->
 
-Several Node.js APIs now have standardized counterparts that are available to other JavaScript runtimes, especially web browsers. In this release, we built on the work done in the `v14` release, and focused on moving away from non-portable modules and APIs. Those were either replaced them with standardized ones, or alternatively pluggable, platform-specific bindings were introduced where necessary.
+Several Node.js APIs now have standardized counterparts that are available to other JavaScript runtimes, especially web browsers. In this release, we built on the work done in the `v14` release, and focused on moving away from non-portable modules and APIs. Those were either replaced with standardized ones, or alternatively pluggable, platform-specific bindings were introduced where necessary.
 
 As a result of this effort, Z-Wave JS is now able to run in Chromium-based browsers (with a bit of bundler magic), and possibly on other runtimes like Deno or Bun in the future.
 


### PR DESCRIPTION
The sentence could use polish, but this the simplest fix.