### PR TITLE
fix: reset writer and close underlying stream when closing ZWaveSerialStream

### DIFF
--- a/packages/serial/src/serialport/ZWaveSerialStream.ts
+++ b/packages/serial/src/serialport/ZWaveSerialStream.ts
@@ -125,10 +125,14 @@ export class ZWaveSerialStream implements
 	public async close(): Promise<void> {
 		this._isOpen = false;
 		// Close the underlying stream
-		try {
-			this._writer?.releaseLock();
-		} catch {
-			// ignore
+		if (this._writer) {
+			try {
+				this._writer?.releaseLock();
+				this._writer = undefined;
+				await this.writable.close();
+			} catch {
+				// ignore
+			}
 		}
 		this.#abort.abort();
 

--- a/packages/serial/src/zniffer/ZnifferSerialStream.ts
+++ b/packages/serial/src/zniffer/ZnifferSerialStream.ts
@@ -100,7 +100,15 @@ export class ZnifferSerialStream implements
 	public async close(): Promise<void> {
 		this._isOpen = false;
 		// Close the underlying stream
-		this._writer?.releaseLock();
+		if (this._writer) {
+			try {
+				this._writer?.releaseLock();
+				this._writer = undefined;
+				await this.writable.close();
+			} catch {
+				// ignore
+			}
+		}
 		this.#abort.abort();
 
 		return Promise.resolve();


### PR DESCRIPTION
This fixes an issue where reusing a browser-based serial port with multiple driver instances did not work.