### PR TITLE
fix: initialize LWR statistics for LR nodes

### DIFF
--- a/packages/zwave-js/src/lib/node/NodeStatistics.ts
+++ b/packages/zwave-js/src/lib/node/NodeStatistics.ts
@@ -1,4 +1,9 @@
-import type { ProtocolDataRate, RSSI } from "@zwave-js/core";
+import {
+	type NodeId,
+	ProtocolDataRate,
+	type RSSI,
+	isLongRangeNodeId,
+} from "@zwave-js/core";
 import { StatisticsHost } from "../driver/Statistics.js";
 
 export class NodeStatisticsHost extends StatisticsHost<NodeStatistics> {
@@ -8,13 +13,23 @@ export class NodeStatisticsHost extends StatisticsHost<NodeStatistics> {
 	}
 
 	createEmpty(): NodeStatistics {
-		return {
+		const stats: NodeStatistics = {
 			commandsTX: 0,
 			commandsRX: 0,
 			commandsDroppedRX: 0,
 			commandsDroppedTX: 0,
 			timeoutResponse: 0,
 		};
+
+		// ZWLR nodes always have a direct connection at 100 kbps
+		if (isLongRangeNodeId((this as unknown as NodeId).id)) {
+			stats.lwr = {
+				protocolDataRate: ProtocolDataRate.LongRange_100k,
+				repeaters: [],
+			};
+		}
+
+		return stats;
 	}
 }
 


### PR DESCRIPTION
With this PR, we automatically populate the LWR statistics for LR nodes on startup/creation. This info never changes, so it makes sense to do this here.

Related to https://github.com/zwave-js/zwave-js-ui/issues/4160#issuecomment-2999123911