### PR TITLE
fix: option `s2VerifyDelivery` not working

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -5527,9 +5527,7 @@ ${handlers.length} left`,
 			if (msg.command instanceof Security2CCNonceGet) {
 				return this.handleSecurity2NonceGet(node);
 			}
-			if (msg.command instanceof Security2CCNonceReport) {
-				return this.handleSecurity2NonceReport(node, msg.command);
-			}
+			// Nonce Report is handled further down, as we might have dynamic handlers for it
 			if (msg.command instanceof Security2CCCommandsSupportedGet) {
 				return this.handleSecurity2CommandsSupportedGet(
 					node,
@@ -5657,6 +5655,11 @@ ${handlers.length} left`,
 					await reply(SupervisionStatus.Success);
 					return;
 				}
+			}
+
+			// Handle Nonce Reports if there was no dynamic handler waiting for them
+			if (msg.command instanceof Security2CCNonceReport) {
+				return this.handleSecurity2NonceReport(node, msg.command);
 			}
 
 			// Some S2 commands contain only extensions. Those are handled by the CC implementation.

--- a/packages/zwave-js/src/lib/test/driver/fixtures/s2CollisionsSupervised/7e570001.jsonl
+++ b/packages/zwave-js/src/lib/test/driver/fixtures/s2CollisionsSupervised/7e570001.jsonl
@@ -22,8 +22,13 @@
 {"k":"node.2.supportsBeaming","v":true}
 {"k":"node.2.deviceClass","v":{"basic":4,"generic":6,"specific":1}}
 {"k":"node.2.interviewStage","v":"Complete"}
+// Basic
+{"k":"node.2.endpoint.0.commandClass.0x20","v":{"isSupported":true,"isControlled":false,"secure":true,"version":1}}
+// Binary Switch
 {"k":"node.2.endpoint.0.commandClass.0x25","v":{"isSupported":true,"isControlled":false,"secure":true,"version":1}}
+// Supervision
 {"k":"node.2.endpoint.0.commandClass.0x6c","v":{"isSupported":true,"isControlled":false,"secure":true,"version":1}}
+// Security S2
 {"k":"node.2.endpoint.0.commandClass.0x9f","v":{"isSupported":true,"isControlled":false,"secure":true,"version":1}}
 {"k":"node.2.securityClasses.S2_AccessControl","v":false}
 {"k":"node.2.securityClasses.S2_Authenticated","v":false}

--- a/packages/zwave-js/src/lib/test/driver/s2Collisions.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s2Collisions.test.ts
@@ -540,10 +540,10 @@ integrationTest(
 	},
 );
 
-integrationTest.only(
+integrationTest(
 	"S2 Collisions: Both nodes send at the same time. Supervision supported, but disabled. Verify delivery",
 	{
-		debug: true,
+		// debug: true,
 
 		// We need the cache to skip the CC interviews and mark S2 as supported
 		provisioningDirectory: path.join(
@@ -699,14 +699,12 @@ integrationTest.only(
 
 			// If the collision was handled gracefully, we should now have the value reported by the node
 			const currentValue = node.getValue(
-				BasicCCValues.currentValue.id,
+				BinarySwitchCCValues.currentValue.id,
 			);
-			t.expect(currentValue).toBe(0);
+			t.expect(currentValue).toBe(true);
 
 			// Ensure the Basic Set causing a collision eventually gets resolved
-			t.expect(p2result).toMatchObject({
-				status: SupervisionStatus.Success,
-			});
+			t.expect(p2result).toBeUndefined();
 		},
 	},
 );

--- a/packages/zwave-js/src/lib/test/driver/s2Collisions.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s2Collisions.test.ts
@@ -539,3 +539,174 @@ integrationTest(
 		},
 	},
 );
