### PR TITLE
fix(config): add missing parameter 117 (Reboot) on Shelly Wave Plug S EU (QNPL-0A112)

### DIFF
--- a/packages/config/config/devices/0x0460/qnpl-0A112.json
+++ b/packages/config/config/devices/0x0460/qnpl-0A112.json
@@ -60,6 +60,10 @@
 			"label": "O4: Relay Type"
 		},
 		{
+			"#": "117",
+			"$import": "templates/wave_template.json#remote_reboot"
+		},
+		{
 			"#": "120",
 			"$import": "templates/wave_template.json#factory_reset"
 		},


### PR DESCRIPTION
**Manufacturer**: Shelly (0x0460)
**Device**: Wave Plug S EU - QNPL-0A112 (0x0087)

Remote Reboot (117) parameter was missing from the device's config json.

[Manufacturer's documentation](https://kb.shelly.cloud/knowledge-base/shelly-wave-plug-s-eu#:~:text=Parameter-,No.%20117%20%2D%20Remote%20Device%20reboot,-This%20parameter%20enable)

Parameter update function was tested with physical device.