### PR TITLE
fix: retry on ACK timeout before soft-resetting, increase timeout

### DIFF
--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -17,7 +17,7 @@ export interface ZWaveOptions {
 	/** Specify timeouts in milliseconds */
 	timeouts: {
 		/** how long to wait for an ACK */
-		ack: number; // >=1, default: 1000 ms
+		ack: number; // >=1, default: 1600 ms
 
 		/** not sure */
 		byte: number; // >=1, default: 150 ms


### PR DESCRIPTION
fixes: https://github.com/zwave-js/zwave-js/discussions/7782

It seems like the functionality to retry after an ACK timeout went missing somewhere between v14 and v15. This PR restores it and adds a test to ensure it stays in.