### PR TITLE
fix(config): disallow manual entry for param 3 on Zooz ZSE70

### DIFF
--- a/packages/config/config/devices/0x027a/zse70_800lr.json
+++ b/packages/config/config/devices/0x027a/zse70_800lr.json
@@ -55,9 +55,8 @@
 			"#": "3",
 			"label": "Motion Reports: Basic Set Values",
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 7,
 			"defaultValue": 7,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Disable",


### PR DESCRIPTION
fixes: #7792