### PR TITLE
fix(config): improve accuracy of N4002/N4012 rate parameter labels

### DIFF
--- a/packages/config/config/devices/0x0312/n4002.json
+++ b/packages/config/config/devices/0x0312/n4002.json
@@ -37,7 +37,7 @@
 		},
 		{
 			"#": "9",
-			"label": "Ramp Rate (On/Off Control)",
+			"label": "Dimming Rate (Normal)",
 			"valueSize": 1,
 			"unit": "seconds",
 			"minValue": 0,
@@ -46,7 +46,7 @@
 		},
 		{
 			"#": "10",
-			"label": "Ramp Rate (Dimmer/Z-Wave Control)",
+			"label": "Dimming Rate (Local Dimmer Control)",
 			"valueSize": 1,
 			"unit": "seconds",
 			"minValue": 0,


### PR DESCRIPTION
After providing #7600 to bring the existing config to par with the latest manuals provided by the manufacturer, I learned that parameters 9 and 10 don't do exactly what the manuals imply.  These new descriptions are more accurate for N4012, but may not be optimal.  While it is difficult to be certain due to obvious translation issues, I believe the manufacturer's support intended to indicate to me that the behavior is the same on the N4002.  As the parameter names might be further improved upon, consider these observations, confirmed with the manufacturer's support as by design:

Parameter 9:
- When turning the dimmer on or off using the physical button, the ramp rate is <parameter 9> seconds.
- When turning the dimmer on or off using associations or commands from the hub, the ramp rate is <parameter 9> seconds.
- When adjusting the brightness using associations or commands from the hub, the dimming rate is <parameter 9> seconds.

Parameter 10:
- When adjusting the brightness using the physical button, the dimming rate is <parameter 10> seconds.

For reference, the statements received from support are as follows:
With regard to my original report that the N4012 behavior doesn't match the parameter names in the manual:
> When Z-wave adjusts the brightness, it uses parameter 9 instead of parameter 10. This is the original design of the product and is a normal phenomenon in the product's operation.

with regard to my followup question regarding whether the behavior is consistent between the N4002 and N4012:
> zwave product N4002 is subject to the manual instructions, N4002 adjusts the brightness in z-wave and also uses parameter 9.
