### PR TITLE
fix: preserve known NVM section when dumping NVM

### DIFF
--- a/packages/nvmedit/src/lib/NVM3.ts
+++ b/packages/nvmedit/src/lib/NVM3.ts
@@ -298,11 +298,14 @@ export class NVM3 implements NVM<number, Uint8Array> {
 		);
 	}
 
-	public async get(fileId: number): Promise<Uint8Array | undefined> {
+	public async get(
+		fileId: number,
+		section?: NVM3SectionInfo,
+	): Promise<Uint8Array | undefined> {
 		this._info ??= await this.init();
 
-		// Determine which ring buffer to read in
-		const section = this.getNVMSectionForFile(fileId);
+		// Determine which ring buffer to read in, unless we were told to use a specific one
+		section ??= this.getNVMSectionForFile(fileId);
 
 		const pages = section.pages;
 

--- a/packages/nvmedit/src/lib/nvm3/utils.ts
+++ b/packages/nvmedit/src/lib/nvm3/utils.ts
@@ -164,7 +164,7 @@ export async function dumpNVM(nvm: NVM3): Promise<void> {
 			const page = section.pages[pageIndex];
 			const objectHeader = page.objects.findLast((o) => o.key === fileId);
 			if (!objectHeader) continue;
-			const objectData = await nvm.get(fileId);
+			const objectData = await nvm.get(fileId, section);
 
 			dumpObject({
 				offset: objectHeader.offset,


### PR DESCRIPTION
This helps when debugging 700 series NVMs with unknown objects