### PR TITLE
fix: omit empty fields from TX reports, ignore missing RSSI in stats

### DIFF
--- a/packages/core/src/definitions/RSSI.ts
+++ b/packages/core/src/definitions/RSSI.ts
@@ -1,5 +1,4 @@
 /** A number between -128 and +124 dBm or one of the special values in {@link RssiError} indicating an error */
-
 export type RSSI = number | RssiError;
 
 export enum RssiError {
@@ -11,8 +10,8 @@ export enum RssiError {
 export function isRssiError(rssi: RSSI): rssi is RssiError {
 	return rssi >= RssiError.NoSignalDetected;
 }
-/** Averages RSSI measurements using an exponential moving average with the given weight for the accumulator */
 
+/** Averages RSSI measurements using an exponential moving average with the given weight for the accumulator */
 export function averageRSSI(
 	acc: number | undefined,
 	rssi: RSSI,
@@ -37,10 +36,10 @@ export function averageRSSI(
 	if (acc == undefined) return rssi;
 	return Math.round(acc * weight + rssi * (1 - weight));
 }
+
 /**
  * Converts an RSSI value to a human readable format, i.e. the measurement including the unit or the corresponding error message.
  */
-
 export function rssiToString(rssi: RSSI): string {
 	switch (rssi) {
 		case RssiError.NotAvailable:

--- a/packages/serial/src/serialapi/transport/SendDataShared.ts
+++ b/packages/serial/src/serialapi/transport/SendDataShared.ts
@@ -128,18 +128,17 @@ export function parseTXReport(
 		// These might be missing:
 		failedRouteLastFunctionalNodeId: buffer[17],
 		failedRouteFirstNonFunctionalNodeId: buffer[18],
-		txPower: parseTXPower(buffer, 19),
-		measuredNoiseFloor: tryParseRSSI(buffer, 20),
-		destinationAckTxPower: includeACK
-			? parseTXPower(buffer, 21)
-			: undefined,
-		destinationAckMeasuredRSSI: includeACK
-			? tryParseRSSI(buffer, 22)
-			: undefined,
-		destinationAckMeasuredNoiseFloor: includeACK
-			? tryParseRSSI(buffer, 23)
-			: undefined,
 	};
+	// These fields are only available for Z-Wave LR:
+	if (ret.txChannelNo >= 3) {
+		ret.txPower = parseTXPower(buffer, 19);
+		ret.measuredNoiseFloor = tryParseRSSI(buffer, 20);
+		if (includeACK) {
+			ret.destinationAckTxPower = parseTXPower(buffer, 21);
+			ret.destinationAckMeasuredRSSI = tryParseRSSI(buffer, 22);
+			ret.destinationAckMeasuredNoiseFloor = tryParseRSSI(buffer, 23);
+		}
+	}
 	// Remove unused repeaters from arrays
 	ret.repeaterNodeIds = ret.repeaterNodeIds.slice(
 		0,
@@ -150,6 +149,11 @@ export function parseTXReport(
 			0,
 			numRepeaters,
 		) as any;
+	}
+	// Remove ACK RSSI if not available
+	if (ret.ackRSSI === RssiError.NotAvailable) {
+		delete ret.ackRSSI;
+		delete ret.ackChannelNo;
 	}
 
 	return stripUndefined(ret as any) as any;

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -3621,7 +3621,10 @@ ${formatRouteHealthCheckSummary(this.id, otherNode.id, summary)}`,
 		this.updateStatistics((current) => {
 			const ret = { ...current };
 			// Update ACK RSSI
-			if (txReport.ackRSSI != undefined) {
+			if (
+				txReport.ackRSSI != undefined
+				&& txReport.ackRSSI !== RssiError.NotAvailable
+			) {
 				ret.rssi =
 					ret.rssi == undefined || isRssiError(txReport.ackRSSI)
 						? txReport.ackRSSI
@@ -3632,9 +3635,7 @@ ${formatRouteHealthCheckSummary(this.id, otherNode.id, summary)}`,
 			const newStats: RouteStatistics = {
 				protocolDataRate: txReport.routeSpeed,
 				repeaters: (txReport.repeaterNodeIds ?? []) as number[],
-				rssi: txReport.ackRSSI
-					?? ret.lwr?.rssi
-					?? RssiError.NotAvailable,
+				rssi: txReport.ackRSSI ?? ret.lwr?.rssi,
 			};
 			if (txReport.ackRepeaterRSSI != undefined) {
 				newStats.repeaterRSSI = txReport.ackRepeaterRSSI as number[];


### PR DESCRIPTION
Fixes the first half of https://github.com/zwave-js/zwave-js/issues/6275
closes: https://github.com/zwave-js/zwave-js/discussions/7804#discussioncomment-13097805
might help with https://github.com/home-assistant/core/issues/142965