### PR TITLE
fix: abort pending SendData when response CC is received before ACK

### DIFF
--- a/packages/serial/src/message/Message.ts
+++ b/packages/serial/src/message/Message.ts
@@ -401,9 +401,6 @@ export class Message {
 		return false;
 	}
 
-	/** Gets set by the driver to remember an expected node update for this message that arrived before the Serial API command has finished. */
-	public prematureNodeUpdate: Message | undefined;
-
 	/** Finds the ID of the target or source node in a message, if it contains that information */
 	public getNodeId(): number | undefined {
 		if (hasNodeId(this)) return this.nodeId;

--- a/packages/zwave-js/src/lib/driver/MessageGenerators.ts
+++ b/packages/zwave-js/src/lib/driver/MessageGenerators.ts
@@ -165,8 +165,6 @@ export const simpleMessageGenerator: MessageGeneratorImplementation<Message> =
 
 		// Pass this message to the send thread and wait for it to be sent
 		let result: Message;
-		// At this point we can't have received a premature update
-		msg.prematureNodeUpdate = undefined;
 
 		try {
 			// The yield can throw and must be handled here
@@ -194,9 +192,6 @@ export const simpleMessageGenerator: MessageGeneratorImplementation<Message> =
 
 		// If the sent message expects an update from the node, wait for it
 		if (msg.expectsNodeUpdate()) {
-			// We might have received the update prematurely. In that case, return it.
-			if (msg.prematureNodeUpdate) return msg.prematureNodeUpdate;
-
 			// CommandTime is measured by the application
 			// ReportTime timeout SHOULD be set to CommandTime + 1 second.
 			const timeout = getNodeUpdateTimeout(

--- a/packages/zwave-js/src/lib/test/driver/sendDataAbortAfterPrematureResponse.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/sendDataAbortAfterPrematureResponse.test.ts
@@ -1,0 +1,93 @@
+import { BasicCCGet, BasicCCReport } from "@zwave-js/cc";
+import { TransmitStatus } from "@zwave-js/core";
+import {
+	FunctionType,
+	SendDataAbort,
+	SendDataBridgeRequest,
+	SendDataRequestTransmitReport,
+} from "@zwave-js/serial";
+import type {
+	MockControllerBehavior,
+	MockNodeBehavior,
+} from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import path from "node:path";
+import {
+	MockControllerCommunicationState,
+	MockControllerStateKeys,
+} from "../../controller/MockControllerState.js";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest(
+	"Abort SendData transaction when expected response is received prematurely",
+	{
+		// debug: true,
+
+		provisioningDirectory: path.join(__dirname, "fixtures/base_2_nodes"),
+
+		async customSetup(driver, mockController, mockNode) {
+			let lastCallbackId: number | undefined;
+			const handleSendDataAbort: MockControllerBehavior = {
+				onHostMessage(controller, msg) {
+					if (msg instanceof SendDataBridgeRequest) {
+						// Remember the last callback ID
+						lastCallbackId = msg.callbackId;
+						return false;
+					}
+					if (msg instanceof SendDataAbort && lastCallbackId) {
+						// Finish the transmission by sending the callback
+						const cb = new SendDataRequestTransmitReport({
+							callbackId: lastCallbackId,
+							transmitStatus: TransmitStatus.NoAck,
+						});
+
+						setTimeout(() => {
+							controller.sendMessageToHost(cb);
+						}, 100);
+
+						// Put the controller into idle state
+						controller.state.set(
+							MockControllerStateKeys.CommunicationState,
+							MockControllerCommunicationState.Idle,
+						);
+
+						return true;
+					}
+				},
+			};
+			mockController.defineBehavior(handleSendDataAbort);
+
+			const respondToBasicGet: MockNodeBehavior = {
+				async handleCC(controller, self, receivedCC) {
+					if (receivedCC instanceof BasicCCGet) {
+						const cc = new BasicCCReport({
+							nodeId: self.id,
+							currentValue: 42,
+						});
+						return { action: "sendCC", cc };
+					}
+				},
+			};
+			mockNode.defineBehavior(respondToBasicGet);
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// Disable automatic ACKs to simulate poor connectivity
+			mockNode.autoAckControllerFrames = false;
+
+			// Send Basic CC Get - this should resolve due to premature response
+			const result = await node.commandClasses.Basic.get();
+			t.expect(result?.currentValue).toBe(42);
+
+			// Wait a bit to allow any pending operations to complete
+			await wait(50);
+
+			// Assert that the controller received a SendDataAbort
+			// This proves that the ongoing transaction was aborted when the
+			// premature response arrived
+			mockController.assertReceivedHostMessage(
+				(msg) => msg.functionType === FunctionType.SendDataAbort,
+			);
+		},
+	},
+);


### PR DESCRIPTION
Until now, we used to keep waiting if the response to a Get-type CC was received before the SendData request used to send it has been acknowledged (or timed out). There's really no need for this, so now we abort the pending transaction immediately.

fixes: #8194