### PR TITLE
feat: mock secure inclusion of nodes and fix S0 auto-inclusion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/cc/src/cc/SecurityCC.ts
+++ b/packages/cc/src/cc/SecurityCC.ts
@@ -919,6 +919,17 @@ export class SecurityCCSchemeReport extends SecurityCC {
 @CCCommand(SecurityCommand.SchemeGet)
 @expectedCCResponse(SecurityCCSchemeReport)
 export class SecurityCCSchemeGet extends SecurityCC {
+	public static from(
+		raw: CCRaw,
+		ctx: CCParsingContext,
+	): SecurityCCSchemeGet {
+		validatePayload(raw.payload.length >= 1);
+		// The joining node MUST NOT perform any validation of the Supported Security Schemes byte
+		return new this({
+			nodeId: ctx.sourceNodeId,
+		});
+	}
+
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
 		// Since it is unlikely that any more schemes will be added to S0, we hardcode the default scheme here (bit 0 = 0)
 		this.payload = Bytes.from([0]);
@@ -937,6 +948,17 @@ export class SecurityCCSchemeGet extends SecurityCC {
 @CCCommand(SecurityCommand.SchemeInherit)
 @expectedCCResponse(SecurityCCSchemeReport)
 export class SecurityCCSchemeInherit extends SecurityCC {
+	public static from(
+		raw: CCRaw,
+		ctx: CCParsingContext,
+	): SecurityCCSchemeInherit {
+		validatePayload(raw.payload.length >= 1);
+		// The joining node MUST NOT perform any validation of the Supported Security Schemes byte
+		return new this({
+			nodeId: ctx.sourceNodeId,
+		});
+	}
+
 	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
 		// Since it is unlikely that any more schemes will be added to S0, we hardcode the default scheme here (bit 0 = 0)
 		this.payload = Bytes.from([0]);

--- a/packages/serial/src/serialapi/network-mgmt/AddNodeToNetworkRequest.ts
+++ b/packages/serial/src/serialapi/network-mgmt/AddNodeToNetworkRequest.ts
@@ -10,6 +10,7 @@ import {
 	NodeType,
 	type NodeUpdatePayload,
 	Protocols,
+	encodeNodeID,
 	encodeNodeUpdatePayload,
 	isLongRangeNodeId,
 	parseNodeID,
@@ -401,6 +402,14 @@ export class AddNodeToNetworkRequestStatusReport
 					this.statusContext as NodeUpdatePayload,
 					ctx.nodeIdType,
 				),
+			]);
+		} else if (
+			this.status === AddNodeStatus.Done
+			&& this.statusContext?.nodeId != undefined
+		) {
+			this.payload = Bytes.concat([
+				this.payload,
+				encodeNodeID(this.statusContext.nodeId, ctx.nodeIdType),
 			]);
 		}
 		return super.serialize(ctx);

--- a/packages/testing/src/MockController.ts
+++ b/packages/testing/src/MockController.ts
@@ -195,7 +195,10 @@ export class MockController {
 
 	/** Node info for the node that is pending inclusion. Set this before starting inclusion to simulate a node joining. */
 	public nodePendingInclusion:
-		| Omit<MockNodeOptions, "controller">
+		| (Omit<MockNodeOptions, "controller"> & {
+			/** Optional callback that is called when the node is created during inclusion */
+			setup?: (node: MockNode) => void;
+		})
 		| undefined;
 
 	/** Controls whether the controller automatically ACKs messages from the host before handling them */

--- a/packages/testing/src/MockController.ts
+++ b/packages/testing/src/MockController.ts
@@ -29,7 +29,7 @@ import {
 	type MockControllerCapabilities,
 	getDefaultMockControllerCapabilities,
 } from "./MockControllerCapabilities.js";
-import type { MockNode } from "./MockNode.js";
+import type { MockNode, MockNodeOptions } from "./MockNode.js";
 import {
 	type LazyMockZWaveFrame,
 	MOCK_FRAME_ACK_TIMEOUT,
@@ -192,6 +192,11 @@ export class MockController {
 
 	/** Can be used by behaviors to store controller related state */
 	public readonly state = new Map<string, unknown>();
+
+	/** Node info for the node that is pending inclusion. Set this before starting inclusion to simulate a node joining. */
+	public nodePendingInclusion:
+		| Omit<MockNodeOptions, "controller">
+		| undefined;
 
 	/** Controls whether the controller automatically ACKs messages from the host before handling them */
 	public autoAckHostMessages: boolean = true;

--- a/packages/testing/src/MockControllerCapabilities.ts
+++ b/packages/testing/src/MockControllerCapabilities.ts
@@ -45,6 +45,7 @@ export function getDefaultSupportedFunctionTypes(): FunctionType[] {
 		FunctionType.GetNodeProtocolInfo,
 		FunctionType.RequestNodeInfo,
 		FunctionType.AssignSUCReturnRoute,
+		FunctionType.DeleteSUCReturnRoute,
 		FunctionType.AddNodeToNetwork,
 		FunctionType.RemoveNodeFromNetwork,
 	];

--- a/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
+++ b/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
@@ -7,6 +7,7 @@ import {
 } from "@zwave-js/cc/ZWaveProtocolCC";
 import {
 	NodeType,
+	type NodeUpdatePayload,
 	TransmitOptions,
 	TransmitStatus,
 	ZWaveDataRate,
@@ -25,6 +26,9 @@ import {
 	AssignSUCReturnRouteRequest,
 	AssignSUCReturnRouteRequestTransmitReport,
 	AssignSUCReturnRouteResponse,
+	DeleteSUCReturnRouteRequest,
+	DeleteSUCReturnRouteRequestTransmitReport,
+	DeleteSUCReturnRouteResponse,
 	GetControllerCapabilitiesRequest,
 	GetControllerCapabilitiesResponse,
 	GetControllerIdRequest,
@@ -66,10 +70,11 @@ import {
 	MOCK_FRAME_ACK_TIMEOUT,
 	type MockController,
 	type MockControllerBehavior,
-	type MockNode,
+	MockNode,
 	MockZWaveFrameType,
 	createMockZWaveRequestFrame,
 } from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
 import {
 	MockControllerCommunicationState,
 	MockControllerInclusionState,
@@ -719,6 +724,115 @@ const handleRequestNodeInfo: MockControllerBehavior = {
 	},
 };
 
+async function transmitSUCReturnRoute(
+	controller: MockController,
+	node: MockNode,
+	callbackId: number,
+	options: {
+		destinationSpeed: ZWaveDataRate;
+		destinationWakeUp: WakeUpTime;
+		repeaters: number[];
+	},
+): Promise<boolean> {
+	const expectCallback = callbackId !== 0;
+
+	// Send the command to the node
+	const command = new ZWaveProtocolCCAssignSUCReturnRoute({
+		nodeId: node.id,
+		destinationNodeId: controller.ownNodeId,
+		routeIndex: 0, // don't care
+		...options,
+	});
+	const frame = createMockZWaveRequestFrame(command, {
+		ackRequested: expectCallback,
+	});
+	const ackPromise = controller.sendToNode(node, frame);
+
+	let ack = false;
+	if (expectCallback) {
+		// Put the controller into waiting state
+		controller.state.set(
+			MockControllerStateKeys.CommunicationState,
+			MockControllerCommunicationState.WaitingForNode,
+		);
+
+		// Wait for the ACK and notify the host
+		try {
+			const ackResult = await ackPromise;
+			ack = !!ackResult?.ack;
+		} catch {
+			// No response
+		}
+	}
+	controller.state.set(
+		MockControllerStateKeys.CommunicationState,
+		MockControllerCommunicationState.Idle,
+	);
+
+	return ack;
+}
+
+const handleDeleteSUCReturnRoute: MockControllerBehavior = {
+	async onHostMessage(controller, msg) {
+		if (msg instanceof DeleteSUCReturnRouteRequest) {
+			// Check if this command is legal right now
+			const state = controller.state.get(
+				MockControllerStateKeys.CommunicationState,
+			) as MockControllerCommunicationState | undefined;
+			if (
+				state != undefined
+				&& state !== MockControllerCommunicationState.Idle
+			) {
+				throw new Error(
+					"Received DeleteSUCReturnRouteRequest while not idle",
+				);
+			}
+
+			// Put the controller into sending state
+			controller.state.set(
+				MockControllerStateKeys.CommunicationState,
+				MockControllerCommunicationState.Sending,
+			);
+
+			const expectCallback = msg.callbackId !== 0;
+
+			// Send the command to the node
+			const node = controller.nodes.get(msg.getNodeId()!)!;
+
+			// Respond with success
+			const response = new DeleteSUCReturnRouteResponse({
+				wasExecuted: true,
+			});
+			await controller.sendMessageToHost(response);
+
+			const ack = await transmitSUCReturnRoute(
+				controller,
+				node,
+				msg.callbackId ?? 0,
+				// Set the empty route
+				{
+					destinationSpeed: ZWaveDataRate["9k6"],
+					destinationWakeUp: WakeUpTime.None,
+					repeaters: [],
+				},
+			);
+
+			if (expectCallback) {
+				const transmitReport =
+					new DeleteSUCReturnRouteRequestTransmitReport({
+						callbackId: msg.callbackId,
+						transmitStatus: ack
+							? TransmitStatus.OK
+							: TransmitStatus.NoAck,
+					});
+				await controller.sendMessageToHost(transmitReport);
+			}
+
+			return true;
+		}
+	},
+};
+
 const handleAssignSUCReturnRoute: MockControllerBehavior = {
 	async onHostMessage(controller, msg) {
 		if (msg instanceof AssignSUCReturnRouteRequest) {
@@ -745,18 +859,6 @@ const handleAssignSUCReturnRoute: MockControllerBehavior = {
 
 			// Send the command to the node
 			const node = controller.nodes.get(msg.getNodeId()!)!;
-			const command = new ZWaveProtocolCCAssignSUCReturnRoute({
-				nodeId: node.id,
-				destinationNodeId: controller.ownNodeId,
-				repeaters: [], // don't care
-				routeIndex: 0, // don't care
-				destinationSpeed: ZWaveDataRate["100k"],
-				destinationWakeUp: WakeUpTime.None,
-			});
-			const frame = createMockZWaveRequestFrame(command, {
-				ackRequested: expectCallback,
-			});
-			const ackPromise = controller.sendToNode(node, frame);
 
 			// Notify the host that the message was sent
 			const res = new AssignSUCReturnRouteResponse({
@@ -764,25 +866,17 @@ const handleAssignSUCReturnRoute: MockControllerBehavior = {
 			});
 			await controller.sendMessageToHost(res);
 
-			let ack = false;
-			if (expectCallback) {
-				// Put the controller into waiting state
-				controller.state.set(
-					MockControllerStateKeys.CommunicationState,
-					MockControllerCommunicationState.WaitingForNode,
-				);
-
-				// Wait for the ACK and notify the host
-				try {
-					const ackResult = await ackPromise;
-					ack = !!ackResult?.ack;
-				} catch {
-					// No response
-				}
-			}
-			controller.state.set(
-				MockControllerStateKeys.CommunicationState,
-				MockControllerCommunicationState.Idle,
+			// Assign uses 100kbps speed and empty repeaters (supports beaming)
+			const ack = await transmitSUCReturnRoute(
+				controller,
+				node,
+				msg.callbackId ?? 0,
+				// Don't care about the actual settings here
+				{
+					destinationSpeed: ZWaveDataRate["100k"],
+					destinationWakeUp: WakeUpTime.None,
+					repeaters: [],
+				},
 			);
 
 			if (expectCallback) {
@@ -819,10 +913,23 @@ const handleAddNode: MockControllerBehavior = {
 						MockControllerStateKeys.InclusionState,
 						MockControllerInclusionState.Idle,
 					);
-					cb = new AddNodeToNetworkRequestStatusReport({
-						callbackId: msg.callbackId,
-						status: AddNodeStatus.Failed,
-					});
+
+					// If there's a node pending inclusion, send Done status with node ID
+					const pendingNode = controller.nodePendingInclusion;
+					if (pendingNode) {
+						cb = new AddNodeToNetworkRequestStatusReport({
+							callbackId: msg.callbackId,
+							status: AddNodeStatus.Done,
+							nodeId: pendingNode.id,
+						});
+						// Clear the pending node
+						controller.nodePendingInclusion = undefined;
+					} else {
+						cb = new AddNodeToNetworkRequestStatusReport({
+							callbackId: msg.callbackId,
+							status: AddNodeStatus.Failed,
+						});
+					}
 				} else {
 					cb = new AddNodeToNetworkRequestStatusReport({
 						callbackId: msg.callbackId,
@@ -839,7 +946,6 @@ const handleAddNode: MockControllerBehavior = {
 				// Idle
 
 				// Set the controller into "adding node" state
-				// For now we don't actually do anything in that state
 				controller.state.set(
 					MockControllerStateKeys.InclusionState,
 					MockControllerInclusionState.AddingNode,
@@ -849,6 +955,62 @@ const handleAddNode: MockControllerBehavior = {
 					callbackId: msg.callbackId,
 					status: AddNodeStatus.Ready,
 				});
+
+				// If there's a node pending inclusion, simulate the inclusion sequence
+				// after responding to the add request
+				if (controller.nodePendingInclusion) {
+					const node = new MockNode({
+						controller,
+						...controller.nodePendingInclusion,
+					});
+
+					const supportedCCs = [...node.implementedCCs]
+						.filter(([, info]) =>
+							info.isSupported && info.version > 0
+						)
+						.map(([cc]) => cc);
+
+					const nodeInfo: NodeUpdatePayload = {
+						nodeId: node.id,
+						basicDeviceClass: node.capabilities.basicDeviceClass,
+						genericDeviceClass:
+							node.capabilities.genericDeviceClass,
+						specificDeviceClass:
+							node.capabilities.specificDeviceClass,
+						supportedCCs,
+					};
+
+					void (async () => {
+						// Wait a bit, then send NodeFound
+						await wait(10);
+						const nodeFoundMsg =
+							new AddNodeToNetworkRequestStatusReport({
+								callbackId: msg.callbackId,
+								status: AddNodeStatus.NodeFound,
+							});
+						await controller.sendMessageToHost(nodeFoundMsg);
+
+						// Wait a bit, then send AddingSlave with node info
+						await wait(10);
+						const addingSlaveMsg =
+							new AddNodeToNetworkRequestStatusReport({
+								callbackId: msg.callbackId,
+								status: AddNodeStatus.AddingSlave,
+								nodeInfo,
+							});
+						await controller.sendMessageToHost(addingSlaveMsg);
+
+						// Wait a bit, add the node to the controller's list, then send ProtocolDone
+						await wait(10);
+						controller.addNode(node);
+						const protocolDoneMsg =
+							new AddNodeToNetworkRequestStatusReport({
+								callbackId: msg.callbackId,
+								status: AddNodeStatus.ProtocolDone,
+							});
+						await controller.sendMessageToHost(protocolDoneMsg);
+					})();
+				}
 			}
 
 			if (expectCallback && cb) {
@@ -978,6 +1140,7 @@ export function createDefaultBehaviors(): MockControllerBehavior[] {
 		handleSendDataBridge,
 		handleSendDataMulticastBridge,
 		handleRequestNodeInfo,
+		handleDeleteSUCReturnRoute,
 		handleAssignSUCReturnRoute,
 		handleAddNode,
 		handleRemoveNode,

--- a/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
+++ b/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
@@ -959,10 +959,14 @@ const handleAddNode: MockControllerBehavior = {
 				// If there's a node pending inclusion, simulate the inclusion sequence
 				// after responding to the add request
 				if (controller.nodePendingInclusion) {
+					const { setup, ...nodeOptions } =
+						controller.nodePendingInclusion;
 					const node = new MockNode({
 						controller,
-						...controller.nodePendingInclusion,
+						...nodeOptions,
 					});
+					// Allow the tests to set up the node before inclusion happens
+					setup?.(node);
 
 					const supportedCCs = [...node.implementedCCs]
 						.filter(([, info]) =>

--- a/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
+++ b/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
@@ -75,6 +75,7 @@ import {
 	createMockZWaveRequestFrame,
 } from "@zwave-js/testing";
 import { wait } from "alcalzone-shared/async";
+import { createDefaultMockNodeBehaviors } from "../../Testing.js";
 import {
 	MockControllerCommunicationState,
 	MockControllerInclusionState,
@@ -965,7 +966,9 @@ const handleAddNode: MockControllerBehavior = {
 						controller,
 						...nodeOptions,
 					});
-					// Allow the tests to set up the node before inclusion happens
+					// Apply default behaviors that are required for interacting with the driver correctly
+					node.defineBehavior(...createDefaultMockNodeBehaviors());
+					// Allow the tests to set up additional behavior before inclusion happens
 					setup?.(node);
 
 					const supportedCCs = [...node.implementedCCs]

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -2930,7 +2930,12 @@ export class Driver extends TypedEventTarget<DriverEventCallbacks>
 			}
 		}
 
-		this.cachePurge(cacheKeys.node(node.id)._baseKey);
+		this.cachePurge(
+			cacheKeys.node(node.id)._baseKey,
+			// Preserve the device class though - this is set during the initial inclusion
+			// https://github.com/zwave-js/zwave-js/issues/8346
+			(key) => key === cacheKeys.node(node.id).deviceClass,
+		);
 	}
 
 	/** This is called when a new node has been added to the network */
@@ -8051,9 +8056,12 @@ ${handlers.length} left`,
 		return ret;
 	}
 
-	private cachePurge(prefix: string): void {
+	private cachePurge(
+		prefix: string,
+		except?: (key: string) => boolean,
+	): void {
 		for (const key of this.networkCache.keys()) {
-			if (key.startsWith(prefix)) {
+			if (key.startsWith(prefix) && !(except?.(key))) {
 				this.networkCache.delete(key);
 			}
 		}

--- a/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
+++ b/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
@@ -55,6 +55,7 @@ const respondToRequestNodeInfo: MockNodeBehavior = {
 					.filter(([ccId]) => ccId !== CommandClasses.Basic)
 					// Only include supported CCs
 					.filter(([, info]) => info.isSupported)
+					// FIXME: Filter out secure CCs if the node isn't secure
 					.map(([ccId]) => ccId),
 			});
 			return { action: "sendCC", cc };

--- a/packages/zwave-js/src/lib/test/driver/deviceInclusion.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/deviceInclusion.test.ts
@@ -1,5 +1,31 @@
-import { CommandClasses } from "@zwave-js/core";
+import {
+	SecurityCC,
+	SecurityCCCommandEncapsulation,
+	SecurityCCCommandsSupportedGet,
+	SecurityCCCommandsSupportedReport,
+	SecurityCCNetworkKeySet,
+	SecurityCCNetworkKeyVerify,
+	SecurityCCNonceGet,
+	SecurityCCNonceReport,
+	SecurityCCSchemeGet,
+	SecurityCCSchemeReport,
+} from "@zwave-js/cc";
+import {
+	CommandClasses,
+	SecurityManager,
+	isEncapsulationCC,
+} from "@zwave-js/core";
+import {
+	type MockNode,
+	type MockNodeBehavior,
+	type MockZWaveFrame,
+	MockZWaveFrameType,
+	createMockZWaveRequestFrame,
+} from "@zwave-js/testing";
+import { InclusionStrategy } from "../../controller/Inclusion.js";
+import type { ZWaveNode } from "../../node/Node.js";
 import { integrationTest } from "../integrationTestSuite.js";
+import { integrationTest as integrationTestMulti } from "../integrationTestSuiteMulti.js";
 
 integrationTest(
 	"Device inclusion process should emit 'node added' event",
@@ -42,7 +68,7 @@ integrationTest(
 
 			// Start the inclusion process
 			await driver.controller.beginInclusion({
-				strategy: 0, // Default strategy
+				strategy: InclusionStrategy.Default,
 			});
 
 			// Wait for the "node added" event
@@ -52,6 +78,255 @@ integrationTest(
 			const addedNode = driver.controller.nodes.get(3);
 			t.expect(addedNode).toBeDefined();
 			t.expect(addedNode?.id).toBe(3);
+		},
+	},
+);
+
+function setupS0NodeBehaviorsForNewlyIncludedNode(
+	mockNode: MockNode,
+): void {
+	// Create a security manager for the node with temporary key (all zeros)
+	// The real network key will be set after receiving SecurityCCNetworkKeySet
+	const temporaryKey = new Uint8Array(16).fill(0x00);
+	const sm0Node = new SecurityManager({
+		ownNodeId: mockNode.id,
+		networkKey: temporaryKey,
+		nonceTimeout: 100000,
+	});
+	mockNode.securityManagers.securityManager = sm0Node;
+
+	// Respond to Scheme Get with Scheme Report
+	const respondToSchemeGet: MockNodeBehavior = {
+		handleCC(controller, self, receivedCC) {
+			if (receivedCC instanceof SecurityCCSchemeGet) {
+				const cc = new SecurityCCSchemeReport({
+					nodeId: controller.ownNodeId,
+				});
+				return { action: "sendCC", cc };
+			}
+		},
+	};
+	mockNode.defineBehavior(respondToSchemeGet);
+
+	// Respond to S0 Nonce Get
+	const respondToS0NonceGet: MockNodeBehavior = {
+		handleCC(controller, self, receivedCC) {
+			if (receivedCC instanceof SecurityCCNonceGet) {
+				const nonce = sm0Node.generateNonce(controller.ownNodeId, 8);
+				const cc = new SecurityCCNonceReport({
+					nodeId: controller.ownNodeId,
+					nonce,
+				});
+				return { action: "sendCC", cc };
+			}
+		},
+	};
+	mockNode.defineBehavior(respondToS0NonceGet);
+
+	// Respond to Network Key Set with Network Key Verify
+	const respondToNetworkKeySet: MockNodeBehavior = {
+		async handleCC(controller, self, receivedCC) {
+			if (
+				receivedCC instanceof SecurityCCCommandEncapsulation
+				&& receivedCC.encapsulated instanceof SecurityCCNetworkKeySet
+			) {
+				// Update the node's security manager to use the received network key
+				const receivedKey = receivedCC.encapsulated.networkKey;
+				self.securityManagers.securityManager!.networkKey = receivedKey;
+
+				const nonceGet = new SecurityCCNonceGet({
+					nodeId: controller.ownNodeId,
+				});
+				await self.sendToController(
+					createMockZWaveRequestFrame(nonceGet, {
+						ackRequested: false,
+					}),
+				);
+
+				const nonceReport = await self.expectControllerFrame(
+					1000,
+					(
+						resp,
+					): resp is MockZWaveFrame & {
+						type: MockZWaveFrameType.Request;
+						payload: SecurityCCNonceReport;
+					} => resp.type === MockZWaveFrameType.Request
+						&& resp.payload instanceof SecurityCCNonceReport,
+				);
+				const receiverNonce = nonceReport.payload.nonce;
+
+				const response = new SecurityCCNetworkKeyVerify({
+					nodeId: controller.ownNodeId,
+				});
+				const cc = SecurityCC.encapsulate(
+					self.id,
+					self.securityManagers.securityManager!,
+					response,
+				);
+				cc.nonce = receiverNonce;
+
+				await self.sendToController(
+					createMockZWaveRequestFrame(cc, {
+						ackRequested: false,
+					}),
+				);
+
+				return { action: "stop" };
+			}
+		},
+	};
+	mockNode.defineBehavior(respondToNetworkKeySet);
+
+	// Respond to S0 Commands Supported Get
+	const respondToS0CommandsSupportedGet: MockNodeBehavior = {
+		async handleCC(controller, self, receivedCC) {
+			if (
+				receivedCC instanceof SecurityCCCommandEncapsulation
+				&& receivedCC.encapsulated
+					instanceof SecurityCCCommandsSupportedGet
+			) {
+				const nonceGet = new SecurityCCNonceGet({
+					nodeId: controller.ownNodeId,
+				});
+				await self.sendToController(
+					createMockZWaveRequestFrame(nonceGet, {
+						ackRequested: false,
+					}),
+				);
+
+				const nonceReport = await self.expectControllerFrame(
+					1000,
+					(
+						resp,
+					): resp is MockZWaveFrame & {
+						type: MockZWaveFrameType.Request;
+						payload: SecurityCCNonceReport;
+					} => resp.type === MockZWaveFrameType.Request
+						&& resp.payload instanceof SecurityCCNonceReport,
+				);
+				const receiverNonce = nonceReport.payload.nonce;
+
+				// Determine securely supported CCs from the mock node's implementedCCs
+				const supportedCCs = [...mockNode.implementedCCs.entries()]
+					.filter(
+						([cc, info]) =>
+							info.secure === true
+							&& !isEncapsulationCC(cc),
+					)
+					.map(([cc]) => cc);
+
+				const response = new SecurityCCCommandsSupportedReport({
+					nodeId: controller.ownNodeId,
+					supportedCCs,
+					controlledCCs: [],
+					reportsToFollow: 0,
+				});
+				const cc = SecurityCC.encapsulate(
+					self.id,
+					self.securityManagers.securityManager!,
+					response,
+				);
+				cc.nonce = receiverNonce;
+
+				await self.sendToController(
+					createMockZWaveRequestFrame(cc, {
+						ackRequested: false,
+					}),
+				);
+
+				return { action: "stop" };
+			}
+		},
+	};
+	mockNode.defineBehavior(respondToS0CommandsSupportedGet);
+
+	// Parse Security CC commands. This MUST be defined last, since defineBehavior will prepend it to the list
+	const parseS0CC: MockNodeBehavior = {
+		async handleCC(controller, self, receivedCC) {
+			// We don't support sequenced commands here
+			if (receivedCC instanceof SecurityCCCommandEncapsulation) {
+				await receivedCC.mergePartialCCs([], {
+					sourceNodeId: controller.ownNodeId,
+					__internalIsMockNode: true,
+					frameType: "singlecast",
+					...self.encodingContext,
+					...self.securityManagers,
+				});
+			}
+			// This just decodes - we need to call further handlers
+			return undefined;
+		},
+	};
+	mockNode.defineBehavior(parseS0CC);
+}
+
+integrationTestMulti(
+	"Inclusion with S0 should work",
+	{
+		// debug: true,
+
+		async customSetup(driver, mockController, mockNodes) {
+			// Create a security manager for the controller with the real network key
+			const sm0Ctrlr = new SecurityManager({
+				ownNodeId: mockController.ownNodeId,
+				networkKey: driver.options.securityKeys!.S0_Legacy!,
+				nonceTimeout: 100000,
+			});
+			mockController.securityManagers.securityManager = sm0Ctrlr;
+		},
+
+		testBody: async (t, driver, nodes, mockController, mockNodes) => {
+			// Set up a promise to wait for the "node added" event
+			let includedNode: ZWaveNode | undefined;
+			const nodeAddedPromise = new Promise<void>((resolve) => {
+				driver.controller.once("node added", (node) => {
+					includedNode = node;
+					resolve();
+				});
+			});
+
+			// Set up the node that will be included
+			mockController.nodePendingInclusion = {
+				id: 3,
+				capabilities: {
+					basicDeviceClass: 0x04,
+					genericDeviceClass: 0x10,
+					specificDeviceClass: 0x01,
+					commandClasses: [
+						CommandClasses["Z-Wave Plus Info"],
+						CommandClasses["Manufacturer Specific"],
+						CommandClasses["Device Reset Locally"],
+						CommandClasses.Security,
+						CommandClasses.Powerlevel,
+						CommandClasses["Firmware Update Meta Data"],
+					],
+				},
+				setup: setupS0NodeBehaviorsForNewlyIncludedNode,
+			};
+
+			// Start the inclusion process with S0
+			await driver.controller.beginInclusion({
+				strategy: InclusionStrategy.Security_S0,
+			});
+
+			// Wait for the "node added" event
+			await nodeAddedPromise;
+
+			// FIXME: Wait for the interview to complete
+			// const interviewCompletePromise = new Promise<void>((resolve) => {
+			// 	includedNode!.once("interview completed", () => {
+			// 		resolve();
+			// 	});
+			// });
+			// await interviewCompletePromise;
+
+			// Verify that the node was added to the controller's nodes map
+			t.expect(includedNode).toBeDefined();
+			t.expect(includedNode!.id).toBe(3);
+			t.expect(includedNode!.isSecure).toBe(true);
+			t.expect(includedNode!.supportsCC(CommandClasses.Security)).toBe(
+				true,
+			);
 		},
 	},
 );

--- a/packages/zwave-js/src/lib/test/driver/deviceInclusion.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/deviceInclusion.test.ts
@@ -1,0 +1,57 @@
+import { CommandClasses } from "@zwave-js/core";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest(
+	"Device inclusion process should emit 'node added' event",
+	{
+		// debug: true,
+
+		additionalDriverOptions: {
+			testingHooks: {
+				skipNodeInterview: true,
+			},
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			// Set up a promise to wait for the "node added" event
+			const nodeAddedPromise = new Promise<void>((resolve) => {
+				driver.controller.once("node added", (addedNode, result) => {
+					t.expect(addedNode.id).toBe(3);
+					t.expect(result).toBeDefined();
+					resolve();
+				});
+			});
+
+			// Set up the node that will be included
+			mockController.nodePendingInclusion = {
+				id: 3,
+				capabilities: {
+					basicDeviceClass: 0x04,
+					genericDeviceClass: 0x10,
+					specificDeviceClass: 0x01,
+					commandClasses: [
+						CommandClasses["Z-Wave Plus Info"],
+						CommandClasses["Manufacturer Specific"],
+						CommandClasses["Device Reset Locally"],
+						CommandClasses.Security,
+						CommandClasses.Powerlevel,
+						CommandClasses["Firmware Update Meta Data"],
+					],
+				},
+			};
+
+			// Start the inclusion process
+			await driver.controller.beginInclusion({
+				strategy: 0, // Default strategy
+			});
+
+			// Wait for the "node added" event
+			await nodeAddedPromise;
+
+			// Verify that the node was added to the controller's nodes map
+			const addedNode = driver.controller.nodes.get(3);
+			t.expect(addedNode).toBeDefined();
+			t.expect(addedNode?.id).toBe(3);
+		},
+	},
+);


### PR DESCRIPTION
This PR allows us to run tests for secure (S0) inclusion of devices. This made it possible to reproduce the underlying issue of #8346

Fixes: #8346