### PR TITLE
feat(cc): clean up Indicator CC values and fix their implementation

### DIFF
--- a/packages/cc/src/cc/IndicatorCC.ts
+++ b/packages/cc/src/cc/IndicatorCC.ts
@@ -1271,20 +1271,6 @@ export class IndicatorCCReport extends IndicatorCC {
 		ctx: GetValueDB,
 		value: IndicatorObject,
 	): void {
-		// Only expose the value if it should be user-facing
-		if (value.indicatorId === Indicator["Node Identify"]) {
-			return;
-		}
-		const prop = getIndicatorProperty(value.propertyId);
-		if (!prop?.exposeAsValue) return;
-
-		// And only if it is actually supported and not just reported by accident
-		const supportedPropertyIDs = this.getValue<number[]>(
-			ctx,
-			IndicatorCCValues.supportedPropertyIDs(value.indicatorId),
-		) ?? [];
-		if (!supportedPropertyIDs.includes(value.propertyId)) return;
-
 		// Manufacturer-defined indicators may need a custom label
 		const overrideIndicatorLabel = this
 			.getManufacturerDefinedIndicatorLabel(ctx, value.indicatorId);
@@ -1298,6 +1284,20 @@ export class IndicatorCCReport extends IndicatorCC {
 		if (metadata.type === "boolean") {
 			value.value = !!value.value;
 		}
+
+		// Only expose the value if it should be user-facing
+		if (value.indicatorId === Indicator["Node Identify"]) {
+			return;
+		}
+		const prop = getIndicatorProperty(value.propertyId);
+		if (!prop?.exposeAsValue) return;
+
+		// And only if it is actually supported and not just reported by accident
+		const supportedPropertyIDs = this.getValue<number[]>(
+			ctx,
+			IndicatorCCValues.supportedPropertyIDs(value.indicatorId),
+		) ?? [];
+		if (!supportedPropertyIDs.includes(value.propertyId)) return;
 
 		// Publish the value
 		const valueV2 = IndicatorCCValues.valueV2(

--- a/packages/cc/src/cc/_CCValues.generated.ts
+++ b/packages/cc/src/cc/_CCValues.generated.ts
@@ -3658,36 +3658,6 @@ export const IndicatorCCValues = Object.freeze({
 			autoCreate: true,
 		} as const satisfies CCValueOptions,
 	},
-	timeout: {
-		id: {
-			commandClass: CommandClasses.Indicator,
-			property: "timeout",
-		} as const,
-		endpoint: (endpoint: number = 0) => ({
-			commandClass: CommandClasses.Indicator,
-			endpoint,
-			property: "timeout",
-		} as const),
-		is: (valueId: ValueID): boolean => {
-			return valueId.commandClass === CommandClasses.Indicator
-				&& valueId.property === "timeout"
-				&& valueId.propertyKey == undefined;
-		},
-		get meta() {
-			return {
-				...ValueMetadata.String,
-				label: "Timeout",
-			} as const;
-		},
-		options: {
-			internal: false,
-			minVersion: 3,
-			secret: false,
-			stateful: true,
-			supportsEndpoints: true,
-			autoCreate: true,
-		} as const satisfies CCValueOptions,
-	},
 	supportedPropertyIDs: Object.assign(
 		(indicatorId: number) => {
 			const property = "supportedPropertyIDs";
@@ -3765,6 +3735,51 @@ export const IndicatorCCValues = Object.freeze({
 			options: {
 				internal: false,
 				minVersion: 2,
+				secret: false,
+				stateful: true,
+				supportsEndpoints: true,
+				autoCreate: true,
+			} as const satisfies CCValueOptions,
+		},
+	),
+	timeout: Object.assign(
+		(indicatorId: number) => {
+			const property = indicatorId;
+			const propertyKey = "timeout";
+
+			return {
+				id: {
+					commandClass: CommandClasses.Indicator,
+					property,
+					propertyKey,
+				} as const,
+				endpoint: (endpoint: number = 0) => ({
+					commandClass: CommandClasses.Indicator,
+					endpoint,
+					property: property,
+					propertyKey: propertyKey,
+				} as const),
+				get meta() {
+					return {
+						...ValueMetadata.String,
+						label: "Timeout",
+						ccSpecific: {
+							indicatorId,
+						},
+					} as const;
+				},
+			};
+		},
+		{
+			is: (valueId: ValueID): boolean => {
+				return valueId.commandClass === CommandClasses.Indicator
+					&& (({ property, propertyKey }) =>
+						typeof property === "number"
+						&& propertyKey === "timeout")(valueId);
+			},
+			options: {
+				internal: false,
+				minVersion: 3,
 				secret: false,
 				stateful: true,
 				supportsEndpoints: true,

--- a/packages/core/src/registries/Indicators.ts
+++ b/packages/core/src/registries/Indicators.ts
@@ -122,6 +122,8 @@ export interface IndicatorPropertyDefinition {
 	readonly max?: number;
 	readonly readonly?: boolean;
 	readonly type?: ValueType;
+	/** Whether this property should be exposed as a CC value. Default: false */
+	readonly exposeAsValue?: boolean;
 }
 
 export interface IndicatorProperty extends IndicatorPropertyDefinition {
@@ -132,10 +134,12 @@ const indicatorProperties = Object.freeze(
 	{
 		[0x01]: {
 			label: "Multilevel",
+			exposeAsValue: true,
 		},
 		[0x02]: {
 			label: "Binary",
 			type: "boolean",
+			exposeAsValue: true,
 		},
 		[0x03]: {
 			label: "On/Off Period: Duration",
@@ -177,6 +181,7 @@ const indicatorProperties = Object.freeze(
 			description:
 				"This property is used to set the volume of a indicator. 0 means off/mute.",
 			max: 100,
+			exposeAsValue: true,
 		},
 		[0x10]: {
 			label: "Low power",

--- a/packages/testing/src/CCSpecificCapabilities.ts
+++ b/packages/testing/src/CCSpecificCapabilities.ts
@@ -47,6 +47,17 @@ export interface ColorSwitchCCCapabilities {
 	colorComponents: Partial<Record<ColorComponent, number | undefined>>;
 }
 
+export interface IndicatorCCCapabilities {
+	indicators: Record<number, {
+		properties: number[];
+		manufacturerSpecificDescription?: string;
+	}>;
+	getValue?: (
+		indicatorId: number,
+		propertyId: number,
+	) => number | undefined;
+}
+
 export interface NotificationCCCapabilities {
 	supportsV1Alarm: boolean;
 	notificationTypesAndEvents: Record<number, number[]>;
@@ -176,6 +187,7 @@ export type CCSpecificCapabilities = {
 	[99 /* User Code */]: UserCodeCCCapabilities;
 	[78 /* Schedule Entry Lock */]: ScheduleEntryLockCCCapabilities;
 	[CommandClasses.Meter]: MeterCCCapabilities;
+	[CommandClasses.Indicator]: IndicatorCCCapabilities;
 };
 
 export type CCIdToCapabilities<T extends CommandClasses = CommandClasses> =

--- a/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
+++ b/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
@@ -23,6 +23,7 @@ import { BinarySwitchCCBehaviors } from "./mockCCBehaviors/BinarySwitch.js";
 import { ColorSwitchCCBehaviors } from "./mockCCBehaviors/ColorSwitch.js";
 import { ConfigurationCCBehaviors } from "./mockCCBehaviors/Configuration.js";
 import { EnergyProductionCCBehaviors } from "./mockCCBehaviors/EnergyProduction.js";
+import { IndicatorCCBehaviors } from "./mockCCBehaviors/Indicator.js";
 import { ManufacturerSpecificCCBehaviors } from "./mockCCBehaviors/ManufacturerSpecific.js";
 import { MeterCCBehaviors } from "./mockCCBehaviors/Meter.js";
 import {
@@ -193,6 +194,7 @@ export function createDefaultBehaviors(): MockNodeBehavior[] {
 		...ColorSwitchCCBehaviors,
 		...ConfigurationCCBehaviors,
 		...EnergyProductionCCBehaviors,
+		...IndicatorCCBehaviors,
 		...ManufacturerSpecificCCBehaviors,
 		...MeterCCBehaviors,
 		...MultilevelSensorCCBehaviors,

--- a/packages/zwave-js/src/lib/node/mockCCBehaviors/Indicator.ts
+++ b/packages/zwave-js/src/lib/node/mockCCBehaviors/Indicator.ts
@@ -1,0 +1,215 @@
+import {
+	IndicatorCCDescriptionGet,
+	IndicatorCCDescriptionReport,
+	IndicatorCCGet,
+	IndicatorCCReport,
+	IndicatorCCSupportedGet,
+	IndicatorCCSupportedReport,
+	type IndicatorObject,
+} from "@zwave-js/cc";
+import { CommandClasses } from "@zwave-js/core";
+import type {
+	IndicatorCCCapabilities,
+	MockNodeBehavior,
+} from "@zwave-js/testing";
+
+const defaultCapabilities: IndicatorCCCapabilities = {
+	indicators: {},
+};
+
+// const STATE_KEY_PREFIX = "Indicator_";
+// const StateKeys = {
+// 	value: (indicatorId: number, propertyId: number) =>
+// 		`${STATE_KEY_PREFIX}value_${indicatorId}_${propertyId}`,
+// } as const;
+
+const respondToIndicatorGet: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		if (receivedCC instanceof IndicatorCCGet) {
+			const capabilities = {
+				...defaultCapabilities,
+				...self.getCCCapabilities(
+					CommandClasses.Indicator,
+					receivedCC.endpointIndex,
+				),
+			};
+
+			let cc: IndicatorCCReport;
+			if (receivedCC.indicatorId) {
+				// V2+
+
+				const indicatorId = receivedCC.indicatorId ?? 0;
+				const supportedProperties =
+					capabilities.indicators[indicatorId]?.properties ?? [];
+
+				const indicatorObjects: IndicatorObject[] = supportedProperties
+					.map((propertyId) => {
+						const value =
+							capabilities.getValue?.(indicatorId, propertyId)
+								?? 0;
+						return {
+							indicatorId,
+							propertyId,
+							value,
+						};
+					});
+
+				cc = new IndicatorCCReport({
+					nodeId: controller.ownNodeId,
+					values: indicatorObjects,
+				});
+			} else {
+				// V1
+				const value = capabilities.getValue?.(0, 0) ?? 0;
+				cc = new IndicatorCCReport({
+					nodeId: controller.ownNodeId,
+					value,
+				});
+			}
+
+			return { action: "sendCC", cc };
+		}
+	},
+};
+
+// const respondToIndicatorSet: MockNodeBehavior = {
+// 	handleCC(controller, self, receivedCC) {
+// 		if (receivedCC instanceof IndicatorCCSet) {
+// 			const capabilities = {
+// 				...defaultCapabilities,
+// 				...self.getCCCapabilities(
+// 					CommandClasses.Indicator,
+// 					receivedCC.endpointIndex,
+// 				),
+// 			};
+// 			const parameter = receivedCC.parameter;
+// 			const paramInfo = capabilities.parameters.find(
+// 				(p) => p["#"] === parameter,
+// 			);
+// 			// Do nothing if the parameter is not supported
+// 			if (!paramInfo) return { action: "fail" };
+
+// 			if (receivedCC.resetToDefault) {
+// 				self.state.delete(StateKeys.value(parameter));
+// 				return { action: "ok" };
+// 			}
+
+// 			const value = receivedCC.value!;
+
+// 			// Do nothing if the value is out of range
+// 			if (paramInfo.minValue != undefined && value < paramInfo.minValue) {
+// 				return { action: "fail" };
+// 			} else if (
+// 				paramInfo.maxValue != undefined
+// 				&& value > paramInfo.maxValue
+// 			) {
+// 				return { action: "fail" };
+// 			}
+
+// 			self.state.set(StateKeys.value(parameter), value);
+// 			return { action: "ok" };
+// 		}
+// 	},
+// };
+
+const respondToIndicatorSupportedGet: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		if (receivedCC instanceof IndicatorCCSupportedGet) {
+			const capabilities = {
+				...defaultCapabilities,
+				...self.getCCCapabilities(
+					CommandClasses.Indicator,
+					receivedCC.endpointIndex,
+				),
+			};
+
+			function createReport(
+				indicatorId: number,
+			): IndicatorCCSupportedReport {
+				const supportedProperties = capabilities
+					.indicators[indicatorId]
+					?.properties ?? [];
+
+				const allSupportedIndicators = Object
+					.keys(capabilities.indicators)
+					.map((id) => parseInt(id, 10))
+					.filter((id) => !isNaN(id));
+
+				const indicatorIndex = allSupportedIndicators.indexOf(
+					indicatorId,
+				);
+				const nextIndicatorId =
+					allSupportedIndicators[indicatorIndex + 1];
+
+				return new IndicatorCCSupportedReport({
+					nodeId: controller.ownNodeId,
+					indicatorId,
+					nextIndicatorId: nextIndicatorId ?? 0,
+					supportedProperties,
+				});
+			}
+
+			let cc: IndicatorCCSupportedReport;
+			if (receivedCC.indicatorId === 0) {
+				// Return first supported indicator
+				const firstIndicatorId = Object
+					.keys(capabilities.indicators)
+					.map((id) => parseInt(id, 10))
+					.find((id) => !isNaN(id))
+					?? 0;
+
+				cc = createReport(firstIndicatorId);
+			} else {
+				cc = createReport(receivedCC.indicatorId);
+			}
+
+			return { action: "sendCC", cc };
+		}
+	},
+};
+
+const respondToIndicatorDescriptionGet: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		if (receivedCC instanceof IndicatorCCDescriptionGet) {
+			const capabilities = {
+				...defaultCapabilities,
+				...self.getCCCapabilities(
+					CommandClasses.Indicator,
+					receivedCC.endpointIndex,
+				),
+			};
+
+			const indicatorInfo =
+				capabilities.indicators[receivedCC.indicatorId];
+			let cc: IndicatorCCDescriptionReport;
+			if (
+				!indicatorInfo
+				|| receivedCC.indicatorId < 0x80
+				|| receivedCC.indicatorId > 0x9f
+			) {
+				// Unsupported indicator, or not a manufacturer-specific indicator
+				cc = new IndicatorCCDescriptionReport({
+					nodeId: controller.ownNodeId,
+					indicatorId: receivedCC.indicatorId,
+					description: "",
+				});
+			} else {
+				cc = new IndicatorCCDescriptionReport({
+					nodeId: controller.ownNodeId,
+					indicatorId: receivedCC.indicatorId,
+					description: indicatorInfo.manufacturerSpecificDescription
+						?? "",
+				});
+			}
+
+			return { action: "sendCC", cc };
+		}
+	},
+};
+
+export const IndicatorCCBehaviors = [
+	respondToIndicatorGet,
+	// respondToIndicatorSet,
+	respondToIndicatorSupportedGet,
+	respondToIndicatorDescriptionGet,
+];

--- a/packages/zwave-js/src/lib/test/cc-specific/indicatorValues.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/indicatorValues.test.ts
@@ -1,0 +1,75 @@
+import { CommandClasses, Indicator } from "@zwave-js/core";
+import { pick } from "@zwave-js/shared";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest(
+	"Indicator values exposed to the user are human-friendly and have sensible labels",
+	{
+		// debug: true,
+
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				{
+					ccId: CommandClasses.Indicator,
+					version: 4,
+					indicators: {
+						[Indicator["Button 1 indication"]]: {
+							properties: [
+								0x02, // Binary
+								0x03, // On/Off Periods
+								0x04, // On/Off Cycle count
+								0x05, // On/Off Period: On time
+							],
+						},
+						[Indicator["Button 2 indication"]]: {
+							properties: [
+								0x01, // Multilevel
+								0x0A, // Timeout hours
+							],
+						},
+						[Indicator["Button 3 indication"]]: {
+							properties: [
+								0x02, // Binary
+								0x06, // Timeout minutes
+							],
+						},
+					},
+				},
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const indicatorValueIds = node.getDefinedValueIDs()
+				.filter((vid) => vid.commandClass === CommandClasses.Indicator)
+				// Ignore the "identify" value
+				.filter((vid) => vid.property !== "identify")
+				// Ignore the legacy v1 value
+				.filter((vid) => vid.property !== "value");
+
+			// There should only be 3 binary/multilevel values
+			// t.expect(indicatorValueIds.length).toBe(3);
+			const humanReadable = indicatorValueIds.map((vid) => {
+				return pick(vid, [
+					"propertyName",
+					"propertyKeyName",
+				]);
+			});
+
+			t.expect(humanReadable).toEqual([
+				{
+					propertyName: "Button 1 indication",
+					propertyKeyName: "Binary",
+				},
+				{
+					propertyName: "Button 2 indication",
+					propertyKeyName: "Multilevel",
+				},
+				{
+					propertyName: "Button 3 indication",
+					propertyKeyName: "Binary",
+				},
+			]);
+		},
+	},
+);

--- a/packages/zwave-js/src/lib/test/cc-specific/indicatorValues.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/indicatorValues.test.ts
@@ -1,3 +1,4 @@
+import { IndicatorCCValues } from "@zwave-js/cc";
 import { CommandClasses, Indicator } from "@zwave-js/core";
 import { pick } from "@zwave-js/shared";
 import { integrationTest } from "../integrationTestSuite.js";
@@ -88,6 +89,15 @@ integrationTest(
 					propertyKeyName: "Timeout",
 				},
 			]);
+
+			// The value metadata for the timeout values should exist
+			const timeoutMeta = node.getValueMetadata(
+				IndicatorCCValues.timeout(Indicator["Button 2 indication"]).id,
+			);
+			t.expect(timeoutMeta).toMatchObject({
+				type: "string",
+				label: "Button 2 indication - Timeout",
+			});
 		},
 	},
 );

--- a/packages/zwave-js/src/lib/test/cc-specific/indicatorValues.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/indicatorValues.test.ts
@@ -47,14 +47,24 @@ integrationTest(
 				// Ignore the legacy v1 value
 				.filter((vid) => vid.property !== "value");
 
-			// There should only be 3 binary/multilevel values
-			// t.expect(indicatorValueIds.length).toBe(3);
 			const humanReadable = indicatorValueIds.map((vid) => {
 				return pick(vid, [
 					"propertyName",
 					"propertyKeyName",
 				]);
+			}).sort((a, b) => {
+				let result = (a.propertyName ?? "").localeCompare(
+					b.propertyName ?? "",
+				);
+				result ||= (a.propertyKeyName ?? "").localeCompare(
+					b.propertyKeyName ?? "",
+				);
+				return result;
 			});
+
+			// There should only be:
+			// - 3 binary/multilevel values
+			// - 2 timeout values for buttons 2 and 3
 
 			t.expect(humanReadable).toEqual([
 				{
@@ -66,8 +76,16 @@ integrationTest(
 					propertyKeyName: "Multilevel",
 				},
 				{
+					propertyName: "Button 2 indication",
+					propertyKeyName: "Timeout",
+				},
+				{
 					propertyName: "Button 3 indication",
 					propertyKeyName: "Binary",
+				},
+				{
+					propertyName: "Button 3 indication",
+					propertyKeyName: "Timeout",
 				},
 			]);
 		},


### PR DESCRIPTION
This PR removes a lot of the Indicator CC values that are user-facing right now, but cannot actually be used in a meaningful way. Furthermore, it prevents creating values for unsupported indicator properties that are included in an `IndicatorCCReport`. The remaining values have their labels cleaned up, so one can understand what they do.
The timeout value has been reworked, so it is created for each indicator, not for the whole device, and it can actually be set now.

All in all, this removes about 100 values for the Ring Keypad v2 alone.

fixes: #5597
fixes: https://github.com/zwave-js/backlog/issues/125