### PR TITLE
fix(serial): hide TX report fields when transmitStatus is Fail

### DIFF
--- a/packages/serial/src/serialapi/transport/SendDataBridgeMessages.test.ts
+++ b/packages/serial/src/serialapi/transport/SendDataBridgeMessages.test.ts
@@ -1,0 +1,206 @@
+import { TransmitStatus } from "@zwave-js/core";
+import { describe, expect, test } from "vitest";
+import { SendDataBridgeRequestTransmitReport } from "./SendDataBridgeMessages.js";
+
+describe("SendDataBridgeRequestTransmitReport", () => {
+	test("should not show TX report fields when transmitStatus is Fail", () => {
+		const rawMessage = new Uint8Array([
+			80,
+			TransmitStatus.Fail,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+		]);
+		const report = SendDataBridgeRequestTransmitReport.from(
+			{ payload: rawMessage } as any,
+			{} as any,
+		);
+
+		expect(report.transmitStatus).toBe(TransmitStatus.Fail);
+		expect(report.callbackId).toBe(80);
+
+		const logEntry = report.toLogEntry();
+		expect(logEntry.message).toStrictEqual({
+			"callback id": 80,
+			"transmit status": "Fail",
+		});
+	});
+
+	test("should show TX report fields when transmitStatus is OK", () => {
+		const rawMessage = new Uint8Array([
+			80,
+			TransmitStatus.OK,
+			10,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+		]);
+		const report = SendDataBridgeRequestTransmitReport.from(
+			{ payload: rawMessage } as any,
+			{} as any,
+		);
+
+		expect(report.transmitStatus).toBe(TransmitStatus.OK);
+		expect(report.callbackId).toBe(80);
+
+		const logEntry = report.toLogEntry();
+		expect(logEntry.message).toMatchObject({
+			"callback id": 80,
+			"transmit status": "OK, took 25600 ms",
+		});
+		// Should have TX report fields
+		expect(logEntry.message).toHaveProperty("routing attempts");
+		expect(logEntry.message).toHaveProperty("protocol & route speed");
+	});
+
+	test("should show TX report fields when transmitStatus is NoAck", () => {
+		const rawMessage = new Uint8Array([
+			80,
+			TransmitStatus.NoAck,
+			10,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+		]);
+		const report = SendDataBridgeRequestTransmitReport.from(
+			{ payload: rawMessage } as any,
+			{} as any,
+		);
+
+		expect(report.transmitStatus).toBe(TransmitStatus.NoAck);
+		expect(report.callbackId).toBe(80);
+
+		const logEntry = report.toLogEntry();
+		expect(logEntry.message).toMatchObject({
+			"callback id": 80,
+			"transmit status": "NoAck, took 25600 ms",
+		});
+		// Should have TX report fields (NoAck still provides useful routing info)
+		expect(logEntry.message).toHaveProperty("routing attempts");
+		expect(logEntry.message).toHaveProperty("protocol & route speed");
+	});
+
+	test("should not show TX report fields when transmitStatus is NotIdle", () => {
+		const rawMessage = new Uint8Array([
+			80,
+			TransmitStatus.NotIdle,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+		]);
+		const report = SendDataBridgeRequestTransmitReport.from(
+			{ payload: rawMessage } as any,
+			{} as any,
+		);
+
+		expect(report.transmitStatus).toBe(TransmitStatus.NotIdle);
+		expect(report.callbackId).toBe(80);
+
+		const logEntry = report.toLogEntry();
+		expect(logEntry.message).toStrictEqual({
+			"callback id": 80,
+			"transmit status": "NotIdle",
+		});
+	});
+
+	test("should not show TX report fields when transmitStatus is NoRoute", () => {
+		const rawMessage = new Uint8Array([
+			80,
+			TransmitStatus.NoRoute,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+		]);
+		const report = SendDataBridgeRequestTransmitReport.from(
+			{ payload: rawMessage } as any,
+			{} as any,
+		);
+
+		expect(report.transmitStatus).toBe(TransmitStatus.NoRoute);
+		expect(report.callbackId).toBe(80);
+
+		const logEntry = report.toLogEntry();
+		expect(logEntry.message).toStrictEqual({
+			"callback id": 80,
+			"transmit status": "NoRoute",
+		});
+	});
+});

