### PR TITLE
fix: preserve status of awake nodes when interview starts

### DIFF
--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -825,23 +825,20 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 		const { resetSecurityClasses = false, waitForWakeup = true } = options;
 		// Unless desired, don't forget the information about sleeping nodes immediately, so they continue to function
 		let didWakeUp = false;
-		let wasAwake = false;
+		const wasAwake = this.status === NodeStatus.Awake;
 		if (
 			waitForWakeup
 			&& this.canSleep
+			&& !wasAwake
 			&& this.supportsCC(CommandClasses["Wake Up"])
 		) {
-			if (this.status === NodeStatus.Awake) {
-				wasAwake = true;
-			} else {
-				this.driver.controllerLog.logNode(
-					this.id,
-					"Re-interview scheduled, waiting for node to wake up...",
-				);
-				didWakeUp = await this.waitForWakeup()
-					.then(() => true)
-					.catch(() => false);
-			}
+			this.driver.controllerLog.logNode(
+				this.id,
+				"Re-interview scheduled, waiting for node to wake up...",
+			);
+			didWakeUp = await this.waitForWakeup()
+				.then(() => true)
+				.catch(() => false);
 		}
 
 		// preserve the node name and location, since they might not be stored on the node

--- a/packages/zwave-js/src/lib/test/node/Node.rememberAwakeForInterview.test.ts
+++ b/packages/zwave-js/src/lib/test/node/Node.rememberAwakeForInterview.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { integrationTest } from "../integrationTestSuite.js";
 
 integrationTest(
-	"If a node is considered awake when the interview starts, this should be remembered",
+	"If a node is considered awake when the interview starts, this should be remembered (waitForWakeup = true)",
 	{
 		// debug: true,
 		provisioningDirectory: path.join(__dirname, "fixtures/sleepingNode"),
@@ -44,7 +44,7 @@ integrationTest(
 );
 
 integrationTest(
-	"If the interview waits for a node to wake up, it should be remembered as being awake",
+	"If the interview waits for a node to wake up, it should be remembered as being awake (waitForWakeup = true)",
 	{
 		// debug: true,
 		provisioningDirectory: path.join(__dirname, "fixtures/sleepingNode"),
@@ -66,6 +66,87 @@ integrationTest(
 			// Mark the node as awake shortly after the interview starts
 			node.markAsAsleep();
 			void node.refreshInfo();
+			setTimeout(() => {
+				node.markAsAwake();
+			}, 100);
+
+			const interviewDone = createDeferredPromise<void>();
+			node.once("interview completed", () => {
+				interviewDone.resolve();
+			});
+
+			// The interview should complete quickly
+			const testResult = await Promise.race([
+				interviewDone.then(() => true),
+				wait(2000).then(() => false),
+			]);
+			t.expect(testResult, "The interview did not complete").toBe(true);
+		},
+	},
+);
+
+integrationTest(
+	"If a node is considered awake when the interview starts, this should be remembered (waitForWakeup = false)",
+	{
+		// debug: true,
+		provisioningDirectory: path.join(__dirname, "fixtures/sleepingNode"),
+
+		nodeCapabilities: {
+			manufacturerId: 0x0000,
+			productType: 0xdead,
+			productId: 0xbeef,
+
+			isListening: false,
+			isFrequentListening: false,
+
+			commandClasses: [
+				CommandClasses["Manufacturer Specific"],
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// Mark the node as awake shortly before the interview starts
+			node.markAsAwake();
+			void node.refreshInfo({ waitForWakeup: false });
+
+			const interviewDone = createDeferredPromise<void>();
+			node.once("interview completed", () => {
+				interviewDone.resolve();
+			});
+
+			// The interview should complete quickly
+			const testResult = await Promise.race([
+				interviewDone.then(() => true),
+				wait(2000).then(() => false),
+			]);
+			t.expect(testResult, "The interview did not complete").toBe(true);
+		},
+	},
+);
+
+integrationTest(
+	"If the interview waits for a node to wake up, it should be remembered as being awake (waitForWakeup = false)",
+	{
+		// debug: true,
+		provisioningDirectory: path.join(__dirname, "fixtures/sleepingNode"),
+
+		nodeCapabilities: {
+			manufacturerId: 0x0000,
+			productType: 0xdead,
+			productId: 0xbeef,
+
+			isListening: false,
+			isFrequentListening: false,
+
+			commandClasses: [
+				CommandClasses["Manufacturer Specific"],
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// Mark the node as awake shortly after the interview starts
+			node.markAsAsleep();
+			void node.refreshInfo({ waitForWakeup: false });
 			setTimeout(() => {
 				node.markAsAwake();
 			}, 100);

--- a/packages/zwave-js/src/lib/test/node/Node.rememberAwakeForInterview.test.ts
+++ b/packages/zwave-js/src/lib/test/node/Node.rememberAwakeForInterview.test.ts
@@ -1,0 +1,86 @@
+import { CommandClasses } from "@zwave-js/core";
+import { wait } from "alcalzone-shared/async";
+import { createDeferredPromise } from "alcalzone-shared/deferred-promise";
+import path from "node:path";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest(
+	"If a node is considered awake when the interview starts, this should be remembered",
+	{
+		// debug: true,
+		provisioningDirectory: path.join(__dirname, "fixtures/sleepingNode"),
+
+		nodeCapabilities: {
+			manufacturerId: 0x0000,
+			productType: 0xdead,
+			productId: 0xbeef,
+
+			isListening: false,
+			isFrequentListening: false,
+
+			commandClasses: [
+				CommandClasses["Manufacturer Specific"],
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// Mark the node as awake shortly before the interview starts
+			node.markAsAwake();
+			void node.refreshInfo();
+
+			const interviewDone = createDeferredPromise<void>();
+			node.once("interview completed", () => {
+				interviewDone.resolve();
+			});
+
+			// The interview should complete quickly
+			const testResult = await Promise.race([
+				interviewDone.then(() => true),
+				wait(2000).then(() => false),
+			]);
+			t.expect(testResult, "The interview did not complete").toBe(true);
+		},
+	},
+);
+
+integrationTest(
+	"If the interview waits for a node to wake up, it should be remembered as being awake",
+	{
+		// debug: true,
+		provisioningDirectory: path.join(__dirname, "fixtures/sleepingNode"),
+
+		nodeCapabilities: {
+			manufacturerId: 0x0000,
+			productType: 0xdead,
+			productId: 0xbeef,
+
+			isListening: false,
+			isFrequentListening: false,
+
+			commandClasses: [
+				CommandClasses["Manufacturer Specific"],
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// Mark the node as awake shortly after the interview starts
+			node.markAsAsleep();
+			void node.refreshInfo();
+			setTimeout(() => {
+				node.markAsAwake();
+			}, 100);
+
+			const interviewDone = createDeferredPromise<void>();
+			node.once("interview completed", () => {
+				interviewDone.resolve();
+			});
+
+			// The interview should complete quickly
+			const testResult = await Promise.race([
+				interviewDone.then(() => true),
+				wait(2000).then(() => false),
+			]);
+			t.expect(testResult, "The interview did not complete").toBe(true);
+		},
+	},
+);

--- a/packages/zwave-js/src/lib/test/node/fixtures/sleepingNode/7e570001.jsonl
+++ b/packages/zwave-js/src/lib/test/node/fixtures/sleepingNode/7e570001.jsonl
@@ -1,0 +1,22 @@
+{"k":"cacheFormat","v":1}
+{"k":"node.1.isListening","v":true}
+{"k":"node.1.isFrequentListening","v":false}
+{"k":"node.1.isRouting","v":true}
+{"k":"node.1.supportedDataRates","v":[40000,9600,100000]}
+{"k":"node.1.protocolVersion","v":3}
+{"k":"node.1.nodeType","v":"Controller"}
+{"k":"node.1.supportsSecurity","v":false}
+{"k":"node.1.supportsBeaming","v":true}
+{"k":"node.1.deviceClass","v":{"basic":2,"generic":2,"specific":7}}
+{"k":"node.1.endpoint.0.commandClass.0x72","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x86","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x20","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x60","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.interviewStage","v":"Complete"}
+
+{"k":"node.2.hasSUCReturnRoute","v":true}
+// Wake Up CC
+{"k":"node.2.endpoint.0.commandClass.0x84","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.2.isListening","v":false}
+{"k":"node.2.isFrequentListening","v":false}
+{"k":"node.2.interviewStage","v":"Complete"}


### PR DESCRIPTION
Fixes an issue where sleeping nodes that report being awake after a firmware update will cause their interview to start, but pause immediately after the ProtocolInfo stage is completed.