### PR TITLE
feat(config): update Inovelli VZW31-SN to FW 1.04

### DIFF
--- a/packages/config/config/devices/0x031e/vzw31-sn.json
+++ b/packages/config/config/devices/0x031e/vzw31-sn.json
@@ -23,7 +23,7 @@
 					"isLifeline": true
 				},
 				"2": {
-					"label": "Basic Switch Set",
+					"label": "Basic Set",
 					"maxNodes": 10
 				},
 				"3": {
@@ -35,15 +35,15 @@
 					"maxNodes": 10
 				},
 				"5": {
-					"label": "Basic Double-tap Set",
+					"label": "Basic Set Double-tap",
 					"maxNodes": 10
 				},
 				"6": {
-					"label": "Basic Triple-tap Set",
+					"label": "Basic Set Triple-tap",
 					"maxNodes": 10
 				},
 				"7": {
-					"label": "Multilevel Config Set",
+					"label": "Multilevel Switch Set (Config Button)",
 					"maxNodes": 10
 				}
 			}
@@ -322,11 +322,18 @@
 			"#": "23",
 			"$if": "firmwareVersion >= 1.4",
 			"label": "Quick Start Time",
-			"description": "Duration of initial increased power output when light turns on.  0 = disabled, 1-59 = X 60ths of a second, 60 = 1 second",
+			"description": "Duration of initial increased power output when light turns on",
 			"valueSize": 1,
+			"unit": "1/60 seconds",
 			"minValue": 0,
 			"maxValue": 60,
