### PR TITLE
fix(serial): don't parse TX report fields when transmit status is Fail

### DIFF
--- a/packages/serial/src/serialapi/transport/SendDataBridgeMessages.test.ts
+++ b/packages/serial/src/serialapi/transport/SendDataBridgeMessages.test.ts
@@ -1,0 +1,202 @@
+import { TransmitStatus } from "@zwave-js/core";
+import { test } from "vitest";
+import { SendDataBridgeRequestTransmitReport } from "./SendDataBridgeMessages.js";
+
+test("SendDataBridgeRequestTransmitReport should parse TX report but not show it in logs when transmitStatus is Fail", (t) => {
+	const rawMessage = new Uint8Array([
+		80,
+		TransmitStatus.Fail,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+	]);
+
+	const report = SendDataBridgeRequestTransmitReport.from(
+		{ payload: rawMessage } as any,
+		{} as any,
+	);
+
+	t.expect(report.txReport).toBeDefined();
+	t.expect(report.txReport?.txTicks).toBe(0);
+	t.expect(report.transmitStatus).toBe(TransmitStatus.Fail);
+	t.expect(report.callbackId).toBe(80);
+
+	const logEntry = report.toLogEntry();
+	t.expect(logEntry.message).toStrictEqual({
+		"callback id": 80,
+		"transmit status": "Fail",
+	});
+});
+
+test("SendDataBridgeRequestTransmitReport should show TX report fields when transmitStatus is OK", (t) => {
+	const report = new SendDataBridgeRequestTransmitReport({
+		callbackId: 80,
+		transmitStatus: TransmitStatus.OK,
+		txReport: {
+			txTicks: 5,
+			txChannelNo: 1,
+			routeSchemeState: 0,
+			repeaterNodeIds: [],
+			beam1000ms: false,
+			beam250ms: false,
+			routeSpeed: 0 as any,
+			routingAttempts: 1,
+			ackRSSI: -50,
+			ackChannelNo: 1,
+		},
+	});
+
+	const logEntry = report.toLogEntry();
+	t.expect(logEntry.message).toMatchObject({
+		"callback id": 80,
+		"transmit status": "OK, took 50 ms",
+		"routing attempts": 1,
+		"protocol & route speed": "Unknown (0x00)",
+		"routing scheme": "Idle",
+		"ACK RSSI": "-50 dBm",
+		"ACK channel no.": 1,
+		"TX channel no.": 1,
+	});
+});
+
+test("SendDataBridgeRequestTransmitReport should parse TX report but not show it in logs when transmitStatus is NoAck", (t) => {
+	const rawMessage = new Uint8Array([
+		80,
+		TransmitStatus.NoAck,
+		10,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+	]);
+
+	const report = SendDataBridgeRequestTransmitReport.from(
+		{ payload: rawMessage } as any,
+		{} as any,
+	);
+
+	t.expect(report.txReport).toBeDefined();
+	t.expect(report.txReport?.txTicks).toBe(2560);
+	t.expect(report.transmitStatus).toBe(TransmitStatus.NoAck);
+	t.expect(report.callbackId).toBe(80);
+
+	const logEntry = report.toLogEntry();
+	t.expect(logEntry.message).toStrictEqual({
+		"callback id": 80,
+		"transmit status": "NoAck",
+	});
+});
+
+test("SendDataBridgeRequestTransmitReport should parse TX report but not show it in logs when transmitStatus is NoRoute", (t) => {
+	const rawMessage = new Uint8Array([
+		80,
+		TransmitStatus.NoRoute,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+	]);
+
+	const report = SendDataBridgeRequestTransmitReport.from(
+		{ payload: rawMessage } as any,
+		{} as any,
+	);
+
+	t.expect(report.txReport).toBeDefined();
+	t.expect(report.txReport?.txTicks).toBe(0);
+	t.expect(report.transmitStatus).toBe(TransmitStatus.NoRoute);
+	t.expect(report.callbackId).toBe(80);
+
+	const logEntry = report.toLogEntry();
+	t.expect(logEntry.message).toStrictEqual({
+		"callback id": 80,
+		"transmit status": "NoRoute",
+	});
+});
+
+test("SendDataBridgeRequestTransmitReport should parse TX report but not show it in logs when transmitStatus is NotIdle", (t) => {
+	const rawMessage = new Uint8Array([
+		80,
+		TransmitStatus.NotIdle,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+	]);
+
+	const report = SendDataBridgeRequestTransmitReport.from(
+		{ payload: rawMessage } as any,
+		{} as any,
+	);
+
+	t.expect(report.txReport).toBeDefined();
+	t.expect(report.txReport?.txTicks).toBe(0);
+	t.expect(report.transmitStatus).toBe(TransmitStatus.NotIdle);
+	t.expect(report.callbackId).toBe(80);
+
+	const logEntry = report.toLogEntry();
+	t.expect(logEntry.message).toStrictEqual({
+		"callback id": 80,
+		"transmit status": "NotIdle",
+	});
+});

