### PR TITLE
feat: Fantem FT117 range extender

### DIFF
--- a/packages/config/config/devices/0x016a/ft117.json
+++ b/packages/config/config/devices/0x016a/ft117.json
@@ -1,0 +1,61 @@
+{
+	"manufacturer": "Fantem",
+	"manufacturerId": "0x016a",
+	"label": "FT117",
+	"description": "Range Extender",
+	"devices": [
+		{
+			"productType": "0x0004",
+			"productId": "0x0076"
+		},
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 1,
+			"isLifeline": true
+		}
+	},
+	"paramInformation": [
+		{
+			"#": "82",
+			"$import": "~/templates/master_template.json#led_indicator_two_options",
+			"options": [
+				{
+					"label": "On for 2 seconds",
+					"value": 0
+				},
+				{
+					"label": "Disable",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "200",
+			"$import": "templates/aeotec_template.json#partner_id_other"
+		},
+		{
+			"#": "252",
+			"$import": "templates/aeotec_template.json#lock_configuration"
+		},
+		{
+			"#": "254",
+			"$import": "templates/aeotec_template.json#device_tag"
+		},
+		{
+			"#": "255",
+			"$import": "templates/aeotec_template.json#factory_reset_exclude"
+		}
+	],
+	"metadata": {
+		"inclusion": "Press the Z-Wave Button on Range Extender",
+		"exclusion": "Press the Z-Wave Button on Range Extender",
+		"reset": "Press and hold the Z-Wave Button for 20 seconds and then release it",
+		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=MarketCertificationFiles/2520/Range%20Extender%206%20manual.pdf"
+	}
+}

--- a/packages/config/config/devices/0x016a/templates/fantem_template.json
+++ b/packages/config/config/devices/0x016a/templates/fantem_template.json
@@ -1,0 +1,53 @@
+{
+	"partner_id_other": {
+		"label": "Partner ID",
+		"valueSize": 1,
+		"defaultValue": 0,
+		"unsigned": true,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Aeotec",
+				"value": 0
+			},
+			{
+				"label": "Other",
+				"value": 1
+			}
+		]
+	},
+	"lock_configuration": {
+		"$import": "~/templates/master_template.json#base_enable_disable",
+		"label": "Lock Configuration"
+	},
+	"device_tag": {
+		"label": "Device Tag",
+		"valueSize": 2,
+		"minValue": 0,
+		"maxValue": 65535,
+		"defaultValue": 0,
+		"unsigned": true
+	},
+	"factory_reset_exclude": {
+		"label": "Reset to Factory Default Setting",
+		"valueSize": 4,
+		"defaultValue": 0,
+		"unsigned": true,
+		"writeOnly": true,
+		"allowManualEntry": false,
+		"options": [
+			{
+				"label": "Normal Operation",
+				"value": 0
+			},
+			{
+				"label": "Reset the product to factory default setting and exclude from Z-Wave network",
+				"value": 1431655765
+			},
+			{
+				"label": "Resets all configuration parameters to default setting",
+				"value": 1
+			}
+		]
+	},
+}


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

Device file and template for Fantem FT117 - a rebadged Aeotec ZW117 ZW+ range extender.