### PR TITLE
fix: try to reopen serialport when it closes unexpectedly

### DIFF
--- a/packages/core/src/error/ZWaveError.ts
+++ b/packages/core/src/error/ZWaveError.ts
@@ -27,6 +27,9 @@ export enum ZWaveErrorCodes {
 	/** The task was removed from the task queue */
 	Driver_TaskRemoved,
 
+	/** The serial port closed unexpectedly */
+	Driver_SerialPortClosed,
+
 	/** There was a timeout while waiting for a message from the controller */
 	Controller_Timeout = 200,
 	/** There was a timeout while waiting for a response from a node */

--- a/packages/serial/src/serialport/LegacyBindingWrapper.ts
+++ b/packages/serial/src/serialport/LegacyBindingWrapper.ts
@@ -52,7 +52,7 @@ export function wrapLegacySerialBinding(
 					controller.error(
 						new ZWaveError(
 							`The serial port closed unexpectedly!`,
-							ZWaveErrorCodes.Driver_Failed,
+							ZWaveErrorCodes.Driver_SerialPortClosed,
 						),
 					);
 				});

--- a/packages/serial/src/serialport/NodeSerialPort.ts
+++ b/packages/serial/src/serialport/NodeSerialPort.ts
@@ -45,7 +45,7 @@ export function createNodeSerialPortFactory(
 					reject(
 						new ZWaveError(
 							`The serial port closed unexpectedly!`,
-							ZWaveErrorCodes.Driver_Failed,
+							ZWaveErrorCodes.Driver_SerialPortClosed,
 						),
 					);
 				};
@@ -107,7 +107,7 @@ export function createNodeSerialPortFactory(
 						controller.error(
 							new ZWaveError(
 								`The serial port closed unexpectedly!`,
-								ZWaveErrorCodes.Driver_Failed,
+								ZWaveErrorCodes.Driver_SerialPortClosed,
 							),
 						);
 					}

--- a/packages/serial/src/serialport/NodeSocket.ts
+++ b/packages/serial/src/serialport/NodeSocket.ts
@@ -23,7 +23,7 @@ export function createNodeSocketFactory(
 					reject(
 						new ZWaveError(
 							`The socket closed unexpectedly!`,
-							ZWaveErrorCodes.Driver_Failed,
+							ZWaveErrorCodes.Driver_SerialPortClosed,
 						),
 					);
 				};
@@ -94,7 +94,7 @@ export function createNodeSocketFactory(
 					controller.error(
 						new ZWaveError(
 							`The serial port closed unexpectedly!`,
-							ZWaveErrorCodes.Driver_Failed,
+							ZWaveErrorCodes.Driver_SerialPortClosed,
 						),
 					);
 				});
@@ -103,7 +103,7 @@ export function createNodeSocketFactory(
 					controller.error(
 						new ZWaveError(
 							`The serial port closed unexpectedly!`,
-							ZWaveErrorCodes.Driver_Failed,
+							ZWaveErrorCodes.Driver_SerialPortClosed,
 						),
 					);
 				});

--- a/packages/serial/src/serialport/ZWaveSerialStream.ts
+++ b/packages/serial/src/serialport/ZWaveSerialStream.ts
@@ -125,7 +125,11 @@ export class ZWaveSerialStream implements
 	public async close(): Promise<void> {
 		this._isOpen = false;
 		// Close the underlying stream
-		this._writer?.releaseLock();
+		try {
+			this._writer?.releaseLock();
+		} catch {
+			// ignore
+		}
 		this.#abort.abort();
 
 		return Promise.resolve();


### PR DESCRIPTION
With this PR, we now try to reopen the serial port when it closes unexpectedly. If this happens in the middle of a command, that command will be retried afterwards.

This should help with situations where the controller reconnects to the USB host and is only unavailable for a short amount of time, e.g. while soft-resetting 500 series controllers.

fixes: #7815