-			"defaultValue": 0
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
 		},
 		{
 			"#": "24",
@@ -368,7 +375,7 @@
 		{
 			"#": "32",
 			"$if": "firmwareVersion >= 1.2",
-			"label": "Internel Temperature",
+			"label": "Internal Temperature",
 			"description": "Temperature inside of the switch",
 			"valueSize": 1,
 			"unit": "°C",
@@ -732,12 +739,12 @@
 			"#": "130",
 			"$if": "firmwareVersion >= 1.4",
 			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Group 7 Enable"
+			"label": "Group 7: Enable"
 		},
 		{
 			"#": "131",
 			"$if": "firmwareVersion >= 1.4",
-			"label": "Group 7 Low Level",
+			"label": "Group 7: Low Level",
 			"description": "Low level to use when group 7 cycles levels",
 			"valueSize": 1,
 			"minValue": 1,
@@ -747,7 +754,7 @@
 		{
 			"#": "132",
 			"$if": "firmwareVersion >= 1.4",
-			"label": "Group 7 Medium Level",
+			"label": "Group 7: Medium Level",
 			"description": "Medium level to use when group 7 cycles levels",
 			"valueSize": 1,
 			"minValue": 2,
@@ -757,7 +764,7 @@
 		{
 			"#": "133",
 			"$if": "firmwareVersion >= 1.4",
-			"label": "Group 7 High Level",
+			"label": "Group 7: High Level",
 			"description": "High level to use when group 7 cycles levels",
 			"valueSize": 1,
 			"minValue": 3,
@@ -768,7 +775,7 @@
 			"#": "134",
 			"$if": "firmwareVersion >= 1.4",
 			"$import": "templates/inovelli_templates.json#hue_color_wheel_white",
-			"label": "Group 7 LED Color",
+			"label": "Group 7: LED Color",
 			"description": "Color to use for the LED bar while briefly indicating group 7 command transmission",
 			"valueSize": 1,
 			"defaultValue": 255

--- a/packages/config/config/devices/0x031e/vzw31-sn.json
+++ b/packages/config/config/devices/0x031e/vzw31-sn.json
@@ -697,14 +697,14 @@
 			"#": "130",
 			"$if": "firmwareVersion >= 1.4",
 			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Fan Module Control",
-			"description": "Config button presses cycle fan speeds"
+			"label": "Group 7 Enable",
+			"description": "Use config button triggers association group 7"
 		},
 		{
 			"#": "131",
 			"$if": "firmwareVersion >= 1.4",
-			"label": "Fan Module Low Level",
-			"description": "Level to use to set the fan to low speed",
+			"label": "Group 7 Low Level",
+			"description": "Low level to use when group 7 cycles levels",
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 97,
@@ -713,8 +713,8 @@
 		{
 			"#": "132",
 			"$if": "firmwareVersion >= 1.4",
-			"label": "Fan Module Medium Level",
-			"description": "Level to use to set the fan to medium speed",
+			"label": "Group 7 Medium Level",
+			"description": "Medium level to use when group 7 cycles levels",
 			"valueSize": 1,
 			"minValue": 2,
 			"maxValue": 98,
@@ -723,8 +723,8 @@
 		{
 			"#": "133",
 			"$if": "firmwareVersion >= 1.4",
-			"label": "Fan Module High Level",
-			"description": "Level to use to set the fan to high speed",
+			"label": "Group 7 High Level",
+			"description": "High level to use when group 7 cycles levels",
 			"valueSize": 1,
 			"minValue": 3,
 			"maxValue": 99,
@@ -734,8 +734,8 @@
 			"#": "134",
 			"$if": "firmwareVersion >= 1.4",
 			"$import": "templates/inovelli_templates.json#hue_color_wheel_white",
-			"label": "Fan Mode LED Color",
-			"description": "Color to use for the LED bar when the fan module is being controlled",
+			"label": "Group 7 LED Color",
+			"description": "Color to use for the LED bar while briefly indicating group 7 activity",
 			"valueSize": 1,
 			"defaultValue": 255
 		},

--- a/packages/config/config/devices/0x031e/vzw31-sn.json
+++ b/packages/config/config/devices/0x031e/vzw31-sn.json
@@ -14,6 +14,41 @@
 		"min": "0.3",
 		"max": "255.255"
 	},
+	"endpoints": {
+		"0": {
+			"associations": {
+				"1": {
+					"label": "Lifeline",
+					"maxNodes": 10,
+					"isLifeline": true
+				},
+				"2": {
+					"label": "Basic Set",
+					"maxNodes": 10
+				},
+				"3": {
+					"label": "Switch Multilevel Set",
+					"maxNodes": 10
+				},
+				"4": {
+					"label": "Switch Multilevel Start/Stop",
+					"maxNodes": 10
+				},
+				"5": {
+					"label": "Double-tap Basic Set",
+					"maxNodes": 10
+				},
+				"6": {
+					"label": "Triple-tap Basic Set",
+					"maxNodes": 10
+				},
+				"7": {
+					"label": "Config Multilevel Set",
+					"maxNodes": 10
+				}
+			}
+		}
+	},
 	"paramInformation": [
 		{
 			"#": "1",
@@ -697,8 +732,7 @@
 			"#": "130",
 			"$if": "firmwareVersion >= 1.4",
 			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Group 7 Enable",
-			"description": "Use config button triggers association group 7"
+			"label": "Group 7 Enable"
 		},
 		{
 			"#": "131",
@@ -735,7 +769,7 @@
 			"$if": "firmwareVersion >= 1.4",
 			"$import": "templates/inovelli_templates.json#hue_color_wheel_white",
 			"label": "Group 7 LED Color",
-			"description": "Color to use for the LED bar while briefly indicating group 7 activity",
+			"description": "Color to use for the LED bar while briefly indicating group 7 command transmission",
 			"valueSize": 1,
 			"defaultValue": 255
 		},

--- a/packages/config/config/devices/0x031e/vzw31-sn.json
+++ b/packages/config/config/devices/0x031e/vzw31-sn.json
@@ -284,6 +284,26 @@
 			]
 		},
 		{
+			"#": "23",
+			"$if": "firmwareVersion >= 1.4",
+			"label": "Quick Start Time",
+			"description": "Duration of initial increased power output when light turns on.  0 = disabled, 1-59 = X 60ths of a second, 60 = 1 second",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 60,
+			"defaultValue": 0
+		},
+		{
+			"#": "24",
+			"$if": "firmwareVersion >= 1.4",
+			"label": "Quick Start Level",
+			"description": "Level of initial increased power output when light turns on.",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 99,
+			"defaultValue": 99
+		},
+		{
 			"#": "25",
 			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Increase Output Power (Non-Neutral)",
@@ -309,6 +329,24 @@
 					"value": 1
 				}
 			]
+		},
+		{
+			"#": "32",
+			"$if": "firmwareVersion >= 1.2",
+			"label": "Internel Temperature",
+			"description": "Temperature inside of the switch",
+			"valueSize": 1,
+			"unit": "°C",
+			"minValue": 0,
+			"maxValue": 127,
+			"readOnly": true
+		},
+		{
+			"#": "33",
+			"$if": "firmwareVersion >= 1.2",
+			"$import": "~/templates/master_template.json#base_true_false",
+			"label": "Overheat Detected",
+			"readOnly": true
 		},
 		{
 			"#": "50",
@@ -371,12 +409,12 @@
 		{
 			"#": "53",
 			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Double Up to Param 55 Level"
+			"label": "Double Up Level Enable"
 		},
 		{
 			"#": "54",
 			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Double Down to Param 56 Level"
+			"label": "Double Down Level Enable"
 		},
 		{
 			"#": "55",
@@ -627,10 +665,79 @@
 			]
 		},
 		{
+			"#": "120",
+			"$if": "firmwareVersion >= 1.4",
+			"label": "Single-Tap Behavior",
+			"description": "What happens when the switch is single-tapped",
+			"valueSize": 1,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Up - On, down - Off",
+					"value": 0
+				},
+				{
+					"label": "Up - Increment level up (Off > low > medium > high), down - Increment level down (High > medium > low > off)",
+					"value": 1
+				},
+				{
+					"label": "Up - Increment level up (Off > low > medium > high > low > ...), down - Off",
+					"value": 2
+				}
+			]
+		},
+		{
 			"#": "123",
 			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Aux Switch Scenes",
 			"description": "Send different scene numbers when the Aux switch is clicked"
+		},
+		{
+			"#": "130",
+			"$if": "firmwareVersion >= 1.4",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Fan Module Control",
+			"description": "Config button presses cycle fan speeds"
+		},
+		{
+			"#": "131",
+			"$if": "firmwareVersion >= 1.4",
+			"label": "Fan Module Low Level",
+			"description": "Level to use to set the fan to low speed",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 97,
+			"defaultValue": 25
+		},
+		{
+			"#": "132",
+			"$if": "firmwareVersion >= 1.4",
+			"label": "Fan Module Medium Level",
+			"description": "Level to use to set the fan to medium speed",
+			"valueSize": 1,
+			"minValue": 2,
+			"maxValue": 98,
+			"defaultValue": 50
+		},
+		{
+			"#": "133",
+			"$if": "firmwareVersion >= 1.4",
+			"label": "Fan Module High Level",
+			"description": "Level to use to set the fan to high speed",
+			"valueSize": 1,
+			"minValue": 3,
+			"maxValue": 99,
+			"defaultValue": 99
+		},
+		{
+			"#": "134",
+			"$if": "firmwareVersion >= 1.4",
+			"$import": "templates/inovelli_templates.json#hue_color_wheel_white",
+			"label": "Fan Mode LED Color",
+			"description": "Color to use for the LED bar when the fan module is being controlled",
+			"valueSize": 1,
+			"defaultValue": 255
 		},
 		{
 			"#": "158",
@@ -700,7 +807,7 @@
 	"metadata": {
 		"inclusion": "Triple-click config button",
 		"exclusion": "Triple-click config button",
-		"reset": "Simultaniously hold the config button and the up button until the LED bar turns red.  Release the buttons and the switch will reset to factory defaults.",
+		"reset": "Simultaneously hold the config button and the up button until the LED bar turns red.  Release the buttons and the switch will reset to factory defaults.",
 		"manual": "https://community.inovelli.com/t/resources-red-series-smart-2-1-switch-on-off-dimmer-manual/13706"
 	}
 }

