### PR TITLE
fix(config): add new product type for Shelly Wave PM Mini, FW 12.0

### DIFF
--- a/packages/config/config/devices/0x0460/qmem-0A1PC16.json
+++ b/packages/config/config/devices/0x0460/qmem-0A1PC16.json
@@ -5,7 +5,7 @@
 	"description": "Wave PM Mini",
 	"devices": [
 		{
-			"productType": "0x0007",
+			"productType": "0x0004",
 			"productId": "0x0081",
 			"zwaveAllianceId": 5078
 		}

--- a/packages/config/config/devices/0x0460/qmem-0A1PC16.json
+++ b/packages/config/config/devices/0x0460/qmem-0A1PC16.json
@@ -5,12 +5,12 @@
 	"description": "Wave PM Mini",
 	"devices": [
 		{
-			// Firmware version < 12.0
+			// Firmware version < 12.0 and 12.0 <
 			"productType": "0x0007",
 			"productId": "0x0081"
 		},
 		{
-			// Firmware version >= 12.0
+			// Firmware version = 12.0
 			"productType": "0x0004",
 			"productId": "0x0081"
 		}

--- a/packages/config/config/devices/0x0460/qmem-0A1PC16.json
+++ b/packages/config/config/devices/0x0460/qmem-0A1PC16.json
@@ -5,12 +5,13 @@
 	"description": "Wave PM Mini",
 	"devices": [
 		{
-			// Firmware version < 12.0 and 12.0 <
 			"productType": "0x0007",
 			"productId": "0x0081"
 		},
 		{
-			// Firmware version = 12.0
+			// In firmware version 12.0, the product type was mistakenly
+			// changed to 0x0004:
+			// https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/issues/8#issuecomment-4153013931
 			"productType": "0x0004",
 			"productId": "0x0081"
 		}

--- a/packages/config/config/devices/0x0460/qmem-0A1PC16.json
+++ b/packages/config/config/devices/0x0460/qmem-0A1PC16.json
@@ -5,6 +5,11 @@
 	"description": "Wave PM Mini",
 	"devices": [
 		{
+			"productType": "0x0007",
+			"productId": "0x0081",
+			"zwaveAllianceId": 5078
+		},
+		{
 			"productType": "0x0004",
 			"productId": "0x0081",
 			"zwaveAllianceId": 5078

--- a/packages/config/config/devices/0x0460/qmem-0A1PC16.json
+++ b/packages/config/config/devices/0x0460/qmem-0A1PC16.json
@@ -5,14 +5,14 @@
 	"description": "Wave PM Mini",
 	"devices": [
 		{
+			// Firmware version < 12.0
 			"productType": "0x0007",
-			"productId": "0x0081",
-			"zwaveAllianceId": 5078
+			"productId": "0x0081"
 		},
 		{
+			// Firmware version >= 12.0
 			"productType": "0x0004",
-			"productId": "0x0081",
-			"zwaveAllianceId": 5078
+			"productId": "0x0081"
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
It changed from 0x0007 to 0x0004 in latest FW update (12.0.0).

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

ProductType changed from 0x0007 to 0x0004 in latest FW update (12.0.0).


Fixes: #8687
