### PR TITLE
feat: convert Battery CC `isLow` value to notification event

### DIFF
--- a/docs/api/CCs/Battery.md
+++ b/docs/api/CCs/Battery.md
@@ -7,7 +7,7 @@
 ### `get`
 
 ```ts
-async get(): Promise<Pick<BatteryCCReport, "level" | "isLow" | "chargingStatus" | "rechargeable" | "backup" | "overheating" | "lowFluid" | "rechargeOrReplace" | "lowTemperatureStatus" | "disconnected"> | undefined>;
+async get(): Promise<Pick<BatteryCCReport, "level" | "chargingStatus" | "rechargeable" | "backup" | "overheating" | "lowFluid" | "rechargeOrReplace" | "lowTemperatureStatus" | "disconnected"> | undefined>;
 ```
 
 ### `getHealth`
@@ -68,24 +68,6 @@ async getHealth(): Promise<Pick<BatteryCCHealthReport, "maximumCapacity" | "temp
 
 - **label:** Battery is disconnected
 - **min. CC version:** 2
-- **readable:** true
-- **writeable:** false
-- **stateful:** true
-- **secret:** false
-- **value type:** `"boolean"`
-
-### `isLow`
-
-```ts
-{
-	commandClass: CommandClasses.Battery,
-	endpoint: number,
-	property: "isLow",
-}
-```
-
-- **label:** Low battery level
-- **min. CC version:** 1
 - **readable:** true
 - **writeable:** false
 - **stateful:** true

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -1481,6 +1481,31 @@ where
 
 The CCs that use this event bring specialized versions of the callback and arguments.
 
+#### `Battery CC`
+
+uses the following signature
+
+<!-- #import ZWaveNotificationCallbackParams_BatteryCC from "zwave-js" -->
+
+```ts
+type ZWaveNotificationCallbackParams_BatteryCC = [
+	endpoint: Endpoint,
+	ccId: (typeof CommandClasses.Battery),
+	args: ZWaveNotificationCallbackArgs_BatteryCC,
+];
+```
+
+where the argument object has the type
+
+<!-- #import ZWaveNotificationCallbackArgs_BatteryCC from "zwave-js" -->
+
+```ts
+type ZWaveNotificationCallbackArgs_BatteryCC = {
+	eventType: "battery low";
+	urgency: BatteryReplacementStatus.Soon | BatteryReplacementStatus.Now;
+};
+```
+
 #### `Entry Control CC`
 
 uses the following signature

