### PR TITLE
fix(config): correct parameter size for factory reset of Shelly Wave devices

### DIFF
--- a/packages/config/config/devices/0x0460/templates/wave_template.json
+++ b/packages/config/config/devices/0x0460/templates/wave_template.json
@@ -195,7 +195,7 @@
 	"factory_reset": {
 		"label": "Factory Reset",
 		"description": "Reset to factory default settings and remove from the Z-Wave network.",
-		"valueSize": 4,
+		"valueSize": 1,
 		"defaultValue": 0,
 		"allowManualEntry": false,
 		"options": [


### PR DESCRIPTION
Adjusted the factory_reset parameter to use the proper value size so that the configuration aligns with device specifications