### PR TITLE
fix(config): remove unlock mapping for Schlage lock FE599

### DIFF
--- a/packages/config/config/devices/0x003b/fe599nx.json
+++ b/packages/config/config/devices/0x003b/fe599nx.json
@@ -100,9 +100,6 @@
 			},
 			{
 				"$import": "templates/schlage_template.json#alarm_map_keypad_busy"
-			},
-			{
-				"$import": "templates/schlage_template.json#alarm_map_keypad_unlock"
 			}
 		]
 	}

--- a/packages/config/config/devices/0x003b/templates/schlage_template.json
+++ b/packages/config/config/devices/0x003b/templates/schlage_template.json
@@ -18,17 +18,5 @@
 			"notificationType": 6, // Access Control
 			"notificationEvent": 17 // Keypad busy
 		}
-	},
-	"alarm_map_keypad_unlock": {
-		"from": {
-			"alarmType": 16
-		},
-		"to": {
-			"notificationType": 6, // Access Control
-			"notificationEvent": 6, // Keypad unlock operation
-			"eventParameters": {
-				"userId": "alarmLevel"
-			}
-		}
 	}
 }


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

The unlock mapping creates unexpected behaviors with this lock since the physical lock auto re-locks after ~10 seconds but that action is not captured anywhere and so zwave thinks the lock is still unlocked when it actually is locked.

I created a discussion on this but haven't gotten any input there yet: https://github.com/zwave-js/zwave-js/discussions/7511

Also commented on original pull request and did not get any feedback there how the unlock mapping was helpful: https://github.com/zwave-js/zwave-js/pull/7122
