### PR TITLE
feat: add options to set powerlevel within legal limits on region change

### DIFF
--- a/packages/core/src/definitions/RFRegion.ts
+++ b/packages/core/src/definitions/RFRegion.ts
@@ -75,3 +75,27 @@ export enum ZnifferLRChannelConfig {
 	"Classic & LR B" = 2,
 	"LR A & B" = 3,
 }
+
+export function getLegalPowerlevelMesh(region: RFRegion): number | undefined {
+	switch (region) {
+		case RFRegion.Europe:
+		case RFRegion["Europe (Long Range)"]:
+			return +13; // dBm
+		case RFRegion.USA:
+		case RFRegion["USA (Long Range)"]:
+			return -1; // dBm
+	}
+	// Nobody knows
+}
+
+export function getLegalPowerlevelLR(region: RFRegion): number | undefined {
+	switch (region) {
+		case RFRegion.Europe:
+		case RFRegion["Europe (Long Range)"]:
+			return +14; // dBm
+		case RFRegion.USA:
+		case RFRegion["USA (Long Range)"]:
+			return +20; // dBm
+	}
+	// Nobody knows
+}

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -544,12 +544,24 @@ function checkOptions(options: ZWaveOptions): void {
 					`rf.txPower must be an object!`,
 					ZWaveErrorCodes.Driver_InvalidOptions,
 				);
-			} else if (
+			}
+
+			if (
 				typeof options.rf.txPower.powerlevel !== "number"
-				|| typeof options.rf.txPower.measured0dBm !== "number"
+				&& options.rf.txPower.powerlevel !== "auto"
 			) {
 				throw new ZWaveError(
-					`rf.txPower must contain the following numeric properties: powerlevel, measured0dBm!`,
+					`rf.txPower.powerlevel must be a number or "auto"!`,
+					ZWaveErrorCodes.Driver_InvalidOptions,
+				);
+			}
+
+			if (
+				options.rf.txPower.measured0dBm != undefined
+				&& typeof options.rf.txPower.measured0dBm !== "number"
+			) {
+				throw new ZWaveError(
+					`rf.txPower.measured0dBm must be a number!`,
 					ZWaveErrorCodes.Driver_InvalidOptions,
 				);
 			}

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -342,14 +342,25 @@ export interface ZWaveOptions {
 		preferLRRegion?: boolean;
 
 		txPower?: {
-			/** The desired TX power in dBm. */
-			powerlevel: number;
+			/**
+			 * The desired TX power in dBm.
+			 *
+			 * The special value "auto" will apply the known legal limits for the configured RF region,
+			 * but only if the region is actually changed as a result of using the `rf.region` setting.
+			 */
+			powerlevel: number | "auto";
+
 			/** A hardware-specific calibration value. */
-			measured0dBm: number;
+			measured0dBm?: number;
 		};
 
-		/** The desired max. powerlevel setting for Z-Wave Long Range in dBm. */
-		maxLongRangePowerlevel?: number;
+		/**
+		 * The desired max. powerlevel setting for Z-Wave Long Range in dBm.
+		 *
+		 * The special value "auto" will apply the known legal limits for the configured RF region,
+		 * but only if the region is actually changed as a result of using the `rf.region` setting.
+		 */
+		maxLongRangePowerlevel?: number | "auto";
 
 		/**
 		 * The desired channel to use for Z-Wave Long Range.


### PR DESCRIPTION
fixes: #7852

This PR adds `"auto"` as a valid value for the default TX powerlevel settings in the driver options, both for Z-Wave classic and Long Range. This option will determine the legal limits for the desired regions and apply them automatically - for now EU and US only.

To avoid breaking existing networks by messing with the powerlevel settings, they will only be applied if the region is actually changed because of a mismatch from the desired region.