### PR TITLE
feat(config): add fingerprint `0x8101:0x4a36` to McoHome MH4936

### DIFF
--- a/packages/config/config/devices/0x015f/mh4936.json
+++ b/packages/config/config/devices/0x015f/mh4936.json
@@ -7,6 +7,10 @@
 		{
 			"productType": "0x8101",
 			"productId": "0x4936"
+		},
+		{
+			"productType": "0x8101",
+			"productId": "0x4a36"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
Per #7506, a different product ID is assigned to units with upgraded firmware that supports being used as a repeater when hard wired.