### PR TITLE
feat(config): add association group for Vesternet VES-ZW-DIM-001

### DIFF
--- a/packages/config/config/devices/0x0330/ves-zw-dim-001.json
+++ b/packages/config/config/devices/0x0330/ves-zw-dim-001.json
@@ -1,7 +1,7 @@
 {
-	"manufacturer": "ShenZhen Sunricher Technology, Ltd.",
+	"manufacturer": "Vesternet",
 	"manufacturerId": "0x0330",
-	"label": "SR-ZV9040A",
+	"label": "VES-ZW-DIM-001",
 	"description": "2-Wire Capable Dimmer",
 	"devices": [
 		{
@@ -16,7 +16,7 @@
 	},
 	"associations": {
 		"1": {
-			"label": "Group 1",
+			"label": "Lifeline",
 			"maxNodes": 5,
 			"isLifeline": true
 		}
@@ -34,30 +34,20 @@
 		},
 		{
 			"#": "4",
-			"label": "Default Fade Time",
-			"description": "Default fade time (unit is second)",
+			"label": "Dimming Speed",
 			"valueSize": 1,
 			"unit": "seconds",
 			"minValue": 0,
 			"maxValue": 127,
-			"defaultValue": 1,
-			"unsigned": true,
-			"options": [
-				{
-					"label": "Instantly",
-					"value": 0
-				}
-			]
+			"defaultValue": 1
 		},
 		{
 			"#": "5",
-			"label": "Setting Minimum Brightness Value",
-			"description": "The bigger the value is, the higher the load’s minimum brightness is",
+			"label": "Minimum Dim Level",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 50,
-			"defaultValue": 0,
-			"unsigned": true
+			"defaultValue": 15
 		},
 		{
 			"#": "6",
@@ -69,26 +59,18 @@
 		},
 		{
 			"#": "8",
-			"label": "External Switch Type",
-			"description": "External switch type",
+			"label": "Switch Type",
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
 			"defaultValue": 0,
-			"unsigned": true,
 			"allowManualEntry": false,
 			"options": [
 				{
-					"label": "Push button switch",
+					"label": "Momentary",
 					"value": 0
 				},
 				{
-					"label": "Normal on/off switch",
+					"label": "Toggle",
 					"value": 1
-				},
-				{
-					"label": "3-way switch",
-					"value": 2
 				}
 			]
 		},
@@ -101,12 +83,10 @@
 		{
 			"#": "11",
 			"label": "Wiring Type",
-			"description": "Wiring type  note: this parameter is read only",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 2,
 			"defaultValue": 0,
-			"unsigned": true,
 			"readOnly": true,
 			"options": [
 				{
@@ -114,11 +94,11 @@
 					"value": 0
 				},
 				{
-					"label": "2 wire with no neutral",
+					"label": "2-Wire (No neutral)",
 					"value": 1
 				},
 				{
-					"label": "3 wire with neutral",
+					"label": "3-Wire (With neutral)",
 					"value": 2
 				}
 			]
@@ -126,12 +106,10 @@
 		{
 			"#": "12",
 			"label": "Load Type",
-			"description": "Load type  note: this parameter is read only",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 3,
 			"defaultValue": 0,
-			"unsigned": true,
 			"readOnly": true,
 			"options": [
 				{
@@ -161,36 +139,30 @@
 		},
 		{
 			"#": "14",
-			"label": "Power Automatic Report Absolute Threshold, Unit is W",
-			"description": "When power changes above the absolute threshold, immediately report current power value",
+			"label": "Power Report: Change Threshold",
 			"valueSize": 2,
 			"unit": "W",
 			"minValue": 0,
-			"maxValue": 10,
-			"defaultValue": 10,
-			"unsigned": true
+			"maxValue": 400,
+			"defaultValue": 10
 		},
 		{
 			"#": "15",
-			"label": "Power Automatic Report Percentage Threshold, Unit is %",
-			"description": "When power changes above the percentage threshold, immediately report current power value",
+			"label": "Power Report: Relative Change Threshold",
 			"valueSize": 1,
 			"unit": "%",
 			"minValue": 0,
-			"maxValue": 20,
-			"defaultValue": 20,
-			"unsigned": true
+			"maxValue": 100,
+			"defaultValue": 20
 		},
 		{
 			"#": "21",
-			"label": "Power Metering Automatic Report Time Cycle, Unit is Second",
-			"description": "Power metering automatic report time cycle, unit is second",
+			"label": "Power Report Interval",
 			"valueSize": 4,
 			"unit": "seconds",
 			"minValue": 0,
-			"maxValue": 600,
+			"maxValue": 2678400,
 			"defaultValue": 600,
-			"unsigned": true,
 			"options": [
 				{
 					"label": "Disable",
@@ -200,14 +172,12 @@
 		},
 		{
 			"#": "22",
-			"label": "Energy Metering Automatic Report Time Cycle, Unit is Second",
-			"description": "Energy metering automatic report time cycle, unit is second",
+			"label": "Energy Report Interval",
 			"valueSize": 4,
 			"unit": "seconds",
 			"minValue": 0,
-			"maxValue": 1800,
+			"maxValue": 2678400,
 			"defaultValue": 1800,
-			"unsigned": true,
 			"options": [
 				{
 					"label": "Disable",
@@ -217,14 +187,12 @@
 		},
 		{
 			"#": "23",
-			"label": "Voltage Metering Automatic Report Time Cycle, Unit is Second",
-			"description": "Voltage metering automatic report time cycle, unit is second",
+			"label": "Voltage Report Interval",
 			"valueSize": 4,
 			"unit": "seconds",
 			"minValue": 0,
-			"maxValue": 3600,
+			"maxValue": 2678400,
 			"defaultValue": 3600,
-			"unsigned": true,
 			"options": [
 				{
 					"label": "Disable",
@@ -234,14 +202,12 @@
 		},
 		{
 			"#": "24",
-			"label": "Current Metering Automatic Report Time Cycle, Unit is Second",
-			"description": "Current metering automatic report time cycle, unit is second",
+			"label": "Current Report Interval",
 			"valueSize": 4,
 			"unit": "seconds",
 			"minValue": 0,
-			"maxValue": 3600,
+			"maxValue": 2678400,
 			"defaultValue": 3600,
-			"unsigned": true,
 			"options": [
 				{
 					"label": "Disable",
@@ -272,37 +238,12 @@
 			"label": "Startup Brightness",
 			"description": "When the light is turned from off to on, if the target brightness is lower than the startup brightness, the brightness will first go to the startup brightness then fall to the target brightness.",
 			"defaultValue": 0
-		},
-		{
-			"#": "10",
-			"label": "Enable/Disable to Detect Load After Re-power On",
-			"description": "Enable/disable to detect load after re-power on (detect load type, minimum brightness, maximum brightness)  note: when the device does not belong to any network, load detection will be enabled every time after re-power on. when the device has already been added to a network, load detection will be disabled",
-			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
-			"defaultValue": 0,
-			"unsigned": true,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Disable",
-					"value": 0
-				},
-				{
-					"label": "Enable to detect every time after re-power on",
-					"value": 1
-				},
-				{
-					"label": "Enable to detect only after first re-power on",
-					"value": 2
-				}
-			]
 		}
 	],
 	"metadata": {
-		"inclusion": "1. Set primary controller/gateway into inclusion mode (Please refer to your primary controller’s manual on how to turn your controller into inclusion).\n2. Power on the in-wall dimmer and set it into inclusion mode. There are two methods to set the in-wall dimmer into inclusion mode:\n1)Repower on the dimmer, it will be set into inclusion mode automatically, and waiting to be included.\n2)Triple press the action button on the dimmer, it will set the dimmer into inclusion mode.\nThe connected light will stay solid on for 3 seconds to indicate successful inclusion",
-		"exclusion": "There are two exclusion methods:\nMethod 1: Exclusion from the primary controller/gateway as follows:\n1. Set the primary controller/gateway into exclusion mode (Please refer to your primary controllers manual on how to set your controller into exclusion).\n2. Triple press the action button, the dimmer will be set to exclusion mode, and waiting to be excluded, then the dimmer will be excluded from the network.\nMethod 2: Factory reset the dimmer will force it to be excluded from a network. (please refer to the part “Factory Reset” of this manual)\nNote: Factory reset is not recommended for exclusion, please use this procedure only if the primary controller/gateway is missing or otherwise inoperable",
-		"reset": "Press and hold down the action button for over 10 seconds, the dimmer will be reset to factory defaults.\n\nNote: Factory reset is not recommended for exclusion, please use this procedure only if the primary controller/gateway is missing or otherwise inoperable",
-		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/3331/SR-ZV9040A-A%20Micro%20Smart%20Dimmer.pdf"
+		"inclusion": "Step 1. Set primary controller/gateway into inclusion mode.\nStep 2. Either power cycle the product, or triple press the action button.\n Step 3. The connected light will stay on solid for 3 seconds to indicate successful inclusion.",
+		"exclusion": "Step 1. Set primary controller/gateway into exclusion mode.\nStep 2. Triple press the action button.",
+		"reset": "Press and hold the action button for over 10 seconds. The connected light will be set to 50% brightness and flash slowly.",
+		"manual": "https://cdn.shopify.com/s/files/1/0066/8149/3559/files/VES-ZW-DIM-001.pdf"
 	}
 }


### PR DESCRIPTION
This pull request will revert almost all of the changes from the automatic import by zwave-js-bot. The device being imported is already in the database, and the current config file appears to match the manual. The only thing I see missing is association group 1.

The import was done in response to #7050. However, that issue referenced a zwave alliance page that did not match the fingerprint in question - `0x0330/0x0202/0xD01C`. That issue can be closed as support for that fingerprint was added in #7400.