### PR TITLE
fix: keep stream writer around for writes in quick succession

### DIFF
--- a/packages/bindings-browser/src/serial/browser.ts
+++ b/packages/bindings-browser/src/serial/browser.ts
@@ -3,17 +3,16 @@ import { type ZWaveSerialBindingFactory } from "@zwave-js/serial";
 export function createWebSerialPortFactory(
 	port: SerialPort,
 ): ZWaveSerialBindingFactory {
+	let writer: WritableStreamDefaultWriter<Uint8Array> | undefined;
+
 	const sink: UnderlyingSink<Uint8Array> = {
 		close() {
+			writer?.releaseLock();
 			port.close();
 		},
 		async write(chunk) {
-			const writer = port.writable!.getWriter();
-			try {
-				await writer.write(chunk);
-			} finally {
-				writer.releaseLock();
-			}
+			writer ??= port.writable!.getWriter();
+			await writer.write(chunk);
 		},
 	};
 

--- a/packages/serial/src/mock/MockPort.ts
+++ b/packages/serial/src/mock/MockPort.ts
@@ -1,3 +1,4 @@
+import { wait } from "alcalzone-shared/async";
 import type { UnderlyingSink, UnderlyingSource } from "node:stream/web";
 import {
 	type ZWaveSerialBindingFactory,
@@ -12,6 +13,9 @@ export class MockPort {
 		this.readable = readable;
 	}
 
+	/** How long each write operation should take */
+	public writeDelay: number = 0;
+
 	// Remembers the last written data
 	public lastWrite: Uint8Array | undefined;
 
@@ -25,6 +29,7 @@ export class MockPort {
 
 	public factory(): ZWaveSerialBindingFactory {
 		return () => {
+			let writer: WritableStreamDefaultWriter<Uint8Array> | undefined;
 			const sink: UnderlyingSink<Uint8Array> = {
 				write: async (chunk, _controller) => {
 					// Remember the last written data
@@ -32,13 +37,17 @@ export class MockPort {
 					// Only write to the sink if its readable side has a reader attached.
 					// Otherwise, we get backpressure on the writable side of the mock port
 					if (this.readable.locked) {
-						const writer = this.#sink.getWriter();
-						try {
-							await writer.write(chunk);
-						} finally {
-							writer.releaseLock();
+						writer ??= this.#sink.getWriter();
+						// Simulate a slow write if necessary
+						if (this.writeDelay > 0) {
+							await wait(this.writeDelay);
 						}
+						// This will finish immediately on the mock port
+						await writer.write(chunk);
 					}
+				},
+				close: () => {
+					writer?.releaseLock();
 				},
 			};
 

--- a/packages/serial/src/serialport/ZWaveSerialStream.ts
+++ b/packages/serial/src/serialport/ZWaveSerialStream.ts
@@ -125,6 +125,7 @@ export class ZWaveSerialStream implements
 	public async close(): Promise<void> {
 		this._isOpen = false;
 		// Close the underlying stream
+		this._writer?.releaseLock();
 		this.#abort.abort();
 
 		return Promise.resolve();
@@ -137,6 +138,8 @@ export class ZWaveSerialStream implements
 	public get isOpen(): boolean {
 		return this._isOpen;
 	}
+
+	private _writer: WritableStreamDefaultWriter<Uint8Array> | undefined;
 
 	public async writeAsync(data: Uint8Array): Promise<void> {
 		if (!this.isOpen) {
@@ -160,11 +163,10 @@ export class ZWaveSerialStream implements
 			this.logger.data("outbound", data);
 		}
 
-		const writer = this.writable.getWriter();
-		try {
-			await writer.write(data);
-		} finally {
-			writer.releaseLock();
-		}
+		// Keep a writer instance to avoid locking and unlocking the
+		// writable stream for every write, as this can cause errors
+		// when writing in quick succession.
+		this._writer ??= this.writable.getWriter();
+		await this._writer.write(data);
 	}
 }

--- a/packages/serial/src/zniffer/ZnifferSerialStream.ts
+++ b/packages/serial/src/zniffer/ZnifferSerialStream.ts
@@ -100,6 +100,7 @@ export class ZnifferSerialStream implements
 	public async close(): Promise<void> {
 		this._isOpen = false;
 		// Close the underlying stream
+		this._writer?.releaseLock();
 		this.#abort.abort();
 
 		return Promise.resolve();
@@ -113,6 +114,8 @@ export class ZnifferSerialStream implements
 		return this._isOpen;
 	}
 
+	private _writer: WritableStreamDefaultWriter<Uint8Array> | undefined;
+
 	public async writeAsync(data: Uint8Array): Promise<void> {
 		if (!this.isOpen) {
 			throw new Error("The serial port is not open!");
@@ -120,11 +123,10 @@ export class ZnifferSerialStream implements
 
 		this.logger.data("outbound", data);
 
-		const writer = this.writable.getWriter();
-		try {
-			await writer.write(data);
-		} finally {
-			writer.releaseLock();
-		}
+		// Keep a writer instance to avoid locking and unlocking the
+		// writable stream for every write, as this can cause errors
+		// when writing in quick succession.
+		this._writer ??= this.writable.getWriter();
+		await this._writer.write(data);
 	}
 }

--- a/packages/zwave-js/src/lib/test/driver/quickWrites.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/quickWrites.test.ts
@@ -1,0 +1,49 @@
+import { GetControllerIdResponse } from "@zwave-js/serial";
+import { Bytes } from "@zwave-js/shared";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest(
+	"The driver should not crash when ACKing lots of frames",
+	{
+		// debug: true,
+
+		async testBody(t, driver, node, mockController, mockNode) {
+			// Simulate a slow (realistic) serialport
+			mockController.mockPort.writeDelay = 5;
+
+			const res = new GetControllerIdResponse({
+				homeId: 0xdeadbeef,
+				ownNodeId: 1,
+			});
+			const resBuffer = await res.serialize(
+				driver["getEncodingContext"](),
+			);
+
+			const data = Bytes.concat([
+				resBuffer,
+				resBuffer,
+				resBuffer,
+				resBuffer,
+				resBuffer,
+				resBuffer,
+				resBuffer,
+				resBuffer,
+				resBuffer,
+				resBuffer,
+			]);
+			mockController.mockPort.emitData(data);
+
+			// Ensure the driver ACKed 10 messages
+			await mockController.expectHostACK(1000);
+			await mockController.expectHostACK(1000);
+			await mockController.expectHostACK(1000);
+			await mockController.expectHostACK(1000);
+			await mockController.expectHostACK(1000);
+			await mockController.expectHostACK(1000);
+			await mockController.expectHostACK(1000);
+			await mockController.expectHostACK(1000);
+			await mockController.expectHostACK(1000);
+			await mockController.expectHostACK(1000);
+		},
+	},
+);


### PR DESCRIPTION
Probably fixes all of these:
- https://github.com/zwave-js/zwave-js/discussions/7712
- https://github.com/zwave-js/zwave-js/discussions/7714
- https://github.com/hassio-addons/addon-zwave-js-ui/issues/765 (once released)