--- a/packages/serial/src/serialapi/transport/SendDataBridgeMessages.test.ts
+++ b/packages/serial/src/serialapi/transport/SendDataBridgeMessages.test.ts
@@ -7,6 +7,18 @@ describe("SendDataBridgeRequestTransmitReport", () => {
 		const report = new SendDataBridgeRequestTransmitReport({
 			callbackId: 80,
 			transmitStatus: TransmitStatus.Fail,
+			txReport: {
+				txTicks: 1,
+				routingAttempts: 0,
+				routeSpeed: ProtocolDataRate.ZWave_9k6,
+				routeSchemeState: 0,
+				ackRSSI: 0,
+				ackChannelNo: 0,
+				txChannelNo: 0,
+				repeaterNodeIds: [0, 0, 0, 0],
+				beam1000ms: false,
+				beam250ms: false,
+			},
 		});
 
 		expect(report.transmitStatus).toBe(TransmitStatus.Fail);
@@ -15,7 +27,7 @@ describe("SendDataBridgeRequestTransmitReport", () => {
 		const logEntry = report.toLogEntry();
 		expect(logEntry.message).toStrictEqual({
 			"callback id": 80,
-			"transmit status": "Fail",
+			"transmit status": "Fail, took 10 ms",
 		});
 	});
 

--- a/packages/serial/src/serialapi/transport/SendDataBridgeMessages.test.ts
+++ b/packages/serial/src/serialapi/transport/SendDataBridgeMessages.test.ts
@@ -38,7 +38,7 @@ describe("SendDataBridgeRequestTransmitReport", () => {
 		const logEntry = report.toLogEntry();
 		expect(logEntry.message).toStrictEqual({
 			"callback id": 80,
-			"transmit status": "Fail",
+			"transmit status": "Fail, took 0 ms",
 		});
 	});
 
@@ -161,7 +161,7 @@ describe("SendDataBridgeRequestTransmitReport", () => {
 		const logEntry = report.toLogEntry();
 		expect(logEntry.message).toStrictEqual({
 			"callback id": 80,
-			"transmit status": "NotIdle",
+			"transmit status": "NotIdle, took 0 ms",
 		});
 	});
 
@@ -200,7 +200,7 @@ describe("SendDataBridgeRequestTransmitReport", () => {
 		const logEntry = report.toLogEntry();
 		expect(logEntry.message).toStrictEqual({
 			"callback id": 80,
-			"transmit status": "NoRoute",
+			"transmit status": "NoRoute, took 0 ms",
 		});
 	});
 });