--- a/packages/serial/src/serialapi/transport/SendDataBridgeMessages.ts
+++ b/packages/serial/src/serialapi/transport/SendDataBridgeMessages.ts
@@ -268,8 +268,6 @@ export class SendDataBridgeRequestTransmitReport
 	): SendDataBridgeRequestTransmitReport {
 		const callbackId = raw.payload[0];
 		const transmitStatus: TransmitStatus = raw.payload[1];
-
-		// TODO: Consider NOT parsing this for transmit status other than OK or NoACK
 		const txReport = parseTXReport(
 			transmitStatus !== TransmitStatus.NoAck,
 			raw.payload.subarray(2),
@@ -310,9 +308,11 @@ export class SendDataBridgeRequestTransmitReport
 				"transmit status":
 					getEnumMemberName(TransmitStatus, this.transmitStatus)
 					+ (this.txReport
+							&& this.transmitStatus === TransmitStatus.OK
 						? `, took ${this.txReport.txTicks * 10} ms`
 						: ""),
-				...(this.txReport
+				// Only show TX report fields when transmission was successful
+				...(this.txReport && this.transmitStatus === TransmitStatus.OK
 					? txReportToMessageRecord(this.txReport)
 					: {}),
 			},
@@ -607,6 +607,10 @@ export class SendDataMulticastBridgeRequestTransmitReport
 					TransmitStatus,
 					this.transmitStatus,
 				),
+				// Only show TX report fields when transmission was successful
+				...(this.txReport && this.transmitStatus === TransmitStatus.OK
+					? txReportToMessageRecord(this.txReport)
+					: {}),
 			},
 		};
 	}

