### PR TITLE
fix: pass join network user callbacks to `expectSecurityBootstrapS2`

### DIFF
--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -10027,6 +10027,7 @@ export class ZWaveController
 						.expectSecurityBootstrapS2(
 							bootstrappingNode,
 							grant,
+							this._joinNetworkOptions?.userCallbacks,
 						);
 					if (bootstrapResult !== undefined) {
 						// If there was a failure, mark S2 as not supported


### PR DESCRIPTION
...so we actually show the user the DSK