### PR TITLE
fix(cli): parse multiline command descriptions correctly

### DIFF
--- a/packages/serial/src/parsers/CLIParser.test.ts
+++ b/packages/serial/src/parsers/CLIParser.test.ts
@@ -1,0 +1,60 @@
+import { Bytes } from "@zwave-js/shared";
+import { wait } from "alcalzone-shared/async";
+import { test } from "vitest";
+import { CLIParser } from "./CLIParser.js";
+import { CLIChunkType, ZWaveSerialFrameType } from "./ZWaveSerialFrame.js";
+
+test("does not treat argument placeholders as the CLI prompt", async (t) => {
+	const parser = new CLIParser();
+	const writer = parser.writable.getWriter();
+	const received: {
+		type: ZWaveSerialFrameType.CLI;
+		data:
+			| { type: CLIChunkType.Message; message: string }
+			| { type: CLIChunkType.Prompt };
+	}[] = [];
+
+	const consume = (async () => {
+		for await (const frame of parser.readable) {
+			if (frame.type !== ZWaveSerialFrameType.CLI) continue;
+			if (frame.data.type === CLIChunkType.FlowControl) continue;
+			received.push(frame as (typeof received)[number]);
+		}
+	})();
+
+	await writer.write(Bytes.from(
+		`help\r
+set_region                    Set the configured region\r
+                              [string] <region>\r
+set_powerlevel                Set the configured RF power values\r
+                              [int16] <iTxPowerLevelMax> <iTxPowe`,
+		"ascii",
+	));
+	await wait(25);
+	t.expect(received).toHaveLength(0);
+
+	await writer.write(Bytes.from(
+		`rLevelAdjust> <iTxPowerLevelMaxLR>\r
+bootloader                    Restart into bootloader\r
+> `,
+		"ascii",
+	));
+	await wait(25);
+
+	t.expect(received).toHaveLength(2);
+	t.expect(received[0].data.type).toBe(CLIChunkType.Message);
+	t.expect(
+		(received[0].data as { type: CLIChunkType.Message; message: string })
+			.message,
+	).toContain(
+		"[int16] <iTxPowerLevelMax> <iTxPowerLevelAdjust> <iTxPowerLevelMaxLR>",
+	);
+	t.expect(
+		(received[0].data as { type: CLIChunkType.Message; message: string })
+			.message,
+	).toContain("bootloader                    Restart into bootloader");
+	t.expect(received[1].data.type).toBe(CLIChunkType.Prompt);
+
+	await writer.close();
+	await consume;
+});

--- a/packages/serial/src/parsers/CLIParser.ts
+++ b/packages/serial/src/parsers/CLIParser.ts
@@ -18,6 +18,15 @@ function isFlowControl(byte: number): boolean {
 	);
 }
 
+function normalizeLine(line: string): string {
+	return line.startsWith("\r") ? line.slice(1) : line;
+}
+
+function isPromptLine(line: string): boolean {
+	const normalizedLine = normalizeLine(line).trimEnd();
+	return normalizedLine === ">" || normalizedLine.startsWith("> ");
+}
+
 export class CLIParser extends TransformStream<
 	Uint8Array,
 	ZWaveSerialFrame & { type: ZWaveSerialFrameType.CLI }
@@ -64,10 +73,17 @@ export class CLIParser extends TransformStream<
 				// When logging is involved, the log line may be output after the prompt due to a delay, e.g. "> [I] some log"
 
 				// We emit this as a message, followed by a prompt
-				if (receiveBuffer.includes("> ")) {
+				const lines = receiveBuffer.split("\n");
+				if (lines.some(isPromptLine)) {
 					// There is a prompt input, that means the output is complete
-					const output = receiveBuffer.split("\n").map(
-						(line) => line.startsWith("> ") ? line.slice(2) : line,
+					const output = lines.map(
+						(line) => {
+							if (!isPromptLine(line)) return line;
+							const normalized = normalizeLine(line);
+							return normalized.startsWith("> ")
+								? normalized.slice(2)
+								: "";
+						},
 					).join("\n").trim();
 
 					if (output) {

--- a/packages/zwave-js/src/lib/driver/EndDeviceCLI.test.ts
+++ b/packages/zwave-js/src/lib/driver/EndDeviceCLI.test.ts
@@ -40,3 +40,31 @@ test("executeCommand trims the command before validating and matching echoes", a
 	t.expect(written).toBe("set_region EU\r\n");
 	t.expect(response).toBe("OK");
 });
+
+test("detectCommands ignores wrapped descriptions and arguments", async (t) => {
+	let written: string | undefined;
+	const cli = new EndDeviceCLI(
+		async (data) => {
+			written = Buffer.from(data).toString("ascii");
+		},
+		async () =>
+			`help\r
+set_learn_mode                Include / exclude the device into / from a z-w\r
+                              ave network\r
+set_region                    Set the current region\r
+                              [string] <region>\r
+bootloader                    Restart into bootloader`,
+	);
+
+	await cli.detectCommands();
+
+	t.expect(written).toBe("help\r\n");
+	t.expect([...cli.commands.entries()]).toStrictEqual([
+		[
+			"set_learn_mode",
+			"Include / exclude the device into / from a z-wave network",
+		],
+		["set_region", "Set the current region [string] <region>"],
+		["bootloader", "Restart into bootloader"],
+	]);
+});

--- a/packages/zwave-js/src/lib/driver/EndDeviceCLI.ts
+++ b/packages/zwave-js/src/lib/driver/EndDeviceCLI.ts
@@ -1,6 +1,27 @@
 import { ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
 import { Bytes, type BytesView } from "@zwave-js/shared";
 
+function parseCommandList(output: string): [string, string][] {
+	const commands: [string, string][] = [];
+	for (const line of output.trim().split("\n")) {
+		const match = line.match(
+			/^\s*([A-Za-z][A-Za-z0-9_]*)\s{2,}(.*?)\s*$/,
+		);
+		if (match) {
+			commands.push([match[1], match[2]]);
+		} else if (commands.length > 0) {
+			// Continuation line — append to the previous command's description
+			let trimmed = line.trim();
+			if (trimmed) {
+				// "[" indicates an argument description
+				if (trimmed.startsWith("[")) trimmed = " " + trimmed;
+				commands.at(-1)![1] += trimmed;
+			}
+		}
+	}
+	return commands;
+}
+
 /** Encapsulates information about the currently active bootloader */
 export class EndDeviceCLI {
 	public constructor(
@@ -54,16 +75,6 @@ export class EndDeviceCLI {
 				ZWaveErrorCodes.Driver_NotSupported,
 			);
 		}
-		const commands = commandList.trim()
-			.split("\n")
-			.map((line) => line.trim())
-			.map((line) =>
-				line.split(/\s+/, 2).map((part) => part.trim()) as [
-					string,
-					string,
-				]
-			)
-			.filter((parts) => parts.every((part) => !!part));
-		this._commands = new Map(commands);
+		this._commands = new Map(parseCommandList(commandList));
 	}
 }


### PR DESCRIPTION
Previously, the parser would choke on descriptions that contain `> `, and it would not correctly include wrapped descriptions that are too long for a single line.