### PR TITLE
fix: remove browser-unsafe serial export

### DIFF
--- a/packages/serial/src/index.ts
+++ b/packages/serial/src/index.ts
@@ -12,7 +12,6 @@ export * from "./parsers/ZWaveSerialFrame.js";
 export * from "./parsers/ZnifferSerialFrame.js";
 export * from "./plumbing/Faucet.js";
 export type * from "./serialport/Bindings.js";
-export * from "./serialport/ESPHomeSocket.js";
 export * from "./serialport/LegacyBindingWrapper.js";
 export * from "./serialport/ZWaveSerialPortImplementation.js";
 export * from "./serialport/ZWaveSerialStream.js";


### PR DESCRIPTION
This export was not needed and caused warnings from bundlers.