### PR TITLE
fix: controller device config after migration from different hardware

### DIFF
--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -1842,6 +1842,9 @@ export class ZWaveController
 			VersionCCValues.sdkVersion.id,
 			this._sdkVersion,
 		);
+
+		// Look up the device config afterwards
+		await this.nodes.get(this._ownNodeId!)?.["loadDeviceConfig"]();
 	}
 
 	private createValueDBForNode(nodeId: number, ownKeys?: Set<string>) {

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1904,6 +1904,7 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 				async () => {
 					// Try to restore the network information from the cache
 					if (getenv("NO_CACHE") !== "true") {
+						// FIXME: This entire thing is a pretty convoluted way of looking up the device config
 						await this.restoreNetworkStructureFromCache();
 					}
 				},

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -2573,8 +2573,12 @@ protocol version:      ${this.protocolVersion}`;
 	public async deserialize(): Promise<void> {
 		if (!this.driver.networkCache) return;
 
-		// Restore the device config
-		await this.loadDeviceConfig();
+		// Restore the device config. For the controller, this needs to happen
+		// after the interview, as we could have migrated to a different controller
+		// but the cache still contains the old fingerprint
+		if (!this.isControllerNode) {
+			await this.loadDeviceConfig();
+		}
 
 		// Mark already-interviewed nodes as potentially ready
 		if (this.interviewStage === InterviewStage.Complete) {


### PR DESCRIPTION
Not the most pretty fix, but this change makes sure that we load the correct device config for the controller after migrating from one to another.

fixes: #7774