--- a/packages/cc/src/cc/BatteryCC.ts
+++ b/packages/cc/src/cc/BatteryCC.ts
@@ -486,7 +486,19 @@ export class BatteryCCReport extends BatteryCC {
 	}
 
 	public persistValues(ctx: PersistValuesContext): boolean {
+		// This is a bit hacky, but we need to avoid persisting 0xff as the battery level
+		// because the report is meant as a notification in that case.
+		if (this.level === 0xff) {
+			// @ts-expect-error
+			this.level = undefined;
+		}
+
 		if (!super.persistValues(ctx)) return false;
+
+		if (this.level === undefined) {
+			// @ts-expect-error
+			this.level = 0xff;
+		}
 
 		// Naïve heuristic for a full battery
 		if (this.level >= 90) {

--- a/packages/cc/src/cc/BatteryCC.ts
+++ b/packages/cc/src/cc/BatteryCC.ts
@@ -72,14 +72,6 @@ export const BatteryCCValues = V.defineCCValues(CommandClasses.Battery, {
 	),
 
 	...V.staticProperty(
-		"isLow",
-		{
-			...ValueMetadata.ReadOnlyBoolean,
-			label: "Low battery level",
-		} as const,
-	),
-
-	...V.staticProperty(
 		"maximumCapacity",
 		{
 			...ValueMetadata.ReadOnlyUInt8,
@@ -215,7 +207,6 @@ export class BatteryCCAPI extends PhysicalCCAPI {
 		return async function(this: BatteryCCAPI, { property }) {
 			switch (property) {
 				case "level":
-				case "isLow":
 				case "chargingStatus":
 				case "rechargeable":
 				case "backup":
@@ -251,7 +242,6 @@ export class BatteryCCAPI extends PhysicalCCAPI {
 		if (response) {
 			return pick(response, [
 				"level",
-				"isLow",
 				"chargingStatus",
 				"rechargeable",
 				"backup",
@@ -328,8 +318,10 @@ export class BatteryCC extends CommandClass {
 		const batteryStatus = await api.get();
 		if (batteryStatus) {
 			let logMessage = `received response for battery information:
-level:                           ${batteryStatus.level}${
-				batteryStatus.isLow ? " (low)" : ""
+level:                           ${
+				batteryStatus.level === 0xff
+					? "low"
+					: (batteryStatus.level + " %")
 			}`;
 			if (api.version >= 2) {
 				logMessage += `
@@ -403,16 +395,9 @@ temperature:   ${batteryHealth.temperature} °C`;
 
 // @publicAPI
 export type BatteryCCReportOptions =
-	& (
-		| {
-			isLow?: false;
-			level: number;
-		}
-		| {
-			isLow: true;
-			level?: undefined;
-		}
-	)
+	& {
+		level: number | "low";
+	}
 	& AllOrNone<{
 		// V2+
 		chargingStatus: BatteryChargingStatus;
@@ -430,7 +415,6 @@ export type BatteryCCReportOptions =
 
 @CCCommand(BatteryCommand.Report)
 @ccValueProperty("level", BatteryCCValues.level)
-@ccValueProperty("isLow", BatteryCCValues.isLow)
 @ccValueProperty("chargingStatus", BatteryCCValues.chargingStatus)
 @ccValueProperty("rechargeable", BatteryCCValues.rechargeable)
 @ccValueProperty("backup", BatteryCCValues.backup)
@@ -445,8 +429,7 @@ export class BatteryCCReport extends BatteryCC {
 	) {
 		super(options);
 
-		this.level = options.isLow ? 0 : options.level;
-		this.isLow = !!options.isLow;
+		this.level = typeof options.level === "number" ? options.level : 0xff;
 		this.chargingStatus = options.chargingStatus;
 		this.rechargeable = options.rechargeable;
 		this.backup = options.backup;
@@ -463,16 +446,9 @@ export class BatteryCCReport extends BatteryCC {
 		validatePayload(raw.payload.length >= 1);
 		const level = raw.payload[0];
 
-		if (level === 0xff) {
-			ccOptions = {
-				isLow: true,
-			};
-		} else {
-			ccOptions = {
-				isLow: false,
-				level,
-			};
-		}
+		ccOptions = {
+			level,
+		};
 
 		if (raw.payload.length >= 3) {
 			// Starting with V2
@@ -549,8 +525,6 @@ export class BatteryCCReport extends BatteryCC {
 
 	public readonly level: number;
 
-	public readonly isLow: boolean;
-
 	public readonly chargingStatus: BatteryChargingStatus | undefined;
 
 	public readonly rechargeable: boolean | undefined;
@@ -568,7 +542,7 @@ export class BatteryCCReport extends BatteryCC {
 	public readonly lowTemperatureStatus: boolean | undefined;
 
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
-		this.payload = Bytes.from([this.isLow ? 0xff : this.level]);
+		this.payload = Bytes.from([this.level]);
 		if (this.chargingStatus != undefined) {
 			this.payload = Bytes.concat([
 				this.payload,
@@ -593,10 +567,10 @@ export class BatteryCCReport extends BatteryCC {
 	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
-		const message: MessageRecord = {
-			level: this.level,
-			"is low": this.isLow,
-		};
+		const message: MessageRecord = this.level === 0xff
+			? { "is low": true }
+			: { level: this.level };
+
 		if (this.chargingStatus != undefined) {
 			message["charging status"] = getEnumMemberName(
 				BatteryChargingStatus,

--- a/packages/cc/src/cc/_CCValues.generated.ts
+++ b/packages/cc/src/cc/_CCValues.generated.ts
@@ -962,36 +962,6 @@ export const BatteryCCValues = Object.freeze({
 			autoCreate: true,
 		} as const satisfies CCValueOptions,
 	},
-	isLow: {
-		id: {
-			commandClass: CommandClasses.Battery,
-			property: "isLow",
-		} as const,
-		endpoint: (endpoint: number = 0) => ({
-			commandClass: CommandClasses.Battery,
-			endpoint,
-			property: "isLow",
-		} as const),
-		is: (valueId: ValueID): boolean => {
-			return valueId.commandClass === CommandClasses.Battery
-				&& valueId.property === "isLow"
-				&& valueId.propertyKey == undefined;
-		},
-		get meta() {
-			return {
-				...ValueMetadata.ReadOnlyBoolean,
-				label: "Low battery level",
-			} as const;
-		},
-		options: {
-			internal: false,
-			minVersion: 1,
-			secret: false,
-			stateful: true,
-			supportsEndpoints: true,
-			autoCreate: true,
-		} as const satisfies CCValueOptions,
-	},
 	maximumCapacity: {
 		id: {
 			commandClass: CommandClasses.Battery,

--- a/packages/zwave-js/src/lib/node/CCHandlers/BatteryCC.ts
+++ b/packages/zwave-js/src/lib/node/CCHandlers/BatteryCC.ts
@@ -1,0 +1,30 @@
+import {
+	type BatteryCCReport,
+	BatteryReplacementStatus,
+	type PersistValuesContext,
+} from "@zwave-js/cc";
+import { CommandClasses, type LogNode } from "@zwave-js/core";
+import type { ZWaveNode } from "../Node.js";
+
+/** Handles the receipt of a BatteryCCReport */
+export function handleBatteryReport(
+	ctx: PersistValuesContext & LogNode,
+	node: ZWaveNode,
+	command: BatteryCCReport,
+): void {
+	const endpoint = node.getEndpoint(command.endpointIndex ?? 0) ?? node;
+
+	if (command.level === 0xff) {
+		// Low battery, treat it as a notification
+		node.emit(
+			"notification",
+			endpoint,
+			CommandClasses.Battery,
+			{
+				eventType: "battery low",
+				urgency: command.rechargeOrReplace
+					|| BatteryReplacementStatus.Soon,
+			},
+		);
+	}
+}

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1,4 +1,5 @@
 import {
+	BatteryCCReport,
 	type CCAPI,
 	ClockCommand,
 	CommandClass,
@@ -171,6 +172,7 @@ import {
 	handleAssociationSupportedGroupingsGet,
 } from "./CCHandlers/AssociationGroupInformationCC.js";
 import { handleBasicCommand } from "./CCHandlers/BasicCC.js";
+import { handleBatteryReport } from "./CCHandlers/BatteryCC.js";
 import { handleBinarySwitchCommand } from "./CCHandlers/BinarySwitchCC.js";
 import {
 	getDefaultCentralSceneHandlerStore,
@@ -2329,6 +2331,8 @@ protocol version:      ${this.protocolVersion}`;
 				command,
 				this.notificationHandlerStore,
 			);
+		} else if (command instanceof BatteryCCReport) {
+			return handleBatteryReport(this.driver, this, command);
 		} else if (command instanceof ClockCCReport) {
 			return handleClockReport(
 				this.driver,

--- a/packages/zwave-js/src/lib/node/_Types.ts
+++ b/packages/zwave-js/src/lib/node/_Types.ts
@@ -1,4 +1,5 @@
 import type {
+	BatteryReplacementStatus,
 	EntryControlDataTypes,
 	EntryControlEventTypes,
 	FirmwareUpdateProgress,
@@ -195,12 +196,27 @@ export interface ZWaveNotificationCapability_EntryControlCC {
 	supportedEventTypes: Record<EntryControlEventTypes, string>;
 }
 
+export type ZWaveNotificationCallbackArgs_BatteryCC = {
+	eventType: "battery low";
+	urgency: BatteryReplacementStatus.Soon | BatteryReplacementStatus.Now;
+};
+
+/**
+ * Parameter types for the Battery CC specific version of ZWaveNotificationCallback
+ */
+export type ZWaveNotificationCallbackParams_BatteryCC = [
+	endpoint: Endpoint,
+	ccId: (typeof CommandClasses.Battery),
+	args: ZWaveNotificationCallbackArgs_BatteryCC,
+];
+
 export type ZWaveNotificationCallback = (
 	...args:
 		| ZWaveNotificationCallbackParams_NotificationCC
 		| ZWaveNotificationCallbackParams_EntryControlCC
 		| ZWaveNotificationCallbackParams_PowerlevelCC
 		| ZWaveNotificationCallbackParams_MultilevelSwitchCC
+		| ZWaveNotificationCallbackParams_BatteryCC
 ) => void;
 
 export type ZWaveNotificationCapability =

--- a/packages/zwave-js/src/lib/test/cc/BatteryCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/BatteryCC.test.ts
@@ -13,7 +13,8 @@ import { CommandClasses } from "@zwave-js/core";
 import { Bytes } from "@zwave-js/shared";
 import { createMockZWaveRequestFrame } from "@zwave-js/testing";
 import { wait } from "alcalzone-shared/async";
-import { test } from "vitest";
+import sinon from "sinon";
+import { expect, test } from "vitest";
 import { integrationTest } from "../integrationTestSuite.js";
 
 test("the Get command should serialize correctly", async (t) => {
@@ -40,7 +41,6 @@ test("the Report command (v1) should be deserialized correctly: when the battery
 	t.expect(batteryCC.constructor).toBe(BatteryCCReport);
 
 	t.expect(batteryCC.level).toBe(55);
-	t.expect(batteryCC.isLow).toBe(false);
 });
 
 test("the Report command (v1) should be deserialized correctly: when the battery is low", async (t) => {
@@ -55,8 +55,7 @@ test("the Report command (v1) should be deserialized correctly: when the battery
 	) as BatteryCCReport;
 	t.expect(batteryCC.constructor).toBe(BatteryCCReport);
 
-	t.expect(batteryCC.level).toBe(0);
-	t.expect(batteryCC.isLow).toBe(true);
+	t.expect(batteryCC.level).toBe(0xff);
 });
 
 test("the Report command (v2) should be deserialized correctly: all flags set", async (t) => {
@@ -157,6 +156,71 @@ integrationTest(
 				.toMatchObject({
 					unit: "°C",
 				});
+		},
+	},
+);
+
+integrationTest.only(
+	"Receiving a BatteryReport with the level marked low should cause a notification to be emitted",
+	{
+		// debug: true,
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Battery,
+			],
+		},
+
+		async testBody(t, driver, node, mockController, mockNode) {
+			const onNodeNotifcation = sinon.spy();
+			node.on("notification", onNodeNotifcation);
+
+			let report = new BatteryCCReport({
+				nodeId: node.id,
+				level: "low",
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(report, {
+					ackRequested: false,
+				}),
+			);
+
+			await wait(100);
+			t.expect(onNodeNotifcation.callCount).toBe(1);
+			let args = onNodeNotifcation.getCall(0).args;
+			expect(args[1]).toBe(CommandClasses.Battery);
+			t.expect(args[2].eventType).toBe("battery low");
+			t.expect(args[2].urgency).toBe(
+				BatteryReplacementStatus.Soon,
+			);
+
+			onNodeNotifcation.resetHistory();
+
+			// Now pass the urgency
+			report = new BatteryCCReport({
+				nodeId: node.id,
+				level: "low",
+				rechargeOrReplace: BatteryReplacementStatus.Now,
+
+				chargingStatus: BatteryChargingStatus.Discharging,
+				rechargeable: true,
+				backup: false,
+				overheating: false,
+				lowFluid: false,
+				disconnected: false,
+			});
+
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(report, {
+					ackRequested: false,
+				}),
+			);
+
+			await wait(100);
+			t.expect(onNodeNotifcation.callCount).toBe(1);
+			args = onNodeNotifcation.getCall(0).args;
+			expect(args[1]).toBe(CommandClasses.Battery);
+			t.expect(args[2].eventType).toBe("battery low");
+			t.expect(args[2].urgency).toBe(BatteryReplacementStatus.Now);
 		},
 	},
 );

--- a/packages/zwave-js/src/lib/test/cc/BatteryCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/BatteryCC.test.ts
@@ -160,7 +160,7 @@ integrationTest(
 	},
 );
 
-integrationTest.only(
+integrationTest(
 	"Receiving a BatteryReport with the level marked low should cause a notification to be emitted",
 	{
 		// debug: true,

--- a/packages/zwave-js/src/lib/test/driver/createCCValuesUsingKnownVersion.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/createCCValuesUsingKnownVersion.test.ts
@@ -21,7 +21,7 @@ integrationTest("CC values are created using the known CC version", {
 	testBody: async (t, driver, node, mockController, mockNode) => {
 		const batteryReport = new BatteryCCReport({
 			nodeId: mockController.ownNodeId,
-			isLow: true,
+			level: 0,
 		});
 		await mockNode.sendToController(
 			createMockZWaveRequestFrame(batteryReport),
@@ -35,13 +35,11 @@ integrationTest("CC values are created using the known CC version", {
 		await wait(100);
 
 		const levelValue = BatteryCCValues.level;
-		const isLowValue = BatteryCCValues.isLow;
 
 		// The level value should be defined because it is included in the report
 		// The overheating value shouldn't, since the interview is not complete
 		t.expect(updatedMetadata).to.have.members([
 			levelValue.id.property,
-			isLowValue.id.property,
 		]);
 
 		// Also the correct metadata should be returned dynamically
@@ -51,7 +49,6 @@ integrationTest("CC values are created using the known CC version", {
 			.map((id) => id.property);
 		t.expect(definedProperties).to.have.members([
 			levelValue.id.property,
-			isLowValue.id.property,
 		]);
 
 		t.expect(node.getValue(levelValue.id)).toBe(0);


### PR DESCRIPTION
After re-reading the corresponding specs, it became clear that "battery low" is not meant as a status to replace the current battery level, but as a warning notification.

This PR removes the `isLow` property in favor of a new possible argument to the node's or endpoint's `"notification"` event. A low battery report will now trigger that event instead of changing the current battery level.