### PR TITLE
fix(nvmedit): offset calculation when parsing `ApplicationCCsFile`

### DIFF
--- a/packages/nvmedit/src/lib/nvm3/files/ApplicationCCsFile.ts
+++ b/packages/nvmedit/src/lib/nvm3/files/ApplicationCCsFile.ts
@@ -33,13 +33,13 @@ export class ApplicationCCsFile extends NVMFile {
 			this.includedInsecurely = [
 				...this.payload.subarray(offset + 1, offset + 1 + numCCs),
 			];
-			offset += MAX_CCs;
+			offset += 1 + MAX_CCs;
 
 			numCCs = this.payload[offset];
 			this.includedSecurelyInsecureCCs = [
 				...this.payload.subarray(offset + 1, offset + 1 + numCCs),
 			];
-			offset += MAX_CCs;
+			offset += 1 + MAX_CCs;
 			numCCs = this.payload[offset];
 			this.includedSecurelySecureCCs = [
 				...this.payload.subarray(offset + 1, offset + 1 + numCCs),


### PR DESCRIPTION
Fixes an issue that can happen when the controller's NVM has exactly 35 supported CCs in its list, causing an out of bounds Buffer access during migration.