### PR TITLE
fix: return payload from `sendAndReceiveData` method of Manufacturer Proprietary CC

### DIFF
--- a/packages/cc/src/cc/ManufacturerProprietaryCC.ts
+++ b/packages/cc/src/cc/ManufacturerProprietaryCC.ts
@@ -1,7 +1,6 @@
 import { type CCEncodingContext, type CCParsingContext } from "@zwave-js/cc";
 import {
 	CommandClasses,
-	type WithAddress,
 	ZWaveError,
 	ZWaveErrorCodes,
 	validatePayload,
@@ -11,6 +10,7 @@ import { validateArgs } from "@zwave-js/transformers";
 import { CCAPI, type CCAPIEndpoint, type CCAPIHost } from "../lib/API.js";
 import {
 	type CCRaw,
+	type CommandClassOptions,
 	CommandClass,
 	type InterviewContext,
 	type RefreshValuesContext,
@@ -104,7 +104,7 @@ export class ManufacturerProprietaryCCAPI extends CCAPI {
 }
 
 // @publicAPI
-export interface ManufacturerProprietaryCCOptions {
+export interface ManufacturerProprietaryCCOptions extends CommandClassOptions {
 	manufacturerId?: number;
 	unspecifiedExpectsResponse?: boolean;
 }
@@ -133,7 +133,7 @@ export class ManufacturerProprietaryCC extends CommandClass {
 	declare ccCommand: undefined;
 
 	public constructor(
-		options: WithAddress<ManufacturerProprietaryCCOptions>,
+		options: ManufacturerProprietaryCCOptions,
 	) {
 		super(options);
 
@@ -155,9 +155,10 @@ export class ManufacturerProprietaryCC extends CommandClass {
 		const PCConstructor = getManufacturerProprietaryCCConstructor(
 			manufacturerId,
 		);
+		const payload = raw.payload.subarray(2);
 		if (PCConstructor) {
 			return PCConstructor.from(
-				raw.withPayload(raw.payload.subarray(2)),
+				raw.withPayload(payload),
 				ctx,
 			);
 		}
@@ -165,6 +166,7 @@ export class ManufacturerProprietaryCC extends CommandClass {
 		return new ManufacturerProprietaryCC({
 			nodeId: ctx.sourceNodeId,
 			manufacturerId,
+			payload,
 		});
 	}
 

--- a/packages/cc/src/cc/ManufacturerProprietaryCC.ts
+++ b/packages/cc/src/cc/ManufacturerProprietaryCC.ts
@@ -1,6 +1,7 @@
 import { type CCEncodingContext, type CCParsingContext } from "@zwave-js/cc";
 import {
 	CommandClasses,
+	type WithAddress,
 	ZWaveError,
 	ZWaveErrorCodes,
 	validatePayload,
@@ -11,7 +12,6 @@ import { CCAPI, type CCAPIEndpoint, type CCAPIHost } from "../lib/API.js";
 import {
 	type CCRaw,
 	CommandClass,
-	type CommandClassOptions,
 	type InterviewContext,
 	type RefreshValuesContext,
 } from "../lib/CommandClass.js";
@@ -104,9 +104,11 @@ export class ManufacturerProprietaryCCAPI extends CCAPI {
 }
 
 // @publicAPI
-export interface ManufacturerProprietaryCCOptions extends CommandClassOptions {
+export interface ManufacturerProprietaryCCOptions {
 	manufacturerId?: number;
 	unspecifiedExpectsResponse?: boolean;
+	// Needed to support unknown proprietary commands
+	payload?: Uint8Array;
 }
 
 function getReponseForManufacturerProprietary(cc: ManufacturerProprietaryCC) {
@@ -133,7 +135,7 @@ export class ManufacturerProprietaryCC extends CommandClass {
 	declare ccCommand: undefined;
 
 	public constructor(
-		options: ManufacturerProprietaryCCOptions,
+		options: WithAddress<ManufacturerProprietaryCCOptions>,
 	) {
 		super(options);
 

--- a/packages/cc/src/cc/ManufacturerProprietaryCC.ts
+++ b/packages/cc/src/cc/ManufacturerProprietaryCC.ts
@@ -10,8 +10,8 @@ import { validateArgs } from "@zwave-js/transformers";
 import { CCAPI, type CCAPIEndpoint, type CCAPIHost } from "../lib/API.js";
 import {
 	type CCRaw,
-	type CommandClassOptions,
 	CommandClass,
+	type CommandClassOptions,
 	type InterviewContext,
 	type RefreshValuesContext,
 } from "../lib/CommandClass.js";

--- a/packages/zwave-js/src/lib/test/cc/ManufacturerProprietary.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/ManufacturerProprietary.test.ts
@@ -1,0 +1,52 @@
+import { ManufacturerProprietaryCC } from "@zwave-js/cc";
+import { CommandClasses } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import { type MockNodeBehavior } from "@zwave-js/testing";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest(
+	"sendAndReceiveData works",
+	{
+		// debug: true,
+
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses["Manufacturer Proprietary"],
+			],
+		},
+
+		customSetup: async (driver, mockController, mockNode) => {
+			const respondToManufacturerProprietary: MockNodeBehavior = {
+				handleCC(controller, self, receivedCC) {
+					if (
+						receivedCC.ccId
+							=== CommandClasses["Manufacturer Proprietary"]
+					) {
+						// Simply echo the received CC
+						const received =
+							receivedCC as ManufacturerProprietaryCC;
+						const response = new ManufacturerProprietaryCC({
+							nodeId: self.id,
+							manufacturerId: received.manufacturerId!,
+							payload: received.payload,
+						});
+						return { action: "sendCC", cc: response };
+					}
+				},
+			};
+			mockNode.defineBehavior(respondToManufacturerProprietary);
+		},
+
+		async testBody(t, driver, node, mockController, mockNode) {
+			const manufacturerId = 0x1234;
+			const data = Bytes.from("c0ffee", "hex");
+			const response = await node
+				.commandClasses["Manufacturer Proprietary"].sendAndReceiveData(
+					manufacturerId,
+					data,
+				);
+			t.expect(response?.manufacturerId).toBe(manufacturerId);
+			t.expect(response?.data).toEqual(data);
+		},
+	},
+);


### PR DESCRIPTION
Addresses the issue below where the sendAndReceiveData method of Manufacturer Proprietary no longer returns the payload.

https://github.com/zwave-js/zwave-js-ui/issues/4181
