### PR TITLE
feat: add API to query supported `notification` events of a node

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -65,6 +65,43 @@ getDefinedValueIDs(): TranslatedValueID[]
 
 When building a user interface for a Z-Wave application, you might need to know all possible values in advance. This method returns an array of all ValueIDs that are available for this node.
 
+### `getSupportedNotificationEvents`
+
+```ts
+getSupportedNotificationEvents(): ZWaveNotificationCapability[]
+```
+
+Likewise, this method allows querying information about all events that might be emitted using the `"notification"` event. It returns a list of notification capabilities that are either
+
+<!-- #import ZWaveNotificationCapability_NotificationCC from "zwave-js" -->
+
+```ts
+interface ZWaveNotificationCapability_NotificationCC {
+	commandClass: CommandClasses.Notification;
+	endpoint: number;
+	/** A dictionary of supported event types and information */
+	supportedNotificationTypes: Record<number, {
+		/** The human-readable label for the notification type */
+		label: string;
+		/** A dictionary of supported events for this notification type and their human-readable labels */
+		supportedEvents: Record<number, string>;
+	}>;
+}
+```
+
+or
+
+<!-- #import ZWaveNotificationCapability_EntryControlCC from "zwave-js" -->
+
+```ts
+interface ZWaveNotificationCapability_EntryControlCC {
+	commandClass: (typeof CommandClasses)["Entry Control"];
+	endpoint: number;
+	/** A dictionary of supported event types and their human-readable labels */
+	supportedEventTypes: Record<EntryControlEventTypes, string>;
+}
+```
+
 ### `interview`
 
 ```ts

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -259,6 +259,7 @@ import {
 	type RouteHealthCheckResult,
 	type RouteHealthCheckSummary,
 	type ZWaveNodeEventCallbacks,
+	type ZWaveNotificationCapability,
 } from "./_Types.js";
 import { InterviewStage, NodeStatus } from "./_Types.js";
 import { ZWaveNodeMixins } from "./mixins/index.js";
@@ -737,6 +738,11 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 			property: valueId.property,
 			propertyKey: valueId.propertyKey,
 		});
+	}
+
+	/** Returns a list of all `"notification"` event arguments that are known to be supported by this node */
+	public getSupportedNotificationEvents(): ZWaveNotificationCapability[] {
+		return nodeUtils.getSupportedNotificationEvents(this.driver, this);
 	}
 
 	private _interviewAttempts: number = 0;

--- a/packages/zwave-js/src/lib/node/_Types.ts
+++ b/packages/zwave-js/src/lib/node/_Types.ts
@@ -143,6 +143,18 @@ export type ZWaveNotificationCallbackParams_NotificationCC = [
 	args: ZWaveNotificationCallbackArgs_NotificationCC,
 ];
 
+export interface ZWaveNotificationCapability_NotificationCC {
+	commandClass: CommandClasses.Notification;
+	endpoint: number;
+	/** A dictionary of supported event types and information */
+	supportedNotificationTypes: Record<number, {
+		/** The human-readable label for the notification type */
+		label: string;
+		/** A dictionary of supported events for this notification type and their human-readable labels */
+		supportedEvents: Record<number, string>;
+	}>;
+}
+
 /**
  * This is emitted when an unsolicited powerlevel test report is received
  */
@@ -180,6 +192,13 @@ export type ZWaveNotificationCallbackParams_EntryControlCC = [
 	args: ZWaveNotificationCallbackArgs_EntryControlCC,
 ];
 
+export interface ZWaveNotificationCapability_EntryControlCC {
+	commandClass: (typeof CommandClasses)["Entry Control"];
+	endpoint: number;
+	/** A dictionary of supported event types and their human-readable labels */
+	supportedEventTypes: Record<EntryControlEventTypes, string>;
+}
+
 export type ZWaveNotificationCallback = (
 	...args:
 		| ZWaveNotificationCallbackParams_NotificationCC
@@ -187,6 +206,10 @@ export type ZWaveNotificationCallback = (
 		| ZWaveNotificationCallbackParams_PowerlevelCC
 		| ZWaveNotificationCallbackParams_MultilevelSwitchCC
 ) => void;
+
+export type ZWaveNotificationCapability =
+	| ZWaveNotificationCapability_NotificationCC
+	| ZWaveNotificationCapability_EntryControlCC;
 
 export interface ZWaveNodeValueEventCallbacks {
 	"value added": ZWaveNodeValueAddedCallback;


### PR DESCRIPTION
similar to `getDefinedValueIDs`, the new `getSupportedNotificationEvents` method allows discovering which specific events will be emitted through the `notification` event.