### PR TITLE
feat: add options to omit optional data during NVM migration

### DIFF
--- a/packages/nvmedit/src/cli.ts
+++ b/packages/nvmedit/src/cli.ts
@@ -5,6 +5,7 @@ import { fs } from "@zwave-js/core/bindings/fs/node";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import {
+	type MigrateNVMOptions,
 	json500To700,
 	json700To500,
 	jsonToNVM,
@@ -224,11 +225,57 @@ Create a backup of the target stick, use the nvm2json command to convert it to J
 						type: "string",
 						required: true,
 					},
+					noAppData: {
+						describe:
+							"Whether application data should be stripped during the migration",
+						type: "boolean",
+						default: false,
+					},
+					noRoutes: {
+						describe:
+							"Whether known routes should be stripped during the migration",
+						type: "boolean",
+						default: false,
+					},
+					noNeighbors: {
+						describe:
+							"Whether information about neighbors should be stripped during the migration",
+						type: "boolean",
+						default: false,
+					},
+					noSUCEntries: {
+						describe:
+							"Whether SUC update entries should be stripped during the migration",
+						type: "boolean",
+						default: false,
+					},
+					noOptional: {
+						describe:
+							"Strip all optional information from the NVM. Overrides all other noXYZ flags.",
+						type: "boolean",
+						default: false,
+					},
 				}),
 		async (argv) => {
+			const {
+				noAppData,
+				noNeighbors,
+				noRoutes,
+				noSUCEntries,
+				noOptional,
+			} = argv;
+			const options: MigrateNVMOptions = {
+				preserveApplicationData: !noOptional && !noAppData,
+				preserveRoutes: !noOptional && !noRoutes,
+				preserveNeighbors: !noOptional && !noNeighbors,
+				preserveSUCUpdateEntries: !noOptional && !noSUCEntries,
+			};
+
 			const source = await fs.readFile(argv.source);
 			const target = await fs.readFile(argv.target);
-			const output = await migrateNVM(source, target);
+
+			const output = await migrateNVM(source, target, options);
+
 			await fs.writeFile(argv.out, output);
 			console.error(`Converted NVM written to ${argv.out}`);
 

--- a/packages/nvmedit/src/index.ts
+++ b/packages/nvmedit/src/index.ts
@@ -10,6 +10,7 @@ export {
 	nvmToJSON,
 } from "./convert.js";
 export type {
+	MigrateNVMOptions,
 	NVMJSON,
 	NVMJSONController,
 	NVMJSONControllerRFConfig,

--- a/packages/nvmedit/src/index_browser.ts
+++ b/packages/nvmedit/src/index_browser.ts
@@ -12,6 +12,7 @@ export {
 	nvmToJSON,
 } from "./convert.js";
 export type {
+	MigrateNVMOptions,
 	NVMJSON,
 	NVMJSONController,
 	NVMJSONControllerRFConfig,

--- a/packages/zwave-js/src/Controller.ts
+++ b/packages/zwave-js/src/Controller.ts
@@ -12,6 +12,7 @@ export {
 } from "@zwave-js/core/safe";
 export type { RSSI, TXReport } from "@zwave-js/core/safe";
 export type { ZWaveApiVersion, ZWaveLibraryTypes } from "@zwave-js/core/safe";
+export type { MigrateNVMOptions } from "@zwave-js/nvmedit";
 export { SerialAPISetupCommand } from "@zwave-js/serial/serialapi";
 export { ZWaveController } from "./lib/controller/Controller.js";
 export type { ControllerEvents } from "./lib/controller/Controller.js";

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -105,6 +105,7 @@ import {
 } from "@zwave-js/core";
 import {
 	BufferedNVMReader,
+	type MigrateNVMOptions,
 	NVM3,
 	NVM3Adapter,
 	NVM500,
@@ -7894,11 +7895,13 @@ export class ZWaveController
 	 * @param nvmData The NVM backup to be restored
 	 * @param convertProgress Can be used to monitor the progress of the NVM conversion, which may take several seconds up to a few minutes depending on the NVM size
 	 * @param restoreProgress Can be used to monitor the progress of the restore operation, which may take several seconds up to a few minutes depending on the NVM size
+	 * @param migrateOptions Influence which data should be preserved during a migration
 	 */
 	public async restoreNVM(
 		nvmData: Uint8Array,
 		convertProgress?: (bytesRead: number, total: number) => void,
 		restoreProgress?: (bytesWritten: number, total: number) => void,
+		migrateOptions?: MigrateNVMOptions,
 	): Promise<void> {
 		// Turn Z-Wave radio off to avoid having the protocol write to the NVM while dumping it
 		if (!(await this.toggleRF(false))) {
@@ -7926,7 +7929,11 @@ export class ZWaveController
 			} else {
 				targetNVM = await this.backupNVMRaw500(convertProgress);
 			}
-			const convertedNVM = await migrateNVM(nvmData, targetNVM);
+			const convertedNVM = await migrateNVM(
+				nvmData,
+				targetNVM,
+				migrateOptions,
+			);
 
 			this.driver.controllerLog.print("Restoring NVM backup...");
 			if (this.sdkVersionGte("7.0")) {


### PR DESCRIPTION
When migrating between different controller hardware, at least deleting the known routes can make sense, especially if the hardware has vastly different RF characteristics.

This PR adds the possibility to do that, along with options to strip other optional information.