### PR TITLE
docs: correct the explanation of the node `ready` event

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -1358,8 +1358,8 @@ The node is passed as the single argument to the callback:
 
 There are two situations when this event is emitted:
 
-1. The interview of a node is completed for the first time ever.
-2. The node that has previously been interviewed completely and it either responds or is asleep.
+1. The interview of a node is completed (either for the first time or during a re-interview).
+2. When the driver restarts and a node that has previously been interviewed completely either responds or is asleep.
 
 > [!NOTE]
 > This event does not imply that the node is currently awake or will respond to requests.


### PR DESCRIPTION
fixes: #4998