### PR TITLE
fix(config): add ZVIDAR WM25C

### DIFF
--- a/packages/config/config/devices/0x045a/WM25C.json
+++ b/packages/config/config/devices/0x045a/WM25C.json
@@ -5,7 +5,7 @@
 	"description": "Smart Roller Curtain Motor",
 	"devices": [
 		{
-			"productType": "0x004",
+			"productType": "0x0004",
 			"productId": "0x0507"
 		}
 	],

--- a/packages/config/config/devices/0x045a/WM25C.json
+++ b/packages/config/config/devices/0x045a/WM25C.json
@@ -1,0 +1,196 @@
+{
+	"manufacturer": "ZVIDAR",
+	"manufacturerId": "0x045a",
+	"label": "WM25C",
+	"description": "Smart Roller Curtain Motor",
+	"devices": [
+		{
+			"productType": "0x004",
+			"productId": "0x0507"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"label": "Hand Button Action",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Close",
+					"value": 0
+				},
+				{
+					"label": "Open",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "2",
+			"label": "Motor Direction",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Forward",
+					"value": 1
+				},
+				// TODO: The difference between these two is unknown.
+				// If anyone knows, please tell us.
+				{
+					"label": "Opposite",
+					"value": 2
+				},
+				{
+					"label": "Reverse",
+					"value": 3
+				}
+			]
+		},
+		{
+			"#": "3",
+			"label": "Manually Set Open Boundary",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Cancel",
+					"value": 0
+				},
+				{
+					"label": "Start",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "4",
+			"label": "Manually Set Closed Boundary",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Cancel",
+					"value": 0
+				},
+				{
+					"label": "Start",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "5",
+			"label": "Control Motor",
+			"valueSize": 1,
+			"defaultValue": 3,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Open (Up)",
+					"value": 1
+				},
+				{
+					"label": "Close (Down)",
+					"value": 2
+				},
+				{
+					"label": "Stop",
+					"value": 3
+				}
+			]
+		},
+		{
+			"#": "6",
+			"label": "Calibrate Limit Position",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Upper limit",
+					"value": 1
+				},
+				{
+					"label": "Lower limit",
+					"value": 2
+				},
+				{
+					"label": "Third limit",
+					"value": 3
+				}
+			]
+		},
+		{
+			"#": "7",
+			"label": "Delete Limit Position",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "All limits",
+					"value": 0
+				},
+				{
+					"label": "Only upper limit",
+					"value": 1
+				},
+				{
+					"label": "Only lower limit",
+					"value": 2
+				},
+				{
+					"label": "Only third limit",
+					"value": 3
+				}
+			]
+		},
+		{
+			"#": "8",
+			"label": "Low Battery Level Alarm Threshold",
+			"valueSize": 1,
+			"unit": "%",
+			"minValue": 0,
+			"maxValue": 50,
+			"defaultValue": 10
+		},
+		{
+			"#": "9",
+			"label": "Battery Report Interval",
+			"valueSize": 4,
+			"unit": "seconds",
+			"minValue": 0,
+			"maxValue": 2678400,
+			"defaultValue": 3600
+		},
+		{
+			"#": "10",
+			"label": "Battery Change Report Threshold",
+			"valueSize": 1,
+			"unit": "%",
+			"minValue": 0,
+			"maxValue": 50,
+			"defaultValue": 5
+		}
+	],
+	"compat": {
+		"commandClasses": {
+			"remove": {
+				// The device has a bugged Window Covering CC implementation: https://github.com/zwave-js/zwave-js/issues/7501
+				"Window Covering": {
+					"endpoints": "*"
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes the issue that this motor has a broken Window Cover implementation, just like some other Zvidar products. More info: https://github.com/zwave-js/zwave-js/issues/7501

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