+
+integrationTest.only(
+	"S2 Collisions: Both nodes send at the same time. Supervision supported, but disabled. Verify delivery",
+	{
+		debug: true,
+
+		// We need the cache to skip the CC interviews and mark S2 as supported
+		provisioningDirectory: path.join(
+			__dirname,
+			"fixtures/s2CollisionsSupervised",
+		),
+
+		customSetup: async (driver, controller, mockNode) => {
+			// Create a security manager for the node
+			const smNode = await SecurityManager2.create();
+			// Copy keys from the driver
+			await smNode.setKey(
+				SecurityClass.S2_AccessControl,
+				driver.options.securityKeys!.S2_AccessControl!,
+			);
+			await smNode.setKey(
+				SecurityClass.S2_Authenticated,
+				driver.options.securityKeys!.S2_Authenticated!,
+			);
+			await smNode.setKey(
+				SecurityClass.S2_Unauthenticated,
+				driver.options.securityKeys!.S2_Unauthenticated!,
+			);
+			mockNode.securityManagers.securityManager2 = smNode;
+			mockNode.encodingContext.getHighestSecurityClass = () =>
+				SecurityClass.S2_Unauthenticated;
+
+			// Create a security manager for the controller
+			const smCtrlr = await SecurityManager2.create();
+			// Copy keys from the driver
+			await smCtrlr.setKey(
+				SecurityClass.S2_AccessControl,
+				driver.options.securityKeys!.S2_AccessControl!,
+			);
+			await smCtrlr.setKey(
+				SecurityClass.S2_Authenticated,
+				driver.options.securityKeys!.S2_Authenticated!,
+			);
+			await smCtrlr.setKey(
+				SecurityClass.S2_Unauthenticated,
+				driver.options.securityKeys!.S2_Unauthenticated!,
+			);
+			controller.securityManagers.securityManager2 = smCtrlr;
+			controller.encodingContext.getHighestSecurityClass = () =>
+				SecurityClass.S2_Unauthenticated;
+
+			// Respond to Nonce Get
+			const respondToNonceGet: MockNodeBehavior = {
+				async handleCC(controller, self, receivedCC) {
+					if (receivedCC instanceof Security2CCNonceGet) {
+						const nonce = await smNode.generateNonce(
+							controller.ownNodeId,
+						);
+						const cc = new Security2CCNonceReport({
+							nodeId: controller.ownNodeId,
+							SOS: true,
+							MOS: false,
+							receiverEI: nonce,
+						});
+						return { action: "sendCC", cc };
+					}
+				},
+			};
+			mockNode.defineBehavior(respondToNonceGet);
+
+			// Handle decode errors
+			const handleInvalidCC: MockNodeBehavior = {
+				async handleCC(controller, self, receivedCC) {
+					if (receivedCC instanceof InvalidCC) {
+						if (
+							receivedCC.reason
+								=== ZWaveErrorCodes.Security2CC_CannotDecode
+							|| receivedCC.reason
+								=== ZWaveErrorCodes.Security2CC_NoSPAN
+						) {
+							const nonce = await smNode.generateNonce(
+								controller.ownNodeId,
+							);
+							const cc = new Security2CCNonceReport({
+								nodeId: controller.ownNodeId,
+								SOS: true,
+								MOS: false,
+								receiverEI: nonce,
+							});
+							return { action: "sendCC", cc };
+						}
+					}
+				},
+			};
+			mockNode.defineBehavior(handleInvalidCC);
+
+			// Just have the node respond to all Supervision Get positively
+			const respondToSupervisionGet: MockNodeBehavior = {
+				handleCC(controller, self, receivedCC) {
+					if (
+						receivedCC
+							instanceof Security2CCMessageEncapsulation
+						&& receivedCC.encapsulated
+							instanceof SupervisionCCGet
+					) {
+						let cc: CommandClass = new SupervisionCCReport({
+							nodeId: controller.ownNodeId,
+							sessionId: receivedCC.encapsulated.sessionId,
+							moreUpdatesFollow: false,
+							status: SupervisionStatus.Success,
+						});
+						cc = Security2CC.encapsulate(
+							cc,
+							self.id,
+							self.securityManagers,
+						);
+						return { action: "sendCC", cc };
+					}
+				},
+			};
+			mockNode.defineBehavior(respondToSupervisionGet);
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// Send a secure Binary Switch SET to sync the SPAN
+			await node.commandClasses["Binary Switch"].set(false);
+
+			driver.driverLog.print("----------");
+			driver.driverLog.print("START TEST");
+			driver.driverLog.print("----------");
+
+			// We use supervision here, so we can ensure that the SET requests were completed
+
+			// Now create a collision by having both parties send at the same time
+			const nodeToHost = Security2CC.encapsulate(
+				new BinarySwitchCCReport({
+					nodeId: mockController.ownNodeId,
+					currentValue: true,
+				}),
+				mockNode.id,
+				mockNode.securityManagers,
+			);
+			const p1 = mockNode.sendToController(
+				createMockZWaveRequestFrame(nodeToHost, {
+					ackRequested: true,
+				}),
+			);
+			// Disable supervision for the controller command. This should cause a NonceReport to be received
+			// after the transaction is considered complete.
+			const p2 = node.commandClasses.Basic
+				.withOptions({ useSupervision: false, s2VerifyDelivery: true })
+				.set(0);
+
+			const [, p2result] = await Promise.all([p1, p2]);
+
+			// Give the node a chance to respond
+			await wait(250);
+
+			// If the collision was handled gracefully, we should now have the value reported by the node
+			const currentValue = node.getValue(
+				BasicCCValues.currentValue.id,
+			);
+			t.expect(currentValue).toBe(0);
+
+			// Ensure the Basic Set causing a collision eventually gets resolved
+			t.expect(p2result).toMatchObject({
+				status: SupervisionStatus.Success,
+			});
+		},
+	},
+);


### PR DESCRIPTION
fixes: https://github.com/zwave-js/zwave-js/issues/7793

Since the device in the issue had Supervision disabled, the S2 delivery verification should have handled the collision, but it didn't.
The refactorings done in v15 broke the `s2VerifyDelivery` because the "unexpected" S2 nonce was now discarded before dynamic handlers were executed. Simply moving the default Nonce handler fixes this.