### PR TITLE
revert: avoid controller lockup on retransmit after `NoACK`

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -6430,14 +6430,6 @@ ${handlers.length} left`,
 								throw e;
 							}
 						} else if (
-							isTransmitReport(e.context)
-							&& e.context.transmitStatus === TransmitStatus.NoAck
-						) {
-							// If retrying communication with an unresponsive node too quickly,
-							// the controller may lock up --> GH#7764
-							// Try waiting a bit so this doesn't happen
-							waitDurationMs = 100;
-						} else if (
 							e.code === ZWaveErrorCodes.Controller_MessageDropped
 						) {
 							// We gave up on this command, so don't retry it


### PR DESCRIPTION
Reverts zwave-js/zwave-js#7766

This is the actual fix: https://github.com/AlCalzone/nc-zwave-esp-bridge/pull/7