### PR TITLE
chore: update devcontainer image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:20",
 	"containerEnv": {
 		// Avoids cross-link issues due to different filesystems between /home and /workspaces
 		"YARN_GLOBAL_FOLDER": "/workspaces/zwave-js/.yarn/global",


### PR DESCRIPTION
The old one was using some outdated GLIBC versions which broke `dprint`.