### PR TITLE
feat(config): add productID `0x0111` to Fakro AMZ Solar awning

### DIFF
--- a/packages/config/config/devices/0x0085/amz_solar.json
+++ b/packages/config/config/devices/0x0085/amz_solar.json
@@ -15,7 +15,7 @@
 		{
 			"productType": "0x0005",
 			"productId": "0x0111"
-		},		
+		},
 		{
 			"productType": "0x0005",
 			"productId": "0x0112",

--- a/packages/config/config/devices/0x0085/amz_solar.json
+++ b/packages/config/config/devices/0x0085/amz_solar.json
@@ -14,6 +14,10 @@
 		},
 		{
 			"productType": "0x0005",
+			"productId": "0x0111"
+		},		
+		{
+			"productType": "0x0005",
 			"productId": "0x0112",
 			"zwaveAllianceId": 2627
 		}


### PR DESCRIPTION
Add ProductID 0x0111 which is another version of the Fakro AMZ solar awning
