### PR TITLE
chore: enforce a minimal dependency age of 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       timezone: Europe/Berlin
     open-pull-requests-limit: 5
     versioning-strategy: increase
+    cooldown:
+      default-days: 7 # In line with yarn configuration npmMinimalAgeGate
     allow:
       # Z-Wave JS is a library. We have no control over which transient dependencies
       # get installed when Z-Wave JS is used elsewhere.
@@ -36,3 +38,5 @@ updates:
       time: '04:00'
       timezone: Europe/Berlin
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -11,3 +11,6 @@ plugins:
     spec: "https://raw.githubusercontent.com/zwave-js/yarn-plugins/master/packages/changed/bundles/%40yarnpkg/plugin-changed.js"
 
 preferInteractive: true
+
+# Prevent installation of packages that are too new, to make it less likely to pick up supply chain attacks
+npmMinimalAgeGate: 7d


### PR DESCRIPTION
This should make us less likely to become a victim of supply chain attacks