### PR TITLE
feat: support OTW updates via the firmware update service

### DIFF
--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -309,10 +309,12 @@ Updates a subset of the driver options without having to restart the driver. The
 ### Updating the firmware of the Z-Wave module (OTW)
 
 ```ts
-firmwareUpdateOTW(data: Buffer): Promise<OTWFirmwareUpdateResult>
+firmwareUpdateOTW(data: Buffer | FirmwareUpdateInfo): Promise<OTWFirmwareUpdateResult>
 ```
 
 > [!WARNING] We don't take any responsibility if devices upgraded using Z-Wave JS don't work after an update. Always double-check that the correct update is about to be installed.
+
+Besides the raw firmware image, you can also pass a `FirmwareUpdateInfo` object as returned from the [`getAvailableFirmwareUpdates` controller method](api/controller.md#getavailablefirmwareupdates). In that case, the firmware image will automatically be downloaded and validated before performing the update.
 
 Performs an over-the-wire (OTW) firmware update for the Z-Wave module (controller) using the given firmware image. To do so, the device gets put in bootloader mode where a new firmware image can be uploaded. This method can be called in bootloader mode, while connected to a Serial API controller, or with a CLI based firmware that has an option to return to bootloader.
 

--- a/packages/zwave-js/src/lib/controller/_Types.ts
+++ b/packages/zwave-js/src/lib/controller/_Types.ts
@@ -45,6 +45,23 @@ export type FirmwareUpdateInfo = Expand<
 	}
 >;
 
