### PR TITLE
fix(zniffer): parse multiple frames from ZLF, support attachments

### DIFF
--- a/packages/zwave-js/src/lib/test/zniffer/parseZLFEntry.test.ts
+++ b/packages/zwave-js/src/lib/test/zniffer/parseZLFEntry.test.ts
@@ -9,7 +9,7 @@ test("parse complete command frame", async (t) => {
 	const rawMsg = Bytes.from("1f95cd4d13addd888103000000230500fe", "hex");
 	const parsed = parseZLFEntry(rawMsg, 0);
 	t.expect(parsed.complete).toBe(true);
-	const rawData = [...parsed.entry?.rawData ?? []];
+	const rawData = [...parsed.entries[0]?.capture?.rawData ?? []];
 	t.expect(rawData).toEqual([0x23, 0x5, 0x00]);
 });
 
@@ -24,7 +24,7 @@ test("parse incomplete command frame", async (t) => {
 	rawMsg = Bytes.from("3b0ace4d13addd8801020000000500fe", "hex");
 	parsed = parseZLFEntry(rawMsg, 0, parsed.accumulator);
 	t.expect(parsed.complete).toBe(true);
-	const rawData = [...parsed.entry?.rawData ?? []];
+	const rawData = [...parsed.entries[0]?.capture?.rawData ?? []];
 	t.expect(rawData).toEqual([0x23, 0x5, 0x00]);
 });
 
