### PR TITLE
feat(config): add config for Zooz ZEN75 800 series device

### DIFF
--- a/packages/config/config/devices/0x027a/zen75_800lr.json
+++ b/packages/config/config/devices/0x027a/zen75_800lr.json
@@ -1,0 +1,129 @@
+{
+	"manufacturer": "Zooz",
+	"manufacturerId": "0x027a",
+	"label": "ZEN75 800LR",
+	"description": "Heavy Duty Switch",
+	"devices": [
+		{
+			"productType": "0x7000",
+			"productId": "0xa005",
+			"zwaveAllianceId": 5179
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "On/Off",
+			"maxNodes": 5
+		}
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"$import": "~/templates/master_template.json#orientation_momentary"
+		},
+		{
+			"#": "2",
+			"$import": "~/templates/master_template.json#led_indicator_four_options"
+		},
+		{
+			"#": "3",
+			"$import": "templates/zooz_template.json#auto_off_timer_0x_1x_3x_7x"
+		},
+		{
+			"#": "5",
+			"$import": "templates/zooz_template.json#auto_on_timer_0x_1x_3x_7x"
+		},
+		{
+			"#": "7[0x01]",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Send Status Change Report: Local Control",
+			"description": "Determine whether a trigger of this type should prompt a status change report to associated devices.",
+			"defaultValue": 1
+		},
+		{
+			"#": "7[0x02]",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Send Status Change Report: 3-Way",
+			"description": "Determine whether a trigger of this type should prompt a status change report to associated devices.",
+			"defaultValue": 1
+		},
+		{
+			"#": "7[0x04]",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Send Status Change Report: Z-Wave",
+			"description": "Determine whether a trigger of this type should prompt a status change report to associated devices.",
+			"defaultValue": 1
+		},
+		{
+			"#": "7[0x08]",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Send Status Change Report: Timer",
+			"description": "Determine whether a trigger of this type should prompt a status change report to associated devices.",
+			"defaultValue": 1
+		},
+		{
+			"#": "8",
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
+		},
+		{
+			"#": "9",
+			"$import": "templates/zooz_template.json#enable_scene_control"
+		},
+		{
+			"#": "11",
+			"$import": "~/templates/master_template.json#smart_switch_mode_0-2"
+		},
+		{
+			"#": "12",
+			"$import": "templates/zooz_template.json#3way_switch_type"
+		},
+		{
+			"#": "13",
+			"$import": "templates/zooz_template.json#smart_switch_mode_reporting"
+		},
+		{
+			"#": "14",
+			"$import": "templates/zooz_template.json#led_indicator_color"
+		},
+		{
+			"#": "15",
+			"$import": "templates/zooz_template.json#led_indicator_brightness"
+		},
+		{
+			"#": "16",
+			"$import": "templates/zooz_template.json#association_reports_binary"
+		},
+		{
+			"#": "17",
+			"$import": "templates/zooz_template.json#local_programming"
+		},
+		{
+			"#": "18",
+			"$import": "templates/zooz_template.json#enable_scene_control_3way"
+		},
+		{
+			"#": "19",
+			"$import": "templates/zooz_template.json#led_confirm_config_change"
+		}
+	],
+	"compat": {
+		// The device sends Configuration CC info reports in 4-byte chunks, causing each query to block the network for roughly 1.5 seconds.
+		"skipConfigurationNameQuery": true,
+		"skipConfigurationInfoQuery": true
+	},
+	"metadata": {
+		"inclusion": "Tap the upper paddle 3 times quickly. The LED indicator will blink blue. It will turn green for 3 seconds if inclusion is successful or turn red for 3 seconds if the pairing attempt fails.",
+		"exclusion": "Tap the lower paddle 3 times quickly. The LED indicator will start blinking blue. It will turn green for 3 seconds when exclusion is successful.",
+		"reset": "1. Press and hold the lower paddle for 10 seconds until the LED indicator starts blinking.\n2. Release paddle, and immediately after, tap the lower paddle 5 times to complete the reset. The LED will flash blue 3 times and turn red for 3 seconds to confirm successful reset",
+		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=cert_portal/certs/1430/zooz-zen75-advanced-manual.pdf"
+	}
+}


### PR DESCRIPTION
Adding a config for the ZEN75. This device is essentially a ZEN71 but with a strong relay for bigger loads. It only exists in the 800 series and it only has 1 firmware version available at this time. 

Passes all lint tests. I tested locally and verified it's working as expected.

This addresses https://github.com/zwave-js/zwave-js-ui/issues/4192