+export function isFirmwareUpdateInfo(
+	info: any,
+): info is FirmwareUpdateInfo {
+	return typeof info === "object"
+		&& info !== null
+		&& typeof info.version === "string"
+		&& typeof info.normalizedVersion === "string"
+		&& typeof info.changelog === "string"
+		&& typeof info.channel === "string"
+		&& typeof info.device === "object"
+		&& info.device !== null
+		&& typeof info.device.manufacturerId === "number"
+		&& typeof info.device.productType === "number"
+		&& typeof info.device.productId === "number"
+		&& typeof info.device.firmwareVersion === "string";
+}
+
 export interface GetFirmwareUpdatesOptions {
 	/** Allows overriding the API key for the firmware update service */
 	apiKey?: string;

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -65,6 +65,7 @@ import {
 	ControllerStatus,
 	Duration,
 	EncapsulationFlags,
+	type Firmware,
 	type HostIDs,
 	type LogConfig,
 	type LogContainer,
@@ -213,12 +214,17 @@ import { isArray, isObject } from "alcalzone-shared/typeguards";
 import path from "pathe";
 import { PACKAGE_NAME, PACKAGE_VERSION } from "../_version.js";
 import { ZWaveController } from "../controller/Controller.js";
+import { downloadFirmwareUpdate } from "../controller/FirmwareUpdateService.js";
 import {
 	type FoundNode,
 	InclusionState,
 	RemoveNodeReason,
 } from "../controller/Inclusion.js";
 import { determineNIF } from "../controller/NodeInformationFrame.js";
+import {
+	type FirmwareUpdateInfo,
+	isFirmwareUpdateInfo,
+} from "../controller/_Types.js";
 import { DriverLogger } from "../log/Driver.js";
 import type { Endpoint } from "../node/Endpoint.js";
 import type { ZWaveNode } from "../node/Node.js";
@@ -8229,6 +8235,8 @@ ${handlers.length} left`,
 
 	/**
 	 * Updates the firmware of the controller using the given firmware file.
+	 * The file can be provided as binary data or as a {@link FirmwareUpdateInfo} object as returned
+	 * from the firmware update service. The latter will be downloaded automatically.
 	 *
 	 * The return value indicates whether the update was successful.
 	 * **WARNING:** After a successful update, the Z-Wave driver will destroy itself so it can be restarted.
@@ -8236,7 +8244,7 @@ ${handlers.length} left`,
 	 * **WARNING:** A failure during this process may put your controller in recovery mode, rendering it unusable until a correct firmware image is uploaded. Use at your own risk!
 	 */
 	public async firmwareUpdateOTW(
-		data: Uint8Array,
+		data: Uint8Array | FirmwareUpdateInfo,
 	): Promise<OTWFirmwareUpdateResult> {
 		// Don't interrupt ongoing OTA firmware updates
 		if (this._controller?.isAnyOTAFirmwareUpdateInProgress()) {
@@ -8252,6 +8260,11 @@ ${handlers.length} left`,
 				`Failed to start the update: The controller is currently being updated!`;
 			this.controllerLog.print(message, "error");
 			throw new ZWaveError(message, ZWaveErrorCodes.OTW_Update_Busy);
+		}
+
+		// If the data is provided as a FirmwareUpdateInfo, we need to download the firmware first
+		if (isFirmwareUpdateInfo(data)) {
+			data = await this.extractOTWUpdateInfo(data);
 		}
 
 		// When in bootloader mode, we can use the 700 series update method
@@ -8287,6 +8300,93 @@ ${handlers.length} left`,
 			`Firmware updates are not supported on this Z-Wave module`,
 			ZWaveErrorCodes.Controller_NotSupported,
 		);
+	}
+
+	/**
+	 * Downloads the desired firmware update from the Z-Wave JS firmware update service and extracts the firmware data.
+	 * @param updateInfo The desired entry from the updates array that was returned by {@link getAvailableFirmwareUpdates}.
+	 * Before applying the update, Z-Wave JS will check whether the device IDs, firmware version and region match.
+	 */
+	private async extractOTWUpdateInfo(
+		updateInfo: FirmwareUpdateInfo,
+	): Promise<Uint8Array> {
+		// Controller updates must have exactly one file
+		if (updateInfo.files?.length !== 1) {
+			throw new ZWaveError(
+				`Invalid number of update files for OTW firmware updates.`,
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+		const update = updateInfo.files[0];
+
+		// The controller must also not be downgraded this way
+		if (updateInfo.downgrade) {
+			throw new ZWaveError(
+				`Invalid update file: Downgrades are not supported!`,
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
+
+		// Make sure we're not applying the update to the wrong device
+		if (
+			updateInfo.device.manufacturerId !== this.controller.manufacturerId
+			|| updateInfo.device.productType !== this.controller.productType
+			|| updateInfo.device.productId !== this.controller.productId
+		) {
+			throw new ZWaveError(
+				`Cannot update controller firmware: The firmware update is for a different device!`,
+				ZWaveErrorCodes.FWUpdateService_DeviceMismatch,
+			);
+		} else if (
+			updateInfo.device.firmwareVersion
+				!== this.controller.firmwareVersion
+		) {
+			throw new ZWaveError(
+				`Cannot update controller firmware: The update is for a different original firmware version!`,
+				ZWaveErrorCodes.FWUpdateService_DeviceMismatch,
+			);
+		}
+
+		const loglevel = this.getLogConfig().level;
+
+		let logMessage = `Downloading OTW firmware update...`;
+		if (loglevel === "silly") {
+			logMessage += `
+URL:       ${update.url}
+integrity: ${update.integrity}`;
+		}
+		this.controllerLog.print(logMessage);
+
+		let firmware: Firmware;
+		try {
+			firmware = await downloadFirmwareUpdate(update);
+		} catch (e: any) {
+			let message = `Downloading the OTW firmware update failed:\n`;
+			if (isZWaveError(e)) {
+				// Pass "real" Z-Wave errors through
+				throw new ZWaveError(message + e.message, e.code);
+			} else if (e.response) {
+				// And construct a better error message for HTTP errors
+				if (
+					isObject(e.response.data)
+					&& typeof e.response.data.message === "string"
+				) {
+					message += `${e.response.data.message} `;
+				}
+				message += `[${e.response.status} ${e.response.statusText}]`;
+			} else if (typeof e.message === "string") {
+				message += e.message;
+			} else {
+				message += `Failed to download firmware update!`;
+			}
+
+			throw new ZWaveError(
+				message,
+				ZWaveErrorCodes.FWUpdateService_RequestError,
+			);
+		}
+
+		return firmware.data;
 	}
 
 	private async firmwareUpdateOTW500(


### PR DESCRIPTION
With this PR, the `driver.firmwareUpdateOTW` method now also accepts a `FirmwareUpdateInfo` as returned by the `getAvailableFirmwareUpdates` method. In that case, downloading and verifying the firmware update is before attempting the update, just like with OTA updates.