### PR TITLE
feat: support parsing Zniffer frames from file

### DIFF
--- a/docs/api/zniffer.md
+++ b/docs/api/zniffer.md
@@ -136,6 +136,16 @@ await zniffer.getCaptureAsZLFBuffer((frame) => {
 });
 ```
 
+Previously saved captures and those created by the official Zniffer applications can be loaded from disk using the `loadCaptureFromFile` or `loadCaptureFromBuffer` methods.
+
+```ts
+await zniffer.loadCaptureFromFile("/path/to/file.zlf");
+// or
+await zniffer.loadCaptureFromBuffer(buffer);
+```
+
+The loaded data is available through the `capturedFrames` property and can be processed in the same way as live captured data.
+
 ## Frequency selection
 
 The configured frequency of the Zniffer has to match the frequency of the Z-Wave network it is capturing. Zniffers based on 700/800 series firmware support frequencies that match the `ZnifferRegion` enum:

--- a/packages/zwave-js/src/lib/test/zniffer/parseZLFEntry.test.ts
+++ b/packages/zwave-js/src/lib/test/zniffer/parseZLFEntry.test.ts
@@ -1,0 +1,62 @@
+import { ZWaveProtocolCCSetNWIMode } from "@zwave-js/cc";
+import { ZnifferDataMessage } from "@zwave-js/serial";
+import { Bytes } from "@zwave-js/shared";
+import { test } from "vitest";
+import { Zniffer, parseZLFEntry } from "../../zniffer/Zniffer.js";
+
+test("parse complete command frame", async (t) => {
+	const rawMsg = Bytes.from("1f95cd4d13addd888103000000230500fe", "hex");
+	const parsed = parseZLFEntry(rawMsg, 0);
+	t.expect(parsed.complete).toBe(true);
+	const rawData = [...parsed.entry?.rawData ?? []];
+	t.expect(rawData).toEqual([0x23, 0x5, 0x00]);
+});
+
+test("parse incomplete command frame", async (t) => {
+	let rawMsg = Bytes.from("e9e2cd4d13addd88010100000023fe", "hex");
+	let parsed = parseZLFEntry(rawMsg, 0);
+	t.expect(parsed.complete).toBe(false);
+	t.expect(parsed.bytesRead).toBe(rawMsg.length);
+	const accumulated = [...parsed.accumulator?.rawData ?? []];
+	t.expect(accumulated).toEqual([0x23]);
+
+	rawMsg = Bytes.from("3b0ace4d13addd8801020000000500fe", "hex");
+	parsed = parseZLFEntry(rawMsg, 0, parsed.accumulator);
+	t.expect(parsed.complete).toBe(true);
+	const rawData = [...parsed.entry?.rawData ?? []];
+	t.expect(rawData).toEqual([0x23, 0x5, 0x00]);
+});
+
+test("parse complete data frame", async (t) => {
+	const rawMsg = Bytes.from(
+		"8013fa7c93addd88011600000021010000020b2c21030cc4dae60701410a0c02008f68fe",
+		"hex",
+	);
+	const parsed = parseZLFEntry(rawMsg, 0);
+	t.expect(parsed.complete).toBe(true);
+	t.expect(parsed.msg).toBeInstanceOf(ZnifferDataMessage);
+});
+
+test("parse incomplete data frame", async (t) => {
+	let rawMsg = Bytes.from("0c0b3e6713addd88010100000021fe", "hex");
+	let parsed = parseZLFEntry(rawMsg, 0);
+	t.expect(parsed.complete).toBe(false);
+	t.expect(parsed.bytesRead).toBe(rawMsg.length);
+	const accumulated = [...parsed.accumulator?.rawData ?? []];
+	t.expect(accumulated).toEqual([0x21]);
+
+	rawMsg = Bytes.from(
+		"0c0b3e6713addd88011f000000010000210b2d210316c4dae60701050116ff2000fa40000000000122010054fe",
+		"hex",
+	);
+	parsed = parseZLFEntry(rawMsg, 0, parsed.accumulator);
+	t.expect(parsed.complete).toBe(true);
+	const rawData = [...parsed.entry?.rawData ?? []];
+	t.expect(rawData.at(-1)).toBe(0x54);
+
+	const mockZniffer = new Zniffer("/dev/mock");
+	const frame = await mockZniffer["parseFrame"](
+		parsed.msg as ZnifferDataMessage,
+	);
+	t.expect(frame.cc).toBeInstanceOf(ZWaveProtocolCCSetNWIMode);
+});


### PR DESCRIPTION
This is almost done, just one more edge case needs to be handled: The official Zniffer application writes received serial messages to disk as they are received, even if they are partial commands or partial data frames:
```
# outgoing command:
1f95cd4d13addd888103000000230500fe
# one incoming command, split across 2 serial messages
e9e2cd4d13addd88010100000023fe
3b0ace4d13addd8801020000000500fe
```