### PR TITLE
fix: unwanted delay in `Node.pollValue`

### DIFF
--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -797,10 +797,12 @@ export class ZWaveNode extends ZWaveNodeMixins implements QuerySecurityClasses {
 				valueId.commandClass
 			] as CCAPI
 		).withOptions({
-			// We do not want to delay more important communication by polling, so give it
-			// the lowest priority and don't retry unless overwritten by the options
+			// We do not want to delay more important communication by polling, so...
+			// ...don't retry
 			maxSendAttempts: 1,
-			priority: MessagePriority.Poll,
+			// ...and give it the lowest priority for user interactions
+			priority: MessagePriority.NodeQuery,
+			// ...unless overwritten by the options
 			...sendCommandOptions,
 		});
 

--- a/packages/zwave-js/src/lib/test/driver/pollValueTiming.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/pollValueTiming.test.ts
@@ -1,0 +1,41 @@
+import { BasicCCGet, BasicCCReport, BasicCCValues } from "@zwave-js/cc";
+import { type MockNodeBehavior } from "@zwave-js/testing";
+import path from "node:path";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest(
+	"Node.pollValue should not wait more than a few milliseconds before sending the command",
+	{
+		debug: true,
+
+		provisioningDirectory: path.join(__dirname, "fixtures/basicCC"),
+
+		async customSetup(_driver, _mockController, mockNode) {
+			const respondToBasicGet: MockNodeBehavior = {
+				async handleCC(controller, _self, receivedCC) {
+					if (receivedCC instanceof BasicCCGet) {
+						const cc = new BasicCCReport({
+							nodeId: controller.ownNodeId,
+							currentValue: 42,
+						});
+						return { action: "sendCC", cc };
+					}
+				},
+			};
+			mockNode.defineBehavior(respondToBasicGet);
+		},
+
+		testBody: async (t, _driver, node, _mockController, _mockNode) => {
+			const currentValueId = BasicCCValues.currentValue.endpoint(0);
+
+			// Measure how long it takes for pollValue to send the command
+			const start = Date.now();
+			await node.pollValue(currentValueId);
+			const elapsed = Date.now() - start;
+
+			// The command should be sent and completed very quickly (within a few milliseconds)
+			// This test verifies that pollValue does not add unnecessary delays
+			t.expect(elapsed).toBeLessThan(100);
+		},
+	},
+);

--- a/packages/zwave-js/src/lib/test/driver/pollValueTiming.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/pollValueTiming.test.ts
@@ -6,7 +6,7 @@ import { integrationTest } from "../integrationTestSuite.js";
 integrationTest(
 	"Node.pollValue should not wait more than a few milliseconds before sending the command",
 	{
-		debug: true,
+		// debug: true,
 
 		provisioningDirectory: path.join(__dirname, "fixtures/basicCC"),
 


### PR DESCRIPTION
https://github.com/zwave-js/zwave-js/pull/8662 introduced an unwanted delay because it used `MessagePriority.Poll`, which is now meant for automatic background activity.