### PR TITLE
fix: query actual value immediately after successful supervised `Multilevel Switch Set` with value 255

### DIFF
--- a/packages/cc/src/cc/MultilevelSwitchCC.ts
+++ b/packages/cc/src/cc/MultilevelSwitchCC.ts
@@ -474,12 +474,10 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 					switch (result?.status) {
 						case SupervisionStatus.Success:
 						case SupervisionStatus.Fail:
-							await this.pollValue!.call(
-								this,
-								currentValueValueId,
-							);
+							await this.pollValue!(currentValueValueId);
 							break;
-						default:
+						case SupervisionStatus.Working:
+						default: // (not supervised)
 							(this as this).schedulePoll(
 								currentValueValueId,
 								value === 255 ? undefined : value,

--- a/packages/cc/src/lib/API.ts
+++ b/packages/cc/src/lib/API.ts
@@ -85,7 +85,7 @@ export type SetValueImplementationHooks =
 		// Check if a verification of the set value is required, even if the API response suggests otherwise
 		forceVerifyChanges?: () => boolean;
 		// Verify the changes
-		verifyChanges?: () => void | Promise<void>;
+		verifyChanges?: (result?: SupervisionResult) => void | Promise<void>;
 	};
 
 export type SetValueImplementationHooksFactory = (

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -657,7 +657,7 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 				) {
 					// Let the CC API implementation handle the verification.
 					// It may still decide not to do it.
-					await hooks.verifyChanges?.();
+					await hooks.verifyChanges?.(result);
 				}
 			}
 

--- a/packages/zwave-js/src/lib/node/VirtualNode.ts
+++ b/packages/zwave-js/src/lib/node/VirtualNode.ts
@@ -218,7 +218,7 @@ export class VirtualNode extends VirtualEndpoint {
 				) {
 					// Let the CC API implementation handle the verification.
 					// It may still decide not to do it.
-					await hooks.verifyChanges?.();
+					await hooks.verifyChanges?.(result);
 				}
 			}
 

--- a/packages/zwave-js/src/lib/test/driver/setValueSupervision255Verify.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/setValueSupervision255Verify.test.ts
@@ -1,0 +1,69 @@
+import {
+	MultilevelSwitchCCGet,
+	MultilevelSwitchCCReport,
+	MultilevelSwitchCCValues,
+} from "@zwave-js/cc";
+import { CommandClasses, type MaybeUnknown } from "@zwave-js/core";
+import type { MockNodeBehavior } from "@zwave-js/testing";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest(
+	"successful supervised setValue(255): expect verify GET",
+	{
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses["Multilevel Switch"],
+				CommandClasses.Supervision,
+			],
+		},
+
+		customSetup: async (driver, controller, mockNode) => {
+			{
+				let call = 0;
+				const responses: [
+					target: number,
+					current: MaybeUnknown<number>,
+				][] = [
+					// during interview
+					[20, 20],
+					// change verification (`verifyChanges`)
+					[50, 50],
+				];
+				const respondToMultilevelSwitchGet: MockNodeBehavior = {
+					handleCC(controller, self, receivedCC) {
+						if (receivedCC instanceof MultilevelSwitchCCGet) {
+							const [targetValue, currentValue] = responses[call];
+							const cc = new MultilevelSwitchCCReport({
+								nodeId: controller.ownNodeId,
+								targetValue,
+								currentValue,
+							});
+
+							call += 1;
+
+							return { action: "sendCC", cc };
+						}
+					},
+				};
+				mockNode.defineBehavior(respondToMultilevelSwitchGet);
+			}
+		},
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			{
+				const currentValue = node.getValue(
+					MultilevelSwitchCCValues.currentValue.id,
+				);
+				t.expect(currentValue, "should be initial value").toBe(20);
+			}
+
+			await node.setValue(MultilevelSwitchCCValues.targetValue.id, 255);
+
+			{
+				const currentValue = node.getValue(
+					MultilevelSwitchCCValues.currentValue.id,
+				);
+				t.expect(currentValue, "should be updated value").toBe(50);
+			}
+		},
+	},
+);

--- a/packages/zwave-js/src/lib/test/driver/setValueSupervision255Verify.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/setValueSupervision255Verify.test.ts
@@ -1,10 +1,21 @@
 import {
 	MultilevelSwitchCCGet,
 	MultilevelSwitchCCReport,
+	MultilevelSwitchCCSet,
 	MultilevelSwitchCCValues,
+	SupervisionCCGet,
+	SupervisionCCReport,
 } from "@zwave-js/cc";