@@ -35,7 +35,7 @@ test("parse complete data frame", async (t) => {
 	);
 	const parsed = parseZLFEntry(rawMsg, 0);
 	t.expect(parsed.complete).toBe(true);
-	t.expect(parsed.msg).toBeInstanceOf(ZnifferDataMessage);
+	t.expect(parsed.entries[0].msg).toBeInstanceOf(ZnifferDataMessage);
 });
 
 test("parse incomplete data frame", async (t) => {
@@ -52,12 +52,12 @@ test("parse incomplete data frame", async (t) => {
 	);
 	parsed = parseZLFEntry(rawMsg, 0, parsed.accumulator);
 	t.expect(parsed.complete).toBe(true);
-	const rawData = [...parsed.entry?.rawData ?? []];
+	const rawData = [...parsed.entries[0]?.capture?.rawData ?? []];
 	t.expect(rawData.at(-1)).toBe(0x54);
 
 	const mockZniffer = new Zniffer("/dev/mock");
 	const frame = await mockZniffer["parseFrame"](
-		parsed.msg as ZnifferDataMessage,
+		parsed.entries[0].msg as ZnifferDataMessage,
 	);
 	t.expect(frame.cc).toBeInstanceOf(ZWaveProtocolCCSetNWIMode);
 });

--- a/packages/zwave-js/src/lib/test/zniffer/parseZLFEntry.test.ts
+++ b/packages/zwave-js/src/lib/test/zniffer/parseZLFEntry.test.ts
@@ -2,7 +2,8 @@ import { ZWaveProtocolCCSetNWIMode } from "@zwave-js/cc";
 import { ZnifferDataMessage } from "@zwave-js/serial";
 import { Bytes } from "@zwave-js/shared";
 import { test } from "vitest";
-import { Zniffer, parseZLFEntry } from "../../zniffer/Zniffer.js";
+import { parseZLFEntry } from "../../zniffer/ZLFEntry.js";
+import { Zniffer } from "../../zniffer/Zniffer.js";
 
 test("parse complete command frame", async (t) => {
 	const rawMsg = Bytes.from("1f95cd4d13addd888103000000230500fe", "hex");

--- a/packages/zwave-js/src/lib/zniffer/MPDU.ts
+++ b/packages/zwave-js/src/lib/zniffer/MPDU.ts
@@ -828,21 +828,21 @@ export class ZWaveBeamStart {
 		const data = options.data;
 		this.frameInfo = options.frameInfo;
 
-		const channelConfig = getChannelConfiguration(this.frameInfo.region);
-		switch (channelConfig) {
-			case "1/2":
-			case "3":
+		switch (options.frameInfo.channel) {
+			case 0:
+			case 1:
+			case 2:
 				// OK
 				break;
-			case "4": {
+			case 3:
+			case 4: {
 				validatePayload.fail(
-					`Channel configuration 4 (ZWLR) must be parsed as a LongRangeMPDU!`,
+					`Channel ${options.frameInfo.channel} (ZWLR) must be parsed as a LongRangeMPDU!`,
 				);
 			}
 			default: {
 				validatePayload.fail(
-					// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-					`Unsupported channel configuration ${channelConfig}. MPDU payload: ${
+					`Unsupported channel ${options.frameInfo.channel}. MPDU payload: ${
 						buffer2hex(data)
 					}`,
 				);
@@ -885,21 +885,22 @@ export class LongRangeBeamStart {
 		const data = options.data;
 		this.frameInfo = options.frameInfo;
 
-		const channelConfig = getChannelConfiguration(this.frameInfo.region);
-		switch (channelConfig) {
-			case "1/2":
-			case "3":
+		switch (options.frameInfo.channel) {
+			case 0:
+			case 1:
+			case 2:
+				validatePayload.fail(
+					`Channel ${options.frameInfo.channel} (Mesh) must be parsed as a ZWaveMPDU!`,
+				);
+
+			case 3:
+			case 4: {
 				// OK
 				break;
-			case "4": {
-				validatePayload.fail(
-					`Channel configuration 4 (ZWLR) must be parsed as a LongRangeMPDU!`,
-				);
 			}
 			default: {
 				validatePayload.fail(
-					// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-					`Unsupported channel configuration ${channelConfig}. MPDU payload: ${
+					`Unsupported channel ${options.frameInfo.channel}. MPDU payload: ${
 						buffer2hex(data)
 					}`,
 				);

--- a/packages/zwave-js/src/lib/zniffer/ZLFAttachment.ts
+++ b/packages/zwave-js/src/lib/zniffer/ZLFAttachment.ts
@@ -1,0 +1,289 @@
+import { ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+
+export enum AttachmentTypes {
+	NetworkKeys = 0x03,
+	FrameComment = 0x04,
+	Session = 0x05,
+}
+
+export type ZLFAttachmentConstructor<T extends ZLFAttachment> =
+	& typeof ZLFAttachment
+	& {
+		new (
+			options: ZLFAttachmentOptions,
+		): T;
+	};
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface ZLFAttachmentBaseOptions {
+	// Intentionally empty
+}
+
+export interface ZLFAttachmentOptions extends ZLFAttachmentBaseOptions {
+	type: AttachmentTypes;
+	version: number;
+	data?: Bytes;
+}
+
+export class ZLFAttachmentRaw {
+	public constructor(
+		public readonly type: AttachmentTypes,
+		public readonly version: number,
+		public readonly data: Bytes,
+	) {}
+
+	public static parse(buffer: Uint8Array): {
+		raw: ZLFAttachmentRaw;
+		bytesRead: number;
+	} {
+		if (buffer.length < 2) {
+			throw new ZWaveError(
+				"Incomplete ZLF attachment",
+				ZWaveErrorCodes.PacketFormat_Truncated,
+			);
+		}
+
+		const type = buffer[0] as AttachmentTypes;
+		const version = buffer[1];
+
+		// The remaining bytes are the data
+		const data = Bytes.view(buffer.subarray(2));
+
+		return {
+			raw: new ZLFAttachmentRaw(type, version, data),
+			bytesRead: buffer.length,
+		};
+	}
+
+	public withData(data: Bytes): ZLFAttachmentRaw {
+		return new ZLFAttachmentRaw(this.type, this.version, data);
+	}
+}
+
+/**
+ * Retrieves the correct constructor for the attachment based on its type.
+ */
+function getZLFAttachmentConstructor(
+	raw: ZLFAttachmentRaw,
+): ZLFAttachmentConstructor<ZLFAttachment> {
+	switch (raw.type) {
+		case AttachmentTypes.NetworkKeys:
+			return ZLFNetworkKeysAttachment as any;
+		case AttachmentTypes.FrameComment:
+			return ZLFFrameCommentAttachment as any;
+		case AttachmentTypes.Session:
+			return ZLFSessionAttachment as any;
+		default:
+			return ZLFAttachment;
+	}
+}
+
+/**
+ * Represents a ZLF attachment for parsing data from a Zniffer trace
+ */
+export class ZLFAttachment {
+	public constructor(
+		options: ZLFAttachmentOptions,
+	) {
+		this.type = options.type;
+		this.version = options.version;
+		this.data = options.data || new Bytes();
+	}
+
+	public static parse(
+		buffer: Uint8Array,
+	): {
+		attachment: ZLFAttachment;
+		bytesRead: number;
+	} {
+		const { raw, bytesRead } = ZLFAttachmentRaw.parse(buffer);
+		const Constructor = getZLFAttachmentConstructor(raw);
+		return {
+			attachment: Constructor.from(raw),
+			bytesRead,
+		};
+	}
+
+	/** Creates an instance of the attachment that is serialized in the given buffer */
+	public static from(raw: ZLFAttachmentRaw): ZLFAttachment {
+		return new this({
+			type: raw.type,
+			version: raw.version,
+			data: raw.data,
+		});
+	}
+
+	public type: AttachmentTypes;
+	public version: number;
+	public data: Bytes;
+
+	/** Serializes this attachment into a Buffer */
+	public serialize(): Bytes {
+		return Bytes.concat([
+			Bytes.from([this.type, this.version]),
+			this.data,
+		]);
+	}
+}
+
+export interface ZLFNetworkKeysAttachmentOptions
+	extends ZLFAttachmentBaseOptions
+{
+	homeId: number;
+	keys: Uint8Array[];
+	tempKeys: Uint8Array[];
+}
+
+export class ZLFNetworkKeysAttachment extends ZLFAttachment {
+	public constructor(
+		options: ZLFNetworkKeysAttachmentOptions,
+	) {
+		super({
+			type: AttachmentTypes.NetworkKeys,
+			version: 1,
+		});
+
+		this.homeId = options.homeId;
+		this.keys = options.keys.map((key) => Bytes.from(key));
+		this.tempKeys = options.tempKeys.map((key) => Bytes.from(key));
+	}
+
+	public static from(raw: ZLFAttachmentRaw): ZLFNetworkKeysAttachment {
+		// This attachment consists of at least 2x4 home ID bytes,
+		// 2x1 byte count and 2x1 byte flags, plus 16 bytes per key
+		if (raw.data.length < 12) {
+			throw new ZWaveError(
+				"Incomplete NetworkKeysAttachment",
+				ZWaveErrorCodes.PacketFormat_Truncated,
+			);
+		}
+
+		let offset = 0;
+		// Home ID seems to not be populated by the Zniffer software,
+		// but we'll parse it anyways
+		const homeId = raw.data.readUInt32BE(offset);
+		offset += 4;
+
+		const tempKeys: Bytes[] = [];
+		const keys: Bytes[] = [];
+
+		// Read first set of keys
+		let count = raw.data[offset++];
+		let isTemporary = !!(raw.data[offset++] & 0x01);
+
+		if (offset + count * 16 + 6 >= raw.data.length) {
+			throw new ZWaveError(
+				"Incomplete NetworkKeysAttachment",
+				ZWaveErrorCodes.PacketFormat_Truncated,
+			);
+		}
+
+		for (let i = 0; i < count; i++) {
+			const key = raw.data.subarray(offset, offset + 16);
+			offset += 16;
+			if (isTemporary) {
+				tempKeys.push(key);
+			} else {
+				keys.push(key);
+			}
+		}
+
+		// Read second set of keys
+		// Skip homeID bytes
+		offset += 4;
+		count = raw.data[offset++];
+		isTemporary = !!(raw.data[offset++] & 0x01);
+
+		if (offset + count * 16 > raw.data.length) {
+			throw new ZWaveError(
+				"Incomplete NetworkKeysAttachment",
+				ZWaveErrorCodes.PacketFormat_Truncated,
+			);
+		}
+
+		for (let i = 0; i < count; i++) {
+			const key = raw.data.subarray(offset, offset + 16);
+			offset += 16;
+			if (isTemporary) {
+				tempKeys.push(key);
+			} else {
+				keys.push(key);
+			}
+		}
+
+		return new ZLFNetworkKeysAttachment({
+			homeId,
+			keys,
+			tempKeys,
+		});
+	}
+
+	public readonly homeId: number;
+	public readonly keys: Bytes[];
+	public readonly tempKeys: Bytes[];
+}
+
+export interface ZLFFrameCommentAttachmentOptions
+	extends ZLFAttachmentBaseOptions
+{
+	comment: string;
+	version?: number;
+	data?: Bytes;
+	// Additional fields will be added when implementing
+}
+
+export class ZLFFrameCommentAttachment extends ZLFAttachment {
+	public constructor(
+		options: ZLFFrameCommentAttachmentOptions,
+	) {
+		super({
+			type: AttachmentTypes.FrameComment,
+			version: options.version || 1,
+			data: options.data,
+		});
+
+		this.comment = options.comment;
+	}
+
+	public static from(_raw: ZLFAttachmentRaw): ZLFFrameCommentAttachment {
+		// TODO: Implement parsing logic
+		throw new ZWaveError(
+			"ZLFFrameCommentAttachment parsing not yet implemented",
+			ZWaveErrorCodes.Deserialization_NotImplemented,
+		);
+	}
+
+	public readonly comment: string;
+}
+
+export interface ZLFSessionAttachmentOptions extends ZLFAttachmentBaseOptions {
+	sessionId: number;
+	version?: number;
+	data?: Bytes;
+	// Additional fields will be added when implementing
+}
+
+export class ZLFSessionAttachment extends ZLFAttachment {
+	public constructor(
+		options: ZLFSessionAttachmentOptions,
+	) {
+		super({
+			type: AttachmentTypes.Session,
+			version: options.version || 1,
+			data: options.data,
+		});
+
+		this.sessionId = options.sessionId;
+	}
+
+	public static from(_raw: ZLFAttachmentRaw): ZLFSessionAttachment {
+		// TODO: Implement parsing logic
+		throw new ZWaveError(
+			"ZLFSessionAttachment parsing not yet implemented",
+			ZWaveErrorCodes.Deserialization_NotImplemented,
+		);
+	}
+
+	public readonly sessionId: number;
+}

--- a/packages/zwave-js/src/lib/zniffer/ZLFEntry.ts
+++ b/packages/zwave-js/src/lib/zniffer/ZLFEntry.ts
@@ -73,6 +73,7 @@ type ParsedZLFEntry =
 	| {
 		kind: ZLFEntryKind.Attachment;
 		attachment: ZLFAttachment;
+		capture?: undefined;
 	};
 
 type ParseZLFEntryResult =

--- a/packages/zwave-js/src/lib/zniffer/ZLFEntry.ts
+++ b/packages/zwave-js/src/lib/zniffer/ZLFEntry.ts
@@ -1,0 +1,230 @@
+import { ZWaveError, ZWaveErrorCodes, isZWaveError } from "@zwave-js/core";
+import {
+	ZnifferDataMessage,
+	ZnifferMessage,
+	ZnifferMessageType,
+} from "@zwave-js/serial";
+import { Bytes } from "@zwave-js/shared";
+import { ZLFAttachment } from "./ZLFAttachment.js";
+import type { CapturedData } from "./Zniffer.js";
+
+export function captureToZLFEntry(
+	capture: CapturedData,
+): Uint8Array {
+	const buffer = new Bytes(14 + capture.rawData.length).fill(0);
+	// Convert the date to a .NET datetime
+	let ticks = BigInt(capture.timestamp.getTime()) * 10000n
+		+ 621355968000000000n;
+	// https://github.com/dotnet/runtime/blob/179473d3c8a1012b036ad732d02804b062923e8d/src/libraries/System.Private.CoreLib/src/System/DateTime.cs#L161
+	ticks = ticks | (2n << 62n); // DateTimeKind.Local << KindShift
+
+	buffer.writeBigUInt64LE(ticks, 0);
+	const direction = 0; // inbound, outbound would be 0b1000_0000
+
+	buffer[8] = direction | 0x01; // dir + session ID
+	buffer.writeUInt32LE(capture.rawData.length, 9);
+	buffer.set(capture.rawData, 13);
+	buffer[buffer.length - 1] = 0xfe; // end of frame
+	return buffer;
+}
+
+export function parseZLFHeader(buffer: Uint8Array): {
+	znifferVersion: number;
+	checksum: number;
+	bytesRead: number;
+} {
+	if (buffer.length < 2048) {
+		throw new ZWaveError(
+			"Invalid ZLF file: header too small",
+			ZWaveErrorCodes.Argument_Invalid,
+		);
+	}
+
+	const bytes = Bytes.view(buffer);
+
+	const znifferVersion = bytes[0];
+	const checksum = bytes.readUInt16BE(2046);
+
+	return {
+		znifferVersion,
+		checksum,
+		bytesRead: 2048,
+	};
+}
+
+export enum ZLFEntryKind {
+	Zniffer = 0x00,
+	Attachment = 0x06,
+}
+
+type ParsedZLFEntry =
+	| {
+		kind: ZLFEntryKind.Zniffer;
+		type: ZnifferMessageType.Data;
+		msg: ZnifferDataMessage;
+		capture: CapturedData;
+	}
+	| {
+		kind: ZLFEntryKind.Zniffer;
+		type: ZnifferMessageType.Command;
+		msg: ZnifferMessage;
+		capture: CapturedData;
+	}
+	| {
+		kind: ZLFEntryKind.Attachment;
+		attachment: ZLFAttachment;
+	};
+
+type ParseZLFEntryResult =
+	& ({
+		complete: true;
+		bytesRead: number;
+		accumulator?: undefined;
+	} | {
+		complete: false;
+		bytesRead: number;
+		accumulator: CapturedData;
+	})
+	& {
+		entries: ParsedZLFEntry[];
+	};
+
+/** @internal */
+export function parseZLFEntry(
+	buffer: Uint8Array,
+	offset: number,
+	accumulator?: CapturedData,
+): ParseZLFEntryResult {
+	const bytes = Bytes.view(buffer.subarray(offset));
+
+	// Each ZLF entry has a 14-byte overhead, so the buffer must have at least that size
+	if (bytes.length < 14) {
+		throw new ZWaveError(
+			"Invalid ZLF file: entry truncated",
+			ZWaveErrorCodes.PacketFormat_Truncated,
+		);
+	}
+
+	// Parse .NET DateTime ticks (8 bytes, little-endian)
+	const ticks = bytes.readBigUInt64LE(0);
+	// Kind: 1 = UTC, 2 = Local
+	// const dateTimeKind = Number((ticks >> 62n) & 0b11n);
+	const timeStampMask = (1n << 62n) - 1n;
+	const jsTimestamp = Number(
+		((ticks & timeStampMask) - 621355968000000000n) / 10000n,
+	);
+	// FIXME: dateTimeKind should always be local. Properly support UTC
+	const timestamp = new Date(jsTimestamp);
+
+	// Ignore the direction and session ID byte
+	const rawDataLength = bytes.readUInt32LE(9);
+	const totalLength = 14 + rawDataLength;
+	if (bytes.length < totalLength) {
+		throw new ZWaveError(
+			"Invalid ZLF file: entry truncated",
+			ZWaveErrorCodes.PacketFormat_Truncated,
+		);
+	}
+	const kind: ZLFEntryKind = 0xfe - bytes[totalLength - 1];
+	// Skip unsupported entries:
+	if (kind !== ZLFEntryKind.Zniffer && kind !== ZLFEntryKind.Attachment) {
+		return {
+			complete: true,
+			bytesRead: totalLength,
+			entries: [],
+		};
+	}
+
+	let rawData = bytes.subarray(13, totalLength - 1);
+	if (accumulator) {
+		rawData = Bytes.concat([
+			accumulator.rawData,
+			rawData,
+		]);
+	}
+
+	const parsed: ParsedZLFEntry[] = [];
+
+	try {
+		// Parse all entries in this chunk
+		if (kind === ZLFEntryKind.Zniffer) {
+			while (rawData.length > 0) {
+				const { msg, bytesRead } = ZnifferMessage.parse(rawData);
+				if (bytesRead === 0) break;
+
+				const capture: CapturedData = {
+					timestamp,
+					rawData,
+					frameData: msg.payload,
+				};
+
+				// Help TypeScript out a bit
+				if (msg instanceof ZnifferDataMessage) {
+					parsed.push({
+						kind: ZLFEntryKind.Zniffer,
+						type: ZnifferMessageType.Data,
+						msg,
+						capture,
+					});
+				} else {
+					// We are dealing with a command frame
+					parsed.push({
+						kind: ZLFEntryKind.Zniffer,
+						type: ZnifferMessageType.Command,
+						msg,
+						capture,
+					});
+				}
+				// Advance the buffer for the next iteration
+				rawData = rawData.subarray(bytesRead);
+			}
+		} else if (kind === ZLFEntryKind.Attachment) {
+			try {
+				// There should only be one attachment per entry
+				const { attachment } = ZLFAttachment.parse(rawData);
+				parsed.push({
+					kind: ZLFEntryKind.Attachment,
+					attachment,
+				});
+			} catch (e) {
+				if (
+					isZWaveError(e)
+					&& e.code === ZWaveErrorCodes.Deserialization_NotImplemented
+				) {
+					// Ignore unknown attachment types
+					console.warn("Ignoring unsupported ZLF attachment");
+				}
+			}
+		}
+
+		// All data was consumed
+		return {
+			complete: true,
+			bytesRead: totalLength,
+			entries: parsed,
+		};
+	} catch (e) {
+		if (
+			isZWaveError(e) && e.code === ZWaveErrorCodes.PacketFormat_Truncated
+		) {
+			// We are dealing with an incomplete frame, so we need to accumulate the data for the next iteration
+			accumulator ??= {
+				timestamp,
+				rawData: new Bytes(),
+				frameData: new Bytes(), // Cannot be determined yet
+			};
+			accumulator.rawData = rawData; // rawData only contains the unparsed data
+
+			return {
+				complete: false,
+				bytesRead: totalLength,
+				accumulator,
+				// Include what was parsed already
+				entries: parsed,
+			};
+		}
+
+		debugger;
+		throw e;
+	}
+}

--- a/packages/zwave-js/src/lib/zniffer/Zniffer.ts
+++ b/packages/zwave-js/src/lib/zniffer/Zniffer.ts
@@ -39,7 +39,7 @@ import {
 import {
 	type ZWaveSerialBindingFactory,
 	type ZWaveSerialPortImplementation,
-	ZnifferDataMessage,
+	type ZnifferDataMessage,
 	ZnifferFrameType,
 	ZnifferGetFrequenciesRequest,
 	ZnifferGetFrequenciesResponse,
@@ -75,6 +75,7 @@ import {
 	Bytes,
 	TypedEventTarget,
 	getEnumMemberName,
+	getErrorMessage,
 	isAbortError,
 	isEnumMember,
 	noop,
@@ -101,6 +102,12 @@ import {
 	parseMPDU,
 	znifferDataMessageToCorruptedFrame,
 } from "./MPDU.js";
+import {
+	ZLFEntryKind,
+	captureToZLFEntry,
+	parseZLFEntry,
+	parseZLFHeader,
+} from "./ZLFEntry.js";
 
 // Force-load all Command Classes:
 registerCCs();
@@ -202,7 +209,7 @@ function tryConvertRSSI(
 	}
 }
 
-interface CapturedData {
+export interface CapturedData {
 	timestamp: Date;
 	rawData: Uint8Array;
 	frameData: Uint8Array;
@@ -631,11 +638,20 @@ supported frequencies: ${
 		data: Uint8Array,
 	): Promise<void> {
 		let msg: ZnifferMessage | undefined;
+		let bytesRead: number;
 		try {
-			msg = ZnifferMessage.parse(data);
+			({ msg, bytesRead } = ZnifferMessage.parse(data));
 		} catch (e: any) {
 			console.error(e);
 			return;
+		}
+
+		if (bytesRead < data.length) {
+			// This should not actually happen
+			this.znifferLog.print(
+				`Possible data loss: read only ${bytesRead} of ${data.length} bytes!`,
+				"warn",
+			);
 		}
 
 		if (msg.type === ZnifferMessageType.Command) {
@@ -1119,18 +1135,25 @@ supported frequencies: ${
 		let accumulator: CapturedData | undefined;
 
 		while (offset < buffer.length) {
+			if (offset === 0xe8100) debugger;
 			const {
 				bytesRead,
 				complete,
-				type,
-				entry,
-				msg,
 				accumulator: newAccumulator,
+				entries,
 			} = parseZLFEntry(
 				buffer,
 				offset,
 				accumulator,
 			);
+			console.log(
+				`parsing offset ${num2hex(offset)}, len ${bytesRead} (${
+					num2hex(bytesRead)
+				}) - timestamp: ${
+					(entries[0] as any)?.capture?.timestamp.toISOString()
+				}`,
+			);
+
 			// Avoid infinite loops
 			if (bytesRead <= 0) break;
 			offset += bytesRead;
@@ -1142,12 +1165,29 @@ supported frequencies: ${
 				continue;
 			}
 
-			if (type === ZnifferMessageType.Data) {
-				entry.parsedFrame =
-					// FIXME: Figure out which values the Zniffer application actually stores
-					// as RSSI. Both the attempted conversion and the raw values seem wrong.
-					(await this.parseFrame(msg, false)).external;
-				this._capturedFrames.push(entry);
+			let index = 0;
+			for (const entry of entries) {
+				// Skip other entry types for now
+				// We may want to make use of the network key entries in the future
+				if (entry.kind !== ZLFEntryKind.Zniffer) continue;
+
+				try {
+					if (entry.type === ZnifferMessageType.Data) {
+						entry.capture.parsedFrame =
+							// FIXME: Figure out which values the Zniffer application actually stores
+							// as RSSI. Both the attempted conversion and the raw values seem wrong.
+							(await this.parseFrame(entry.msg, false)).external;
+						this._capturedFrames.push(entry.capture);
+					}
+				} catch (e) {
+					console.warn(
+						`Failed to parse entry #${index} at offset ${
+							num2hex(offset - bytesRead)
+						}:`,
+						getErrorMessage(e),
+					);
+				}
+				index++;
 			}
 		}
 	}
@@ -1340,190 +1380,5 @@ supported frequencies: ${
 			cc,
 			external: mpduToFrame(mpdu, cc),
 		};
-	}
-}
-
-function captureToZLFEntry(
-	capture: CapturedData,
-): Uint8Array {
-	const buffer = new Bytes(14 + capture.rawData.length).fill(0);
-	// Convert the date to a .NET datetime
-	let ticks = BigInt(capture.timestamp.getTime()) * 10000n
-		+ 621355968000000000n;
-	// https://github.com/dotnet/runtime/blob/179473d3c8a1012b036ad732d02804b062923e8d/src/libraries/System.Private.CoreLib/src/System/DateTime.cs#L161
-	ticks = ticks | (2n << 62n); // DateTimeKind.Local << KindShift
-
-	buffer.writeBigUInt64LE(ticks, 0);
-	const direction = 0b0000_0000; // inbound, outbound would be 0b1000_0000
-
-	buffer[8] = direction | 0x01; // dir + session ID
-	buffer[9] = capture.rawData.length;
-	// bytes 10-12 are empty
-	buffer.set(capture.rawData, 13);
-	buffer[buffer.length - 1] = 0xfe; // end of frame
-	return buffer;
-}
-
-function parseZLFHeader(buffer: Uint8Array): {
-	znifferVersion: number;
-	checksum: number;
-	bytesRead: number;
-} {
-	if (buffer.length < 2048) {
-		throw new ZWaveError(
-			"Invalid ZLF file: header too small",
-			ZWaveErrorCodes.Argument_Invalid,
-		);
-	}
-
-	const bytes = Bytes.view(buffer);
-
-	const znifferVersion = bytes[0];
-	const checksum = bytes.readUInt16BE(2046);
-
-	return {
-		znifferVersion,
-		checksum,
-		bytesRead: 2048,
-	};
-}
-
-type ParseZLFEntryResult =
-	| (
-		& {
-			complete: true;
-			bytesRead: number;
-			accumulator?: undefined;
-		}
-		& (
-			| {
-				type: ZnifferMessageType.Data;
-				msg: ZnifferDataMessage;
-				entry: CapturedData;
-			}
-			| {
-				type: ZnifferMessageType.Command;
-				msg: ZnifferMessage;
-				entry: CapturedData;
-			}
-			| {
-				type?: undefined;
-				msg?: undefined;
-				entry?: undefined;
-			}
-		)
-	)
-	| ({
-		complete: false;
-		bytesRead: number;
-		accumulator: CapturedData;
-		type?: undefined;
-		msg?: undefined;
-		entry?: undefined;
-	});
-
-/** @internal */
-export function parseZLFEntry(
-	buffer: Uint8Array,
-	offset: number,
-	accumulator?: CapturedData,
-): ParseZLFEntryResult {
-	const bytes = Bytes.view(buffer.subarray(offset));
-
-	// Each ZLF entry has a 14-byte overhead, so the buffer must have at least that size
-	if (bytes.length < 14) {
-		throw new ZWaveError(
-			"Invalid ZLF file: entry truncated",
-			ZWaveErrorCodes.PacketFormat_Truncated,
-		);
-	}
-
-	// Parse .NET DateTime ticks (8 bytes, little-endian)
-	const ticks = bytes.readBigUInt64LE(0);
-	// Kind: 1 = UTC, 2 = Local
-	// const dateTimeKind = Number((ticks >> 62n) & 0b11n);
-	const timeStampMask = (1n << 62n) - 1n;
-	const jsTimestamp = Number(
-		((ticks & timeStampMask) - 621355968000000000n) / 10000n,
-	);
-	// FIXME: dateTimeKind should always be local. Properly support UTC
-	const timestamp = new Date(jsTimestamp);
-
-	// Ignore the direction and session ID byte
-	const rawDataLength = bytes[9];
-	const totalLength = 14 + rawDataLength;
-	if (bytes.length < totalLength) {
-		throw new ZWaveError(
-			"Invalid ZLF file: entry truncated",
-			ZWaveErrorCodes.PacketFormat_Truncated,
-		);
-	}
-	const eod = bytes[totalLength - 1];
-	// 0xfe designates a Zniffer entry
-	if (eod !== 0xfe) {
-		// Skip unsupported entries
-		return {
-			complete: true,
-			bytesRead: totalLength,
-		};
-	}
-	// bytes 10-12 are empty
-
-	let rawData = bytes.subarray(13, totalLength - 1);
-	if (accumulator) {
-		rawData = Bytes.concat([
-			accumulator.rawData,
-			rawData,
-		]);
-	}
-
-	try {
-		const msg = ZnifferMessage.parse(rawData);
-
-		const entry: CapturedData = {
-			timestamp,
-			rawData,
-			frameData: msg.payload,
-		};
-
-		// Help TypeScript out a bit
-		if (msg instanceof ZnifferDataMessage) {
-			return {
-				complete: true,
-				bytesRead: totalLength,
-				type: ZnifferMessageType.Data,
-				msg,
-				entry,
-			};
-		} else {
-			// We are dealing with a command frame
-			return {
-				complete: true,
-				bytesRead: totalLength,
-				type: ZnifferMessageType.Command,
-				msg,
-				entry,
-			};
-		}
-	} catch (e) {
-		if (
-			isZWaveError(e) && e.code === ZWaveErrorCodes.PacketFormat_Truncated
-		) {
-			// We are dealing with an incomplete frame, so we need to accumulate the data for the next iteration
-			accumulator ??= {
-				timestamp,
-				rawData: new Bytes(),
-				frameData: new Bytes(), // Cannot be determined yet
-			};
-			accumulator.rawData = rawData; // rawData is already concatenated
-
-			return {
-				complete: false,
-				bytesRead: totalLength,
-				accumulator,
-			};
-		}
-
-		throw e;
 	}
 }


### PR DESCRIPTION
While trying to investigate a Zniffer trace, I noticed some issues with our ZLF parsing:
- ZLF "lines" can contain multiple ZnifferMessages, but we only handled fragmented ones
- The length field is actually a 32-bit integer, we only parsed the first byte of it
- Attachments were not supported

This PR fixes all of the above, with the exception of only parsing network key attachments, but not the other kinds.