### PR TITLE
fix: wait for complete transmission, even when no ACK is requested

### DIFF
--- a/packages/core/src/definitions/Transmission.ts
+++ b/packages/core/src/definitions/Transmission.ts
@@ -20,7 +20,7 @@ export enum TransmitOptions {
 	Explore = 1 << 5,
 
 	DEFAULT = ACK | AutoRoute | Explore,
-	DEFAULT_NOACK = DEFAULT & ~ACK,
+	DEFAULT_NOACK = NotSet,
 }
 
 export enum TransmitStatus {

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -6958,10 +6958,6 @@ ${handlers.length} left`,
 		// Specify transmit options for the request
 		if (options.transmitOptions != undefined) {
 			msg.transmitOptions = options.transmitOptions;
-			if (!(options.transmitOptions & TransmitOptions.ACK)) {
-				// If no ACK is requested, set the callback ID to zero, because we won't get a controller callback
-				msg.callbackId = 0;
-			}
 		}
 
 		if (!!options.reportTimeoutMs) {


### PR DESCRIPTION
It turns out that the assumption "no ACK = no callback" is incorrect. By waiting for the callback, we ensure that we're not flooding the TX queue of the radio when transmitting a non-acknowledged frame takes longer than normal.

Might help with https://github.com/home-assistant/addons/issues/3982 if the failing transmissions are the ones directly following a transmitted Supervision Report (no ACK)