-import { CommandClasses, type MaybeUnknown } from "@zwave-js/core";
-import type { MockNodeBehavior } from "@zwave-js/testing";
+import {
+	CommandClasses,
+	type MaybeUnknown,
+	SupervisionStatus,
+} from "@zwave-js/core";
+import {
+	type MockNodeBehavior,
+	createMockZWaveRequestFrame,
+} from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
 import { integrationTest } from "../integrationTestSuite.js";
 
 integrationTest(
@@ -18,6 +29,71 @@ integrationTest(
 		},
 
 		customSetup: async (driver, controller, mockNode) => {
+			// Just have the node respond to all Supervision Get positively
+			const respondToSupervisionGet: MockNodeBehavior = {
+				handleCC(controller, self, receivedCC) {
+					if (receivedCC instanceof SupervisionCCGet) {
+						const cc = new SupervisionCCReport({
+							nodeId: controller.ownNodeId,
+							sessionId: receivedCC.sessionId,
+							moreUpdatesFollow: false,
+							status: SupervisionStatus.Success,
+						});
+						return { action: "sendCC", cc };
+					}
+				},
+			};
+			mockNode.defineBehavior(respondToSupervisionGet);
+
+			// Except the ones with a duration in the command, those need special handling
+			const respondToSupervisionGetWithDuration: MockNodeBehavior = {
+				handleCC(controller, self, receivedCC) {
+					if (
+						receivedCC instanceof SupervisionCCGet
+						&& receivedCC.encapsulated
+							instanceof MultilevelSwitchCCSet
+						&& !!receivedCC.encapsulated.duration
+							?.toMilliseconds()
+					) {
+						const cc1 = new SupervisionCCReport({
+							nodeId: controller.ownNodeId,
+							sessionId: receivedCC.sessionId,
+							moreUpdatesFollow: true,
+							status: SupervisionStatus.Working,
+							duration: receivedCC.encapsulated.duration,
+						});
+
+						const cc2 = new SupervisionCCReport({
+							nodeId: controller.ownNodeId,
+							sessionId: receivedCC.sessionId,
+							moreUpdatesFollow: false,
+							status: SupervisionStatus.Success,
+						});
+
+						void self.sendToController(
+							createMockZWaveRequestFrame(cc1, {
+								ackRequested: false,
+							}),
+						);
+
+						setTimeout(
+							() => {
+								void self.sendToController(
+									createMockZWaveRequestFrame(cc2, {
+										ackRequested: false,
+									}),
+								);
+							},
+							receivedCC.encapsulated.duration
+								.toMilliseconds(),
+						);
+
+						return { action: "stop" };
+					}
+				},
+			};
+			mockNode.defineBehavior(respondToSupervisionGetWithDuration);
+
 			{
 				let call = 0;
 				const responses: [
@@ -26,8 +102,10 @@ integrationTest(
 				][] = [
 					// during interview
 					[20, 20],
-					// change verification (`verifyChanges`)
+					// change with `transitionDuration`
 					[50, 50],
+					// change without
+					[80, 80],
 				];
 				const respondToMultilevelSwitchGet: MockNodeBehavior = {
 					handleCC(controller, self, receivedCC) {
@@ -53,7 +131,20 @@ integrationTest(
 				const currentValue = node.getValue(
 					MultilevelSwitchCCValues.currentValue.id,
 				);
-				t.expect(currentValue, "should be initial value").toBe(20);
+				t.expect(currentValue).toBe(20);
+			}
+
+			await node.setValue(MultilevelSwitchCCValues.targetValue.id, 255, {
+				transitionDuration: "1s",
+			});
+
+			await wait(1500);
+
+			{
+				const currentValue = node.getValue(
+					MultilevelSwitchCCValues.currentValue.id,
+				);
+				t.expect(currentValue).toBe(50);
 			}
 
 			await node.setValue(MultilevelSwitchCCValues.targetValue.id, 255);
@@ -62,7 +153,7 @@ integrationTest(
 				const currentValue = node.getValue(
 					MultilevelSwitchCCValues.currentValue.id,
 				);
-				t.expect(currentValue, "should be updated value").toBe(50);
+				t.expect(currentValue).toBe(80);
 			}
 		},
 	},


### PR DESCRIPTION
fixes #5124

previously a poll was scheduled after the `transitionDuration`.
scheduling a poll for a later  is not neccessary, because `verifyChanges` is only run *after* the value has already changed.

