### PR TITLE
refactor: revise config file hashes, auto-apply some metadata on startup

### DIFF
--- a/packages/config/src/devices/DeviceConfig.hash.test.ts
+++ b/packages/config/src/devices/DeviceConfig.hash.test.ts
@@ -1,27 +1,43 @@
 import { CommandClasses } from "@zwave-js/core";
-import { isUint8Array } from "@zwave-js/shared";
+import { Bytes, isUint8Array } from "@zwave-js/shared";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { test } from "vitest";
+import { beforeAll, test } from "vitest";
 import { ConfigManager } from "../ConfigManager.js";
+import type { DeviceConfig } from "./DeviceConfig.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+let configManager: ConfigManager;
+let testConfig: DeviceConfig;
+let proprietaryConfig: DeviceConfig;
+
+beforeAll(async (t) => {
+	configManager = new ConfigManager({
+		deviceConfigPriorityDir: path.join(__dirname, "__fixtures/hash"),
+	});
+
+	testConfig = (await configManager.lookupDevice(
+		0xffff,
+		0xcafe,
+		0xbeef,
+		"1.0",
+	))!;
+
+	proprietaryConfig = (await configManager.lookupDevice(
+		0xffff,
+		0xdead,
+		0xbeef,
+		"1.0",
+	))!;
+});
 
 test(
 	"hash() works",
 	async (t) => {
-		const configManager = new ConfigManager({
-			deviceConfigPriorityDir: path.join(__dirname, "__fixtures/hash"),
-		});
-		const config = (await configManager.lookupDevice(
-			0xffff,
-			0xcafe,
-			0xbeef,
-			"1.0",
-		))!;
-		t.expect(config).toBeDefined();
+		t.expect(testConfig).toBeDefined();
 
-		const hash = await config.getHash();
+		const hash = await testConfig.getHash();
 		t.expect(isUint8Array(hash)).toBe(true);
 	},
 	// This test might take a while
@@ -31,22 +47,13 @@ test(
 test(
 	"hash() changes when changing a parameter info",
 	async (t) => {
-		const configManager = new ConfigManager({
-			deviceConfigPriorityDir: path.join(__dirname, "__fixtures/hash"),
-		});
-		const config = (await configManager.lookupDevice(
-			0xffff,
-			0xcafe,
-			0xbeef,
-			"1.0",
-		))!;
-		t.expect(config).toBeDefined();
+		t.expect(testConfig).toBeDefined();
 
-		const hash1 = await config.getHash();
+		const hash1 = await testConfig.getHash();
 
 		// @ts-expect-error
-		config.paramInformation!.get({ parameter: 2 })!.unit = "lightyears";
-		const hash2 = await config.getHash();
+		testConfig.paramInformation!.get({ parameter: 2 })!.unit = "lightyears";
+		const hash2 = await testConfig.getHash();
 
 		t.expect(hash1).not.toStrictEqual(hash2);
 	},
@@ -57,25 +64,16 @@ test(
 test(
 	"hash() changes when removing a CC",
 	async (t) => {
-		const configManager = new ConfigManager({
-			deviceConfigPriorityDir: path.join(__dirname, "__fixtures/hash"),
-		});
-		const config = (await configManager.lookupDevice(
-			0xffff,
-			0xcafe,
-			0xbeef,
-			"1.0",
-		))!;
-		t.expect(config).toBeDefined();
+		t.expect(testConfig).toBeDefined();
 
-		const hash1 = await config.getHash();
+		const hash1 = await testConfig.getHash();
 
 		const removeCCs = new Map();
 		removeCCs.set(CommandClasses["All Switch"], "*");
 		// @ts-expect-error
-		config.compat!.removeCCs = removeCCs;
+		testConfig.compat!.removeCCs = removeCCs;
 
-		const hash2 = await config.getHash();
+		const hash2 = await testConfig.getHash();
 
 		t.expect(hash1).not.toStrictEqual(hash2);
 	},
@@ -86,18 +84,50 @@ test(
 test(
 	"hash() does not crash for devices with a proprietary field",
 	async (t) => {
-		const configManager = new ConfigManager({
-			deviceConfigPriorityDir: path.join(__dirname, "__fixtures/hash"),
-		});
-		const config = (await configManager.lookupDevice(
-			0xffff,
-			0xdead,
-			0xbeef,
-			"1.0",
-		))!;
-		t.expect(config).toBeDefined();
+		t.expect(proprietaryConfig).toBeDefined();
 
-		config.getHash();
+		proprietaryConfig.getHash();
+	},
+	// This test might take a while
+	60000,
+);
+
+test(
+	"hash() includes no prefix for version 0",
+	async (t) => {
+		t.expect(testConfig).toBeDefined();
+
+		const hash = await testConfig.getHash(0);
+		const hashString = Bytes.view(hash).toString("utf8");
+		t.expect(hashString.startsWith("$v0$")).toBe(false);
+	},
+	// This test might take a while
+	60000,
+);
+
+test(
+	"hash() includes no prefix for version 1",
+	async (t) => {
+		t.expect(testConfig).toBeDefined();
+
+		const hash = await testConfig.getHash(1);
+		const hashString = Bytes.view(hash).toString("utf8");
+		t.expect(hashString.startsWith("$v1$")).toBe(false);
+	},
+	// This test might take a while
+	60000,
+);
+
+test(
+	"hash() produces different hashes for different algorithms",
+	async (t) => {
+		t.expect(testConfig).toBeDefined();
+
+		const md5Hash = await testConfig.getHash(0);
+		const sha256Hash = await testConfig.getHash(1);
+
+		// Different algorithms should produce different hashes
+		t.expect(md5Hash).not.toStrictEqual(sha256Hash);
 	},
 	// This test might take a while
 	60000,

--- a/packages/config/src/devices/DeviceConfig.ts
+++ b/packages/config/src/devices/DeviceConfig.ts
@@ -8,6 +8,7 @@ import {
 import {
 	Bytes,
 	type JSONObject,
+	cloneDeep,
 	enumFilesRecursive,
 	formatId,
 	getenv,
@@ -887,9 +888,9 @@ export class DeviceConfig {
 				`${param.parameterNumber}${
 					param.valueBitMask ? `[${num2hex(param.valueBitMask)}]` : ""
 				}`;
-			target.paramInformation = [...map.values()].sort((a, b) =>
-				getParamKey(a).localeCompare(getParamKey(b))
-			);
+			target.paramInformation = [...map.values()]
+				.sort((a, b) => getParamKey(a).localeCompare(getParamKey(b)))
+				.map((p) => cloneDeep(p));
 		};
 
 		// Clone associations and param information on the root (ep 0) and endpoints

--- a/packages/core/src/util/compression.ts
+++ b/packages/core/src/util/compression.ts
@@ -1,7 +1,23 @@
-import { deflateSync as defflateSync, gunzipSync as fgunzipSync } from "fflate";
+import {
+	type DeflateOptions,
+	type InflateOptions,
+	deflateSync as defflateSync,
+	gunzipSync as fgunzipSync,
+	inflateSync as infflateSync,
+} from "fflate";
 
-export function deflateSync(data: Uint8Array): Uint8Array {
-	return defflateSync(data);
+export function deflateSync(
+	data: Uint8Array,
+	opts?: DeflateOptions,
+): Uint8Array {
+	return defflateSync(data, opts);
+}
+
+export function inflateSync(
+	data: Uint8Array,
+	opts?: InflateOptions,
+): Uint8Array {
+	return infflateSync(data, opts);
 }
 
 export function gunzipSync(data: Uint8Array): Uint8Array {

--- a/packages/shared/src/Bytes.ts
+++ b/packages/shared/src/Bytes.ts
@@ -3,6 +3,7 @@
 import {
 	type TypedArray,
 	areUint8ArraysEqual,
+	base64ToUint8Array,
 	concatUint8Arrays,
 	hexToUint8Array,
 	includes,
@@ -79,6 +80,8 @@ export class Bytes extends Uint8Array {
 					return Bytes.view(stringToUint8Array(data));
 				case "hex":
 					return Bytes.view(hexToUint8Array(data));
+				case "base64":
+					return Bytes.view(base64ToUint8Array(data));
 			}
 
 			throw new Error(`Unsupported encoding: ${encoding}`);

--- a/packages/zwave-js/src/lib/node/mixins/80_DeviceConfig.ts
+++ b/packages/zwave-js/src/lib/node/mixins/80_DeviceConfig.ts
@@ -1,4 +1,4 @@
-import type { DeviceConfig } from "@zwave-js/config";
+import { DeviceConfig } from "@zwave-js/config";
 import { InterviewStage, type MaybeNotKnown, NOT_KNOWN } from "@zwave-js/core";
 import { Bytes, formatId } from "@zwave-js/shared";
 import { cacheKeys } from "../../driver/NetworkCache.js";
@@ -104,9 +104,11 @@ export abstract class DeviceConfigMixin extends FirmwareUpdateMixin
 			return this.deviceConfig == undefined ? false : NOT_KNOWN;
 		}
 
-		// If it was, a change in hash means the config has changed
+		// If it was, a change in hash means the config has changed.
+		// We handle the different hash versions when loading the config already.
 		if (this._currentDeviceConfigHash) {
-			return !Bytes.view(this._currentDeviceConfigHash).equals(
+			return !DeviceConfig.areHashesEqual(
+				this._currentDeviceConfigHash,
 				this.cachedDeviceConfigHash,
 			);
 		}
@@ -155,15 +157,66 @@ export abstract class DeviceConfigMixin extends FirmwareUpdateMixin
 				this.firmwareVersion,
 			);
 			if (this.deviceConfig) {
-				// Also remember the current hash of the device config
-				if (this.cachedDeviceConfigHash?.length === 16) {
-					// legacy hash using MD5
+				// We need to remember the hash of the device config here, because we're in an async context
+				// and later comparisons are sync.
+
+				// There are two legacy versions of the device config hash:
+				// - 16 byte MD5 hash
+				// - 32 byte SHA-256 hash
+				// Both only support checking for exact equality of the config hashable.
+				// To be able to compare those stored hashes with the current config,
+				// we need to figure out the stored version now and hash the config using
+				// the same version.
+				// New "hashes" are variable length, contain a condensed version of the device config and are prefixed with a version number.
+
+				const versionPrefix = Bytes.from("$v", "utf8");
+				const hasVersionPrefix = !!this.cachedDeviceConfigHash
+					&& Bytes
+						.view(this.cachedDeviceConfigHash.subarray(0, 2))
+						.equals(versionPrefix);
+				let cachedHashVersion: number | undefined;
+
+				if (
+					this.cachedDeviceConfigHash?.length === 16
+					&& !hasVersionPrefix
+				) {
+					// MD5 = version 0
+					cachedHashVersion = 0;
 					this._currentDeviceConfigHash = await this.deviceConfig
-						.getHash("md5");
+						.getHash(0);
+				} else if (
+					this.cachedDeviceConfigHash?.length === 32
+					&& !hasVersionPrefix
+				) {
+					// SHA-256 = version 1
+					cachedHashVersion = 1;
+					this._currentDeviceConfigHash = await this.deviceConfig
+						.getHash(1);
 				} else {
+					// Variable length prefixed hash - simply use the latest version
 					this._currentDeviceConfigHash = await this.deviceConfig
 						.getHash();
+					if (this.cachedDeviceConfigHash) {
+						const versionString = Bytes.view(
+							this.cachedDeviceConfigHash,
+						).toString("utf8").match(/^\$v(\d+)\$/)?.[1];
+						if (versionString) {
+							cachedHashVersion = parseInt(versionString, 10);
+						}
+					}
+					// default to requiring an upgrade if the version cannot be parsed
+					cachedHashVersion ??= 0;
 				}
+
+				// Update the cached device config hash upon restoring, if the node was previously interviewed
+				// and the device config has not changed since then.
+				if (
+					cachedHashVersion < DeviceConfig.maxHashVersion
+					&& this.hasDeviceConfigChanged() === false
+				) {
+					this.cachedDeviceConfigHash = this._currentDeviceConfigHash;
+				}
+
 				this.driver.controllerLog.logNode(
 					this.id,
 					`${

--- a/packages/zwave-js/src/lib/node/mixins/80_DeviceConfig.ts
+++ b/packages/zwave-js/src/lib/node/mixins/80_DeviceConfig.ts
@@ -145,94 +145,98 @@ export abstract class DeviceConfigMixin extends FirmwareUpdateMixin
 	protected async loadDeviceConfig(): Promise<void> {
 		// But the configuration definitions might change
 		if (
-			this.manufacturerId != undefined
-			&& this.productType != undefined
-			&& this.productId != undefined
+			this.manufacturerId == undefined
+			|| this.productType == undefined
+			|| this.productId == undefined
 		) {
-			// Try to load the config file
-			this.deviceConfig = await this.driver.configManager.lookupDevice(
-				this.manufacturerId,
-				this.productType,
-				this.productId,
-				this.firmwareVersion,
-			);
-			if (this.deviceConfig) {
-				// We need to remember the hash of the device config here, because we're in an async context
-				// and later comparisons are sync.
-
-				// There are two legacy versions of the device config hash:
-				// - 16 byte MD5 hash
-				// - 32 byte SHA-256 hash
-				// Both only support checking for exact equality of the config hashable.
-				// To be able to compare those stored hashes with the current config,
-				// we need to figure out the stored version now and hash the config using
-				// the same version.
-				// New "hashes" are variable length, contain a condensed version of the device config and are prefixed with a version number.
-
-				const versionPrefix = Bytes.from("$v", "utf8");
-				const hasVersionPrefix = !!this.cachedDeviceConfigHash
-					&& Bytes
-						.view(this.cachedDeviceConfigHash.subarray(0, 2))
-						.equals(versionPrefix);
-				let cachedHashVersion: number | undefined;
-
-				if (
-					this.cachedDeviceConfigHash?.length === 16
-					&& !hasVersionPrefix
-				) {
-					// MD5 = version 0
-					cachedHashVersion = 0;
-					this._currentDeviceConfigHash = await this.deviceConfig
-						.getHash(0);
-				} else if (
-					this.cachedDeviceConfigHash?.length === 32
-					&& !hasVersionPrefix
-				) {
-					// SHA-256 = version 1
-					cachedHashVersion = 1;
-					this._currentDeviceConfigHash = await this.deviceConfig
-						.getHash(1);
-				} else {
-					// Variable length prefixed hash - simply use the latest version
-					this._currentDeviceConfigHash = await this.deviceConfig
-						.getHash();
-					if (this.cachedDeviceConfigHash) {
-						const versionString = Bytes.view(
-							this.cachedDeviceConfigHash,
-						).toString("utf8").match(/^\$v(\d+)\$/)?.[1];
-						if (versionString) {
-							cachedHashVersion = parseInt(versionString, 10);
-						}
-					}
-					// default to requiring an upgrade if the version cannot be parsed
-					cachedHashVersion ??= 0;
-				}
-
-				// Update the cached device config hash upon restoring, if the node was previously interviewed
-				// and the device config has not changed since then.
-				if (
-					cachedHashVersion < DeviceConfig.maxHashVersion
-					&& this.hasDeviceConfigChanged() === false
-				) {
-					this.cachedDeviceConfigHash = await this.deviceConfig
-						.getHash();
-				}
-
-				this.driver.controllerLog.logNode(
-					this.id,
-					`${
-						this.deviceConfig.isEmbedded
-							? "Embedded"
-							: "User-provided"
-					} device config loaded`,
-				);
-			} else {
-				this.driver.controllerLog.logNode(
-					this.id,
-					"No device config found",
-					"warn",
-				);
-			}
+			return;
 		}
+
+		// Try to load the config file
+		this.deviceConfig = await this.driver.configManager.lookupDevice(
+			this.manufacturerId,
+			this.productType,
+			this.productId,
+			this.firmwareVersion,
+		);
+
+		if (!this.deviceConfig) {
+			this.driver.controllerLog.logNode(
+				this.id,
+				"No device config found",
+				"warn",
+			);
+			return;
+		}
+
+		// We need to remember the hash of the device config here, because we're in an async context
+		// and later comparisons are sync.
+
+		// There are two legacy versions of the device config hash:
+		// - 16 byte MD5 hash
+		// - 32 byte SHA-256 hash
+		// Both only support checking for exact equality of the config hashable.
+		// To be able to compare those stored hashes with the current config,
+		// we need to figure out the stored version now and hash the config using
+		// the same version.
+		// New "hashes" are variable length, contain a condensed version of the device config and are prefixed with a version number.
+
+		const versionPrefix = Bytes.from("$v", "utf8");
+		const hasVersionPrefix = !!this.cachedDeviceConfigHash
+			&& Bytes
+				.view(this.cachedDeviceConfigHash.subarray(0, 2))
+				.equals(versionPrefix);
+		let cachedHashVersion: number | undefined;
+
+		if (
+			this.cachedDeviceConfigHash?.length === 16
+			&& !hasVersionPrefix
+		) {
+			// MD5 = version 0
+			cachedHashVersion = 0;
+			this._currentDeviceConfigHash = await this.deviceConfig
+				.getHash(0);
+		} else if (
+			this.cachedDeviceConfigHash?.length === 32
+			&& !hasVersionPrefix
+		) {
+			// SHA-256 = version 1
+			cachedHashVersion = 1;
+			this._currentDeviceConfigHash = await this.deviceConfig
+				.getHash(1);
+		} else {
+			// Variable length prefixed hash - simply use the latest version
+			this._currentDeviceConfigHash = await this.deviceConfig
+				.getHash();
+			if (this.cachedDeviceConfigHash) {
+				const versionString = Bytes.view(
+					this.cachedDeviceConfigHash,
+				).toString("utf8").match(/^\$v(\d+)\$/)?.[1];
+				if (versionString) {
+					cachedHashVersion = parseInt(versionString, 10);
+				}
+			}
+			// default to requiring an upgrade if the version cannot be parsed
+			cachedHashVersion ??= 0;
+		}
+
+		// Update the cached device config hash upon restoring, if the node was previously interviewed
+		// and the device config has not changed since then.
+		if (
+			cachedHashVersion < DeviceConfig.maxHashVersion
+			&& this.hasDeviceConfigChanged() === false
+		) {
+			this.cachedDeviceConfigHash = await this.deviceConfig
+				.getHash();
+		}
+
+		this.driver.controllerLog.logNode(
+			this.id,
+			`${
+				this.deviceConfig.isEmbedded
+					? "Embedded"
+					: "User-provided"
+			} device config loaded`,
+		);
 	}
 }

--- a/packages/zwave-js/src/lib/node/mixins/80_DeviceConfig.ts
+++ b/packages/zwave-js/src/lib/node/mixins/80_DeviceConfig.ts
@@ -214,7 +214,8 @@ export abstract class DeviceConfigMixin extends FirmwareUpdateMixin
 					cachedHashVersion < DeviceConfig.maxHashVersion
 					&& this.hasDeviceConfigChanged() === false
 				) {
-					this.cachedDeviceConfigHash = this._currentDeviceConfigHash;
+					this.cachedDeviceConfigHash = await this.deviceConfig
+						.getHash();
 				}
 
 				this.driver.controllerLog.logNode(


### PR DESCRIPTION
With this PR, we no longer store actual hashes of the config file contents, but a versioned, compressed subset of the information that should generally be unchanged. On startup, we upgrade old versions of the hash to the new format if we determine them to be unchanged.

Labels and descriptions are now omitted from hashes, so renamed config parameters will no longer cause the "re-interview required" info. Instead, the existing metadata is updated with the strings from otherwise unchanged config files on every startup.