### PR TITLE
feat(config): add Zooz ZSE50 Siren & Chime

### DIFF
--- a/packages/config/config/devices/0x027a/zse50.json
+++ b/packages/config/config/devices/0x027a/zse50.json
@@ -29,6 +29,8 @@
 			"#": "1",
 			"label": "Set siren playback mode.",
 			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 4,
 			"defaultValue": 3,
 			"options": [
 				{
@@ -90,6 +92,8 @@
 			"#": "6",
 			"label": "LED Indicator Mode",
 			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 4,
 			"defaultValue": 1,
 			"options": [
 				{
@@ -160,6 +164,8 @@
 			"#": "9",
 			"label": "LED action in Back-Up Battery Mode",
 			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 2,
 			"defaultValue": 1,
 			"options": [
 				{
@@ -190,6 +196,8 @@
 			"#": "12",
 			"label": "Basic set command to group 2",
 			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 6,
 			"defaultValue": 1,
 			"options": [
 				{

--- a/packages/config/config/devices/0x027a/zse50.json
+++ b/packages/config/config/devices/0x027a/zse50.json
@@ -38,11 +38,11 @@
 					"value": 0
 				},
 				{
-					"label": "Play in a loop for the duration specified in parameter 2.",
+					"label": "Play in a loop for the duration per parameter 2.",
 					"value": 1
 				},
 				{
-					"label": "Play in a loop for set number specified in parameter 3.",
+					"label": "Play the loop per the number set in parameter 3.",
 					"value": 2
 				},
 				{
@@ -57,7 +57,7 @@
 		},
 		{
 			"#": "2",
-			"label": "Set Playback Duration for the Siren.",
+			"label": "Set Playback Duration for the Siren",
 			"valueSize": 2,
 			"unit": "seconds",
 			"minValue": 1,
@@ -66,7 +66,7 @@
 		},
 		{
 			"#": "3",
-			"label": "Set The Number Of Playback Loops",
+			"label": "Set the Number of Playback Loops",
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 99,
@@ -74,7 +74,7 @@
 		},
 		{
 			"#": "4",
-			"label": "Set the Default File Number Tone for the Siren Playback.",
+			"label": "Default File Number Tone for the Siren Playback",
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 50,
@@ -82,7 +82,7 @@
 		},
 		{
 			"#": "5",
-			"label": "Set the Volume for Siren Playback.",
+			"label": "Set the Volume for Siren Playback",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 100,
@@ -202,31 +202,31 @@
 			"defaultValue": 1,
 			"options": [
 				{
-					"label": "No basic set commands sent.",
+					"label": "No basic set commands are sent.",
 					"value": 0
 				},
 				{
-					"label": "Basic set on sent when playback starts, off when playback stops.",
+					"label": "On sent when playback starts, off when stopped.",
 					"value": 1
 				},
 				{
-					"label": "Basic set off sent when playback starts, on when playback stops.",
+					"label": "Off sent when playback starts, on when stopped.",
 					"value": 2
 				},
 				{
-					"label": "Basic set on sent when playback starts only.",
+					"label": "On sent when playback starts only.",
 					"value": 3
 				},
 				{
-					"label": "Basic set OFF when playback stops only.",
+					"label": "Off sent when playback stops only.",
 					"value": 4
 				},
 				{
-					"label": "Basic set off sent when playback starts only.",
+					"label": "Off sent when playback starts only.",
 					"value": 5
 				},
 				{
-					"label": "Basic set on when playback stops only.",
+					"label": "On sent when playback stops only.",
 					"value": 6
 				}
 			]

--- a/packages/config/config/devices/0x027a/zse50.json
+++ b/packages/config/config/devices/0x027a/zse50.json
@@ -247,5 +247,14 @@
 			"maxValue": 20,
 			"defaultValue": 0
 		}
-	]
+	],
+	"compat": {
+		"commandClasses": {
+			"add": {
+				"Basic": {
+					"isSupported": true
+				}
+			}
+		}
+	}
 }

--- a/packages/config/config/devices/0x027a/zse50.json
+++ b/packages/config/config/devices/0x027a/zse50.json
@@ -1,0 +1,260 @@
+{
+	"manufacturer": "Zooz",
+	"manufacturerId": "0x027a",
+	"label": "ZSE50",
+	"description": "Siren & Chime",
+	"devices": [
+		{
+			"productType": "0x0004",
+			"productId": "0x0369"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"associations": {
+		"1": {
+			"label": "Lifeline",
+			"maxNodes": 5,
+			"isLifeline": true
+		},
+		"2": {
+			"label": "On-Off Control",
+			"maxNodes": 5
+		}
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"label": "Set siren playback mode.",
+			"valueSize": 1,
+			"defaultValue": 3,
+			"options": [
+				{
+					"label": "Play Once",
+					"value": 0
+				},
+				{
+					"label": "Play in a loop for set duration (set in parameter 2)",
+					"value": 1
+				},
+				{
+					"label": "Play in a loop for set number (set in parameter 3)",
+					"value": 2
+				},
+				{
+					"label": "Play in a loop until cancelled by user",
+					"value": 3
+				},
+				{
+					"label": "No sound, LED indicator only",
+					"value": 4
+				}
+			]
+		},
+		{
+			"#": "2",
+			"label": "Set playback duration for the siren.",
+			"unit": "seconds",
+			"valueSize": 2,
+			"minValue": 1,
+			"maxValue": 900,
+			"defaultValue": 180
+		},
+		{
+			"#": "3",
+			"label": "Set the number of playback loops",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 99,
+			"defaultValue": 1
+		},
+		{
+			"#": "4",
+			"label": "Set the default file number tone for the siren playback.",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 50,
+			"defaultValue": 1
+		},
+		{
+			"#": "5",
+			"label": "Set the volume for siren playback.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 100,
+			"defaultValue": 100
+		},
+		{
+			"#": "6",
+			"label": "LED Indicator Mode",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"options": [
+				{
+					"label": "LED Always Off",
+					"value": 0
+				},
+				{
+					"label": "LED strobe single color (set in param 7)",
+					"value": 1
+				},
+				{
+					"label": "LED strobe red and blue",
+					"value": 2
+				},
+				{
+					"label": "LED pulse single color (set in param 7)",
+					"value": 3
+				},
+				{
+					"label": "LED solid on single color (set in param 7)",
+					"value": 4
+				}
+			]
+		},
+		{
+			"#": "7",
+			"label": "LED Indicator Color",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"options": [
+			{
+				"label": "Red",
+				"value": 0
+			},
+			{
+				"label": "Yellow",
+				"value": 42
+			},
+			{
+				"label": "Green",
+				"value": 85
+			},
+			{
+				"label": "Indigo",
+				"value": 127
+			},
+			{
+				"label": "Blue",
+				"value": 170
+			},
+			{
+				"label": "Purple",
+				"value": 212
+			},
+			{
+				"label": "White",
+				"value": 255
+			}
+		]
+		},
+		{
+			"#": "8",
+			"$import": "templates/zooz_template.json#low_battery_alarm_threshold"
+		},
+		{
+			"#": "9",
+			"label": "LED action in Back-Up Battery Mode",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"options": [
+				{
+					"label": "LED off (save battery)",
+					"value": 0
+				},
+				{
+					"label": "Regular LED mode (set in param 6)",
+					"value": 1
+				},
+				{
+					"label": "LED pulse white for full battery and red for low battery",
+					"value": 2
+				}
+			]
+		},
+		{
+			"#": "10",
+			"$import": "templates/zooz_template.json#local_control",
+			"description": "Disable tone selection from physical buttons on the siren."
+		},
+		{
+			"#": "11",
+			"$import": "templates/zooz_template.json#local_control",
+			"description": "Disable volume adjustment from physical buttons on the siren"
+		},
+		{
+			"#": "12",
+			"label": "Basic set command to group 2",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"options": [
+				{
+					"label": "No Basic set commands sent",
+					"value": 0
+				},
+				{
+					"label": "Basic Set ON sent when playback starts, Off when playback stops",
+					"value": 1
+				},
+				{
+					"label": "Basic Set OFF sent when playback starts, On when playback stops",
+					"value": 2
+				},
+				{
+					"label": "Basic Set ON sent when playback starts only",
+					"value": 3
+				},
+				{
+					"label": "Basic Set OFF when playback stops only",
+					"value": 4
+				},
+				{
+					"label": "Basic Set OFF sent when playback starts only",
+					"value": 5
+				},
+				{
+					"label": "Basic Set ON when playback stops only",
+					"value": 6
+				}
+			]
+		},
+		{
+			"#": "13",
+			"label": "System Message Volume",
+			"description": "Set the volume for siren system messages",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 100,
+			"defaultValue": 50
+		},
+		{
+			"#": "14",
+			"label": "LED Indicator Brightness",
+			"description": "Choose the LED indicator's brightness level.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 10,
+			"defaultValue": 5
+		},
+		{
+			"#": "15",
+			"label": "Reporting interval for the battery",
+			"unit": "hours",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 84,
+			"defaultValue": 12
+		},
+		{
+			"#": "16",
+			"$import": "templates/zooz_template.json#battery_report_threshold",
+			"minValue": 0,
+			"maxValue": 20,
+			"defaultValue": 0
+		}
+	]
+}

--- a/packages/config/config/devices/0x027a/zse50.json
+++ b/packages/config/config/devices/0x027a/zse50.json
@@ -202,7 +202,7 @@
 			"defaultValue": 1,
 			"options": [
 				{
-					"label": "No basic set commands are sent.",
+					"label": "Basic commands are not sent",
 					"value": 0
 				},
 				{

--- a/packages/config/config/devices/0x027a/zse50.json
+++ b/packages/config/config/devices/0x027a/zse50.json
@@ -202,7 +202,7 @@
 			"defaultValue": 1,
 			"options": [
 				{
-					"label": "No basic set commands are sent",
+					"label": "No basic set commands are sent.",
 					"value": 0
 				},
 				{

--- a/packages/config/config/devices/0x027a/zse50.json
+++ b/packages/config/config/devices/0x027a/zse50.json
@@ -38,11 +38,11 @@
 					"value": 0
 				},
 				{
-					"label": "Play in a loop for the duration per parameter 2.",
+					"label": "Play in a loop for the duration per parameter two",
 					"value": 1
 				},
 				{
-					"label": "Play the loop per the number set in parameter 3.",
+					"label": "Play the loop per the number set in parameter three",
 					"value": 2
 				},
 				{
@@ -202,31 +202,31 @@
 			"defaultValue": 1,
 			"options": [
 				{
-					"label": "No basic set commands are sent.",
+					"label": "No basic set commands are sent",
 					"value": 0
 				},
 				{
-					"label": "On sent when playback starts, off when stopped.",
+					"label": "On sent when playback starts, off when stopped",
 					"value": 1
 				},
 				{
-					"label": "Off sent when playback starts, on when stopped.",
+					"label": "Off sent when playback starts, on when stopped",
 					"value": 2
 				},
 				{
-					"label": "On sent when playback starts only.",
+					"label": "On sent when playback starts only",
 					"value": 3
 				},
 				{
-					"label": "Off sent when playback stops only.",
+					"label": "Off sent when playback stops only",
 					"value": 4
 				},
 				{
-					"label": "Off sent when playback starts only.",
+					"label": "Off sent when playback starts only",
 					"value": 5
 				},
 				{
-					"label": "On sent when playback stops only.",
+					"label": "On sent when playback stops only",
 					"value": 6
 				}
 			]

--- a/packages/config/config/devices/0x027a/zse50.json
+++ b/packages/config/config/devices/0x027a/zse50.json
@@ -13,25 +13,15 @@
 		"min": "0.0",
 		"max": "255.255"
 	},
-	"associations": {
-		"1": {
-			"label": "Lifeline",
-			"maxNodes": 5,
-			"isLifeline": true
-		},
-		"2": {
-			"label": "On-Off Control",
-			"maxNodes": 5
-		}
-	},
 	"paramInformation": [
 		{
 			"#": "1",
-			"label": "Set Siren Playback Mode",
+			"label": "Siren Playback Mode",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 4,
-			"defaultValue": 3,
+			"defaultValue": 0,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Play once",
@@ -57,7 +47,7 @@
 		},
 		{
 			"#": "2",
-			"label": "Set Playback Duration for the Siren",
+			"label": "Siren Playback Duration",
 			"valueSize": 2,
 			"unit": "seconds",
 			"minValue": 1,
@@ -66,7 +56,7 @@
 		},
 		{
 			"#": "3",
-			"label": "Set the Number of Playback Loops",
+			"label": "Number of Playback Loops",
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 99,
@@ -74,7 +64,7 @@
 		},
 		{
 			"#": "4",
-			"label": "Default File Number Tone for the Siren Playback",
+			"label": "Default Siren Playback Tone File Number",
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 50,
@@ -82,7 +72,7 @@
 		},
 		{
 			"#": "5",
-			"label": "Set the Volume for Siren Playback",
+			"label": "Siren Playback Volume",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 100,
@@ -95,6 +85,7 @@
 			"minValue": 0,
 			"maxValue": 4,
 			"defaultValue": 1,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "LED always off",
@@ -126,6 +117,7 @@
 			"maxValue": 255,
 			"defaultValue": 0,
 			"unsigned": true,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Red",
@@ -168,6 +160,7 @@
 			"minValue": 0,
 			"maxValue": 2,
 			"defaultValue": 1,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "LED off to save battery",
@@ -200,6 +193,7 @@
 			"minValue": 0,
 			"maxValue": 6,
 			"defaultValue": 1,
+			"allowManualEntry": false,
 			"options": [
 				{
 					"label": "Basic commands are not sent",
@@ -234,7 +228,6 @@
 		{
 			"#": "13",
 			"label": "System Message Volume",
-			"description": "Set the volume for siren system messages.",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 100,
@@ -243,7 +236,6 @@
 		{
 			"#": "14",
 			"label": "LED Indicator Brightness",
-			"description": "Choose the LED indicator's brightness level.",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 10,
@@ -251,7 +243,7 @@
 		},
 		{
 			"#": "15",
-			"label": "Reporting Interval for the Battery",
+			"label": "Battery Reporting Interval",
 			"valueSize": 1,
 			"unit": "hours",
 			"minValue": 1,

--- a/packages/config/config/devices/0x027a/zse50.json
+++ b/packages/config/config/devices/0x027a/zse50.json
@@ -27,7 +27,7 @@
 	"paramInformation": [
 		{
 			"#": "1",
-			"label": "Set Siren Playback Mode.",
+			"label": "Set Siren Playback Mode",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 4,
@@ -38,11 +38,11 @@
 					"value": 0
 				},
 				{
-					"label": "Play in a loop for set duration as set in parameter 2.",
+					"label": "Play in a loop for the duration specified in parameter 2.",
 					"value": 1
 				},
 				{
-					"label": "Play in a loop for set number as set in parameter 3",
+					"label": "Play in a loop for set number specified in parameter 3.",
 					"value": 2
 				},
 				{
@@ -57,7 +57,7 @@
 		},
 		{
 			"#": "2",
-			"label": "Set Playback Duration For The Siren.",
+			"label": "Set Playback Duration for the Siren.",
 			"valueSize": 2,
 			"unit": "seconds",
 			"minValue": 1,
@@ -74,7 +74,7 @@
 		},
 		{
 			"#": "4",
-			"label": "Set The Default File Number Tone For The Siren Playback.",
+			"label": "Set the Default File Number Tone for the Siren Playback.",
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 50,
@@ -82,7 +82,7 @@
 		},
 		{
 			"#": "5",
-			"label": "Set The Volume For Siren Playback.",
+			"label": "Set the Volume for Siren Playback.",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 100,
@@ -163,7 +163,7 @@
 		},
 		{
 			"#": "9",
-			"label": "LED Action In Back-Up Battery Mode",
+			"label": "LED Action in Back-Up Battery Mode",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 2,
@@ -195,38 +195,38 @@
 		},
 		{
 			"#": "12",
-			"label": "Basic Set Command To Group 2",
+			"label": "Basic Set Command to Group 2",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 6,
 			"defaultValue": 1,
 			"options": [
 				{
-					"label": "No basic set commands sent",
+					"label": "No basic set commands sent.",
 					"value": 0
 				},
 				{
-					"label": "Basic set on sent when playback starts, off when playback stops",
+					"label": "Basic set on sent when playback starts, off when playback stops.",
 					"value": 1
 				},
 				{
-					"label": "Basic set off sent when playback starts, On when playback stops",
+					"label": "Basic set off sent when playback starts, on when playback stops.",
 					"value": 2
 				},
 				{
-					"label": "Basic set on sent when playback starts only",
+					"label": "Basic set on sent when playback starts only.",
 					"value": 3
 				},
 				{
-					"label": "Basic set OFF when playback stops only",
+					"label": "Basic set OFF when playback stops only.",
 					"value": 4
 				},
 				{
-					"label": "Basic set off sent when playback starts only",
+					"label": "Basic set off sent when playback starts only.",
 					"value": 5
 				},
 				{
-					"label": "Basic set on when playback stops only",
+					"label": "Basic set on when playback stops only.",
 					"value": 6
 				}
 			]
@@ -234,7 +234,7 @@
 		{
 			"#": "13",
 			"label": "System Message Volume",
-			"description": "Set the volume for siren system messages",
+			"description": "Set the volume for siren system messages.",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 100,
@@ -251,7 +251,7 @@
 		},
 		{
 			"#": "15",
-			"label": "Reporting Interval For The Battery",
+			"label": "Reporting Interval for the Battery",
 			"valueSize": 1,
 			"unit": "hours",
 			"minValue": 1,

--- a/packages/config/config/devices/0x027a/zse50.json
+++ b/packages/config/config/devices/0x027a/zse50.json
@@ -18,8 +18,6 @@
 			"#": "1",
 			"label": "Siren Playback Mode",
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 4,
 			"defaultValue": 0,
 			"allowManualEntry": false,
 			"options": [
@@ -82,8 +80,6 @@
 			"#": "6",
 			"label": "LED Indicator Mode",
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 4,
 			"defaultValue": 1,
 			"allowManualEntry": false,
 			"options": [
@@ -113,8 +109,6 @@
 			"#": "7",
 			"label": "LED Indicator Color",
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 255,
 			"defaultValue": 0,
 			"unsigned": true,
 			"allowManualEntry": false,
@@ -157,8 +151,6 @@
 			"#": "9",
 			"label": "LED Action in Back-Up Battery Mode",
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 2,
 			"defaultValue": 1,
 			"allowManualEntry": false,
 			"options": [
@@ -190,8 +182,6 @@
 			"#": "12",
 			"label": "Basic Set Command to Group 2",
 			"valueSize": 1,
-			"minValue": 0,
-			"maxValue": 6,
 			"defaultValue": 1,
 			"allowManualEntry": false,
 			"options": [

--- a/packages/config/config/devices/0x027a/zse50.json
+++ b/packages/config/config/devices/0x027a/zse50.json
@@ -122,35 +122,35 @@
 			"maxValue": 255,
 			"defaultValue": 0,
 			"options": [
-			{
-				"label": "Red",
-				"value": 0
-			},
-			{
-				"label": "Yellow",
-				"value": 42
-			},
-			{
-				"label": "Green",
-				"value": 85
-			},
-			{
-				"label": "Indigo",
-				"value": 127
-			},
-			{
-				"label": "Blue",
-				"value": 170
-			},
-			{
-				"label": "Purple",
-				"value": 212
-			},
-			{
-				"label": "White",
-				"value": 255
-			}
-		]
+				{
+					"label": "Red",
+					"value": 0
+				},
+				{
+					"label": "Yellow",
+					"value": 42
+				},
+				{
+					"label": "Green",
+					"value": 85
+				},
+				{
+					"label": "Indigo",
+					"value": 127
+				},
+				{
+					"label": "Blue",
+					"value": 170
+				},
+				{
+					"label": "Purple",
+					"value": 212
+				},
+				{
+					"label": "White",
+					"value": 255
+				}
+			]
 		},
 		{
 			"#": "8",

--- a/packages/config/config/devices/0x027a/zse50.json
+++ b/packages/config/config/devices/0x027a/zse50.json
@@ -27,22 +27,22 @@
 	"paramInformation": [
 		{
 			"#": "1",
-			"label": "Set siren playback mode.",
+			"label": "Set Siren Playback Mode.",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 4,
 			"defaultValue": 3,
 			"options": [
 				{
-					"label": "Play Once",
+					"label": "Play once",
 					"value": 0
 				},
 				{
-					"label": "Play in a loop for set duration (set in parameter 2)",
+					"label": "Play in a loop for set duration as set in parameter 2.",
 					"value": 1
 				},
 				{
-					"label": "Play in a loop for set number (set in parameter 3)",
+					"label": "Play in a loop for set number as set in parameter 3",
 					"value": 2
 				},
 				{
@@ -57,16 +57,16 @@
 		},
 		{
 			"#": "2",
-			"label": "Set playback duration for the siren.",
-			"unit": "seconds",
+			"label": "Set Playback Duration For The Siren.",
 			"valueSize": 2,
+			"unit": "seconds",
 			"minValue": 1,
 			"maxValue": 900,
 			"defaultValue": 180
 		},
 		{
 			"#": "3",
-			"label": "Set the number of playback loops",
+			"label": "Set The Number Of Playback Loops",
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 99,
@@ -74,7 +74,7 @@
 		},
 		{
 			"#": "4",
-			"label": "Set the default file number tone for the siren playback.",
+			"label": "Set The Default File Number Tone For The Siren Playback.",
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 50,
@@ -82,7 +82,7 @@
 		},
 		{
 			"#": "5",
-			"label": "Set the volume for siren playback.",
+			"label": "Set The Volume For Siren Playback.",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 100,
@@ -97,11 +97,11 @@
 			"defaultValue": 1,
 			"options": [
 				{
-					"label": "LED Always Off",
+					"label": "LED always off",
 					"value": 0
 				},
 				{
-					"label": "LED strobe single color (set in param 7)",
+					"label": "LED strobe single color as set in param 7",
 					"value": 1
 				},
 				{
@@ -109,11 +109,11 @@
 					"value": 2
 				},
 				{
-					"label": "LED pulse single color (set in param 7)",
+					"label": "LED pulse single color as set in param 7",
 					"value": 3
 				},
 				{
-					"label": "LED solid on single color (set in param 7)",
+					"label": "LED solid on single color as set in param 7",
 					"value": 4
 				}
 			]
@@ -163,18 +163,18 @@
 		},
 		{
 			"#": "9",
-			"label": "LED action in Back-Up Battery Mode",
+			"label": "LED Action In Back-Up Battery Mode",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 2,
 			"defaultValue": 1,
 			"options": [
 				{
-					"label": "LED off (save battery)",
+					"label": "LED off to save battery",
 					"value": 0
 				},
 				{
-					"label": "Regular LED mode (set in param 6)",
+					"label": "Regular LED mode as set in param 6",
 					"value": 1
 				},
 				{
@@ -195,38 +195,38 @@
 		},
 		{
 			"#": "12",
-			"label": "Basic set command to group 2",
+			"label": "Basic Set Command To Group 2",
 			"valueSize": 1,
 			"minValue": 0,
 			"maxValue": 6,
 			"defaultValue": 1,
 			"options": [
 				{
-					"label": "No Basic set commands sent",
+					"label": "No basic set commands sent",
 					"value": 0
 				},
 				{
-					"label": "Basic Set ON sent when playback starts, Off when playback stops",
+					"label": "Basic set on sent when playback starts, off when playback stops",
 					"value": 1
 				},
 				{
-					"label": "Basic Set OFF sent when playback starts, On when playback stops",
+					"label": "Basic set off sent when playback starts, On when playback stops",
 					"value": 2
 				},
 				{
-					"label": "Basic Set ON sent when playback starts only",
+					"label": "Basic set on sent when playback starts only",
 					"value": 3
 				},
 				{
-					"label": "Basic Set OFF when playback stops only",
+					"label": "Basic set OFF when playback stops only",
 					"value": 4
 				},
 				{
-					"label": "Basic Set OFF sent when playback starts only",
+					"label": "Basic set off sent when playback starts only",
 					"value": 5
 				},
 				{
-					"label": "Basic Set ON when playback stops only",
+					"label": "Basic set on when playback stops only",
 					"value": 6
 				}
 			]
@@ -251,9 +251,9 @@
 		},
 		{
 			"#": "15",
-			"label": "Reporting interval for the battery",
-			"unit": "hours",
+			"label": "Reporting Interval For The Battery",
 			"valueSize": 1,
+			"unit": "hours",
 			"minValue": 1,
 			"maxValue": 84,
 			"defaultValue": 12

--- a/packages/config/config/devices/0x027a/zse50.json
+++ b/packages/config/config/devices/0x027a/zse50.json
@@ -125,6 +125,7 @@
 			"minValue": 0,
 			"maxValue": 255,
 			"defaultValue": 0,
+			"unsigned": true,
 			"options": [
 				{
 					"label": "Red",

--- a/packages/config/config/devices/0x027a/zse50.json
+++ b/packages/config/config/devices/0x027a/zse50.json
@@ -72,6 +72,7 @@
 			"#": "5",
 			"label": "Siren Playback Volume",
 			"valueSize": 1,
+			"unit": "%",
 			"minValue": 0,
 			"maxValue": 100,
 			"defaultValue": 100
@@ -219,6 +220,7 @@
 			"#": "13",
 			"label": "System Message Volume",
 			"valueSize": 1,
+			"unit": "%",
 			"minValue": 0,
 			"maxValue": 100,
 			"defaultValue": 50


### PR DESCRIPTION
PR description here

Introduces device configuration for the Zooz ZSE50 Siren & Chime, including parameter definitions, association groups, and imports for common template settings. This enables support and customization for the ZSE50 in the system.

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->


