### PR TITLE
fix(config): add fingerprint `0x0001:0x0002` to ZHT-630

### DIFF
--- a/packages/config/config/devices/0x026f/zht-630.json
+++ b/packages/config/config/devices/0x026f/zht-630.json
@@ -1,9 +1,13 @@
 {
-	"manufacturer": "Sprue Safety Products, Ltd.",
+	"manufacturer": "FireAngel",
 	"manufacturerId": "0x026f",
 	"label": "ZHT-630",
 	"description": "Thermistek Heat Alarm/Detector",
 	"devices": [
+		{
+			"productType": "0x0001",
+			"productId": "0x0002"
+		},
 		{
 			"productType": "0x0002",
 			"productId": "0x0002",
@@ -16,15 +20,23 @@
 	},
 	"associations": {
 		"1": {
-			"label": "Group 1",
-			"maxNodes": 5,
+			"label": "Lifeline",
+			"maxNodes": 1,
 			"isLifeline": true
+		},
+		"2": {
+			"label": "Basic Report",
+			"maxNodes": 5
+		},
+		"3": {
+			"label": "Notification Report",
+			"maxNodes": 5
 		}
 	},
 	"metadata": {
-		"inclusion": "‘ADDING’ YOUR Z-WAVE UNITS\nDo not attempt to add your Z-Wave Module unless you are familiar with the operation of your Z-Wave Controller.\n1. Read the instructions for your Z-Wave Controller regarding adding new devices. Then initiate the inclusion function from your Z-Wave Controller.\n2. Triple-press the add button once the Z-Wave Module is on the device. The LED will show a quick blink once per second while the module is being added. This process may take as long as 30 seconds, but typically is much quicker. If you triple-press too quickly or too slowly, inclusion will not start. In this case wait a few seconds and then try again.\n3. Upon successful inclusion, the Z-Wave Module LED will flash 3 times. If inclusion fails, the LED will simply stop its blink pattern.\n4. If inclusion does not succeed, restart at step 1.\n5. If successful, place the alarm on its base and wait at least 30 seconds.\n6. Press the alarm’s test button and verify the Z-Wave Controller receives Notification Reports.\n7. After the Z-Wave Module is included, you may define association groups or perform other configuration operations from the Z-Wave Controller.",
-		"exclusion": "‘REMOVING’ YOUR Z-WAVE UNITS\n1. Read the instructions on your Z-Wave Controller regarding removing devices. Note that a device can be removed using any Z-Wave Controller, not just the Controller that was used to add the Module. Initiate the removal process at your Controller.\n2. Triple-press the button on the Z-Wave Module. The LED will show a quick double-blink once per second while the module is being removed. This process may take up to 30 seconds. If you triple-press too quickly or too slowly the removing function will not start. In this case you must wait a few seconds and then try again.\n3. Upon successful removal, the Z-Wave Module LED will flash 5 times. If removal fails, the LED will simply stop its blink pattern.\n4. If the removal operation does not succeed, restart at step 1.\n5. After removing, either a) add the Z-Wave Module into a different Z-Wave Controller, or b) remove the battery from the Z-Wave Module.\n\nNOTE: The effective range of the wireless module may be reduced by walls and other obstructions in the building. It is recommended not to exceed 40m as the maximum distance between smoke alarms and the Controller.",
-		"reset": "‘FACTORY RESET’ YOUR Z-WAVE UNITS \nThis operation should only be performed if the module is to be excluded from the network and if the Z-Wave Controller is also being reset or removed. \n1. Press and hold the button for 10 seconds. The LED will go off. Now release the button. The LED will flash once as the module resets. \n2. After resetting, either a) include the module into a different Z-Wave Controller, or b) remove the battery from the module to avoid power draining. \n* use the reset procedure only when the primary controller is missing or inoperable.",
+		"inclusion": "1. Read the instructions for your Z-Wave Controller regarding adding new devices. Then initiate the inclusion function from your Z-Wave Controller.\n2. Triple-press the add button once the Z-Wave Module is on the device. The LED will show a quick blink once per second while the module is being added. This process may take as long as 30 seconds, but typically is much quicker. If you triple-press too quickly or too slowly, inclusion will not start. In this case wait a few seconds and then try again.\n3. Upon successful inclusion, the Z-Wave Module LED will flash 3 times. If inclusion fails, the LED will simply stop its blink pattern.\n4. If inclusion does not succeed, restart at step 1.\n5. If successful, place the alarm on its base and wait at least 30 seconds.\n6. Press the alarm’s test button and verify the Z-Wave Controller receives Notification Reports.\n7. After the Z-Wave Module is included, you may define association groups or perform other configuration operations from the Z-Wave Controller.",
+		"exclusion": "1. Read the instructions on your Z-Wave Controller regarding removing devices. Note that a device can be removed using any Z-Wave Controller, not just the Controller that was used to add the Module. Initiate the removal process at your Controller.\n2. Triple-press the button on the Z-Wave Module. The LED will show a quick double-blink once per second while the module is being removed. This process may take up to 30 seconds. If you triple-press too quickly or too slowly the removing function will not start. In this case you must wait a few seconds and then try again.\n3. Upon successful removal, the Z-Wave Module LED will flash 5 times. If removal fails, the LED will simply stop its blink pattern.\n4. If the removal operation does not succeed, restart at step 1.\n5. After removing, either a) add the Z-Wave Module into a different Z-Wave Controller, or b) remove the battery from the Z-Wave Module.",
+		"reset": "This operation should only be performed if the module is to be excluded from the network and if the Z-Wave Controller is also being reset or removed. \n1. Press and hold the button for 10 seconds. The LED will go off. Now release the button. The LED will flash once as the module resets. \n2. After resetting, either a) include the module into a different Z-Wave Controller, or b) remove the battery from the module to avoid power draining. \n* use the reset procedure only when the primary controller is missing or inoperable.",
 		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/2631/50253%20combined%20manuals.pdf"
 	}
 }

--- a/packages/config/config/devices/0x026f/zst-630.json
+++ b/packages/config/config/devices/0x026f/zst-630.json
@@ -1,5 +1,5 @@
 {
-	"manufacturer": "Sprue Safety Products Ltd.",
+	"manufacturer": "FireAngel",
 	"manufacturerId": "0x026f",
 	"label": "ZST-630",
 	"description": "Thermoptek Smoke Alarm/Smoke Detector",
@@ -27,5 +27,11 @@
 			"label": "Notification Report",
 			"maxNodes": 5
 		}
+	},
+	"metadata": {
+		"inclusion": "1. Read the instructions for your Z-Wave Controller regarding adding new devices. Then initiate the inclusion function from your Z-Wave Controller.\n2. Triple-press the add button once the Z-Wave Module is on the device. The LED will show a quick blink once per second while the module is being added. This process may take as long as 30 seconds, but typically is much quicker. If you triple-press too quickly or too slowly, inclusion will not start. In this case wait a few seconds and then try again.\n3. Upon successful inclusion, the Z-Wave Module LED will flash 3 times. If inclusion fails, the LED will simply stop its blink pattern.\n4. If inclusion does not succeed, restart at step 1.\n5. If successful, place the alarm on its base and wait at least 30 seconds.\n6. Press the alarm’s test button and verify the Z-Wave Controller receives Notification Reports.\n7. After the Z-Wave Module is included, you may define association groups or perform other configuration operations from the Z-Wave Controller.",
+		"exclusion": "1. Read the instructions on your Z-Wave Controller regarding removing devices. Note that a device can be removed using any Z-Wave Controller, not just the Controller that was used to add the Module. Initiate the removal process at your Controller.\n2. Triple-press the button on the Z-Wave Module. The LED will show a quick double-blink once per second while the module is being removed. This process may take up to 30 seconds. If you triple-press too quickly or too slowly the removing function will not start. In this case you must wait a few seconds and then try again.\n3. Upon successful removal, the Z-Wave Module LED will flash 5 times. If removal fails, the LED will simply stop its blink pattern.\n4. If the removal operation does not succeed, restart at step 1.\n5. After removing, either a) add the Z-Wave Module into a different Z-Wave Controller, or b) remove the battery from the Z-Wave Module.",
+		"reset": "This operation should only be performed if the module is to be excluded from the network and if the Z-Wave Controller is also being reset or removed. \n1. Press and hold the button for 10 seconds. The LED will go off. Now release the button. The LED will flash once as the module resets. \n2. After resetting, either a) include the module into a different Z-Wave Controller, or b) remove the battery from the module to avoid power draining. \n* use the reset procedure only when the primary controller is missing or inoperable.",
+		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/2631/50253%20combined%20manuals.pdf"
 	}
 }


### PR DESCRIPTION
Fixes #7098

I found comments elsewhere that this z-wave module identifies as `0x0001:0x0001` when plugged into the ZST-630 Smoke Alarm and as `0x0001:0x0002` when plugged into the ZHT-630 Heat Alarm. Z-Wave Alliance, however lists a different fingerprint - `0x0002:0x0002` for the heat alarm.

Association groups and inclusion/exclusion/reset metadata adjusted to match for both the ZST and ZHT as they share a user manual, which also shows that they're marketed under the "FireAngel" brand.