### PR TITLE
refactor: deprecate `watchdog` option and preset, do not enable Watchdog by default

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -330,8 +330,8 @@ const defaultOptions: ZWaveOptions = {
 		unresponsiveControllerRecovery: !getenv(
 			"ZWAVEJS_DISABLE_UNRESPONSIVE_CONTROLLER_RECOVERY",
 		),
-		// By default enable the watchdog, unless the env variable is set
-		watchdog: !getenv("ZWAVEJS_DISABLE_WATCHDOG"),
+		// By default disable the watchdog
+		watchdog: false,
 	},
 	// By default, try to recover from bootloader mode
 	bootloaderMode: "recover",
@@ -3391,6 +3391,7 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 		// This is a bit hacky, but what the heck...
 		if (!this._enteringBootloader) {
 			// Start the watchdog again, unless disabled
+			// eslint-disable-next-line @typescript-eslint/no-deprecated
 			if (this.options.features.watchdog) {
 				void this._controller?.startWatchdog();
 			}
@@ -5150,6 +5151,7 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 				}
 
 				// Restart the watchdog unless disabled
+				// eslint-disable-next-line @typescript-eslint/no-deprecated
 				if (this.options.features.watchdog) {
 					await this._controller?.startWatchdog();
 				}

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -271,9 +271,13 @@ export interface ZWaveOptions {
 
 		/**
 		 * Controllers of the 700 series and newer have a hardware watchdog that can be enabled to automatically
-		 * reset the chip in case it becomes unresponsive. This option controls whether the watchdog should be enabled.
+		 * reset the chip in case it becomes unresponsive. This option controls whether Z-Wave JS enables the watchdog automatically.
 		 *
-		 * Default: `true`, except when the ZWAVEJS_DISABLE_WATCHDOG env variable is set.
+		 * @deprecated
+		 * It makes more sense to handle the watchdog in the firmware itself. Recent firmware versions do just that, so
+		 * this option is no longer necessary.
+		 *
+		 * Default: `false`
 		 */
 		watchdog?: boolean;
 	};
@@ -501,8 +505,9 @@ export const driverPresets = Object.freeze(
 		},
 
 		/**
-		 * Prevents enabling the watchdog to be able to deal with controllers
-		 * which frequently get restarted for seemingly no reason.
+		 * @deprecated
+		 * This used to prevent the driver from enabling the watchdog on 700 series controllers.
+		 * This is now the default behavior, so this option is no longer necessary.
 		 */
 		NO_WATCHDOG: {
 			features: {


### PR DESCRIPTION
More recent SDK versions automatically enable the hardware watchdog in the firmware. This makes much more sense than doing it in the host software, and avoids doing it on controllers that don't properly support this.

The `features.watchdog` driver option and the `NO_WATCHDOG` preset are now deprecated, and Z-Wave JS will no longer enable the watchdog automatically, unless the `features.watchdog` option is set to `true`. In the next major release, both will be removed.

fixes: #7112
fixes: #7183