### PR TITLE
fix(config): use SDK instead of firmware version to show SDK warnings

### DIFF
--- a/packages/config/config/devices/0x0000/700_800_series_controller.json
+++ b/packages/config/config/devices/0x0000/700_800_series_controller.json
@@ -18,17 +18,17 @@
 		// 700/800 series firmware bugs that affect multiple controllers
 		"comments": [
 			{
-				"$if": "firmwareVersion < 7.17.2",
+				"$if": "sdkVersion < 7.17.2",
 				"$import": "~/templates/master_template.json#7xx_firmware_bug_pre_7_17_2"
 			},
 			{
 				// Not sure if this is a 700 or 800 series controller. Show the generic warning
-				"$if": "firmwareVersion >= 7.19.1 && firmwareVersion <= 7.21.3",
+				"$if": "sdkVersion >= 7.19.1 && sdkVersion <= 7.21.3",
 				"$import": "~/templates/master_template.json#7xx_8xx_firmware_bug_7_19_to_7_21_3_or_7_22_1"
 			},
 			{
 				// 7.22.x is limited to 800 series
-				"$if": "firmwareVersion === 7.22.0",
+				"$if": "sdkVersion === 7.22.0",
 				"$import": "~/templates/master_template.json#8xx_firmware_bug_pre_7_22_1"
 			}
 		]

--- a/packages/config/config/devices/0x027a/zac93.json
+++ b/packages/config/config/devices/0x027a/zac93.json
@@ -19,7 +19,7 @@
 			// https://www.support.getzooz.com/kb/article/1158-zooz-ota-firmware-files/
 			// 1.40 = SDK 7.22.0. No fixed version available yet.
 			{
-				"$if": "firmwareVersion <= 1.40",
+				"$if": "sdkVersion < 7.22.1",
 				"$import": "~/templates/master_template.json#8xx_firmware_bug_pre_7_22_1"
 			}
 		]

--- a/packages/config/config/devices/0x027a/zst10_700.json
+++ b/packages/config/config/devices/0x027a/zst10_700.json
@@ -17,11 +17,11 @@
 		// 700/800 series firmware bugs that affect multiple controllers
 		"comments": [
 			{
-				"$if": "firmwareVersion < 7.17.2",
+				"$if": "sdkVersion < 7.17.2",
 				"$import": "~/templates/master_template.json#7xx_firmware_bug_pre_7_17_2"
 			},
 			{
-				"$if": "firmwareVersion >= 7.19.1 && firmwareVersion <= 7.21.3",
+				"$if": "sdkVersion >= 7.19.1 && sdkVersion <= 7.21.3",
 				"$import": "~/templates/master_template.json#7xx_firmware_bug_7_19_to_7_21_3"
 			}
 		]

--- a/packages/config/config/devices/0x027a/zst39lr.json
+++ b/packages/config/config/devices/0x027a/zst39lr.json
@@ -19,7 +19,7 @@
 			// https://www.support.getzooz.com/kb/article/1352-zst39-800-long-range-z-wave-stick-change-log/
 			// 1.50 = SDK 7.22.1
 			{
-				"$if": "firmwareVersion < 1.50",
+				"$if": "sdkVersion < 7.22.1",
 				"$import": "~/templates/master_template.json#8xx_firmware_bug_pre_7_22_1"
 			}
 		]


### PR DESCRIPTION
https://github.com/zwave-js/zwave-js/pull/8529 added support for using the `sdkVersion` in config file conditionals.
This means we can now use it to show the warnings for problematic 700/800 series firmwares based on the actual SDK version rather than approximating it using known firmware versions.