### PR TITLE
fix(config): remove non-existent parameter 107 for Shelly Wave Plus S

### DIFF
--- a/packages/config/config/devices/0x0460/qnpl-0A112.json
+++ b/packages/config/config/devices/0x0460/qnpl-0A112.json
@@ -55,11 +55,6 @@
 			"label": "Signal LED Intensity"
 		},
 		{
-			"#": "107",
-			"$import": "templates/wave_template.json#out_relay_type",
-			"label": "O4: Relay Type"
-		},
-		{
 			"#": "117",
 			"$import": "templates/wave_template.json#remote_reboot"
 		},


### PR DESCRIPTION
According to the documentation there is no such thing as parameter 107. 

I think this was a leftover from copying the Shelly Wave i4? (@QubinoHelp)

Documentation: https://www.shelly.com/blogs/documentation/shelly-wave-plug-s-eu