--- a/packages/serial/src/serialapi/transport/SendDataBridgeMessages.test.ts
+++ b/packages/serial/src/serialapi/transport/SendDataBridgeMessages.test.ts
@@ -1,36 +1,13 @@
-import { TransmitStatus } from "@zwave-js/core";
+import { ProtocolDataRate, TransmitStatus } from "@zwave-js/core";
 import { describe, expect, test } from "vitest";
 import { SendDataBridgeRequestTransmitReport } from "./SendDataBridgeMessages.js";
 
 describe("SendDataBridgeRequestTransmitReport", () => {
 	test("should not show TX report fields when transmitStatus is Fail", () => {
-		const rawMessage = new Uint8Array([
-			80,
-			TransmitStatus.Fail,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-		]);
-		const report = SendDataBridgeRequestTransmitReport.from(
-			{ payload: rawMessage } as any,
-			{} as any,
-		);
+		const report = new SendDataBridgeRequestTransmitReport({
+			callbackId: 80,
+			transmitStatus: TransmitStatus.Fail,
+		});
 
 		expect(report.transmitStatus).toBe(TransmitStatus.Fail);
 		expect(report.callbackId).toBe(80);
@@ -38,38 +15,27 @@ describe("SendDataBridgeRequestTransmitReport", () => {
 		const logEntry = report.toLogEntry();
 		expect(logEntry.message).toStrictEqual({
 			"callback id": 80,
-			"transmit status": "Fail, took 0 ms",
+			"transmit status": "Fail",
 		});
 	});
 
 	test("should show TX report fields when transmitStatus is OK", () => {
-		const rawMessage = new Uint8Array([
-			80,
-			TransmitStatus.OK,
-			10,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-		]);
-		const report = SendDataBridgeRequestTransmitReport.from(
-			{ payload: rawMessage } as any,
-			{} as any,
-		);
+		const report = new SendDataBridgeRequestTransmitReport({
+			callbackId: 80,
+			transmitStatus: TransmitStatus.OK,
+			txReport: {
+				txTicks: 2560,
+				routingAttempts: 0,
+				routeSpeed: ProtocolDataRate.ZWave_9k6,
+				routeSchemeState: 0,
+				ackRSSI: 0,
+				ackChannelNo: 0,
+				txChannelNo: 0,
+				repeaterNodeIds: [0, 0, 0, 0],
+				beam1000ms: false,
+				beam250ms: false,
+			},
+		});
 
 		expect(report.transmitStatus).toBe(TransmitStatus.OK);
 		expect(report.callbackId).toBe(80);
@@ -85,33 +51,22 @@ describe("SendDataBridgeRequestTransmitReport", () => {
 	});
 
 	test("should show TX report fields when transmitStatus is NoAck", () => {
-		const rawMessage = new Uint8Array([
-			80,
-			TransmitStatus.NoAck,
-			10,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-		]);
-		const report = SendDataBridgeRequestTransmitReport.from(
-			{ payload: rawMessage } as any,
-			{} as any,
-		);
+		const report = new SendDataBridgeRequestTransmitReport({
+			callbackId: 80,
+			transmitStatus: TransmitStatus.NoAck,
+			txReport: {
+				txTicks: 2560,
+				routingAttempts: 0,
+				routeSpeed: ProtocolDataRate.ZWave_9k6,
+				routeSchemeState: 0,
+				ackRSSI: 0,
+				ackChannelNo: 0,
+				txChannelNo: 0,
+				repeaterNodeIds: [0, 0, 0, 0],
+				beam1000ms: false,
+				beam250ms: false,
+			},
+		});
 
 		expect(report.transmitStatus).toBe(TransmitStatus.NoAck);
 		expect(report.callbackId).toBe(80);
@@ -127,33 +82,10 @@ describe("SendDataBridgeRequestTransmitReport", () => {
 	});
 
 	test("should not show TX report fields when transmitStatus is NotIdle", () => {
-		const rawMessage = new Uint8Array([
-			80,
-			TransmitStatus.NotIdle,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-		]);
-		const report = SendDataBridgeRequestTransmitReport.from(
-			{ payload: rawMessage } as any,
-			{} as any,
-		);
+		const report = new SendDataBridgeRequestTransmitReport({
+			callbackId: 80,
+			transmitStatus: TransmitStatus.NotIdle,
+		});
 
 		expect(report.transmitStatus).toBe(TransmitStatus.NotIdle);
 		expect(report.callbackId).toBe(80);
@@ -161,38 +93,15 @@ describe("SendDataBridgeRequestTransmitReport", () => {
 		const logEntry = report.toLogEntry();
 		expect(logEntry.message).toStrictEqual({
 			"callback id": 80,
-			"transmit status": "NotIdle, took 0 ms",
+			"transmit status": "NotIdle",
 		});
 	});
 
 	test("should not show TX report fields when transmitStatus is NoRoute", () => {
-		const rawMessage = new Uint8Array([
-			80,
-			TransmitStatus.NoRoute,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-		]);
-		const report = SendDataBridgeRequestTransmitReport.from(
-			{ payload: rawMessage } as any,
-			{} as any,
-		);
+		const report = new SendDataBridgeRequestTransmitReport({
+			callbackId: 80,
+			transmitStatus: TransmitStatus.NoRoute,
+		});
 
 		expect(report.transmitStatus).toBe(TransmitStatus.NoRoute);
 		expect(report.callbackId).toBe(80);
@@ -200,7 +109,7 @@ describe("SendDataBridgeRequestTransmitReport", () => {
 		const logEntry = report.toLogEntry();
 		expect(logEntry.message).toStrictEqual({
 			"callback id": 80,
-			"transmit status": "NoRoute, took 0 ms",
+			"transmit status": "NoRoute",
 		});
 	});
 });

--- a/packages/serial/src/serialapi/transport/SendDataBridgeMessages.ts
+++ b/packages/serial/src/serialapi/transport/SendDataBridgeMessages.ts
@@ -310,9 +310,13 @@ export class SendDataBridgeRequestTransmitReport
 				"transmit status":
 					getEnumMemberName(TransmitStatus, this.transmitStatus)
 					+ (this.txReport
+							&& (this.transmitStatus === TransmitStatus.OK
+								|| this.transmitStatus === TransmitStatus.NoAck)
 						? `, took ${this.txReport.txTicks * 10} ms`
 						: ""),
-				...(this.txReport
+				// Show TX report fields for OK and NoAck (NoAck still provides useful routing info)
+				...(this.txReport && (this.transmitStatus === TransmitStatus.OK
+						|| this.transmitStatus === TransmitStatus.NoAck)
 					? txReportToMessageRecord(this.txReport)
 					: {}),
 			},

--- a/packages/serial/src/serialapi/transport/SendDataBridgeMessages.ts
+++ b/packages/serial/src/serialapi/transport/SendDataBridgeMessages.ts
@@ -310,8 +310,6 @@ export class SendDataBridgeRequestTransmitReport
 				"transmit status":
 					getEnumMemberName(TransmitStatus, this.transmitStatus)
 					+ (this.txReport
-							&& (this.transmitStatus === TransmitStatus.OK
-								|| this.transmitStatus === TransmitStatus.NoAck)
 						? `, took ${this.txReport.txTicks * 10} ms`
 						: ""),
 				// Show TX report fields for OK and NoAck (NoAck still provides useful routing info)

--- a/packages/serial/src/serialapi/transport/SendDataMessages.test.ts
+++ b/packages/serial/src/serialapi/transport/SendDataMessages.test.ts
@@ -7,6 +7,18 @@ describe("SendDataRequestTransmitReport", () => {
 		const report = new SendDataRequestTransmitReport({
 			callbackId: 80,
 			transmitStatus: TransmitStatus.Fail,
+			txReport: {
+				txTicks: 0,
+				routingAttempts: 0,
+				routeSpeed: ProtocolDataRate.ZWave_9k6,
+				routeSchemeState: 0,
+				ackRSSI: 0,
+				ackChannelNo: 0,
+				txChannelNo: 0,
+				repeaterNodeIds: [0, 0, 0, 0],
+				beam1000ms: false,
+				beam250ms: false,
+			},
 		});
 
 		expect(report.transmitStatus).toBe(TransmitStatus.Fail);
@@ -15,7 +27,7 @@ describe("SendDataRequestTransmitReport", () => {
 		const logEntry = report.toLogEntry();
 		expect(logEntry.message).toStrictEqual({
 			"callback id": 80,
-			"transmit status": "Fail",
+			"transmit status": "Fail, took 0 ms",
 		});
 	});
 

--- a/packages/serial/src/serialapi/transport/SendDataMessages.test.ts
+++ b/packages/serial/src/serialapi/transport/SendDataMessages.test.ts
@@ -1,0 +1,206 @@
+import { TransmitStatus } from "@zwave-js/core";
+import { describe, expect, test } from "vitest";
+import { SendDataRequestTransmitReport } from "./SendDataMessages.js";
+
+describe("SendDataRequestTransmitReport", () => {
+	test("should not show TX report fields when transmitStatus is Fail", () => {
+		const rawMessage = new Uint8Array([
+			80,
+			TransmitStatus.Fail,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+		]);
+		const report = SendDataRequestTransmitReport.from(
+			{ payload: rawMessage } as any,
+			{} as any,
+		);
+
+		expect(report.transmitStatus).toBe(TransmitStatus.Fail);
+		expect(report.callbackId).toBe(80);
+
+		const logEntry = report.toLogEntry();
+		expect(logEntry.message).toStrictEqual({
+			"callback id": 80,
+			"transmit status": "Fail",
+		});
+	});
+
+	test("should show TX report fields when transmitStatus is OK", () => {
+		const rawMessage = new Uint8Array([
+			80,
+			TransmitStatus.OK,
+			10,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+		]);
+		const report = SendDataRequestTransmitReport.from(
+			{ payload: rawMessage } as any,
+			{} as any,
+		);
+
+		expect(report.transmitStatus).toBe(TransmitStatus.OK);
+		expect(report.callbackId).toBe(80);
+
+		const logEntry = report.toLogEntry();
+		expect(logEntry.message).toMatchObject({
+			"callback id": 80,
+			"transmit status": "OK, took 25600 ms",
+		});
+		// Should have TX report fields
+		expect(logEntry.message).toHaveProperty("routing attempts");
+		expect(logEntry.message).toHaveProperty("protocol & route speed");
+	});
+
+	test("should show TX report fields when transmitStatus is NoAck", () => {
+		const rawMessage = new Uint8Array([
+			80,
+			TransmitStatus.NoAck,
+			10,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+		]);
+		const report = SendDataRequestTransmitReport.from(
+			{ payload: rawMessage } as any,
+			{} as any,
+		);
+
+		expect(report.transmitStatus).toBe(TransmitStatus.NoAck);
+		expect(report.callbackId).toBe(80);
+
+		const logEntry = report.toLogEntry();
+		expect(logEntry.message).toMatchObject({
+			"callback id": 80,
+			"transmit status": "NoAck, took 25600 ms",
+		});
+		// Should have TX report fields (NoAck still provides useful routing info)
+		expect(logEntry.message).toHaveProperty("routing attempts");
+		expect(logEntry.message).toHaveProperty("protocol & route speed");
+	});
+
+	test("should not show TX report fields when transmitStatus is NotIdle", () => {
+		const rawMessage = new Uint8Array([
+			80,
+			TransmitStatus.NotIdle,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+		]);
+		const report = SendDataRequestTransmitReport.from(
+			{ payload: rawMessage } as any,
+			{} as any,
+		);
+
+		expect(report.transmitStatus).toBe(TransmitStatus.NotIdle);
+		expect(report.callbackId).toBe(80);
+
+		const logEntry = report.toLogEntry();
+		expect(logEntry.message).toStrictEqual({
+			"callback id": 80,
+			"transmit status": "NotIdle",
+		});
+	});
+
+	test("should not show TX report fields when transmitStatus is NoRoute", () => {
+		const rawMessage = new Uint8Array([
+			80,
+			TransmitStatus.NoRoute,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+		]);
+		const report = SendDataRequestTransmitReport.from(
+			{ payload: rawMessage } as any,
+			{} as any,
+		);
+
+		expect(report.transmitStatus).toBe(TransmitStatus.NoRoute);
+		expect(report.callbackId).toBe(80);
+
+		const logEntry = report.toLogEntry();
+		expect(logEntry.message).toStrictEqual({
+			"callback id": 80,
+			"transmit status": "NoRoute",
+		});
+	});
+});

--- a/packages/serial/src/serialapi/transport/SendDataMessages.test.ts
+++ b/packages/serial/src/serialapi/transport/SendDataMessages.test.ts
@@ -38,7 +38,7 @@ describe("SendDataRequestTransmitReport", () => {
 		const logEntry = report.toLogEntry();
 		expect(logEntry.message).toStrictEqual({
 			"callback id": 80,
-			"transmit status": "Fail",
+			"transmit status": "Fail, took 0 ms",
 		});
 	});
 
@@ -161,7 +161,7 @@ describe("SendDataRequestTransmitReport", () => {
 		const logEntry = report.toLogEntry();
 		expect(logEntry.message).toStrictEqual({
 			"callback id": 80,
-			"transmit status": "NotIdle",
+			"transmit status": "NotIdle, took 0 ms",
 		});
 	});
 
@@ -200,7 +200,7 @@ describe("SendDataRequestTransmitReport", () => {
 		const logEntry = report.toLogEntry();
 		expect(logEntry.message).toStrictEqual({
 			"callback id": 80,
-			"transmit status": "NoRoute",
+			"transmit status": "NoRoute, took 0 ms",
 		});
 	});
 });

--- a/packages/serial/src/serialapi/transport/SendDataMessages.test.ts
+++ b/packages/serial/src/serialapi/transport/SendDataMessages.test.ts
@@ -1,36 +1,13 @@
-import { TransmitStatus } from "@zwave-js/core";
+import { ProtocolDataRate, TransmitStatus } from "@zwave-js/core";
 import { describe, expect, test } from "vitest";
 import { SendDataRequestTransmitReport } from "./SendDataMessages.js";
 
 describe("SendDataRequestTransmitReport", () => {
 	test("should not show TX report fields when transmitStatus is Fail", () => {
-		const rawMessage = new Uint8Array([
-			80,
-			TransmitStatus.Fail,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-		]);
-		const report = SendDataRequestTransmitReport.from(
-			{ payload: rawMessage } as any,
-			{} as any,
-		);
+		const report = new SendDataRequestTransmitReport({
+			callbackId: 80,
+			transmitStatus: TransmitStatus.Fail,
+		});
 
 		expect(report.transmitStatus).toBe(TransmitStatus.Fail);
 		expect(report.callbackId).toBe(80);
@@ -38,38 +15,27 @@ describe("SendDataRequestTransmitReport", () => {
 		const logEntry = report.toLogEntry();
 		expect(logEntry.message).toStrictEqual({
 			"callback id": 80,
-			"transmit status": "Fail, took 0 ms",
+			"transmit status": "Fail",
 		});
 	});
 
 	test("should show TX report fields when transmitStatus is OK", () => {
-		const rawMessage = new Uint8Array([
-			80,
-			TransmitStatus.OK,
-			10,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-		]);
-		const report = SendDataRequestTransmitReport.from(
-			{ payload: rawMessage } as any,
-			{} as any,
-		);
+		const report = new SendDataRequestTransmitReport({
+			callbackId: 80,
+			transmitStatus: TransmitStatus.OK,
+			txReport: {
+				txTicks: 2560,
+				routingAttempts: 0,
+				routeSpeed: ProtocolDataRate.ZWave_9k6,
+				routeSchemeState: 0,
+				ackRSSI: 0,
+				ackChannelNo: 0,
+				txChannelNo: 0,
+				repeaterNodeIds: [0, 0, 0, 0],
+				beam1000ms: false,
+				beam250ms: false,
+			},
+		});
 
 		expect(report.transmitStatus).toBe(TransmitStatus.OK);
 		expect(report.callbackId).toBe(80);
@@ -85,33 +51,22 @@ describe("SendDataRequestTransmitReport", () => {
 	});
 
 	test("should show TX report fields when transmitStatus is NoAck", () => {
-		const rawMessage = new Uint8Array([
-			80,
-			TransmitStatus.NoAck,
-			10,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-		]);
-		const report = SendDataRequestTransmitReport.from(
-			{ payload: rawMessage } as any,
-			{} as any,
-		);
+		const report = new SendDataRequestTransmitReport({
+			callbackId: 80,
+			transmitStatus: TransmitStatus.NoAck,
+			txReport: {
+				txTicks: 2560,
+				routingAttempts: 0,
+				routeSpeed: ProtocolDataRate.ZWave_9k6,
+				routeSchemeState: 0,
+				ackRSSI: 0,
+				ackChannelNo: 0,
+				txChannelNo: 0,
+				repeaterNodeIds: [0, 0, 0, 0],
+				beam1000ms: false,
+				beam250ms: false,
+			},
+		});
 
 		expect(report.transmitStatus).toBe(TransmitStatus.NoAck);
 		expect(report.callbackId).toBe(80);
@@ -127,33 +82,10 @@ describe("SendDataRequestTransmitReport", () => {
 	});
 
 	test("should not show TX report fields when transmitStatus is NotIdle", () => {
-		const rawMessage = new Uint8Array([
-			80,
-			TransmitStatus.NotIdle,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-		]);
-		const report = SendDataRequestTransmitReport.from(
-			{ payload: rawMessage } as any,
-			{} as any,
-		);
+		const report = new SendDataRequestTransmitReport({
+			callbackId: 80,
+			transmitStatus: TransmitStatus.NotIdle,
+		});
 
 		expect(report.transmitStatus).toBe(TransmitStatus.NotIdle);
 		expect(report.callbackId).toBe(80);
@@ -161,38 +93,15 @@ describe("SendDataRequestTransmitReport", () => {
 		const logEntry = report.toLogEntry();
 		expect(logEntry.message).toStrictEqual({
 			"callback id": 80,
-			"transmit status": "NotIdle, took 0 ms",
+			"transmit status": "NotIdle",
 		});
 	});
 
 	test("should not show TX report fields when transmitStatus is NoRoute", () => {
-		const rawMessage = new Uint8Array([
-			80,
-			TransmitStatus.NoRoute,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-			0,
-		]);
-		const report = SendDataRequestTransmitReport.from(
-			{ payload: rawMessage } as any,
-			{} as any,
-		);
+		const report = new SendDataRequestTransmitReport({
+			callbackId: 80,
+			transmitStatus: TransmitStatus.NoRoute,
+		});
 
 		expect(report.transmitStatus).toBe(TransmitStatus.NoRoute);
 		expect(report.callbackId).toBe(80);
@@ -200,7 +109,7 @@ describe("SendDataRequestTransmitReport", () => {
 		const logEntry = report.toLogEntry();
 		expect(logEntry.message).toStrictEqual({
 			"callback id": 80,
-			"transmit status": "NoRoute, took 0 ms",
+			"transmit status": "NoRoute",
 		});
 	});
 });

--- a/packages/serial/src/serialapi/transport/SendDataMessages.ts
+++ b/packages/serial/src/serialapi/transport/SendDataMessages.ts
@@ -298,8 +298,6 @@ export class SendDataRequestTransmitReport extends SendDataRequestBase
 				"transmit status":
 					getEnumMemberName(TransmitStatus, this.transmitStatus)
 					+ (this.txReport
-							&& (this.transmitStatus === TransmitStatus.OK
-								|| this.transmitStatus === TransmitStatus.NoAck)
 						? `, took ${this.txReport.txTicks * 10} ms`
 						: ""),
 				// Show TX report fields for OK and NoAck (NoAck still provides useful routing info)

--- a/packages/serial/src/serialapi/transport/SendDataMessages.ts
+++ b/packages/serial/src/serialapi/transport/SendDataMessages.ts
@@ -298,9 +298,13 @@ export class SendDataRequestTransmitReport extends SendDataRequestBase
 				"transmit status":
 					getEnumMemberName(TransmitStatus, this.transmitStatus)
 					+ (this.txReport
+							&& (this.transmitStatus === TransmitStatus.OK
+								|| this.transmitStatus === TransmitStatus.NoAck)
 						? `, took ${this.txReport.txTicks * 10} ms`
 						: ""),
-				...(this.txReport
+				// Show TX report fields for OK and NoAck (NoAck still provides useful routing info)
+				...(this.txReport && (this.transmitStatus === TransmitStatus.OK
+						|| this.transmitStatus === TransmitStatus.NoAck)
 					? txReportToMessageRecord(this.txReport)
 					: {}),
 			},


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

- Only show TX report fields in logs when `transmitStatus` is `OK` or `NoAck`
- Prevents misleading log output showing invalid routing/ACK data on failures  
- Add unit tests to verify correct behavior for `TransmitStatus` values

Fixes #8051
