### PR TITLE
feat: add API to enable more frequent background RSSI measurements

### DIFF
--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -365,6 +365,28 @@ This requires an external configuration directory to be configured using the `de
 
 > [!NOTE] Although the updated config gets loaded after the update, bugfixes and changes to device configuration generally require either a driver restart or re-interview of the changed devices to take effect.
 
+Disable sending usage statistics.
+
+### Background RSSI (noise) monitoring
+
+Z-Wave JS periodically measures the background RSSI (noise level) to provide insights about the network environment. By default, this is done only when the queue is idle for several seconds, and repeated at 30s intervals. It can be desirable to get quicker feedback about the noise levels at a certain location, for example when trying to find a good location for a new node or repeater. To achive that, you can enable frequent RSSI monitoring.
+
+### `enableFrequentRSSIMonitoring`
+
+```ts
+enableFrequentRSSIMonitoring(durationMs: number): void
+```
+
+Enables frequent background RSSI monitoring for a given amount of milliseconds. During this time, the background RSSI will be measured every 2 seconds, but only when the queue is idle. The readings will be emitted as statistics event as usual.
+
+### `disableFrequentRSSIMonitoring`
+
+```ts
+disableFrequentRSSIMonitoring(): void
+```
+
+Disables frequent background RSSI monitoring.
+
 ## Driver properties
 
 ### `cacheDir`
@@ -417,6 +439,14 @@ readonly statisticsEnabled: boolean
 ```
 
 Returns whether reporting usage statistics is currently enabled.
+
+### `isFrequentRSSIMonitoringEnabled`
+
+```ts
+readonly isFrequentRSSIMonitoringEnabled: boolean
+```
+
+Returns whether frequent background RSSI monitoring is currently enabled.
 
 ### `userAgent`
 

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -781,8 +781,6 @@ export interface DriverEventCallbacks extends PrefixedNodeEvents {
 	"firmware update finished": (
 		result: OTWFirmwareUpdateResult,
 	) => void;
-	"rssi hf status": (enabled: boolean, timeout?: number) => void;
-
 	error: (err: Error) => void;
 }
 
@@ -9347,8 +9345,6 @@ integrity: ${update.integrity}`;
 			);
 		}
 
-		this.emit("rssi hf status", true, timeoutMs);
-
 		this.poolBackgroundRSSIIHFTimeoutMs = timeoutMs;
 		this.handleQueueIdleChange(this.queueIdle);
 
@@ -9361,8 +9357,6 @@ integrity: ${update.integrity}`;
 	 * This will restore the default behavior of polling the background RSSI only once every 30 seconds.
 	 */
 	public disableBackgroundRSSIHFMode(): void {
-		this.emit("rssi hf status", false);
-
 		this.clearBackgroundRSSIHFTimer();
 		this.poolBackgroundRSSIIHFTimeoutMs = undefined;
 	}

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -5602,12 +5602,12 @@ ${handlers.length} left`,
 			) {
 				// The message we're currently sending is still in progress but expects this message in response.
 				// Remember the message there.
-					this.controllerLog.logNode(msg.getNodeId()!, {
-						message:
+				this.controllerLog.logNode(msg.getNodeId()!, {
+					message:
 						`received expected response prematurely, remembering it...`,
-						level: "verbose",
-						direction: "inbound",
-					});
+					level: "verbose",
+					direction: "inbound",
+				});
 				currentMessage.prematureNodeUpdate = msg;
 				return;
 			}
@@ -9229,6 +9229,12 @@ integrity: ${update.integrity}`;
 	public enableFrequentRSSIMonitoring(
 		durationMs: number,
 	): void {
+		if (durationMs < 10000 || durationMs > 3600 * 1000) {
+			throw new ZWaveError(
+				`The duration must be between 10 seconds and one hour!`,
+				ZWaveErrorCodes.Argument_Invalid,
+			);
+		}
 		this.hfBackgroundRSSIEndTimestamp = Date.now() + durationMs;
 		// Restart a running timer to poll as soon as possible
 		if (this.pollBackgroundRSSITimer) {

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -9226,6 +9226,7 @@ integrity: ${update.integrity}`;
 		this.pollBackgroundRSSITimer = undefined;
 	}
 
+	/** Enable frequent RSSI monitoring for the given amount of milliseconds. During this time, the background RSSI will be measured every 2 seconds. */
 	public enableFrequentRSSIMonitoring(
 		durationMs: number,
 	): void {
@@ -9235,6 +9236,7 @@ integrity: ${update.integrity}`;
 				ZWaveErrorCodes.Argument_Invalid,
 			);
 		}