--- a/packages/serial/src/serialapi/transport/SendDataMessages.test.ts
+++ b/packages/serial/src/serialapi/transport/SendDataMessages.test.ts
@@ -1,0 +1,202 @@
+import { TransmitStatus } from "@zwave-js/core";
+import { test } from "vitest";
+import { SendDataRequestTransmitReport } from "./SendDataMessages.js";
+
+test("SendDataRequestTransmitReport should parse TX report but not show it in logs when transmitStatus is Fail", (t) => {
+	const rawMessage = new Uint8Array([
+		80,
+		TransmitStatus.Fail,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+	]);
+
+	const report = SendDataRequestTransmitReport.from(
+		{ payload: rawMessage } as any,
+		{} as any,
+	);
+
+	t.expect(report.txReport).toBeDefined();
+	t.expect(report.txReport?.txTicks).toBe(0);
+	t.expect(report.transmitStatus).toBe(TransmitStatus.Fail);
+	t.expect(report.callbackId).toBe(80);
+
+	const logEntry = report.toLogEntry();
+	t.expect(logEntry.message).toStrictEqual({
+		"callback id": 80,
+		"transmit status": "Fail",
+	});
+});
+
+test("SendDataRequestTransmitReport should show TX report fields when transmitStatus is OK", (t) => {
+	const report = new SendDataRequestTransmitReport({
+		callbackId: 80,
+		transmitStatus: TransmitStatus.OK,
+		txReport: {
+			txTicks: 5,
+			txChannelNo: 1,
+			routeSchemeState: 0,
+			repeaterNodeIds: [],
+			beam1000ms: false,
+			beam250ms: false,
+			routeSpeed: 0 as any,
+			routingAttempts: 1,
+			ackRSSI: -50,
+			ackChannelNo: 1,
+		},
+	});
+
+	const logEntry = report.toLogEntry();
+	t.expect(logEntry.message).toMatchObject({
+		"callback id": 80,
+		"transmit status": "OK, took 50 ms",
+		"routing attempts": 1,
+		"protocol & route speed": "Unknown (0x00)",
+		"routing scheme": "Idle",
+		"ACK RSSI": "-50 dBm",
+		"ACK channel no.": 1,
+		"TX channel no.": 1,
+	});
+});
+
+test("SendDataRequestTransmitReport should parse TX report but not show it in logs when transmitStatus is NoAck", (t) => {
+	const rawMessage = new Uint8Array([
+		80,
+		TransmitStatus.NoAck,
+		10,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+	]);
+
+	const report = SendDataRequestTransmitReport.from(
+		{ payload: rawMessage } as any,
+		{} as any,
+	);
+
+	t.expect(report.txReport).toBeDefined();
+	t.expect(report.txReport?.txTicks).toBe(2560);
+	t.expect(report.transmitStatus).toBe(TransmitStatus.NoAck);
+	t.expect(report.callbackId).toBe(80);
+
+	const logEntry = report.toLogEntry();
+	t.expect(logEntry.message).toStrictEqual({
+		"callback id": 80,
+		"transmit status": "NoAck",
+	});
+});
+
+test("SendDataRequestTransmitReport should parse TX report but not show it in logs when transmitStatus is NoRoute", (t) => {
+	const rawMessage = new Uint8Array([
+		80,
+		TransmitStatus.NoRoute,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+	]);
+
+	const report = SendDataRequestTransmitReport.from(
+		{ payload: rawMessage } as any,
+		{} as any,
+	);
+
+	t.expect(report.txReport).toBeDefined();
+	t.expect(report.txReport?.txTicks).toBe(0);
+	t.expect(report.transmitStatus).toBe(TransmitStatus.NoRoute);
+	t.expect(report.callbackId).toBe(80);
+
+	const logEntry = report.toLogEntry();
+	t.expect(logEntry.message).toStrictEqual({
+		"callback id": 80,
+		"transmit status": "NoRoute",
+	});
+});
+
+test("SendDataRequestTransmitReport should parse TX report but not show it in logs when transmitStatus is NotIdle", (t) => {
+	const rawMessage = new Uint8Array([
+		80,
+		TransmitStatus.NotIdle,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+	]);
+
+	const report = SendDataRequestTransmitReport.from(
+		{ payload: rawMessage } as any,
+		{} as any,
+	);
+
+	t.expect(report.txReport).toBeDefined();
+	t.expect(report.txReport?.txTicks).toBe(0);
+	t.expect(report.transmitStatus).toBe(TransmitStatus.NotIdle);
+	t.expect(report.callbackId).toBe(80);
+
+	const logEntry = report.toLogEntry();
+	t.expect(logEntry.message).toStrictEqual({
+		"callback id": 80,
+		"transmit status": "NotIdle",
+	});
+});

--- a/packages/serial/src/serialapi/transport/SendDataMessages.ts
+++ b/packages/serial/src/serialapi/transport/SendDataMessages.ts
@@ -253,8 +253,6 @@ export class SendDataRequestTransmitReport extends SendDataRequestBase
 	): SendDataRequestTransmitReport {
 		const callbackId = raw.payload[0];
 		const transmitStatus: TransmitStatus = raw.payload[1];
-
-		// TODO: Consider NOT parsing this for transmit status other than OK or NoACK
 		const txReport = parseTXReport(
 			transmitStatus !== TransmitStatus.NoAck,
 			raw.payload.subarray(2),
@@ -298,9 +296,11 @@ export class SendDataRequestTransmitReport extends SendDataRequestBase
 				"transmit status":
 					getEnumMemberName(TransmitStatus, this.transmitStatus)
 					+ (this.txReport
+							&& this.transmitStatus === TransmitStatus.OK
 						? `, took ${this.txReport.txTicks * 10} ms`
 						: ""),
-				...(this.txReport
+				// Only show TX report fields when transmission was successful
+				...(this.txReport && this.transmitStatus === TransmitStatus.OK
 					? txReportToMessageRecord(this.txReport)
 					: {}),
 			},
@@ -583,6 +583,10 @@ export class SendDataMulticastRequestTransmitReport
 					TransmitStatus,
 					this.transmitStatus,
 				),
+				// Only show TX report fields when transmission was successful
+				...(this.txReport && this.transmitStatus === TransmitStatus.OK
+					? txReportToMessageRecord(this.txReport)
+					: {}),
 			},
 		};
 	}


### PR DESCRIPTION
- Only parse TX report for successful transmissions (OK) or NoAck
- For failure statuses (Fail, NoRoute, NotIdle), TX report data is meaningless
- Prevents misleading log output showing invalid routing/ACK data on failures
- Add comprehensive unit tests for all TransmitStatus values

Fixes #8051

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

PR description here
