### PR TITLE
fix: reset controller recovery phase after successful transmission

### DIFF
--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -6580,11 +6580,18 @@ ${handlers.length} left`,
 							}
 						}
 
+						// A command could be sent, so the controller is no longer jammed
 						if (
 							this.controller.status === ControllerStatus.Jammed
 						) {
-							// A command could be sent, so the controller is no longer jammed
 							this.controller.setStatus(ControllerStatus.Ready);
+						}
+						// and a possible recovery phase is over
+						if (
+							this._recoveryPhase
+								=== ControllerRecoveryPhase.JammedAfterReset
+						) {
+							this._recoveryPhase = ControllerRecoveryPhase.None;
 						}
 
 						if (!prevResult.isOK()) {


### PR DESCRIPTION
Fixes the issue reported in https://github.com/zwave-js/zwave-js/discussions/8016#discussioncomment-14079490