### PR TITLE
fix: omit LR nodes from rebuild routes progress

### DIFF
--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -4723,7 +4723,11 @@ export class ZWaveController
 		// Reset the progress for all nodes
 		this._rebuildRoutesProgress.clear();
 		for (const [id, node] of this._nodes) {
+			// Ignore the controller node
 			if (id === this._ownNodeId) continue;
+			// Ignore LR nodes, they do not route
+			if (isLongRangeNodeId(id)) continue;
+
 			if (
 				// The node is known to be dead
 				node.status === NodeStatus.Dead


### PR DESCRIPTION
Reported in https://github.com/zwave-js/zwave-js/discussions/7907 - it does not make sense to report the status for LR nodes for 2 reasons:
1. LR nodes do not route
2. Theoretically we could end up emitting events with 4000 entries, most of which are irrelevant.