--- a/packages/config/config/devices/0x031e/vzw31-sn.json
+++ b/packages/config/config/devices/0x031e/vzw31-sn.json
@@ -23,27 +23,27 @@
 					"isLifeline": true
 				},
 				"2": {
-					"label": "Basic Set",
+					"label": "Basic Switch Set",
 					"maxNodes": 10
 				},
 				"3": {
-					"label": "Switch Multilevel Set",
+					"label": "Multilevel Switch Set",
 					"maxNodes": 10
 				},
 				"4": {
-					"label": "Switch Multilevel Start/Stop",
+					"label": "Multilevel Switch Start/Stop",
 					"maxNodes": 10
 				},
 				"5": {
-					"label": "Double-tap Basic Set",
+					"label": "Basic Double-tap Set",
 					"maxNodes": 10
 				},
 				"6": {
-					"label": "Triple-tap Basic Set",
+					"label": "Basic Triple-tap Set",
 					"maxNodes": 10
 				},
 				"7": {
-					"label": "Config Multilevel Set",
+					"label": "Multilevel Config Set",
 					"maxNodes": 10
 				}
 			}


### PR DESCRIPTION
Current changes in this PR:

- Change labels of parameters 53 & 54 for better compatibility as HomeAssistant configuration entities.
- Add parameters 32 & 33 for firmware v1.02 and higher.
- Add parameters 23, 24, 120, and 130-134 for beta firmware v1.04.
- Correct typo in metadata.

I have already collaborated with Inovelli on these changes, but am tagging @InovelliUSA for additional review / approval in case it is necessary and because certain added parameters aren't currently in the documentation I could find for this device and weren't explicitly discussed.