### PR TITLE
feat: allow the application to disable support for specific CCs

### DIFF
--- a/docs/api/CCs/Version.md
+++ b/docs/api/CCs/Version.md
@@ -27,7 +27,7 @@ async getCCVersion(
 ### `reportCCVersion`
 
 ```ts
-async reportCCVersion(requestedCC: CommandClasses): Promise<void>;
+async reportCCVersion(requestedCC: CommandClasses, version?: number): Promise<void>;
 ```
 
 ### `getCapabilities`

--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -1026,6 +1026,16 @@ interface ZWaveOptions {
 		 * Default: `true`, except when the ZWAVEJS_DISABLE_UNRESPONSIVE_CONTROLLER_RECOVERY env variable is set.
 		 */
 		unresponsiveControllerRecovery?: boolean;
+		/**
+		 * Z-Wave JS normally uses all Command Classes it implements and responds to version queries for all of them.
+		 *
+		 * However, some Command Classes come with certification requirements that might not be fulfilled by the application.
+		 * To allow for deploying products based on Z-Wave JS without having to implement all of them,
+		 * this option allows you to disable certain Command Classes. Z-Wave JS will act as if the specified Command Classes are not implemented.
+		 *
+		 * Note that this only affects a subset of CCs that is not mandatory.
+		 */
+		disableCommandClasses: CommandClasses[];
 	};
 
 	preferences: {

--- a/packages/cc/src/cc/VersionCC.ts
+++ b/packages/cc/src/cc/VersionCC.ts
@@ -279,7 +279,13 @@ export class VersionCCAPI extends PhysicalCCAPI {
 	}
 
 	@validateArgs()
-	public async reportCCVersion(requestedCC: CommandClasses): Promise<void> {
+	/**
+	 * @param version The version to report. If not given, the implemented version will be used for the report.
+	 */
+	public async reportCCVersion(
+		requestedCC: CommandClasses,
+		version?: number,
+	): Promise<void> {
 		this.assertSupportsCommand(
 			VersionCommand,
 			VersionCommand.CommandClassReport,
@@ -301,7 +307,7 @@ export class VersionCCAPI extends PhysicalCCAPI {
 				break;
 
 			default:
-				ccVersion = getImplementedVersion(requestedCC);
+				ccVersion = version ?? getImplementedVersion(requestedCC);
 				break;
 		}
 

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -1,4 +1,5 @@
 import type {
+	CommandClasses,
 	FileSystem as LegacyFileSystemBindings,
 	LogConfig,
 	LogFactory,
@@ -280,6 +281,17 @@ export interface ZWaveOptions {
 		 * Default: `false`
 		 */
 		watchdog?: boolean;
+
+		/**
+		 * Z-Wave JS normally uses all Command Classes it implements and responds to version queries for all of them.
+		 *
+		 * However, some Command Classes come with certification requirements that might not be fulfilled by the application.
+		 * To allow for deploying products based on Z-Wave JS without having to implement all of them,
+		 * this option allows you to disable certain Command Classes. Z-Wave JS will act as if the specified Command Classes are not implemented.
+		 *
+		 * Note that this only affects a subset of CCs that is not mandatory.
+		 */
+		disableCommandClasses: CommandClasses[];
 	};
 
 	preferences: {

--- a/packages/zwave-js/src/lib/node/CCHandlers/VersionCC.ts
+++ b/packages/zwave-js/src/lib/node/CCHandlers/VersionCC.ts
@@ -55,6 +55,7 @@ export async function handleVersionCommandClassGet(
 	ctx: PersistValuesContext & LogNode,
 	node: ZWaveNode,
 	command: VersionCCCommandClassGet,
+	reportVersion?: number,
 ): Promise<void> {
 	const endpoint = node.getEndpoint(command.endpointIndex) ?? node;
 
@@ -69,7 +70,7 @@ export async function handleVersionCommandClassGet(
 				& ~EncapsulationFlags.Supervision,
 		});
 
-	await api.reportCCVersion(command.requestedCC);
+	await api.reportCCVersion(command.requestedCC, reportVersion);
 }
 
 export async function handleVersionCapabilitiesGet(

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -2368,7 +2368,24 @@ protocol version:      ${this.protocolVersion}`;
 				this.driver.options.vendor,
 			);
 		} else if (command instanceof VersionCCCommandClassGet) {
-			return handleVersionCommandClassGet(this.driver, this, command);
+			// If the application has disabled this CC, set the version to 0
+			// This should be all we need to do, as there are currently no CCs with
+			// requirements for applications where we also respond to Get requests
+			let reportVersion: number | undefined;
+			if (
+				this.driver.options.features.disableCommandClasses?.includes(
+					command.requestedCC,
+				)
+			) {
+				reportVersion = 0;
+			}
+
+			return handleVersionCommandClassGet(
+				this.driver,
+				this,
+				command,
+				reportVersion,
+			);
 		} else if (command instanceof VersionCCCapabilitiesGet) {
 			return handleVersionCapabilitiesGet(this.driver, this, command);
 		} else if (command instanceof ManufacturerSpecificCCGet) {

--- a/packages/zwave-js/src/lib/test/driver/features.disableCCs.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/features.disableCCs.test.ts
@@ -1,0 +1,47 @@
+import {
+	VersionCCCommandClassGet,
+	VersionCCCommandClassReport,
+} from "@zwave-js/cc";
+import { CommandClasses } from "@zwave-js/core";
+import {
+	MockZWaveFrameType,
+	createMockZWaveRequestFrame,
+} from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest(
+	"Respond to CC version queries for disabled CCs with version 0",
+	{
+		// debug: true,
+
+		additionalDriverOptions: {
+			features: {
+				disableCommandClasses: [
+					CommandClasses["Binary Switch"],
+				],
+			},
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const ccGet = new VersionCCCommandClassGet({
+				nodeId: node.id,
+				requestedCC: CommandClasses["Binary Switch"],
+			});
+			await mockNode.sendToController(createMockZWaveRequestFrame(ccGet, {
+				ackRequested: false,
+			}));
+
+			await wait(100);
+
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request
+					&& frame.payload instanceof VersionCCCommandClassReport
+					&& frame.payload.requestedCC
+						=== CommandClasses["Binary Switch"]
+					&& frame.payload.ccVersion === 0,
+			);
+		},
+	},
+);


### PR DESCRIPTION
Z-Wave JS normally uses all Command Classes it implements and responds to version queries for all of them.
However, some Command Classes come with certification requirements that might not be fulfilled by the application.

To allow for deploying products based on Z-Wave JS without having to add (mostly) UI support for all supported CCs, this PR adds a driver option `features.disableCommandClasses` where an application can specify which CCs it will not support.
Z-Wave JS will then act as if it does not implement those CCs.

Note that the list of CCs that can be disabled is only a subset of all CCs - encapsulation CCs and some mandatory CCs cannot be disabled.