+
 		this.hfBackgroundRSSIEndTimestamp = Date.now() + durationMs;
 		// Restart a running timer to poll as soon as possible
 		if (this.pollBackgroundRSSITimer) {
@@ -9243,6 +9245,7 @@ integrity: ${update.integrity}`;
 		}
 	}
 
+	/** Disable frequent RSSI monitoring */
 	public disableFrequentRSSIMonitoring(): void {
 		this.hfBackgroundRSSIEndTimestamp = 0;
 		// Restart a running timer to lower the polling frequency

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -9306,11 +9306,11 @@ integrity: ${update.integrity}`;
 	 * Enables high frequency background RSSI polling.
 	 * This will make the driver poll the background RSSI every `timeoutMs` milliseconds when idle until `timeMs` milliseconds have passed or the mode is disabled manually.
 	 * @param timeoutMs The duration in milliseconds at which the background RSSI will be polled when the send queue is idle.
-	 * @param durationMd The time in milliseconds after which the high frequency background RSSI polling will be disabled automatically.
+	 * @param durationMs The time in milliseconds after which the high frequency background RSSI polling will be disabled automatically.
 	 */
 	public enableBackgroundRSSIHFMode(
 		timeoutMs: number = 2_000,
-		durationMd: number = 2 * 60_000,
+		durationMs: number = 2 * 60_000,
 	): void {
 		// Check the controller supports GetBackgroundRSSI, if not ensure that we don't enable this feature
 		if (
@@ -9335,12 +9335,12 @@ integrity: ${update.integrity}`;
 			);
 		}
 
-		if (durationMd <= timeoutMs) { // If duration is lower than timeout, throw an error
+		if (durationMs <= timeoutMs) { // If duration is lower than timeout, throw an error
 			throw new ZWaveError(
 				`The duration must be greater than the timeout!`,
 				ZWaveErrorCodes.Argument_Invalid,
 			);
-		} else if (durationMd > 10 * 60_000) { // If duration is greater than 10 minutes, throw an error
+		} else if (durationMs > 10 * 60_000) { // If duration is greater than 10 minutes, throw an error
 			throw new ZWaveError(
 				`The duration must be at most 10 minutes!`,
 				ZWaveErrorCodes.Argument_Invalid,
@@ -9352,8 +9352,8 @@ integrity: ${update.integrity}`;
 		this.poolBackgroundRSSIIHFTimeoutMs = timeoutMs;
 		this.handleQueueIdleChange(this.queueIdle);
 
-		if (durationMd !== undefined && durationMd > 0) {
-			this.setBackgroundRSSIHFTimer(durationMd);
+		if (durationMs !== undefined && durationMs > 0) {
+			this.setBackgroundRSSIHFTimer(durationMs);
 		}
 	}
 

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -3955,7 +3955,7 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 				...this.autoRefreshNodeValueTimers.values(),
 				this.statisticsTimeout,
 				this.pollBackgroundRSSITimer,
-				this.poolBackgroundRSSIIHFTimer,
+				this.poolBackgroundRSSIHFTimer,
 				...this.sendNodeToSleepTimers.values(),
 				...this.awaitedCommands.map((c) => c.timeout),
 				...this.awaitedMessages.map((m) => m.timeout),
@@ -9275,7 +9275,7 @@ integrity: ${update.integrity}`;
 	}
 
 	// Used to store the timeout that disables high frequency background RSSI polling
-	private poolBackgroundRSSIIHFTimer: Timer | undefined;
+	private poolBackgroundRSSIHFTimer: Timer | undefined;
 
 	/**
 	 * Returns true if high frequency background RSSI polling is enabled.
@@ -9289,7 +9289,7 @@ integrity: ${update.integrity}`;
 	 * @param timeoutMs The time in milliseconds after which the high frequency background RSSI polling will be disabled automatically.
 	 */
 	private setBackgroundRSSIHFTimer(timeoutMs: number): void {
-		this.poolBackgroundRSSIIHFTimer = setTimer(() => {
+		this.poolBackgroundRSSIHFTimer = setTimer(() => {
 			this.disableBackgroundRSSIHFMode();
 		}, timeoutMs).unref();
 	}
@@ -9298,8 +9298,8 @@ integrity: ${update.integrity}`;
 	 * Clears the timer for high frequency background RSSI polling.
 	 */
 	private clearBackgroundRSSIHFTimer(): void {
-		this.poolBackgroundRSSIIHFTimer?.clear();
-		this.poolBackgroundRSSIIHFTimer = undefined;
+		this.poolBackgroundRSSIHFTimer?.clear();
+		this.poolBackgroundRSSIHFTimer = undefined;
 	}
 
 	/**

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -432,7 +432,7 @@ function checkOptions(options: ZWaveOptions): void {
 		|| options.timeouts.pollBackgroundRSSIMax > 300000
 	) {
 		throw new ZWaveError(
-			`The Poll Background RSSI Max timeout must be between 3001 and 300000 milliseconds!`,
+			`The Poll Background RSSI Max timeout must be between 4000 and 300000 milliseconds!`,
 			ZWaveErrorCodes.Driver_InvalidOptions,
 		);
 	}

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -57,6 +57,16 @@ export interface ZWaveOptions {
 		sendToSleep: number; // [10...5000], default: 250 ms
 
 		/**
+		 *  Minimum value can be specified to avoid polling the background RSSI too frequently.
+		 */
+		pollBackgroundRSSIMin: number; // [3000...290000], default: 5000 ms
+
+		/**
+		 * Maximum value can be specified to avoid polling the background RSSI too infrequently.
+		 */
+		pollBackgroundRSSIMax: number; // [4000...300000], default: 30000 ms
+
+		/**
 		 * **!!! INTERNAL !!!**
 		 *
 		 * Not intended to be used by applications

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -57,16 +57,6 @@ export interface ZWaveOptions {
 		sendToSleep: number; // [10...5000], default: 250 ms
 
 		/**
-		 *  Minimum value can be specified to avoid polling the background RSSI too frequently.
-		 */
-		pollBackgroundRSSIMin: number; // [3000...290000], default: 5000 ms
-
-		/**
-		 * Maximum value can be specified to avoid polling the background RSSI too infrequently.
-		 */
-		pollBackgroundRSSIMax: number; // [4000...300000], default: 30000 ms
-
-		/**
 		 * **!!! INTERNAL !!!**
 		 *
 		 * Not intended to be used by applications

--- a/test/rssi-monitor.ts
+++ b/test/rssi-monitor.ts
@@ -1,0 +1,202 @@
+// demo.ts
+import { Buffer } from "node:buffer";
+import { exit } from "node:process";
+import { Driver } from "zwave-js";
+
+const MINIMUN_RSSI = -120;
+const INTERVAL = 3_000; // The interval between RSSI polls when in high-frequency mode. in milliseconds. Must be between pollBackgroundRSSIMin and pollBackgroundRSSIMax
+const HF_MODE_TIMEOUT = 300_000; // The amount of time to keep high-frequency mode enabled. in milliseconds
+const PORT = "/dev/ttyACM0"; // Adjust this to your USB stick port (e.g., /dev/tty.usbmodemXYZ or /dev/ttyACM0)
+
+function drawRSSIProgressBar(current: number, width = 40) {
+	const ratio = current / MINIMUN_RSSI;
+	const empty = Math.round(ratio * width);
+	const filled = width - empty;
+	//Ensure no negative values in case of very good RSSI
+	if (empty < 0) {
+		return `[${"█".repeat(width)}]`;
+	}
+	return `[${"█".repeat(filled)}${"·".repeat(empty)}]`;
+}
+
+async function main(args: string[] = process.argv.slice(2)) {
+	if (args.includes("--help") || args.includes("-h")) {
+		console.log(`Usage: yarn ts test/rssi-monitor.ts [serial-port]`);
+		exit(0);
+	}
+
+	const driver = new Driver(
+		args[0] || PORT, // Read the first param as the port if provided
+		{
+			securityKeys: {
+				S0_Legacy: Buffer.from(
+					"0102030405060708090a0b0c0d0e0f10",
+					"hex",
+				),
+				S2_Unauthenticated: Buffer.from(
+					"11111111111111111111111111111111",
+					"hex",
+				),
+				S2_AccessControl: Buffer.from(
+					"22222222222222222222222222222222",
+					"hex",
+				),
+				S2_Authenticated: Buffer.from(
+					"33333333333333333333333333333333",
+					"hex",
+				),
+			},
+			securityKeysLongRange: {
+				S2_Authenticated: Buffer.from(
+					"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+					"hex",
+				),
+				S2_AccessControl: Buffer.from(
+					"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+					"hex",
+				),
+			},
+			timeouts: {
+				pollBackgroundRSSIMin: 3_000,
+				pollBackgroundRSSIMax: 15000,
+			},
+			logConfig: {
+				enabled: true,
+				level: "error",
+			},
+		},
+	);
+
+	driver.on("error", (err) => {
+		console.error("Driver error:", err);
+	});
+
+	driver.on("driver ready", () => {
+		// Clear the console
+		process.stdout.write("\x1Bc");
+
+		driver.on("rssi hf status", (enabled, _timeout) => {
+			if (enabled) {
+				console.log(
+					`\r\x1b[8;1HHigh frequency background RSSI polling enabled`,
+				);
+			} else {
+				console.log(
+					"\r\x1b[8;1HHigh frequency background RSSI polling disabled",
+				);
+			}
+		});
+
+		// Raw mode keystroke handling (no need to press Enter)
+		if (process.stdin.isTTY) {
+			process.stdin.setRawMode(true);
+			process.stdin.setEncoding("utf8");
+			process.stdin.resume();
+		}
+
+		const handleKey = (key: string) => {
+			// Ctrl+C or 'x' exits
+			if (key === "\u0003" || key === "x") {
+				// cleanup raw mode
+				if (process.stdin.isTTY) process.stdin.setRawMode(false);
+				process.stdin.removeListener("data", handleKey as any);
+				exit(0);
+			}
+			// 'h' toggles high-frequency mode
+			if (key === "h") {
+				if (!driver.poolBackgroundRSSIHFModeEnabled) {
+					driver.enableBackgroundRSSIHFMode(
+						INTERVAL,
+						HF_MODE_TIMEOUT,
+					);
+				} else {
+					driver.disableBackgroundRSSIHFMode();
+				}
+			}
+		};
+
+		process.stdin.on("data", handleKey);
+
+		driver.controller.on("statistics updated", (stats) => {
+			// Clear the whole console each update
+
+			function writeChannelToConsole(
+				row: number,
+				channel: 0 | 1 | 2 | 3,
+			) {
+				// increment row to leave a space for the header
+				row++;
+				// check if channel exists. if not, write N/A
+				if (
+					stats.backgroundRSSI?.[`channel${channel}`]?.current
+						=== undefined
+				) {
+					process.stdout.write(
+						`
+						\r\x1b[${row};1HChannel ${channel + 1}:
+						\r\x1b[${row};12H ${
+							drawRSSIProgressBar(
+								0,
+								30,
+							)
+						}
+						\x1b[${row};45H${"N/A".padStart(4)} dBm
+						\x1b[${row};56H${"N/A".padStart(4)} dBm`,
+					);
+
+					return;
+				}
+				process.stdout.write(
+					`
+					\r\x1b[${row};1HChannel ${channel + 1}: 
+					\r\x1b[${row};12H${
+						drawRSSIProgressBar(
+							stats.backgroundRSSI?.[`channel${channel}`]?.current
+								|| -120,
+							30,
+						)
+					} 
+					\x1b[${row};45H${
+						stats.backgroundRSSI?.[`channel${channel}`]?.current
+							.toString().padStart(4)
+					} dBm
+					\x1b[${row};56H${
+						stats.backgroundRSSI?.[`channel${channel}`]?.average
+							.toString().padStart(4)
+					} dBm
+					`,
+				);
+			}
+
+			process.stdout.write("\x1Bc");
+			// Header
+			process.stdout.write(
+				`\r\x1b[1;1HChannel\x1b[1;16H Noise - Less is Better \x1b[1;46HCurrent\x1b[1;56H Average`,
+			);
+
+			// Channels 0-3 (looped)
+			const channels = [0, 1, 2, 3] as const;
+			channels.forEach((channel) => {
+				writeChannelToConsole(channel + 1, channel);
+			});
+			//
+
+			// Write on line 5 the serial name and if hf mode is enabled
+			process.stdout.write(
+				`\r\x1b[6;1HSerial: ${PORT} - HF mode: ${
+					driver.poolBackgroundRSSIHFModeEnabled
+						? `enabled (${INTERVAL} ms)`
+						: "disabled"
+				}
+				\r\x1b[7;1H(type "h" to enable HF mode, "x" to exit)`,
+			);
+		});
+	});
+
+	await driver.start();
+}
+
+main().catch((e) => {
+	console.error(e);
+	exit(1);
+});

--- a/test/rssi-monitor.ts
+++ b/test/rssi-monitor.ts
@@ -44,19 +44,13 @@ function writeChannelRow(
 	if (!channel?.current) { // If current is undefined or 0
 		process.stdout.write(
 			`
-						
-						\r\x1b[${row};12H ${
-				drawRSSIProgressBar(
-					0,
-					30,
-				)
-			}`,
+				\r\x1b[${row};12H ${drawRSSIProgressBar(0, 30)}`,
 		);
 	} else { // If current has a valid value
 		process.stdout.write(
 			`
-					\r\x1b[${row};1HChannel ${channel.id + 1}: 
-					\r\x1b[${row};12H${
+				\r\x1b[${row};1HChannel ${channel.id + 1}: 
+				\r\x1b[${row};12H${
 				drawRSSIProgressBar(
 					channel.current
 						|| MINIMUN_RSSI,
@@ -71,12 +65,8 @@ function writeChannelRow(
 	// Writing the current and average columns
 	process.stdout.write(
 		`
-					\x1b[${row};45H${
-			(channel.current || "N/A").toString().padStart(4)
-		} dBm
-					\x1b[${row};56H${
-			(channel.average || "N/A").toString().padStart(4)
-		} dBm
+		\x1b[${row};45H${(channel.current || "N/A").toString().padStart(4)} dBm
+		\x1b[${row};56H${(channel.average || "N/A").toString().padStart(4)} dBm
 					`,
 	);
 }
@@ -109,12 +99,13 @@ function updateDisplay(stats: ControllerStatistics, hfEnabled: boolean) {
 	});
 	// Write the footer
 	process.stdout.write(
-		`\r\x1b[6;1HSerial: ${PORT} - HF mode: ${
+		`
+			\r\x1b[6;1HSerial: ${PORT} - HF mode: ${
 			hfEnabled
 				? `enabled`
 				: "disabled"
 		}
-				\r\x1b[7;1H(type "h" to enable HF mode, "x" to exit)`,
+			\r\x1b[7;1H(type "h" to enable HF mode, "x" to exit)`,
 	);
 }
 

--- a/test/rssi-monitor.ts
+++ b/test/rssi-monitor.ts
@@ -8,7 +8,6 @@ const INTERVAL = 3_000; // The interval between RSSI polls when in high-frequenc
 const HF_MODE_TIMEOUT = 300_000; // The amount of time to keep high-frequency mode enabled. in milliseconds
 const PORT = "/dev/ttyACM0"; // Adjust this to your USB stick port (e.g., /dev/tty.usbmodemXYZ or /dev/ttyACM0)
 
-
 /**
  * @param current The current RSSI value
  * @param width The amount of characters the progress bar will use

--- a/test/rssi-monitor.ts
+++ b/test/rssi-monitor.ts
@@ -38,7 +38,6 @@ function writeChannelRow(
 	rowOffset: number,
 	channel: { id: number; average?: number; current?: number },
 ) {
-
 	// increment row to leave a space for the header
 	row += rowOffset;
 	// Writing the progress bar

--- a/test/rssi-monitor.ts
+++ b/test/rssi-monitor.ts
@@ -71,18 +71,6 @@ async function main(args: string[] = process.argv.slice(2)) {
 		// Clear the console
 		process.stdout.write("\x1Bc");
 
-		driver.on("rssi hf status", (enabled, _timeout) => {
-			if (enabled) {
-				console.log(
-					`\r\x1b[8;1HHigh frequency background RSSI polling enabled`,
-				);
-			} else {
-				console.log(
-					"\r\x1b[8;1HHigh frequency background RSSI polling disabled",
-				);
-			}
-		});
-
 		// Raw mode keystroke handling (no need to press Enter)
 		if (process.stdin.isTTY) {
 			process.stdin.setRawMode(true);


### PR DESCRIPTION
**Why**

closes: https://github.com/zwave-js/zwave-js/issues/8186

**What**

This PR introduces a new High-Frequency RSSI Polling Mode. In this mode, background RSSI measurements are performed at shorter, configurable intervals.

This mode can be enabled or disabled via an API call. It is temporary by default to avoid accidentally leaving it enabled.

Additionally, i've added a test file (actually, is not really a test, but a tool) to monitor Background RSSI in realtime, leveraging also the new HF Mode. 

https://github.com/user-attachments/assets/e4c85a3f-82fe-404c-99c7-f71ce50f8e5a


**Summary**:
* Added High-Frequency RSSI Polling Mode, which reduces the polling time to 2 seconds
* New API to enable/disable HF RSSI mode, with configurable duration.
* New rssi-monitor terminal tool -> yarn ts test/rssi-monitor.ts [serial-port]

Would you mind taking a general look @AlCalzone??
* Do I need to generate the docs manually? 
* In general, I'm completely new to the project, please tell me if something seems off!

Thank You!

