### PR TITLE
feat(config): add Enbrighten 58446

### DIFF
--- a/packages/config/config/devices/0x0063/58446_zwa4013.json
+++ b/packages/config/config/devices/0x0063/58446_zwa4013.json
@@ -1,8 +1,8 @@
 {
-	"manufacturer": "Jasco Products",
+	"manufacturer": "Enbrighten",
 	"manufacturerId": "0x0063",
 	"label": "58446/ZWA4013",
-	"description": "Enbrighten Z-Wave In-Wall Smart Fan Control,White and Light Almond Paddles, 700S",
+	"description": "In-Wall Fan Speed Control, QFSW, 700S",
 	"devices": [
 		{
 			"productType": "0x4944",
@@ -33,111 +33,66 @@
 	"paramInformation": [
 		{
 			"#": "3",
-			"label": "Led Light Mode",
-			"description": "0",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 3,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "~/templates/master_template.json#led_indicator_four_options"
 		},
 		{
 			"#": "4",
-			"label": "Invert Switch",
-			"description": "0",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "~/templates/master_template.json#orientation"
 		},
 		{
 			"#": "5",
-			"label": "Select 3-way Type",
-			"description": "0",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "templates/jasco_template.json#three_way_setup"
 		},
 		{
 			"#": "19",
-			"label": "Alternate Exclusion",
-			"description": "0",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "templates/jasco_template.json#alternate_exclusion_menu"
 		},
 		{
 			"#": "34",
-			"label": "Led Light Color",
-			"description": "0",
-			"valueSize": 1,
-			"minValue": 1,
-			"maxValue": 8,
-			"defaultValue": 5,
-			"unsigned": true
+			"$import": "templates/jasco_template.json#led_indicator_color"
 		},
 		{
 			"#": "35",
-			"label": "Led Light Intensity",
-			"description": "0",
-			"valueSize": 1,
-			"minValue": 1,
-			"maxValue": 7,
-			"defaultValue": 4,
-			"unsigned": true
+			"$import": "templates/jasco_template.json#led_indicator_intensity"
 		},
 		{
 			"#": "36",
-			"label": "Guidelight Mode Intensity",
-			"description": "0",
-			"valueSize": 1,
-			"minValue": 1,
-			"maxValue": 7,
-			"defaultValue": 4,
-			"unsigned": true
+			"$import": "templates/jasco_template.json#led_indicator_intensity",
+			"label": "Guidelight Mode Intensity"
 		},
 		{
 			"#": "39",
-			"label": "Power Up Status",
-			"description": "0",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_prev",
+			"defaultValue": 0
 		},
 		{
 			"#": "40",
-			"label": "Fan Speed Ramp Rate",
-			"description": "0",
+			"label": "Fan Speed Control",
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
 			"defaultValue": 0,
-			"unsigned": true
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Press and hold",
+					"value": 0
+				},
+				{
+					"label": "Single button presses",
+					"value": 1
+				}
+			]
 		},
 		{
 			"#": "84",
-			"label": "Reset Factory Default",
-			"description": "0",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 0,
-			"unsigned": true
+			"$import": "templates/jasco_template.json#factory_default"
 		}
 	],
 	"compat": {
 		"mapBasicSet": "event"
 	},
 	"metadata": {
-		"inclusion": "Adding your device to a Z-Wave network\n1. Follow the instructions for your Z-Wave certified Controller to add a device to the Z-Wave network.\n\n2. Once the controller is ready to add your device, press the top of bottom of the wireless smart Fan controller",
-		"exclusion": "To remove and reset the device\n1. Follow the instructions for your Z-Wave certified controller to remove a device from the Z-wave network\n\n2. Once the controller is ready to remove your device, press the top or bottom of the wireless smart Fan controller",
-		"reset": "To return your switch to factory defaults: \nPull the airgap switch. Press and hold the bottom button, push the airgap switch in and continue holding the bottom button for 10 seconds. The LED will flash once each of the 8 colors then stop"
+		"inclusion": "1. Follow the instructions for your Z-Wave certified Controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press the top of bottom of the wireless smart Fan controller",
+		"exclusion": "1. Follow the instructions for your Z-Wave certified controller to remove a device from the Z-wave network\n2. Once the controller is ready to remove your device, press the top or bottom of the wireless smart Fan controller",
+		"reset": "Pull the airgap switch. Press and hold the bottom button, push the airgap switch in and continue holding the bottom button for 10 seconds. The LED will flash once each of the 8 colors then stop"
 	}
 }

--- a/packages/config/config/devices/0x0063/templates/jasco_template.json
+++ b/packages/config/config/devices/0x0063/templates/jasco_template.json
@@ -56,6 +56,11 @@
 		"label": "Alternate Exclusion",
 		"description": "Press and release OFF, then ON"
 	},
+	"alternate_exclusion_menu": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Alternate Exclusion",
+		"description": "Press MENU button once"
+	},
 	"smooth_level_changes": {
 		"$import": "~/templates/master_template.json#base_enable_disable",
 		"label": "Smooth Level Changes"


### PR DESCRIPTION
Parameters based on product manual at Z-wave Alliance.

New template for Alternate Exclusion as the MENU button method seems to be what the new Jasco hardware is moving to.

Fixes #7671 and #7684