### PR TITLE
fix: logic to fallback to stored slow refresh capability

### DIFF
--- a/packages/zwave-js/src/lib/node/CCHandlers/CentralSceneCC.ts
+++ b/packages/zwave-js/src/lib/node/CCHandlers/CentralSceneCC.ts
@@ -98,7 +98,8 @@ export function handleCentralSceneNotification(
 		// If the node does not advertise support for the slow refresh capability, we might still be dealing with a
 		// slow refresh node. We use the stored value for fallback behavior
 		const slowRefresh = command.slowRefresh
-			?? node.valueDB.getValue<boolean>(slowRefreshValueId);
+			// Prefer the stored value, even if the command claims slowRefresh == false
+			|| node.valueDB.getValue<boolean>(slowRefreshValueId);
 		store.keyHeldDownContext = {
 			sceneNumber: command.sceneNumber,
 			// Unref'ing long running timers allows the process to exit mid-timeout


### PR DESCRIPTION
The problem was that the `slowRefresh` field on KeyReleased Central Scene notifications is always defined, but it is `false`. This lead to us not evaluating the cached/fixed value for that field.

fixes: https://github.com/zwave-js/zwave-js/issues/8066