### PR TITLE
fix(config): typo in Shelly dimmer output label

### DIFF
--- a/packages/config/config/devices/0x0460/qpdm-0A2P01.json
+++ b/packages/config/config/devices/0x0460/qpdm-0A2P01.json
@@ -68,7 +68,7 @@
 		{
 			"#": "10",
 			"$import": "~/templates/master_template.json#base_enable_disable",
-			"label": "Detach O4 Otput"
+			"label": "Detach O4 Output"
 		},
 		{
 			"#": "17",


### PR DESCRIPTION
Fix a small typo ("otput" -> "output") in the device config file for the "Shelly Wave PRO Dimmer 2PM".